### PR TITLE
Acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,13 @@ jobs:
       - setup_remote_docker:
           version: 19.03.13
       - run:
+          name: setup
+          command: make setup
+      - run:
           name: security
           command: docker-compose run --rm editor-app bundle exec brakeman -q --no-pager
       - run:
-          name: test
+          name: unit tests
           command: docker-compose run --rm editor-app bundle exec rspec
       - slack/status: &slack_status
           fail_only: true
@@ -61,6 +64,16 @@ jobs:
           success_message: ":rocket:  Successfully deployed to Test  :guitar:"
           failure_message: ":alert:  Failed to deploy to Test  :try_not_to_cry:"
           include_job_number_field: false
+  acceptance_tests:
+    docker: *ecr_image
+    resource_class: large
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Run acceptance tests
+          command: 'make acceptance-ci -s'
+      - slack/status: *slack_status
 
 workflows:
   version: 2
@@ -74,3 +87,7 @@ workflows:
             branches:
               only:
                 - main
+                - acceptance-tests
+      - acceptance_tests:
+          requires:
+            - build_and_deploy_to_test

--- a/.env.acceptance_tests.ci
+++ b/.env.acceptance_tests.ci
@@ -1,0 +1,1 @@
+ACCEPTANCE_TESTS_EDITOR_APP='https://%{user}:%{password}@fb-editor-test.apps.live-1.cloud-platform.service.justice.gov.uk/'

--- a/.env.acceptance_tests.local
+++ b/.env.acceptance_tests.local
@@ -1,0 +1,1 @@
+ACCEPTANCE_TESTS_EDITOR_APP='http://localhost:9090/'

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-debug.log*
 .yarn-integrity
 
 .env
+.env.acceptance_tests

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development, :test do
   gem 'capybara'
   gem 'dotenv-rails', groups: [:development, :test]
   gem 'rspec-rails'
+  gem 'selenium-webdriver', '3.142.7'
   gem 'site_prism'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crack (0.4.5)
@@ -227,6 +228,7 @@ GEM
       rspec-support (~> 3.10)
     rspec-support (3.10.1)
     ruby2_keywords (0.0.2)
+    rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -237,6 +239,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     semantic_range (2.3.1)
     site_prism (3.7)
       addressable (~> 2.5)
@@ -305,6 +310,7 @@ DEPENDENCIES
   rails (~> 6.1.1)
   rspec-rails
   sass-rails (>= 6)
+  selenium-webdriver (= 3.142.7)
   site_prism
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+UID ?= $(shell id -u)
+DOCKER_COMPOSE = env UID=$(UID) docker-compose -f docker-compose.yml
+
+.PHONY: build
+build:
+	docker-compose build --parallel
+	docker-compose up -d
+
+.PHONY: seed-public-key
+seed-public-key:
+	docker-compose exec editor-service-token-cache-redis redis-cli set 'encoded-public-key-editor' 'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUErT3RxdVZxNGlTS1Y2eFRpYk8zcwpuVzcwQUswL0lMRy92RHQ4S05DUU5mLzQxMUQ3aCtGM0twdyt2TkFOZkhkSlRmSlVWNC9kWXo1SEhzQXhBYUc4CnF5SGlOeWN5OWNOc0hvUkNvbGQ1WnA4aUVCa1NjWE9TaDMycUtENmUwYnJ3SnZweXYwUWNIV2ZLWno0NlBCbTYKVFV4ckM2ejlud2llUFFYL3NyeUZocHpYOHNMN0QwOVF3YzFjLzQyUEhoTGt4dmNDaW9IaGozM3pUK1lPQ052SQo1UnlZUEc2bEt2bjFRU0t2U0orem9BbndQN1I3TDdjL1FpeEFEemxlQXE3SE5FaEU4cDBUME9WZWdXYTg1T3g3CmZLOWovdlp3OWJGWU9LMUNWTlFjZitWR2gyRmFncy83RDlUMG5yaFEzeEt4cEt2bmZ6Vm9xZ2EzOFY3Z1daeXQKOFFJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=='
+
+.PHONY: copy-env-vars-local
+copy-env-vars-local:
+	cp .env.acceptance_tests.local .env.acceptance_tests
+
+
+.PHONY: setup
+setup: build seed-public-key copy-env-vars-local
+
+.PHONY: acceptance-specs
+acceptance: setup
+	bundle exec rspec acceptance
+
+.PHONY: copy-env-vars-ci
+copy-env-vars-ci:
+	cp .env.acceptance_tests.ci .env.acceptance_tests
+
+.PHONY: add-env-vars-ci
+add-env-vars-ci:
+	echo "ACCEPTANCE_TESTS_USER=${ACCEPTANCE_TESTS_USER}" >> .env.acceptance_tests
+	echo "ACCEPTANCE_TESTS_PASSWORD=${ACCEPTANCE_TESTS_PASSWORD}" >> .env.acceptance_tests
+
+.PHONY: setup-ci
+setup-ci:
+	docker-compose -f docker-compose.ci.yml up -d --build editor_ci
+
+.PHONY: acceptance-ci
+acceptance-ci: copy-env-vars-ci add-env-vars-ci setup-ci
+	docker-compose -f docker-compose.ci.yml run --rm editor_ci bundle exec rspec -f doc acceptance

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ seed-public-key:
 copy-env-vars-local:
 	cp .env.acceptance_tests.local .env.acceptance_tests
 
