### PR TITLE
Feature/edit page link v1

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   include Auth0Helper
-  layout 'metadata_presenter/application'
 
   def service
     @service ||= MetadataPresenter::Service.new(service_metadata)
@@ -29,9 +28,7 @@ class ApplicationController < ActionController::Base
     user_data['user_data'] || {}
   end
 
-  private
-
   def service_metadata
-    JSON.parse(File.read(Rails.root.join('service.json')))
+    MetadataApiClient::Service.latest_version(params[:id])
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,2 @@
+class PagesController < ApplicationController
+end

--- a/app/services/metadata_api_client/service.rb
+++ b/app/services/metadata_api_client/service.rb
@@ -1,15 +1,22 @@
 module MetadataApiClient
   class Service
-    attr_accessor :id, :name
+    attr_accessor :id, :name, :metadata
 
     def initialize(attributes={})
       @id = attributes['service_id']
       @name = attributes['service_name']
+      @metadata = attributes
     end
 
     def self.all(user_id:)
       response = connection.get("/services/users/#{user_id}").body['services']
       Array(response).map { |service| new(service) }
+    end
+
+    def self.latest_version(service_id)
+      new(
+        connection.get("/services/#{service_id}/versions/latest").body
+      ).metadata
     end
 
     def self.create(metadata)

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -1,3 +1,7 @@
 Page flow (Form pages)
 
-<%= service.name %>
+<% service.pages.each do |page| %>
+  <div>
+    <%= link_to page.url, edit_page_path(service.service_id, page.url) %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
   end
 
   resources :services, only: [:index, :edit, :create] do
+    member do
+      resources :pages, param: :page_url, only: :edit
+    end
     mount MetadataPresenter::Engine => '/preview', as: :preview
   end
 

--- a/spec/services/metadata_api_client/service_spec.rb
+++ b/spec/services/metadata_api_client/service_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.describe MetadataApiClient::Service do
   let(:metadata_api_url) { 'http://metadata-api' }
   let(:expected_body) {
@@ -79,6 +77,22 @@ RSpec.describe MetadataApiClient::Service do
       it 'returns errors' do
         expect(described_class.create({}).errors?).to be_truthy
       end
+    end
+  end
+
+  describe '.latest_version' do
+    let(:expected_url) { "#{metadata_api_url}/services/12345/versions/latest" }
+    let(:expected_body) do
+      JSON.parse(File.read(Rails.root.join('service.json')))
+    end
+
+    before do
+      stub_request(:get, expected_url)
+        .to_return(status: 200, body: expected_body.to_json, headers: {})
+    end
+
+    it 'returns latest metadata' do
+      expect(described_class.latest_version('12345')).to eq(expected_body)
     end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/eENfp6cT/1180-editing-page-link)

## Context

The user can click on the page URL and is taken to the edit page.

## Caveats

This card doesn't render or make possible to edit any page, it is just adding the link to make easier for next cards.
This card breaks the layout because the metadata presenter layout is considered a "single tenancy" where the editor is kinda like a multi-tenancy (many forms within the editor)