### PR TITLE
Stay on the same page when update settings

### DIFF
--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -8,7 +8,7 @@ class EditorApp < SitePrism::Page
     set_url ENV['ACCEPTANCE_TESTS_EDITOR_APP']
   end
 
-  element :service_name, 'main h1'
+  element :service_name, 'main h1.service-name'
   element :name_field, :field, 'What is the name of this form?'
   element :create_service_button, :button, 'Create a new form'
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -7,7 +7,7 @@ class SettingsController < ApplicationController
     @settings = Settings.new(service_params)
 
     if @settings.update
-      redirect_to settings_path(service.service_id)
+      redirect_to form_information_settings_path(service.service_id)
     else
       render :form_information
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
 
         <% unless controller.controller_name == 'services' && (controller.action_name == 'index' || controller.action_name == 'create') %>
 
-          <h1><%= service.service_name %></h1>
+          <h1 class="service-name"><%= service.service_name %></h1>
 
           <%= render template: 'page_menu/show' %>
         <% end %>

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe 'Settings' do
     context 'when valid' do
       let(:valid) { true }
 
-      it 'redirects to settings index' do
-        expect(response).to redirect_to(settings_path(service.service_id))
+      it 'redirects to form information index' do
+        expect(response).to redirect_to(form_information_settings_path(service.service_id))
       end
     end
 


### PR DESCRIPTION
[Trello Card](https://trello.com/c/uCAziihV/1179-change-form-name-in-settings)

## Context

When updating form information the editor should stay on the same
page as according to our designer of the prototype (see the trello
card for the PR for more details).