### PR TITLE
Add Form Information Settings page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,6 @@ class ApplicationController < ActionController::Base
   end
 
   def service_metadata
-    MetadataApiClient::Service.latest_version(params[:id])
+    @service_metadata ||= MetadataApiClient::Service.latest_version(params[:id])
   end
 end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -23,6 +23,8 @@ class ServicesController < ApplicationController
   private
 
   def service_creation_params
-    params.require(:service_creation).permit(:name).merge(current_user: current_user)
+    params.require(
+      :service_creation
+    ).permit(:service_name).merge(current_user: current_user)
   end
 end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,24 @@
+class SettingsController < ApplicationController
+  def form_information
+    @settings = Settings.new(service_name: service.service_name)
+  end
+
+  def update_form_information
+    @settings = Settings.new(service_params)
+
+    if @settings.update
+      redirect_to settings_path(service.service_id)
+    else
+      render :form_information
+    end
+  end
+
+  private
+
+  def service_params
+    params.require(:service).permit(:service_name).merge(
+      service_id: service.service_id,
+      latest_metadata: service.to_h
+    )
+  end
+end

--- a/app/generators/new_service_generator.rb
+++ b/app/generators/new_service_generator.rb
@@ -1,8 +1,8 @@
 class NewServiceGenerator
-  attr_reader :name, :current_user
+  attr_reader :service_name, :current_user
 
-  def initialize(name:, current_user:)
-    @name = name
+  def initialize(service_name:, current_user:)
+    @service_name = service_name
     @current_user = current_user
   end
 
@@ -12,7 +12,7 @@ class NewServiceGenerator
     metadata.tap do
       metadata['configuration']['service'] = DefaultMetadata['config.service']
       metadata['configuration']['meta'] = DefaultMetadata['config.meta']
-      metadata['service_name'] = name
+      metadata['service_name'] = service_name
       metadata['created_by'] = '1234'
     end
   end

--- a/app/services/editor/service.rb
+++ b/app/services/editor/service.rb
@@ -1,0 +1,15 @@
+module Editor
+  class Service
+    include ActiveModel::Model
+    attr_accessor :service_name, :current_user, :service_id, :latest_metadata
+    validates :service_name, presence: true
+    validates :service_name, length: { minimum: 3, maximum: 128 }, allow_blank: true
+    validates :service_name, format: { with: /\A[\sa-zA-Z0-9-]*\z/ }, allow_blank: true
+
+    def add_errors(service)
+      service.errors.each do |error_message|
+        self.errors.add(:service_name, :taken)
+      end
+    end
+  end
+end

--- a/app/services/metadata_api_client/resource.rb
+++ b/app/services/metadata_api_client/resource.rb
@@ -1,0 +1,32 @@
+module MetadataApiClient
+  class Resource
+    attr_accessor :id, :name, :metadata
+
+    def initialize(attributes={})
+      @id = attributes['service_id']
+      @name = attributes['service_name']
+      @metadata = attributes
+    end
+
+    def self.connection
+      Connection.new
+    end
+
+    def self.error_messages(exception)
+      errors = JSON.parse(
+        exception.response_body, symbolize_names: true
+      )[:message]
+
+      MetadataApiClient::ErrorMessages.new(errors)
+    end
+
+    def ==(other)
+      id == other.id
+    end
+
+    def errors?
+      false
+    end
+  end
+end
+

--- a/app/services/metadata_api_client/service.rb
+++ b/app/services/metadata_api_client/service.rb
@@ -1,13 +1,5 @@
 module MetadataApiClient
-  class Service
-    attr_accessor :id, :name, :metadata
-
-    def initialize(attributes={})
-      @id = attributes['service_id']
-      @name = attributes['service_name']
-      @metadata = attributes
-    end
-
+  class Service < Resource
     def self.all(user_id:)
       response = connection.get("/services/users/#{user_id}").body['services']
       Array(response).map { |service| new(service) }
