### PR TITLE
Add git  to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.7.2-alpine3.12
 
 ARG UID=1001
 
-RUN apk add build-base postgresql-contrib postgresql-dev bash libcurl
+RUN apk add git build-base postgresql-contrib postgresql-dev bash libcurl
 
 RUN addgroup -g ${UID} -S appgroup && \
   adduser -u ${UID} -S appuser -G appgroup


### PR DESCRIPTION
# Context

The build is failing because the metadata presenter gem is installed via git and we don't have git installed in the containers.

The temporary solution is to add git to the container while we implement the gem publishing mechanism into metadata presenter gem