### PR TITLE
Add GOV.UK Frontend assets

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,11 @@
 class ApplicationController < ActionController::Base
   include Auth0Helper
+  layout 'metadata_presenter/application'
 
   def service
     @service ||= MetadataPresenter::Service.new(service_metadata)
   end
+  helper_method :service
 
   def save_user_data
     return {} if params[:answers].blank? || params[:service_id].blank?

--- a/app/javascript/packs/govuk.js
+++ b/app/javascript/packs/govuk.js
@@ -1,0 +1,3 @@
+require("govuk-frontend/govuk/all").initAll()
+require.context('govuk-frontend/govuk/assets/images', true)
+import "./stylesheets/govuk.scss"

--- a/app/javascript/packs/stylesheets/govuk.scss
+++ b/app/javascript/packs/stylesheets/govuk.scss
@@ -1,0 +1,2 @@
+$govuk-assets-path: "~govuk-frontend/govuk/assets/";
+@import "govuk-frontend/govuk/all";

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -52,6 +52,8 @@ development:
   <<: *default
   compile: true
 
+  extract_css: true
+
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
   check_yarn_integrity: true
 
@@ -82,6 +84,8 @@ test:
 
   # Compile test packs to a separate directory
   public_output_path: packs-test
+
+  extract_css: true
 
 production:
   <<: *default

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "@rails/actioncable": "^6.1.1",
     "@rails/activestorage": "^6.1.1",
     "@rails/ujs": "^6.1.1",
-    "@rails/webpacker": "^5.2.1"
+    "@rails/webpacker": "^5.2.1",
+    "govuk-frontend": "^3.10.2"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3382,6 +3382,11 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
+govuk-frontend@^3.10.2:
+  version "3.10.2"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.10.2.tgz#6589401e4adad1ab1dc340a18057ec88c9435a84"
+  integrity sha512-MpMymgLsKoMw40MggZ0XLCAj1FY5N2s8Pf3aQR+k0cZOsegjLsnejxNfEB9qEl9jcma2fiiVcvsEZ+Ipo+Oo2g==
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"


### PR DESCRIPTION
This brings the editor in line with how the runner currently makes assets and stylesheets available to the presenter gem.

Co-authored-by: Steven Burnell <steven.burnell@digital.justice.gov.uk>