### PR TITLE
Feature/edit start page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           command: make setup
       - run:
           name: security
-          command: docker-compose run --rm editor-app bundle exec brakeman -q --no-pager
+          command: docker-compose run --rm editor-app bundle exec brakeman -q --no-pager -i brakeman.ignore
       - run:
           name: unit tests
           command: docker-compose run --rm editor-app bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.2'
 
 gem 'bootsnap', '>= 1.4.2', require: false
-gem 'metadata_presenter', github: 'ministryofjustice/fb-metadata-presenter', branch: 'feature/edit-start-page' # path: '../fb-metadata-presenter' # '~> 0.1.8'
+gem 'metadata_presenter', '0.2.0'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.5.0'

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,11 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.2'
 
 gem 'bootsnap', '>= 1.4.2', require: false
-gem 'metadata_presenter', '~> 0.1.8'
+gem 'metadata_presenter', github: 'ministryofjustice/fb-metadata-presenter', branch: 'feature/edit-start-page' # path: '../fb-metadata-presenter' # '~> 0.1.8'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.5.0'
+gem 'hashie'
 gem 'omniauth'
 gem 'omniauth-auth0', '~> 2.5.0'
 gem 'omniauth-rails_csrf_protection', '~> 0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 5da7da1948f8b7d4f7e6ead7f134022149200aa0
-  branch: feature/edit-start-page
-  specs:
-    metadata_presenter (0.1.8)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (>= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 6.0.3.4, < 6.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -144,6 +133,11 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
+    metadata_presenter (0.2.0)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (>= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 6.0.3.4, < 6.2.0)
     method_source (1.0.0)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
@@ -311,7 +305,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.5.0)
   hashie
   listen (~> 3.4)
-  metadata_presenter!
+  metadata_presenter (= 0.2.0)
   omniauth
   omniauth-auth0 (~> 2.5.0)
   omniauth-rails_csrf_protection (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 5da7da1948f8b7d4f7e6ead7f134022149200aa0
+  branch: feature/edit-start-page
+  specs:
+    metadata_presenter (0.1.8)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (>= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 6.0.3.4, < 6.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -84,7 +95,7 @@ GEM
       xpath (~> 3.2)
     childprocess (3.0.0)
     coderay (1.1.3)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -133,11 +144,6 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.1.8)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (>= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 6.0.3.4, < 6.2.0)
     method_source (1.0.0)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
@@ -262,7 +268,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    thor (1.0.1)
+    thor (1.1.0)
     tilt (2.0.10)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -303,8 +309,9 @@ DEPENDENCIES
   faraday
   faraday_middleware
   fb-jwt-auth (= 0.5.0)
+  hashie
   listen (~> 3.4)
-  metadata_presenter (~> 0.1.8)
+  metadata_presenter!
   omniauth
   omniauth-auth0 (~> 2.5.0)
   omniauth-rails_csrf_protection (~> 0.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :service
 
+  def editable?
+    true
+  end
+  helper_method :editable?
+
   def back_link
   end
   helper_method :back_link

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,9 +9,20 @@ class PagesController < ApplicationController
     end
   end
 
+  def edit
+    @page = service.find_page(params[:page_url])
+  end
+
   def update
-    # find correct page object
-    # update object
+    @page = service.find_page(params[:page_url])
+
+    @metadata_updater = MetadataUpdater.new(page_update_params)
+
+    if @metadata_updater.update
+      redirect_to edit_page_path(service.service_id, params[:page_url])
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def page_creation_params
@@ -19,10 +30,28 @@ class PagesController < ApplicationController
       :page
     ).permit(
       :page_url, :page_type, :component_type
-    ).merge(latest_metadata: service_metadata, service_id: service_id)
+    ).merge(common_params)
+  end
+
+  def page_update_params
+    {
+      id: @page.id
+    }.merge(common_params).merge(params.require(:page).permit!)
+  end
+
+  def common_params
+    {
+      latest_metadata: service_metadata,
+      service_id: service_id
+    }
   end
 
   def service_id
     service.service_id
   end
+
+  def reserved_answers_path(*args)
+    ''
+  end
+  helper_method :reserved_answers_path
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -38,7 +38,11 @@ class PagesController < ApplicationController
   def page_update_params
     {
       id: @page.id
-    }.merge(common_params).merge(params.require(:page).permit!)
+    }.merge(common_params).merge(page_attributes)
+  end
+
+  def page_attributes
+    params.require(:page).permit(@page.editable_attributes.keys)
   end
 
   def common_params

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+
   def create
     @page_creation = PageCreation.new(page_creation_params)
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
 module ApplicationHelper
