### PR TITLE
Use generated _uuid property in pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,15 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.7.2'
 
 gem 'bootsnap', '>= 1.4.2', require: false
-gem 'metadata_presenter', '0.2.0'
+
+# Metadata presenter - if you need to be on development you can uncomment
+# one of these lines:
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'some-branch'
+# gem 'metadata_presenter', path: '../fb-metadata-presenter'
+#
+gem 'metadata_presenter', '0.3.0'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.2.0)
+    metadata_presenter (0.3.0)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -305,7 +305,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.5.0)
   hashie
   listen (~> 3.4)
-  metadata_presenter (= 0.2.0)
+  metadata_presenter (= 0.3.0)
   omniauth
   omniauth-auth0 (~> 2.5.0)
   omniauth-rails_csrf_protection (~> 0.1)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,23 +5,23 @@ class PagesController < ApplicationController
     @page_creation = PageCreation.new(page_creation_params)
 
     if @page_creation.create
-      redirect_to edit_page_path(service_id, @page_creation.page_url)
+      redirect_to edit_page_path(service_id, @page_creation.page_uuid)
     else
       render template: 'services/edit', status: :unprocessable_entity
     end
   end
 
   def edit
-    @page = service.find_page(params[:page_url])
+    @page = service.find_page_by_uuid(params[:page_uuid])
   end
 
   def update
-    @page = service.find_page(params[:page_url])
+    @page = service.find_page_by_uuid(params[:page_uuid])
 
     @metadata_updater = MetadataUpdater.new(page_update_params)
 
     if @metadata_updater.update
-      redirect_to edit_page_path(service.service_id, params[:page_url])
+      redirect_to edit_page_path(service.service_id, params[:page_uuid])
     else
       render :edit, status: :unprocessable_entity
     end
@@ -55,9 +55,4 @@ class PagesController < ApplicationController
   def service_id
     service.service_id
   end
-
-  def reserved_answers_path(*args)
-    ''
-  end
-  helper_method :reserved_answers_path
 end

--- a/app/generators/new_page_generator.rb
+++ b/app/generators/new_page_generator.rb
@@ -14,6 +14,7 @@ class NewPageGenerator
 
     metadata.tap do
       metadata['_id'] = page_name
+      metadata['_uuid'] = SecureRandom.uuid
       metadata['url'] = page_url
       metadata['components'].push(component)
     end

--- a/app/generators/new_service_generator.rb
+++ b/app/generators/new_service_generator.rb
@@ -12,6 +12,8 @@ class NewServiceGenerator
     metadata.tap do
       metadata['configuration']['service'] = DefaultMetadata['config.service']
       metadata['configuration']['meta'] = DefaultMetadata['config.meta']
+      metadata['pages'].push(DefaultMetadata['page.start'])
+      metadata['pages'][0]['_uuid'] = SecureRandom.uuid
       metadata['service_name'] = service_name
       metadata['created_by'] = '1234'
     end

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -1,6 +1,6 @@
 <h3>Page edit</h3>
 
-<%= form_for @page, as: :page, url: page_path(service.service_id, @page.url), method: :patch do |f| %>
+<%= form_for @page, as: :page, url: page_path(service.service_id, @page.uuid), method: :patch do |f| %>
   <% @page.editable_attributes.each do |key, value| %>
     <%= f.hidden_field key, value: value %>
   <% end %>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -2,7 +2,7 @@
 
 <% service.pages.each do |page| %>
   <div>
-    <%= link_to page.url, edit_page_path(service.service_id, page.url) %>
+    <%= link_to page.url, edit_page_path(service.service_id, page.uuid) %>
   </div>
 <% end %>
 

--- a/brakeman.ignore
+++ b/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "2f864ceae7a4e0836c8f9bd0b5268eee42c215e6dc6b4dafd75677c74af01dd1",
+      "fingerprint": "e7a712bc09393b5494d0566c761eebfff983b805e29c590f886babe58a5370f9",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/pages/edit.html.erb",
       "line": 11,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(template => service.find_page(params[:page_url]).template, {})",
+      "code": "render(template => service.find_page_by_uuid(params[:page_uuid]).template, {})",
       "render_path": [
         {
           "type": "controller",
@@ -27,11 +27,11 @@
         "type": "template",
         "template": "pages/edit"
       },
-      "user_input": "params[:page_url]",
+      "user_input": "params[:page_uuid]",
       "confidence": "Weak",
-      "note": "This is temporary until we change the find page to use an ID instead of the URL"
+      "note": "The template is chosen after finding the correct page using the UUID, so this is fine"
     }
   ],
-  "updated": "2021-01-22 16:38:26 +0000",
+  "updated": "2021-01-25 17:11:13 +0000",
   "brakeman_version": "4.10.1"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
 
   resources :services, only: [:index, :edit, :update, :create] do
     member do
-      resources :pages, param: :page_url, only: [:create, :edit, :update]
+      resources :pages, param: :page_uuid, only: [:create, :edit, :update]
       resources :settings, only: [:index] do
         collection do
           get 'form_information'

--- a/spec/generators/new_page_generator_spec.rb
+++ b/spec/generators/new_page_generator_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe NewPageGenerator do
     let(:page_url) { 'home-one' }
     let(:component_type) { 'text' }
 
+    before do
+      allow(SecureRandom). to receive(:uuid).and_return('mandalorian-123')
+    end
+
     context 'when only start page exists' do
       let(:latest_metadata) { metadata_fixture(:service) }
 
@@ -33,10 +37,11 @@ RSpec.describe NewPageGenerator do
         ).to be(valid)
       end
 
-      it 'generates page url' do
+      it 'generates page attributes' do
         expect(generator.to_metadata['pages']).to_not be_blank
         expect(generator.to_metadata['pages'].last).to include(
-          'url' => page_url
+          'url' => page_url,
+          '_uuid' => 'mandalorian-123'
         )
       end
 

--- a/spec/generators/new_service_generator_spec.rb
+++ b/spec/generators/new_service_generator_spec.rb
@@ -4,17 +4,26 @@ RSpec.describe NewServiceGenerator do
       let(:valid) { true }
       let(:service_name) { 'Razorback' }
       let(:current_user) { double(id: '1234') }
-
-      it 'creates a valid service metadata' do
-        service_metadata = NewServiceGenerator.new(
+      let(:service_metadata) do
+        NewServiceGenerator.new(
           service_name: service_name,
           current_user: current_user
         ).to_metadata
+      end
 
+      it 'creates a valid service metadata' do
         expect(
           MetadataPresenter::ValidateSchema.validate(
             service_metadata, 'service.base')
           ).to be(valid)
+      end
+
+      it 'creates start page' do
+        expect(service_metadata['pages']).to be_present
+        expect(service_metadata['pages'][0]).to include(
+          '_type' => 'page.start',
+          'url' => '/'
+        )
       end
     end
 


### PR DESCRIPTION
When:

1. Create a service (the start page uuid)
2. Create a page (the page uuid)

Use metadata presenter 0.3.0 which uses the UUID in the page path. As a result of this version we no longer need to override the reserved_answer_path as it's just a post to the page URL now.

https://trello.com/c/wbZcslTs/1224-use-generated-page-id-instead-of-name

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>