### PR TITLE
Add volume to the editor container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
         BUNDLE_ARGS: ''
     tty: true
     stdin_open: true
+    volumes:
+      - '.:/app'
     ports:
       - 9090:3000
     environment:


### PR DESCRIPTION
This can speed up the development of the editor as we can make changes
to the editor and run the acceptance spec without the need to rebuild
the containers.

So on the workflow can be like. Setup the containers:

```
make setup
```

Then add the acceptance tests that you need to add.
Add the implementation.
Run the tests via `bundle exec rspec acceptance` without the need to rebuild any container.