@@ -23,23 +15,7 @@ module MetadataApiClient
       response = connection.post('/services', metadata)
       new(response.body)
     rescue Faraday::UnprocessableEntityError => exception
-      errors = JSON.parse(
-        exception.response_body, symbolize_names: true
-      )[:message]
-
-      MetadataApiClient::ErrorMessages.new(errors)
-    end
-
-    def self.connection
-      Connection.new
-    end
-
-    def ==(other_service)
-      id == other_service.id
-    end
-
-    def errors?
-      false
+      error_messages(exception)
     end
   end
 end

--- a/app/services/metadata_api_client/version.rb
+++ b/app/services/metadata_api_client/version.rb
@@ -1,0 +1,11 @@
+module MetadataApiClient
+  class Version < Resource
+    def self.create(service_id:, metadata:)
+      new(
+        connection.post("/services/#{service_id}/versions", metadata).body
+      )
+    rescue Faraday::UnprocessableEntityError => exception
+      error_messages(exception)
+    end
+  end
+end

--- a/app/services/service_creation.rb
+++ b/app/services/service_creation.rb
@@ -1,32 +1,27 @@
-class ServiceCreation
-  include ActiveModel::Model
-  attr_accessor :name, :current_user, :service_id
-  validates :name, presence: true
-  validates :name, length: { minimum: 3, maximum: 128 }, allow_blank: true
-  validates :name, format: { with: /\A[\sa-zA-Z0-9-]*\z/ }, allow_blank: true
-
+class ServiceCreation < Editor::Service
   def create
     return false if invalid?
 
     service = MetadataApiClient::Service.create(metadata)
 
     if service.errors?
-      service.errors.each do |error_message|
-        self.errors.add(:base, :invalid, message: error_message)
-      end
-
+      add_errors(service)
       false
     else
-      self.tap do
-        self.service_id = service.id
-      end
+      assign_service_attributes(service)
+    end
+  end
+
+  def assign_service_attributes(service)
+    self.tap do
+      self.service_id = service.id
     end
   end
 
   def metadata
     {
       metadata: NewServiceGenerator.new(
-        name: name.strip,
+        service_name: service_name.strip,
         current_user: current_user
       ).to_metadata
     }

--- a/app/services/settings.rb
+++ b/app/services/settings.rb
@@ -1,0 +1,23 @@
+class Settings < Editor::Service
+  def update
+    return false if invalid? || latest_metadata.blank?
+
+    version = MetadataApiClient::Version.create(
+      service_id: service_id,
+      metadata: metadata
+    )
+
+    add_errors(version) if version.errors?
+
+    !version.errors?
+  end
+
+  def metadata
+    {
+      metadata: latest_metadata.merge(
+        service_name: service_name,
+        created_by: '1234' # current_user
+      )
+    }
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,12 +20,11 @@
   <body class="govuk-template__body">
     <div class="govuk-width-container govuk-body-m">
       <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
-        <% console %>
         <% if user_signed_in? %>
           <%= link_to t('.sign_out'), user_session_path, method: :delete %>
         <% end %>
 
-        <% unless controller.controller_name == 'services' && controller.action_name == 'index' %>
+        <% unless controller.controller_name == 'services' && (controller.action_name == 'index' || controller.action_name == 'create') %>
 
           <h1><%= service.service_name %></h1>
 

--- a/app/views/page_menu/show.html.erb
+++ b/app/views/page_menu/show.html.erb
@@ -1,4 +1,4 @@
 <ul>
   <li><%= link_to t('pages'), edit_service_path(service.service_id) %></li>
-  <li><%= link_to t('settings'), settings_path(service.service_id) %></li>
+  <li><%= link_to t('settings.name'), settings_path(service.service_id) %></li>
 </ul>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -23,8 +23,8 @@
           <%= error.message %>
         <% end %>
 