+  include MetadataPresenter::ApplicationHelper
 end

--- a/app/services/metadata_api_client/version.rb
+++ b/app/services/metadata_api_client/version.rb
@@ -2,7 +2,9 @@ module MetadataApiClient
   class Version < Resource
     def self.create(service_id:, payload:)
       new(
-        connection.post("/services/#{service_id}/versions", payload).body
+        connection.post(
+          "/services/#{service_id}/versions", { metadata: payload }
+        ).body
       )
     rescue Faraday::UnprocessableEntityError => exception
       error_messages(exception)

--- a/app/services/metadata_updater.rb
+++ b/app/services/metadata_updater.rb
@@ -1,0 +1,38 @@
+class MetadataUpdater
+  attr_reader :id, :latest_metadata, :service_id, :attributes
+
+  def initialize(attributes)
+    @latest_metadata = attributes.delete(:latest_metadata).to_h
+    @service_id = attributes.delete(:service_id)
+    @id = attributes.delete(:id)
+    @attributes = attributes
+  end
+
+  def update
+    version = MetadataApiClient::Version.create(
+      service_id: service_id,
+      payload: metadata
+    )
+
+    return version.metadata unless version.errors?
+
+    false
+  end
+
+  def metadata
+    @latest_metadata.extend Hashie::Extensions::DeepLocate
+
+    object = @latest_metadata.deep_locate(find_id).first
+    new_object = object.merge(attributes)
+    index = @latest_metadata['pages'].index(object)
+    @latest_metadata['pages'][index] = new_object
+
+    @latest_metadata
+  end
+
+  def find_id
+    lambda do |key, value, object|
+      key == '_id' && value == @id
+    end
+  end
+end

--- a/app/services/page_creation.rb
+++ b/app/services/page_creation.rb
@@ -17,7 +17,7 @@ class PageCreation
 
     version = MetadataApiClient::Version.create(
       service_id: service_id,
-      payload: { metadata: metadata }
+      payload: metadata
     )
 
     if version.errors?

--- a/app/services/settings.rb
+++ b/app/services/settings.rb
@@ -13,11 +13,9 @@ class Settings < Editor::Service
   end
 
   def metadata
-    {
-      metadata: latest_metadata.merge(
-        service_name: service_name,
-        created_by: '1234' # current_user
-      )
-    }
+    latest_metadata.merge(
+      service_name: service_name,
+      created_by: '1234' # current_user
+    )
   end
 end

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -1,1 +1,12 @@
 <h3>Page edit</h3>
+
+<%= form_for @page, as: :page, url: page_path(service.service_id, @page.url), method: :patch do |f| %>
+  <% @page.editable_attributes.each do |key, value| %>
+    <%= f.hidden_field key, value: value %>
+  <% end %>
+
+  <%= f.submit t('actions.save'), class: 'govuk-button editor-button' %>
+<% end %>
+
+<%= render template: @page.template %>
+

--- a/brakeman.ignore
+++ b/brakeman.ignore
@@ -30,26 +30,6 @@
       "user_input": "params[:page_url]",
       "confidence": "Weak",
       "note": "This is temporary until we change the find page to use an ID instead of the URL"
-    },
-    {
-      "warning_type": "Mass Assignment",
-      "warning_code": 70,
-      "fingerprint": "eedcd0dd72770a8e244ce5c4d03925e9d997b4d06c1ae3bd45f8fb55577fd4be",
-      "check_name": "MassAssignment",
-      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
-      "file": "app/controllers/pages_controller.rb",
-      "line": 41,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:page).permit!",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "PagesController",
-        "method": "page_update_params"
-      },
-      "user_input": null,
-      "confidence": "Medium",
-      "note": "We use the schemas to protect against unwanted params"
     }
   ],
   "updated": "2021-01-22 16:38:26 +0000",

--- a/brakeman.ignore
+++ b/brakeman.ignore
@@ -1,0 +1,57 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "2f864ceae7a4e0836c8f9bd0b5268eee42c215e6dc6b4dafd75677c74af01dd1",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/pages/edit.html.erb",
+      "line": 11,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(template => service.find_page(params[:page_url]).template, {})",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "PagesController",
+          "method": "edit",
+          "line": 16,
+          "file": "app/controllers/pages_controller.rb",
+          "rendered": {
+            "name": "pages/edit",
+            "file": "app/views/pages/edit.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "pages/edit"
+      },
+      "user_input": "params[:page_url]",
+      "confidence": "Weak",
+      "note": "This is temporary until we change the find page to use an ID instead of the URL"
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "eedcd0dd72770a8e244ce5c4d03925e9d997b4d06c1ae3bd45f8fb55577fd4be",
+      "check_name": "MassAssignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
+      "file": "app/controllers/pages_controller.rb",
+      "line": 41,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.require(:page).permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "PagesController",
+        "method": "page_update_params"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": "We use the schemas to protect against unwanted params"
+    }
+  ],
+  "updated": "2021-01-22 16:38:26 +0000",
+  "brakeman_version": "4.10.1"
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
 
   resources :services, only: [:index, :edit, :update, :create] do
     member do