-
 .PHONY: setup
 setup: build seed-public-key copy-env-vars-local
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,35 @@ make setup
 This will spin down any past Docker containers and then spin up new ones.
 
 You should now be able to access the Editor on `localhost:3000`
+
+## Acceptance tests
+
+There are two ways to run the acceptance tests:
+
+1. Pointing to a local editor
+2. Pointing to a remote editor (a test environment for example)
+
+Basically the acceptance tests depends to have a `.env.acceptance_tests` with
+the editor url.
+
+### Pointing to a local editor
+
+There is the docker compose with all containers needed for the editor.
+In order to run the acceptance tests against a local editor all you need to run
+is:
+
+```
+  make acceptance
+```
+
+### Pointing to a remote editor
+
+The editor has a basic authentication so it needs a user and a password.
+This is already added on CircleCI but in case you want to run on your local
+machine to point to the test environment you need to run:
+
+```
+  export ACCEPTANCE_TESTS_USER='my-user'
+  export ACCEPTANCE_TESTS_PASSWORD='my-password'
+  make acceptance-ci -s
+```

--- a/acceptance/Dockerfile
+++ b/acceptance/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.7.2-alpine
+
+ARG UID=1001
+
+RUN apk add git nodejs yarn build-base postgresql-contrib postgresql-dev bash libcurl
+RUN apk add build-base bash tzdata chromium-chromedriver chromium zlib-dev xorg-server
+
+WORKDIR /usr/src/app
+
+COPY Gemfile* ./
+RUN gem update --system && gem install bundler
+RUN bundle check || BUNDLE_JOBS=4 bundle install
+
+COPY acceptance acceptance
+COPY .env.acceptance_tests .

