### PR TITLE
Add encoded keys to config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'metadata_presenter', '~> 0.1.6'
 gem 'faraday'
 gem 'faraday_middleware'
-gem 'fb-jwt-auth', '0.4.0'
+gem 'fb-jwt-auth', '0.5.0'
 gem 'omniauth'
 gem 'omniauth-auth0', '~> 2.4.1'
 gem 'omniauth-rails_csrf_protection', '~> 0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     faraday-net_http (1.0.0)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
-    fb-jwt-auth (0.4.0)
+    fb-jwt-auth (0.5.0)
       activesupport
       json
       jwt
@@ -294,7 +294,7 @@ DEPENDENCIES
   dotenv-rails
   faraday
   faraday_middleware
-  fb-jwt-auth (= 0.4.0)
+  fb-jwt-auth (= 0.5.0)
   listen (~> 3.4)
   metadata_presenter (~> 0.1.6)
   omniauth

--- a/config/initializers/fb_jwt_auth.rb
+++ b/config/initializers/fb_jwt_auth.rb
@@ -1,5 +1,5 @@
 Fb::Jwt::Auth.configure do |config|
-  config.issuer = 'fb-editor'
+  config.issuer = 'editor'
   config.namespace = "formbuilder-saas-#{ENV['PLATFORM_ENV']}"
   config.encoded_private_key = ENV['ENCODED_PRIVATE_KEY']
 end

--- a/deploy/fb-editor-chart/templates/config_map.yaml
+++ b/deploy/fb-editor-chart/templates/config_map.yaml
@@ -10,3 +10,5 @@ data:
   RAILS_SERVE_STATIC_FILES: "true"
   AUTH0_DOMAIN: mojds-trial.eu.auth0.com
   EDITOR_FULL_URL_ROOT: https://fb-editor-{{ .Values.environmentName }}.apps.live-1.cloud-platform.service.justice.gov.uk
+  ENCODED_PUBLIC_KEY: {{ .Values.encoded_public_key }}
+  METADATA_API_URL: http://fb-metadata-api-svc-{{ .Values.environmentName }}

--- a/deploy/fb-editor-chart/templates/deployment.yaml
+++ b/deploy/fb-editor-chart/templates/deployment.yaml
@@ -59,6 +59,11 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: auth0_client_secret
+          - name: ENCODED_PRIVATE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: encoded_private_key
           # secrets created by terraform
           # which may or may not depend on values
           # canonically defined in secrets.tfvars

--- a/deploy/fb-editor-chart/templates/secrets.yaml
+++ b/deploy/fb-editor-chart/templates/secrets.yaml
@@ -8,3 +8,4 @@ data:
   secret_key_base: {{ .Values.secret_key_base }}
   auth0_client_id: {{ .Values.auth0_client_id }}
   auth0_client_secret: {{ .Values.auth0_client_secret }}
+  encoded_private_key: {{ .Values.encoded_private_key}}


### PR DESCRIPTION
This adds the encoded private and public keys to the config map and secrets as well as the metadata api url.

We also need to change the issuer name to be just 'editor' as the service token cache prefixes the name with 'fb-' for us.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>