### PR TITLE
Save user data to session

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.2'
 
 gem 'bootsnap', '>= 1.4.2', require: false
-gem 'metadata_presenter', github: 'ministryofjustice/fb-metadata-presenter', branch: 'main'
+gem 'metadata_presenter', github: 'ministryofjustice/fb-metadata-presenter', branch: 'save-in-the-session'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.1'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.4'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.2'
 
 gem 'bootsnap', '>= 1.4.2', require: false
-gem 'metadata_presenter', github: 'ministryofjustice/fb-metadata-presenter', branch: 'save-in-the-session'
+gem 'metadata_presenter', github: 'ministryofjustice/fb-metadata-presenter', branch: 'main'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.1'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,7 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-<<<<<<< HEAD
-  revision: 482c60c155a008f0d336665ee94307ec592c7a80
+  revision: 51c386cfaf8e8a3ef6b888c34e148b733878bda8
   branch: main
-=======
-  revision: bcb2d591c1b410d7782e0d7f4064fb614bbc3078
-  branch: save-in-the-session
->>>>>>> Update metadata presenter
   specs:
     metadata_presenter (0.1.0)
       govspeak

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,10 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 51c386cfaf8e8a3ef6b888c34e148b733878bda8
+  revision: 78786aeb9c92e122be4065a55b264c91e49315f4
   branch: main
   specs:
     metadata_presenter (0.1.0)
       govspeak
-      json-schema
       rails (~> 6.0.3, >= 6.0.3.4)
 
 GEM
@@ -66,8 +65,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
-    addressable (2.7.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.3.8)
     bindex (0.8.1)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
@@ -81,17 +79,16 @@ GEM
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govspeak (3.5.0)
+    govspeak (3.6.2)
+      addressable (~> 2.3.8)
       htmlentities (~> 4)
-      kramdown (~> 1.5.0)
+      kramdown (~> 1.10.0)
       nokogiri (~> 1.5)
       sanitize (~> 2.1.0)
     htmlentities (4.3.4)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    json-schema (2.8.1)
-      addressable (>= 2.4)
-    kramdown (1.5.0)
+    kramdown (1.10.0)
     listen (3.3.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -112,7 +109,6 @@ GEM
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     pg (1.2.3)
-    public_suffix (4.0.6)
     puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
@@ -209,7 +205,7 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.4.1)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,16 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+<<<<<<< HEAD
   revision: 482c60c155a008f0d336665ee94307ec592c7a80
   branch: main
+=======
+  revision: bcb2d591c1b410d7782e0d7f4064fb614bbc3078
+  branch: save-in-the-session
+>>>>>>> Update metadata presenter
   specs:
     metadata_presenter (0.1.0)
       govspeak
+      json-schema
       rails (~> 6.0.3, >= 6.0.3.4)
 
 GEM
@@ -65,7 +71,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
-    addressable (2.3.8)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     bindex (0.8.1)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
@@ -79,20 +86,21 @@ GEM
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govspeak (3.6.2)
-      addressable (~> 2.3.8)
+    govspeak (3.5.0)
       htmlentities (~> 4)
