### PR TITLE
Add metadata presenter gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.2'
 
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'metadata_presenter', github: 'ministryofjustice/fb-metadata-presenter', branch: 'main'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.1'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 56880660ae9c64394732c424618056482bc5cf68
+  revision: 9b8c0380ad68989acadedce619e0a841e7908a2b
   branch: main
   specs:
     metadata_presenter (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 56880660ae9c64394732c424618056482bc5cf68
+  branch: main
+  specs:
+    metadata_presenter (0.1.0)
+      govspeak
+      rails (~> 6.0.3, >= 6.0.3.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -56,6 +65,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.3.8)
     bindex (0.8.1)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
@@ -69,8 +79,16 @@ GEM
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    govspeak (3.6.2)
+      addressable (~> 2.3.8)
+      htmlentities (~> 4)
+      kramdown (~> 1.10.0)
+      nokogiri (~> 1.5)
+      sanitize (~> 2.1.0)
+    htmlentities (4.3.4)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    kramdown (1.10.0)
     listen (3.3.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -145,6 +163,8 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.10.0)
+    sanitize (2.1.1)
+      nokogiri (>= 1.4.4)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -195,6 +215,7 @@ DEPENDENCIES
   brakeman
   byebug
   listen (~> 3.2)
+  metadata_presenter!
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,36 @@
 class ApplicationController < ActionController::Base
+  def service_metadata
+    {
+      "service_id" => params[:service_id],
+      "service_name" => "Service Name Preview",
+      "version_id" => "ac4b45c5-071e-4d07-b5a2-9f0196a5b267",
+      "created_at" => "2020-10-09T11:51:46",
+      "created_by" => "4634ec01-5618-45ec-a4e2-bb5aa587e751",
+      "configuration" => {
+        "_id" => "service",
+        "_type" => "config.service"
+      },
+      "pages" => [
+        {
+          "_id" => "page.start",
+          "_type" => "page.start",
+          "body" => "You cannot use this form to complain about:\r\n\r\n* the result of a case\r\n* a judge, magistrate, coroner or member of a tribunal\r\n\r\nThis online form is also available in [Welsh (Cymraeg)](https://complain-about-a-court-or-tribunal.form.service.justice.gov.uk/cy).",
+          "heading" => "Service #{params[:service_id]}",
+          "lede" => "Your complaint will not affect your case.",
+          "steps" => [
+            "page-2",
+            "page.do-you-have-a-case-number"
+          ],
+          "url" => "/"
+        },
+        {
+          "_id" => "page-2",
+          "_type" => "page",
+          "body" => "This is page two",
+          "url" => "/page-2"
+        }
+      ],
+      "locale" => "en"
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
   get '/health', to: 'health#show'
+
+  resources :services, only: :index do
+    mount MetadataPresenter::Engine => '/preview', as: :preview
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end


### PR DESCRIPTION
[Trello Card](https://trello.com/c/UaXnu2Vm/1077-add-fb-metadata-presenter-gem-to-fb-editor)

## Context

This adds a minimalistic usage of the metadata presenter gem.

To access just visit `/services/:service_id/preview` 

Obs.: I didn't integrate with MetadataAPI because the card and we agree to add a hardcoded JSON for now.