--- a/acceptance/create_service_spec.rb
+++ b/acceptance/create_service_spec.rb
@@ -1,0 +1,95 @@
+require_relative './spec_helper'
+
+feature 'Create a service' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:another_service_name) { generate_service_name }
+
+  background do
+    editor.load
+  end
+
+  scenario 'validates the service name' do
+    given_I_add_a_service_with_empty_name
+    when_I_create_the_service
+    then_I_should_see_a_validation_message_for_required
+  end
+
+  scenario 'validates the service name min length' do
+    given_I_add_a_service_with_one_character
+    when_I_create_the_service
+    then_I_should_see_a_validation_message_for_min_length
+  end
+
+  scenario 'validates the service name max length' do
+    given_I_add_a_service_with_many_characters
+    when_I_create_the_service
+    then_I_should_see_a_validation_message_for_max_length
+  end
+
+  scenario 'creates the service with a start page' do
+    given_I_add_a_service
+    when_I_create_the_service
+    then_I_should_see_the_new_service_name
+  end
+
+  scenario 'validates uniqueness of the service name' do
+    given_I_have_a_service
+    when_I_try_to_create_a_service_with_the_same_name
+    then_I_should_see_the_unique_validation_message
+  end
+
+  def given_I_add_a_service
+    editor.name_field.set(service_name)
+  end
+
+  def given_I_add_a_service_with_empty_name
+    editor.name_field.set('')
+  end
+
+  def given_I_add_a_service_with_one_character
+    editor.name_field.set('M')
+  end
+
+  def given_I_add_a_service_with_many_characters
+    editor.name_field.set('Stormtroopers' * 100)
+  end
+
+  def when_I_create_the_service
+    editor.create_service_button.click
+  end
+
+  def when_I_try_to_create_a_service_with_the_same_name
+    editor.load
+    editor.name_field.set(another_service_name)
+    editor.create_service_button.click
+  end
+
+  def then_I_should_see_the_new_service_name
+    expect(editor.service_name.text).to eq(service_name)
+  end
+
+  def then_I_should_see_a_validation_message_for_required
+    expect(editor.text).to include(
+      "Your answer for ‘What is the name of this form?’ can not be blank."
+    )
+  end
+
+  def then_I_should_see_a_validation_message_for_min_length
+    expect(editor.text).to include(
+      "Your answer for ‘What is the name of this form?’ is too short (3 characters at least)"
+    )
+  end
+
+  def then_I_should_see_a_validation_message_for_max_length
+    expect(editor.text).to include(
+      "Your answer for ‘What is the name of this form?’ is too long (128 characters at most) "
+    )
+  end
+
+  def then_I_should_see_the_unique_validation_message
+    expect(editor.text).to include(
+      "Your answer for ‘What is the name of this form?' is already used by another form. Please modify it."
+    )
+  end
+end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -1,0 +1,23 @@
+class EditorApp < SitePrism::Page
+  if ENV['ACCEPTANCE_TESTS_USER'] && ENV['ACCEPTANCE_TESTS_PASSWORD']
+    set_url ENV['ACCEPTANCE_TESTS_EDITOR_APP'] % {
+      user: ENV['ACCEPTANCE_TESTS_USER'],
+      password: ENV['ACCEPTANCE_TESTS_PASSWORD']
+    }
+  else
+    set_url ENV['ACCEPTANCE_TESTS_EDITOR_APP']
+  end
+
+  element :service_name, 'main h1'
+  element :name_field, :field, 'What is the name of this form?'
+  element :create_service_button, :button, 'Create a new form'
+
+  element :settings_link, :link, 'Settings'
+  element :form_information_link, :link, 'Form information'
+  element :form_name_field, :field, 'Form name'
+  element :save_button, :button, 'Save'
+
+  def edit_service_link(service_name)
+    find("#service-#{service_name.parameterize} .edit")
+  end
+end

--- a/acceptance/spec_helper.rb
+++ b/acceptance/spec_helper.rb
@@ -1,0 +1,33 @@
+require 'capybara/rspec'
+require 'selenium/webdriver'
+require 'site_prism'
+require 'dotenv'
+Dotenv.load('.env.acceptance_tests')
+require 'rails/all'
+
+Dir[File.join('acceptance', 'pages', '*')].each { |f| require File.expand_path(f) }
+Dir[File.join('acceptance', 'support', '*')].each { |f| require File.expand_path(f) }
+
+puts "Accessing Editor in: #{ENV['ACCEPTANCE_TESTS_EDITOR_APP']}"
+
+RSpec.configure do |config|
+  config.before(:all) do
+    WebMock.allow_net_connect! if defined? WebMock
+  end
+
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
+  config.after do |example_group|
+    if example_group.exception.present?
+      puts editor.text
+    end
+  end
+
+  config.include TestHelpers
+  config.include CommonSteps
+end

