### PR TITLE
Disable auth0

### DIFF
--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -16,7 +16,7 @@ class Auth0Controller < ApplicationController
   def developer_callback
     fail unless Rails.env.development?
 
-    callback
+    # callback
   end
 
   def failure

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,5 +1,5 @@
 class ServicesController < ApplicationController
-  before_action :require_user!
+  # before_action :require_user!
 
   def index
     @service_creation = ServiceCreation.new
@@ -19,7 +19,7 @@ class ServicesController < ApplicationController
   end
 
   def services
-    @services ||= MetadataApiClient::Service.all(user_id: current_user.id)
+    @services ||= MetadataApiClient::Service.all(user_id: '1234')
   end
   helper_method :services
 

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,5 +1,5 @@
 class UserSessionsController < ApplicationController
-  before_action :require_user!, except: [:signup_not_allowed, :signup_error]
+  # before_action :require_user!, except: [:signup_not_allowed, :signup_error]
 
   def destroy
     session.clear

--- a/app/generators/new_service_generator.rb
+++ b/app/generators/new_service_generator.rb
@@ -13,7 +13,7 @@ class NewServiceGenerator
       metadata['configuration']['service'] = DefaultMetadata['config.service']
       metadata['configuration']['meta'] = DefaultMetadata['config.meta']
       metadata['service_name'] = name
-      metadata['created_by'] = current_user.id
+      metadata['created_by'] = '1234'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,5 @@ Rails.application.routes.draw do
     mount MetadataPresenter::Engine => '/preview', as: :preview
   end
 
-  root to: 'home#show'
+  root to: 'services#index'
 end

--- a/deploy/fb-editor-chart/templates/ingress.yaml
+++ b/deploy/fb-editor-chart/templates/ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: "fb-editor-ing-{{ .Values.environmentName }}"
+  annotations:
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: basic-auth
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
This bypasses the use of Auth0 temporarily while access to accounts is sorted out.

In the mean time just use basic auth for accessing the editor in the test environment.