### PR TITLE
Add new generated page to steps

### DIFF
--- a/app/generators/new_page_generator.rb
+++ b/app/generators/new_page_generator.rb
@@ -5,6 +5,7 @@ class NewPageGenerator
   def to_metadata
     latest_metadata.tap do
       latest_metadata['pages'].push(page_metadata)
+      latest_metadata['pages'][0]['steps'].push(page_name)
     end
   end
 

--- a/spec/generators/new_page_generator_spec.rb
+++ b/spec/generators/new_page_generator_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe NewPageGenerator do
           '_type' => component_type
         )
       end
+
+      it 'adds the new page to the steps' do
+        expect(generator.to_metadata['pages'][0]['steps']).to include("page.#{page_url}")
+      end
     end
 
     context 'when existing pages exist' do


### PR DESCRIPTION
Whenever we create a new page it needs to be added to the Steps in the start page object.