--- a/acceptance/support/capybara.rb
+++ b/acceptance/support/capybara.rb
@@ -1,0 +1,13 @@
+Capybara.register_driver :selenium do |app|
+  chrome_options = Selenium::WebDriver::Chrome::Options.new.tap do |o|
+    o.add_argument '--headless'
+    o.add_argument '--no-sandbox'
+  end
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options)
+end
+
+Capybara.default_driver = :selenium
+Capybara.current_session.driver.reset!
+Capybara.default_host = ENV['ACCEPTANCE_TESTS_EDITOR_APP']
+Capybara.app_host = ENV['ACCEPTANCE_TESTS_EDITOR_APP']
+Capybara.run_server = false

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -1,0 +1,8 @@
+module CommonSteps
+  def given_I_have_a_service
+    editor.load
+    editor.name_field.set(another_service_name)
+    editor.create_service_button.click
+  end
+  alias given_I_have_another_service given_I_have_a_service
+end

--- a/acceptance/support/test_helpers.rb
+++ b/acceptance/support/test_helpers.rb
@@ -1,0 +1,6 @@
+module TestHelpers
+  def generate_service_name
+    "Acceptance-test-Stormtrooper-FN-#{SecureRandom.uuid}"
+  end
+end
+

--- a/acceptance/update_settings_form_information_spec.rb
+++ b/acceptance/update_settings_form_information_spec.rb
@@ -1,0 +1,118 @@
+require_relative './spec_helper'
+
+feature 'Update settings form information' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:updated_service_name) { generate_service_name }
+  let(:another_service_name) { generate_service_name }
+
+  background do
+    editor.load
+    given_I_add_a_service
+    and_I_go_to_update_the_form_information_in_settings
+  end
+
+  scenario 'current service name as input value' do
+    then_I_should_see_the_current_service_name_in_the_input
+  end
+
+  scenario 'validates the service name' do
+    given_I_update_a_service_with_empty_name
+    when_I_update_the_service
+    then_I_should_see_a_validation_message_for_required
+  end
+
+  scenario 'validates the service name min length' do
+    given_I_update_a_service_with_one_character
+    when_I_update_the_service
+    then_I_should_see_a_validation_message_for_min_length
+  end
+
+  scenario 'validates the service name max length' do
+    given_I_update_a_service_with_many_characters
+    when_I_update_the_service
+    then_I_should_see_a_validation_message_for_max_length
+  end
+
+  scenario 'updates the service in settings' do
+    given_I_update_the_service_name
+    then_I_should_see_the_new_service_name
+  end
+
+  scenario 'validates uniqueness of the service name' do
+    given_I_have_another_service
+    and_I_go_to_update_the_form_information_in_settings
+    when_I_try_to_change_service_name_adding_an_existing_service_name
+    then_I_should_see_the_unique_validation_message
+  end
+
+  def given_I_add_a_service
+    editor.name_field.set(service_name)
+    editor.create_service_button.click
+  end
+
+  def and_I_go_to_update_the_form_information_in_settings
+    editor.load
+    editor.edit_service_link(service_name).click
+    editor.settings_link.click
+    editor.form_information_link.click
+  end
+
+  def given_I_update_the_service_name
+    editor.form_name_field.set(updated_service_name)
+    editor.save_button.click
+  end
+
+  def given_I_update_a_service_with_empty_name
+    editor.form_name_field.set('')
+  end
+
+  def given_I_update_a_service_with_one_character
+    editor.form_name_field.set('C')
+  end
+
+  def given_I_update_a_service_with_many_characters
+    editor.form_name_field.set('Stormtrooper Aim' * 100)
+  end
+
+  def when_I_update_the_service
+    editor.save_button.click
+  end
+
+  def when_I_try_to_change_service_name_adding_an_existing_service_name
+    editor.form_name_field.set(another_service_name)
+    when_I_update_the_service
+  end
+
+  def then_I_should_see_the_current_service_name_in_the_input
+    expect(editor.form_name_field.value).to eq(service_name)
+  end
+
+  def then_I_should_see_the_new_service_name
+    expect(editor.service_name.text).to eq(updated_service_name)
+  end
+
+  def then_I_should_see_a_validation_message_for_required
+    expect(editor.text).to include(
+      "Your answer for ‘Form name’ can not be blank."
+    )
+  end
+
+  def then_I_should_see_a_validation_message_for_min_length
+    expect(editor.text).to include(
+      "Your answer for ‘Form name’ is too short (3 characters at least)"
+    )
+  end
+
+  def then_I_should_see_a_validation_message_for_max_length
+    expect(editor.text).to include(
+      "Your answer for ‘Form name’ is too long (128 characters at most)"
+    )
+  end
+
+  def then_I_should_see_the_unique_validation_message
+    expect(editor.text).to include(
+      "Your answer for ‘Form name' is already used by another form. Please modify it."
+    )
+  end
+end

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -7,12 +7,12 @@
 
       <dl class="govuk-summary-list govuk-!-margin-bottom-9">
         <% services.each do |service| %>