-        <%= f.label :name %>
-        <%= f.text_field :name %>
+        <%= f.label :service_name %>
+        <%= f.text_field :service_name %>
 
         <%= f.submit t('services.create') %>
       <% end %>

--- a/app/views/settings/form_information.html.erb
+++ b/app/views/settings/form_information.html.erb
@@ -1,1 +1,13 @@
-<h1> Hello!</h1>
+<h1><%= t('settings.form_information') %></h1>
+
+<%= form_for @settings, as: :service, url: update_form_information_settings_path(service.service_id), method: :patch do |f| %>
+  <% f.object.errors.each do |error|  %>
+    <%= error.message %>
+  <% end %>
+
+  <%= f.label :service_name %>
+  <%= f.text_field :service_name %>
+
+  <%= f.submit t('actions.save') %>
+<% end %>
+

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,0 +1,2 @@
+<%= link_to t('settings.form_information'),
+  form_information_settings_path(service.service_id) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,11 @@
 en:
+  actions:
+    save: 'Save'
+  pages:
+    name: 'Pages'
+  settings:
+    name: 'Settings'
+    form_information: 'Form information'
   services:
     edit: 'Edit'
     create: 'Create a new form'
@@ -7,10 +14,14 @@ en:
       service_creation: 'Form'
     attributes:
       service_creation:
-        name: 'What is the name of this form?'
+        service_name: 'What is the name of this form?'
+      settings:
+        service_name: 'Form name'
     errors:
-      models:
-        service_creation:
-          attributes:
-            name:
-              blank: "Name can't be blank"
+      messages:
+        blank: "Your answer for ‘%{attribute}’ can not be blank."
+        too_short: "Your answer for ‘%{attribute}’ is too short (%{count} characters at least)"
+        too_long: "Your answer for ‘%{attribute}’ is too long (%{count} characters at most)"
+        invalid: "Your answer for ‘%{attribute}' contains characters that are not allowed."
+        taken: "Your answer for ‘%{attribute}' is already used by another form. Please modify it."
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,9 +13,15 @@ Rails.application.routes.draw do
     post '/auth/developer/callback' => 'auth0#developer_callback'
   end
 
-  resources :services, only: [:index, :edit, :create] do
+  resources :services, only: [:index, :edit, :update, :create] do
     member do
       resources :pages, param: :page_url, only: :edit
+      resources :settings, only: [:index] do
+        collection do
+          get 'form_information'
+          patch 'update_form_information'
+        end
+      end
     end
     mount MetadataPresenter::Engine => '/preview', as: :preview
   end

--- a/spec/generators/new_service_generator_spec.rb
+++ b/spec/generators/new_service_generator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe NewServiceGenerator do
 
       it 'creates a valid service metadata' do
         service_metadata = NewServiceGenerator.new(
-          name: service_name,
+          service_name: service_name,
           current_user: current_user
         ).to_metadata
 

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe 'Settings' do
+  let(:service) do
+    MetadataPresenter::Service.new(service_id: SecureRandom.uuid)
+  end
+
+  describe 'PATCH /services/:id/settings/update_form_information' do
+    before do
+      expect_any_instance_of(ApplicationController).to receive(:service).at_least(:once).and_return(service)
+      expect_any_instance_of(Settings).to receive(:update).and_return(valid)
+
+      patch "/services/#{service.service_id}/settings/update_form_information",
+            params: { service: { service_name: 'R2-D2' } }
+    end
+
+    context 'when valid' do
+      let(:valid) { true }
+
+      it 'redirects to settings index' do
+        expect(response).to redirect_to(settings_path(service.service_id))
+      end
+    end
+
+    context 'when invalid' do
+      let(:valid) { false }
+
+      it 'shows the previous service name' do
+        expect(response.body).to include('R2-D2')
+      end
+    end
+  end
+end