-      kramdown (~> 1.10.0)
+      kramdown (~> 1.5.0)
       nokogiri (~> 1.5)
       sanitize (~> 2.1.0)
     htmlentities (4.3.4)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    kramdown (1.10.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
+    kramdown (1.5.0)
     listen (3.3.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.7.0)
+    loofah (2.8.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -109,6 +117,7 @@ GEM
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     pg (1.2.3)
+    public_suffix (4.0.6)
     puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,36 +1,23 @@
 class ApplicationController < ActionController::Base
   def service_metadata
-    {
-      "service_id" => params[:service_id],
-      "service_name" => "Service Name Preview",
-      "version_id" => "ac4b45c5-071e-4d07-b5a2-9f0196a5b267",
-      "created_at" => "2020-10-09T11:51:46",
-      "created_by" => "4634ec01-5618-45ec-a4e2-bb5aa587e751",
-      "configuration" => {
-        "_id" => "service",
-        "_type" => "config.service"
-      },
-      "pages" => [
-        {
-          "_id" => "page.start",
-          "_type" => "page.start",
-          "body" => "You cannot use this form to complain about:\r\n\r\n* the result of a case\r\n* a judge, magistrate, coroner or member of a tribunal\r\n\r\nThis online form is also available in [Welsh (Cymraeg)](https://complain-about-a-court-or-tribunal.form.service.justice.gov.uk/cy).",
-          "heading" => "Service #{params[:service_id]}",
-          "lede" => "Your complaint will not affect your case.",
-          "steps" => [
-            "page-2",
-            "page.do-you-have-a-case-number"
-          ],
-          "url" => "/"
-        },
-        {
-          "_id" => "page-2",
-          "_type" => "page",
-          "body" => "This is page two",
-          "url" => "/page-2"
-        }
-      ],
-      "locale" => "en"
-    }
+    JSON.parse(File.read(Rails.root.join('service.json')))
+  end
+
+  def service
+    @service ||= MetadataPresenter::Service.new(service_metadata)
+  end
+
+  def save_user_data	    
+    if params[:answers]
+      session[:user_data] ||= {}
+
+      params[:answers].each do |field, answer|
+        session[:user_data][field] = answer
+      end
+    end
+  end
+
+  def load_user_data
+    session[:user_data] || {}
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,23 +1,29 @@
 class ApplicationController < ActionController::Base
-  def service_metadata
-    JSON.parse(File.read(Rails.root.join('service.json')))
-  end
-
   def service
     @service ||= MetadataPresenter::Service.new(service_metadata)
   end
 
-  def save_user_data	    
-    if params[:answers]
-      session[:user_data] ||= {}
+  def save_user_data
+    return {} if params[:answers].blank? || params[:service_id].blank?
 
-      params[:answers].each do |field, answer|
-        session[:user_data][field] = answer
-      end
+    service_id = params[:service_id]
+    session[service_id] ||= {}
+    session[service_id]['user_data'] ||= {}
+
+    params[:answers].each do |field, answer|
+      session[service_id]['user_data'][field] = answer
     end
   end
 
   def load_user_data
-    session[:user_data] || {}
+    user_data = session[params[:service_id]] || {}
+
+    user_data['user_data'] || {}
+  end
+
+  private
+
+  def service_metadata
+    JSON.parse(File.read(Rails.root.join('service.json')))
   end
 end

--- a/service.json
+++ b/service.json
@@ -1,0 +1,57 @@
+{
+  "service_id": "634aa3d5-a3b3-4d0f-9078-bb754542a1d3",
+  "service_name": "Service Name",
+  "version_id": "ac4b45c5-071e-4d07-b5a2-9f0196a5b267",
+  "created_at": "2020-10-09T11:51:46",
+  "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
+  "configuration": {
+    "_id": "service",
+    "_type": "config.service"
+  },
+  "pages": [
+    {
+      "_id": "page.start",
+      "_type": "page.start",
+      "body": "You cannot use this form to complain about:\r\n\r\n* the result of a case\r\n* a judge, magistrate, coroner or member of a tribunal\r\n\r\nThis online form is also available in [Welsh (Cymraeg)](https://complain-about-a-court-or-tribunal.form.service.justice.gov.uk/cy).",
+      "heading": "Complain about a court or tribunal",
+      "lede": "Your complaint will not affect your case.",
+      "steps": [
+        "page.text-first",
+        "page.text-second"
+      ],
+      "url": "/"
+    },
+    {
+      "_id": "page.text-first",
+      "_type": "page.singlequestion",
+      "components": [
+        {
+          "_id": "page.text-first--text.auto_name__1",
+          "_type": "text",
+          "hint": "Text - First - hint text",
+          "label": "Text - First",
+          "name": "auto_name__1"
+        }
+      ],
+      "section_heading": "Text - First - section heading",
+      "url": "/text-first"
+    },
+    {
+      "_id": "page.text-second",
+      "_type": "page.singlequestion",
+      "section_heading": "Text - Second - section heading",
+      "components": [
+        {
+          "_id": "page.text-second--text.auto_name__2",
+          "_type": "text",
+          "hint": "Text - Second - hint text",
+          "label": "Text - Second",
+          "label_summary": "Text - Second - summary version",
+          "name": "auto_name__2"
+        }
+      ],
+      "url": "/text-second"
+    }
+  ],
+  "locale": "en"
+}

--- a/service.json
+++ b/service.json
@@ -1,6 +1,6 @@
 {
-  "service_id": "634aa3d5-a3b3-4d0f-9078-bb754542a1d3",
-  "service_name": "Service Name",
+  "service_id": "d243f5c0-e8a2-4b13-982c-7b5f3fa128cf",
+  "service_name": "Complain about a court or tribunal",
   "version_id": "ac4b45c5-071e-4d07-b5a2-9f0196a5b267",
   "created_at": "2020-10-09T11:51:46",
   "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
@@ -16,41 +16,47 @@
       "heading": "Complain about a court or tribunal",
       "lede": "Your complaint will not affect your case.",
       "steps": [
-        "page.text-first",
-        "page.text-second"
+        "page.name",
+        "page.email-address"
       ],
       "url": "/"
     },
     {
-      "_id": "page.text-first",
+      "_id": "page.name",
       "_type": "page.singlequestion",
       "components": [
         {
-          "_id": "page.text-first--text.auto_name__1",
+          "_id": "page.name--text.auto_name__1",
           "_type": "text",
-          "hint": "Text - First - hint text",
-          "label": "Text - First",
-          "name": "auto_name__1"
+          "label": "Full name",
+          "name": "full_name"
         }
       ],
-      "section_heading": "Text - First - section heading",
-      "url": "/text-first"
+      "heading": "Your name",
+      "url": "/name"
     },
     {
-      "_id": "page.text-second",
+      "_id": "page.email-address",
       "_type": "page.singlequestion",
-      "section_heading": "Text - Second - section heading",
       "components": [
         {
-          "_id": "page.text-second--text.auto_name__2",
+          "_id": "page.email-address--email.auto_name__2",
           "_type": "text",
-          "hint": "Text - Second - hint text",
-          "label": "Text - Second",
-          "label_summary": "Text - Second - summary version",
-          "name": "auto_name__2"
+          "errors": {
+            "format": {},
+            "required": {
+              "any": "Enter an email address"
+            }
+          },
+          "label": "Your email address",
+          "name": "email_address",
+          "validation": {
+            "required": true
+          }
         }
       ],
-      "url": "/text-second"
+      "heading": "Email address",
+      "url": "/email-address"
     }
   ],
   "locale": "en"


### PR DESCRIPTION
Story: https://trello.com/c/AJe4bfQK/1087-save-text-field-component-user-data-to-session-continue

We are currently not adding the tests as we should have different previews for the Editor that we currently do not have.
So it might be too early for this (happy to have a conversation about this if we think we can do some form of testing).

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>