-          <div class="govuk-summary-list__row">
+          <div class="govuk-summary-list__row" id="service-<%= service.name.parameterize %>">
             <dd class="govuk-summary-list__value">
               <%= service.name %>
             </dd>
             <dd class="govuk-summary-list__actions">
-              <%= link_to t('.services.edit'), edit_service_path(service.id) %>
+              <%= link_to t('.services.edit'), edit_service_path(service.id), class: 'edit' %>
             </dd>
           </div>
         <% end %>

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  editor_ci:
+    build:
+      context: .
+      dockerfile: acceptance/Dockerfile
+      args:
+        BUNDLE_ARGS: ''
+    environment:
+      CI_MODE: 'true'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,59 @@ services:
     tty: true
     stdin_open: true
     ports:
-      - 8081:3000
+      - 9090:3000
     environment:
       DATABASE_URL: "postgres://postgres:password@editor-db/editor_local"
-    links:
+      RAILS_LOG_TO_STDOUT: 'true'
+      ENCODED_PRIVATE_KEY: "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA+OtquVq4iSKV6xTibO3snW70AK0/ILG/vDt8KNCQNf/411D7\nh+F3Kpw+vNANfHdJTfJUV4/dYz5HHsAxAaG8qyHiNycy9cNsHoRCold5Zp8iEBkS\ncXOSh32qKD6e0brwJvpyv0QcHWfKZz46PBm6TUxrC6z9nwiePQX/sryFhpzX8sL7\nD09Qwc1c/42PHhLkxvcCioHhj33zT+YOCNvI5RyYPG6lKvn1QSKvSJ+zoAnwP7R7\nL7c/QixADzleAq7HNEhE8p0T0OVegWa85Ox7fK9j/vZw9bFYOK1CVNQcf+VGh2Fa\ngs/7D9T0nrhQ3xKxpKvnfzVoqga38V7gWZyt8QIDAQABAoIBAQDtpYyh49w0iQGK\ni8jU6J4zfB+WmdCgPTNp2XzjVqOn+ncv0lAiXX6w/rTi/NszTot80HP3mRFrU6UA\n1cqz3R9MXzAjKdh8TJPn2qvnZA4yjJEvv1AdYpKtqqsOeyKT556qCAgPVU5mQJY7\n1WwxvvpgHCpC3mjRMaApcJW7pkLwzOFTiP3B5EYMfPMGJfqPsQYFhRXlft0fC77Y\nADosRuU5IFQbQHENo22PLD+BJ2vY7i/RiOrVhUg9wGjFAU+ghXIdO6BgbMEV7+Dw\nagw6WJfS81cH3RFU6ZwJqDANzrfRRMxebH2WLtbE4iSFeBEpvCV2T6VCDRvPoNbO\n4ATOMzYBAoGBAP6GeamkUYZcIrB0oWZBoFsUmaKxMrEDaoQZ7QFFICEAJWvyUEzI\n4WUILskeK7RnFmfrYPeuCK8D//EZUi3j77DXjOFoSc2/Q10/FVoXPPj1xp2Uo5zZ\nxc0apU3KNL4vvMo7ZHcDO17hy7UDfN6CxmutuE93MXHbQiypN0AC9GVhAoGBAPpc\noIKr86PPs5qF++vTYvAvqGTmQ5JG1hddF1rR4IOS/6MoMZ1pB2+ETFVum/2/gwi9\n4iuARiEbE+imvaDRDIMQ6e1M5CFtRA19y703JwieeLFrzNgNp0CwJB9H+SQj9Z0P\nfeOU3u+nyFwnfGA/lBxaNu3eJmHYlre5hsI6NIKRAoGAM2iL6ETFJqMzanqUIug8\ncEkP4vlxaKls+TOXWDtTCvdRl6UArRGh3NszP/H1F+H+d4zmMACZxmfDaToZDCXO\nwuQ2k0ySI5lvDMVyFZk9+ncB39Am38Zomk24d6bQ0l0n/5zRZOxlMHvgvjXvIa4+\nT39uC7biaMHFcunWu/oczOECgYADLanb/tLZAYoGLC1GkShwZCp/HW0+LigJo+To\nAkIXaYZVS+1VUkAF6mgNrZnNXuEK+14jrz00rmNSUMuXfw/pmg1eNduvkPOMOEyd\n2lVkhp6Bohy3oXS+HX5X51ICY3J6y/eNLBaodDjW8qlhj20R7xNDcc6K73T6YCCV\n1qdUAQKBgHMT8rQMzmCRusDPc2Dl/qjDT/rDQ1iMQQNQB2yvg6z41QgAhb90mOB4\nY8i256sOPWYqRymxq40FR0ZFkW/y1cceceVpjWvhS5ZrjgLmDbZnSUQnMafUNgNy\nK0VWsiR2LxJCBgiw0evtz+W2GOYpOhgpep5AjLITla5FsZUSNI3c\n-----END RSA PRIVATE KEY-----"
+      METADATA_API_URL: "http://editor-metadata-app:3000/"
+      PLATFORM_ENV: "local"
+    depends_on:
       - editor-db