--- a/spec/services/metadata_api_client/service_spec.rb
+++ b/spec/services/metadata_api_client/service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe MetadataApiClient::Service do
           .to_return(status: 422, body: expected_body.to_json, headers: {})
       end
 
-      it 'assigns a service' do
+      it 'assigns an error message' do
         expect(described_class.create({})).to eq(
           MetadataApiClient::ErrorMessages.new(['Name has already been taken'])
         )

--- a/spec/services/metadata_api_client/version_spec.rb
+++ b/spec/services/metadata_api_client/version_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe MetadataApiClient::Version do
+  let(:metadata_api_url) { 'http://metadata-api' }
+  before do
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[]).with('METADATA_API_URL').and_return(metadata_api_url)
+  end
+
+  describe '.create' do
+    let(:service_id) { SecureRandom.uuid }
+    let(:expected_url) { "#{metadata_api_url}/services/#{service_id}/versions" }
+
+    context 'when is created' do
+      let(:expected_body) do
+        { service_name: 'Asohka Tano', service_id: service_id }
+      end
+
+      before do
+        stub_request(:post, expected_url)
+          .to_return(status: 201, body: expected_body.to_json, headers: {})
+      end
+
+      it 'returns a version' do
+        expect(
+          described_class.create(
+            service_id: service_id, metadata: expected_body
+          )
+        ).to eq(described_class.new(expected_body.stringify_keys))
+      end
+    end
+
+    context 'when is unprocessable entity' do
+      let(:expected_body) do
+        { 'message': ['Name has already been taken']}
+      end
+
+      before do
+        stub_request(:post, expected_url)
+          .to_return(status: 422, body: expected_body.to_json, headers: {})
+      end
+
+      it 'assigns an error message' do
+        expect(
+          described_class.create(service_id: service_id, metadata: {})
+        ).to eq(
+          MetadataApiClient::ErrorMessages.new(['Name has already been taken'])
+        )
+      end
+
+      it 'returns errors' do
+        expect(
+          described_class.create(service_id: service_id, metadata: {}).errors?
+        ).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/services/service_creation_spec.rb
+++ b/spec/services/service_creation_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ServiceCreation do
   describe '#create' do
     context 'when is invalid' do
       context 'when name is blank' do
-        let(:attributes) { { name: '' } }
+        let(:attributes) { { service_name: '' } }
 
         it 'returns false' do
           expect(service_creation.create).to be_falsey
@@ -12,7 +12,7 @@ RSpec.describe ServiceCreation do
       end
 
       context 'when name is too short' do
-        let(:attributes) { { name: 'ET' } }
+        let(:attributes) { { service_name: 'ET' } }
 
         it 'returns false' do
           expect(service_creation.create).to be_falsey
@@ -20,7 +20,7 @@ RSpec.describe ServiceCreation do
       end
 
       context 'when name is too long' do
-        let(:attributes) { { name: 'E' * 129 } }
+        let(:attributes) { { service_name: 'E' * 129 } }
 
         it 'returns false' do
           expect(service_creation.create).to be_falsey
@@ -29,11 +29,11 @@ RSpec.describe ServiceCreation do
 
       context 'when user inputs name with trailing whitespace' do
         let(:current_user) { double(id: '1') }
-        let(:attributes) { { name: '  Form Name  ', current_user: current_user } }
+        let(:attributes) { { service_name: '  Form Name  ', current_user: current_user } }
 
         it 'strips whitespace' do
           expect(NewServiceGenerator).to receive(:new)
-            .with(name: 'Form Name', current_user: current_user)
+            .with(service_name: 'Form Name', current_user: current_user)
             .and_return(double(to_metadata: 'metadata'))
           subject.metadata
         end
@@ -41,7 +41,7 @@ RSpec.describe ServiceCreation do
 
       context 'when API returns errors' do
         let(:attributes) do
-          { name: 'Moff Gideon', current_user: double(id: '1') }
+          { service_name: 'Moff Gideon', current_user: double(id: '1') }
         end
         let(:errors) do
           double(errors: ['Name is already been taken'], errors?: true)
