### PR TITLE
Reference the page name locale correctly in form settings

### DIFF
--- a/app/views/page_menu/show.html.erb
+++ b/app/views/page_menu/show.html.erb
@@ -1,4 +1,4 @@
 <ul>
-  <li><%= link_to t('pages'), edit_service_path(service.service_id) %></li>
+  <li><%= link_to t('pages.name'), edit_service_path(service.service_id) %></li>
   <li><%= link_to t('settings.name'), settings_path(service.service_id) %></li>
 </ul>


### PR DESCRIPTION
Should reference the locale properly.

## Before

![Screenshot 2021-01-14 at 18 56 19](https://user-images.githubusercontent.com/3466862/104635868-6981d200-569a-11eb-9aa7-1409d4943f3e.png)


## After

![Screenshot 2021-01-14 at 18 56 09](https://user-images.githubusercontent.com/3466862/104635878-6c7cc280-569a-11eb-9040-d30be0455eaf.png)