+      - editor-metadata-app
+
+  editor-metadata-db:
+    image: postgres:12.4-alpine
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: postgres
+      POSTGRES_DB: metadata_local
+
+  editor-metadata-app:
+    build:
+      context: https://github.com/ministryofjustice/fb-metadata-api.git#main
+      args:
+        BUNDLE_ARGS: ''
+    tty: true
+    stdin_open: true
+    ports:
+      - 9091:3000
+    environment:
+      DATABASE_URL: "postgres://postgres:password@editor-metadata-db/metadata_local"
+      RAILS_ENV: test
+      SERVICE_TOKEN_CACHE_ROOT_URL: 'http://editor-service-token-cache-app:3000'
+      MAX_IAT_SKEW_SECONDS: '60'
+      RAILS_LOG_TO_STDOUT: 'true'
+    depends_on:
+      - editor-metadata-db
+      - editor-service-token-cache-app
+
+  editor-service-token-cache-app:
+    container_name: editor-service-token-cache-app
+    build:
+      context: https://github.com/ministryofjustice/fb-service-token-cache.git
+    environment:
+      SENTRY_DSN: sentry-dsn
+      RAILS_ENV: test
+      RAILS_LOG_TO_STDOUT: 'true'
+      REDIS_URL: editor-service-token-cache-redis
+      SERVICE_TOKEN_CACHE_TTL: 999999
+    depends_on:
+      - editor-service-token-cache-redis
+    ports:
+      - 9092:3000
+
+  editor-service-token-cache-redis:
+    container_name: editor-service-token-cache-redis
+    image: redis:5.0.6-alpine


### PR DESCRIPTION
## Context

This PR adds the acceptance tests for the editor.

The base idea is to have tests where we can run locally against:

1. local editor
2.  or against any editor environment (given a editor url).

### ENV vars

Two env files are manipulated into one file:

1. one for running with local containers
2. other pointing to the test environment (but it can be changed to any other environment if we like)

### Local editor

Added all necessary containers for the editor

- editor-db
- editor-app
- metadata-db
- metadata-app
- service-token-cache-app
- service-token-cache-redis

This will spin up the containers and run the tests against the editor. A future improvement is to transform the editor into a volume to make us more productive.

### CI

To run this you need to have the user and password setup on CircleCI (I already added there) or if you run on your local machine that points to the test environment you can as well. If you face 401 on the tests it is because the user env var and pass aren't set.

### Caveats

I have to make a specific dockerfile for acceptance test because we need chrome driver and other packages to run.