### PR TITLE
Add page uuid call to page creation

### DIFF
--- a/app/services/page_creation.rb
+++ b/app/services/page_creation.rb
@@ -4,13 +4,18 @@ class PageCreation
                 :page_type,
                 :component_type,
                 :latest_metadata,
-                :service_id
+                :service_id,
+                :version
   validates :page_url, :page_type, :component_type, presence: true
   validates :page_url, format: { with: /\A[\sa-zA-Z0-9-]*\z/ }
 
   validates :page_type, metadata_presence: { metadata_key: :page }
   validates :component_type, metadata_presence: { metadata_key: :component }
   validates :page_url, metadata_url: { metadata_method: :latest_metadata }
+
+  def page_uuid
+    version.metadata['pages'].last['_uuid'] if version
+  end
 
   def create
     return false if invalid?
@@ -24,7 +29,7 @@ class PageCreation
       self.errors.add(:base, :invalid, message: version.errors)
       false
     else
-      version
+      @version = version
     end
   end
 

--- a/spec/services/page_creation_spec.rb
+++ b/spec/services/page_creation_spec.rb
@@ -4,6 +4,28 @@ RSpec.describe PageCreation, type: :model do
   end
   let(:attributes) { { latest_metadata: metadata_fixture(:version) } }
 
+  describe '#page_uuid' do
+    context 'when version' do
+      let(:attributes) do
+        { version: double(metadata: service_metadata) }
+      end
+
+      it 'returns the last page uuid' do
+        expect(
+          page_creation.page_uuid
+        ).to eq('b238a22f-c180-48d0-a7d9-8aad2036f1f2')
+      end
+    end
+
+    context 'when version is blank' do
+      it 'returns nil' do
+        expect(
+          page_creation.page_uuid
+        ).to be_nil
+      end
+    end
+  end
+
   describe '#create' do
     let(:attributes) do
       {
@@ -25,6 +47,11 @@ RSpec.describe PageCreation, type: :model do
 
       it 'returns true' do
         expect(page_creation.create).to be_truthy
+      end
+
+      it 'sets the version' do
+        page_creation.create
+        expect(page_creation.version).to eq(version)
       end
     end
 


### PR DESCRIPTION
## Context

The current test environment is raising an error when creating pages. 
```NoMethodError (undefined method `page_uuid' for #<PageCreation:0x0000558662cdcb78>```

This fixes the test environment.

## Caveats

Page creation requires to redirect the user to edit the page when the page is created. So this PR returns the last page UUID.
This will be a problem when we need to create a page and insert in the middle of the service but it solves the problem now.