-      resources :pages, param: :page_url, only: [:create, :edit]
+      resources :pages, param: :page_url, only: [:create, :edit, :update]
       resources :settings, only: [:index] do
         collection do
           get 'form_information'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
         BUNDLE_ARGS: ''
     tty: true
     stdin_open: true
-    volumes:
-      - '.:/app'
     ports:
       - 9090:3000
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
         BUNDLE_ARGS: ''
     tty: true
     stdin_open: true
+    volumes:
+      - '.:/app'
     ports:
       - 9090:3000
     environment:

--- a/spec/services/metadata_updater_spec.rb
+++ b/spec/services/metadata_updater_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe MetadataUpdater do
+  subject(:updater) { MetadataUpdater.new(attributes) }
+  let(:service_id) { service.service_id }
+  let(:updated_metadata) do
+    metadata = service_metadata.deep_dup
+    metadata['pages'][0] = metadata['pages'][0].merge(attributes_to_update)
+    metadata
+  end
+  let(:version) { double(errors?: false, errors: [], metadata: updated_metadata) }
+
+  before do
+    expect(
+      MetadataApiClient::Version
+    ).to receive(:create).with(
+      service_id: service_id,
+      payload: updated_metadata
+    ).and_return(version)
+  end
+
+  describe '#update' do
+    let(:valid) { true }
+
+    context 'page attributes' do
+      let(:page_url) { '/' }
+      let(:attributes) do
+        {
+          id: 'page.start',
+          service_id: service.service_id,
+          latest_metadata: service_metadata,
+        }.merge(attributes_to_update)
+      end
+      let(:attributes_to_update) do
+        {
+          section_heading: 'Some important section heading',
+          heading: 'Some super important heading',
+          lede: 'This is a lede',
+          body: 'And what of the Rebellion?',
+          before_you_start: "Don't try to frighten us with your sorcerer's ways, Lord Vader."
+        }.stringify_keys
+      end
+
+      it 'updates the page metadata' do
+        updated_page = updater.update['pages'][0]
+        expect(updated_page).to include(attributes_to_update)
+      end
+
+      it 'creates valid page metadata' do
+        updated_page = updater.update['pages'][0]
+        expect(
+          MetadataPresenter::ValidateSchema.validate(
+            updated_page, 'page.start'
+          )
+        ).to be(valid)
+      end
+
+      it 'creates valid service metadata' do
+        expect(
+          MetadataPresenter::ValidateSchema.validate(
+            updater.update, 'service.base'
+          )
+        ).to be(valid)
+      end
+    end
+  end
+end

--- a/spec/services/page_creation_spec.rb
+++ b/spec/services/page_creation_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe PageCreation, type: :model do
       context 'when is valid' do
         it 'have no errors' do
           should allow_values(
-            'singlequestion', 'summary', 'confirmation'
+            'singlequestion', 'checkanswers', 'confirmation'
           ).for(:page_type)
         end
       end

--- a/spec/services/settings_spec.rb
+++ b/spec/services/settings_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe Settings do
           MetadataApiClient::Version
         ).to receive(:create).with(
           service_id: '123456',
-          payload: {
-            metadata: { service_name: 'Moff Gideon', created_by: '1234' }
-          }
+          payload: { service_name: 'Moff Gideon', created_by: '1234' }
         ).and_return(service)
       end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/dta3Fs4i/1199-backend-editing-start-page)

## Context

This PR contemplates:

1. Renders the page on the edit page.
2. Add the current properties of the page as hidden inputs
3. The submitted form will be created a new version in the metadata API with the new attributes.

## Observations of the implementation

We add the [Hashie](https://github.com/hashie/hashie#deeplocate) gem to use the deep locate when updating the metadata API. Find the object to be updated passing its id to locate.

We hardcoded the key 'pages' for now but in the future the MetadataUpdater should be responsible to update other nodes as the configuration or others.

## Showing the feature of this PR

The gif shows the page being rendered and the current attributes being created on the API.

![edit-start-page](https://user-images.githubusercontent.com/27509/105515723-cb9e9080-5cb3-11eb-8d0d-5c776a22af5b.gif)