@@ -60,15 +60,15 @@ RSpec.describe ServiceCreation do
         it 'assigns error messages' do
           service_creation.create
           expect(
-            service_creation.errors.full_messages
-          ).to include('Name is already been taken')
+            service_creation.errors.full_messages.first
+          ).to include("is already used by another form. Please modify it.")
         end
       end
     end
 
     context 'when is valid' do
       let(:attributes) do
-        { name: 'Moff Gideon', current_user: double(id: '1') }
+        { service_name: 'Moff Gideon', current_user: double(id: '1') }
       end
       let(:service) do
         double(id: '05e12a93-3978-4624-a875-e59893f2c262', errors?: false)
@@ -94,7 +94,7 @@ RSpec.describe ServiceCreation do
 
     context 'when name is invalid format' do
       [ 'something.invalid', 'with_underscore' ].each do |invalid|
-        let(:attributes) { { name: invalid } }
+        let(:attributes) { { service_name: invalid } }
 
         context "when format is #{invalid}" do
           it 'returns false' do
@@ -107,7 +107,7 @@ RSpec.describe ServiceCreation do
 
   describe '#metadata' do
     let(:attributes) do
-      { name: 'Moff Gideon', current_user: double(id: '1234') }
+      { service_name: 'Moff Gideon', current_user: double(id: '1234') }
     end
 
     it 'generates the metadata for the API' do

--- a/spec/services/settings_spec.rb
+++ b/spec/services/settings_spec.rb
@@ -1,0 +1,91 @@
+RSpec.describe Settings do
+  subject(:settings) do
+    described_class.new(
+      attributes.merge(
+        service_id: '123456',
+        latest_metadata: latest_metadata
+      )
+    )
+  end
+  let(:latest_metadata) do
+    { service_name: 'Grogu' }
+  end
+
+  describe '#update' do
+    context 'when valid' do
+      let(:attributes) do
+        { service_name: 'Moff Gideon', current_user: double(id: '1') }
+      end
+      let(:service) do
+        double(id: '05e12a93-3978-4624-a875-e59893f2c262', errors?: false)
+      end
+
+      before do
+        expect(
+          MetadataApiClient::Version
+        ).to receive(:create).with(
+          service_id: '123456',
+          metadata: {
+            metadata: { service_name: 'Moff Gideon', created_by: '1234' }
+          }
+        ).and_return(service)
+      end
+
+      it 'returns true' do
+        expect(settings.update).to be_truthy
+      end
+    end
+
+    context 'when invalid' do
+      context 'when name is blank' do
+        let(:attributes) { { service_name: '' } }
+
+        it 'returns false' do
+          expect(settings.update).to be_falsey
+        end
+      end
+
+      context 'when name is too short' do
+        let(:attributes) { { service_name: 'ET' } }
+
+        it 'returns false' do
+          expect(settings.update).to be_falsey
+        end
+      end
+
+      context 'when name is too long' do
+        let(:attributes) { { service_name: 'E' * 129 } }
+
+        it 'returns false' do
+          expect(settings.update).to be_falsey
+        end
+      end
+
+      context 'when API returns errors' do
+        let(:attributes) do
+          { service_name: 'Moff Gideon', current_user: double(id: '1') }
+        end
+        let(:errors) do
+          double(errors: ['Name is already been taken'], errors?: true)
+        end
+
+        before do
+          expect(
+            MetadataApiClient::Version
+          ).to receive(:create).and_return(errors)
+        end
+
+        it 'returns false' do
+          expect(settings.update).to be_falsey
+        end
+
+        it 'assigns error messages' do
+          settings.update
+          expect(
+            settings.errors.full_messages.first
+          ).to include("is already used by another form. Please modify it.")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the Form Information page inside Settings enabling the user to
change the name of their form.

Also included are some of the standard error message locales.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>