### PR TITLE
Encrypt username and password for basic authentication

### DIFF
--- a/app/services/default_configuration.rb
+++ b/app/services/default_configuration.rb
@@ -20,13 +20,13 @@ class DefaultConfiguration
 
       create_configuration(
         name: 'ENCODED_PRIVATE_KEY',
-        value: Base64.strict_encode64(key.private_key),
+        value: key.private_key,
         deployment_environment: deployment_environment
       )
 
       create_configuration(
         name: 'ENCODED_PUBLIC_KEY',
-        value: Base64.strict_encode64(key.public_key),
+        value: key.public_key,
         deployment_environment: deployment_environment
       )
     end

--- a/app/services/encryption_service.rb
+++ b/app/services/encryption_service.rb
@@ -1,0 +1,26 @@
+class EncryptionService
+  KEY = ActiveSupport::KeyGenerator.new(
+    ENV.fetch('ENCRYPTION_KEY')
+  ).generate_key(
+    ENV.fetch('ENCRYPTION_SALT'),
+    ActiveSupport::MessageEncryptor.key_len
+  ).freeze
+
+  private_constant :KEY
+
+  delegate :encrypt_and_sign, :decrypt_and_verify, to: :encryptor
+
+  def encrypt(value)
+    encrypt_and_sign(value)
+  end
+
+  def decrypt(value)
+    decrypt_and_verify(value)
+  end
+
+  private
+
+  def encryptor
+    ActiveSupport::MessageEncryptor.new(KEY)
+  end
+end

--- a/app/services/publish_service_creation.rb
+++ b/app/services/publish_service_creation.rb
@@ -42,7 +42,7 @@ class PublishServiceCreation
       name: name.to_s.upcase
     )
 
-    Base64.decode64(configuration.value) if configuration.present?
+    configuration.decrypt_value if configuration.present?
   end
 
   def existing_authentication?(deployment_environment:)
@@ -90,7 +90,7 @@ class PublishServiceCreation
       deployment_environment: deployment_environment,
       name: name
     )
-    service_configuration.value = Base64.strict_encode64(value)
+    service_configuration.value = value
     service_configuration.save!
   end
 
@@ -100,6 +100,16 @@ class PublishServiceCreation
       deployment_environment: deployment_environment,
       name: name
     )
+  end
+
+  def create_or_update_configuration(name:, value:)
+    service_configuration = ServiceConfiguration.find_or_initialize_by(
+      service_id: service_id,
+      deployment_environment: deployment_environment,
+      name: name
+    )
+    service_configuration.value = value
+    service_configuration.save!
   end
 
   def require_authentication?

--- a/app/views/publish/index.html.erb
+++ b/app/views/publish/index.html.erb
@@ -17,6 +17,21 @@
 <%= form_for(@publish_service_creation_dev, url: publish_index_path(service.service_id)) do |f| %>
   <%= render 'form', f: f, deployment_environment: 'dev' %>
 
+  <div class="govuk-form-group">
+    <%= f.check_box :require_authentication %>
+    <%= f.label :require_authentication %>
+  </div>
+
+  <div class="govuk-form-group">
+    <%= f.label :username %>
+    <%= f.text_field :username %>
+  </div>
+
+  <div class="govuk-form-group">
+    <%= f.label :password %>
+    <%= f.text_field :password %>
+  </div>
+
   <%= f.submit t('actions.publish_to_test'), class: 'govuk-button editor-button' %>
 <% end %>
 

--- a/app/views/publish/index.html.erb
+++ b/app/views/publish/index.html.erb
@@ -17,21 +17,6 @@
 <%= form_for(@publish_service_creation_dev, url: publish_index_path(service.service_id)) do |f| %>
   <%= render 'form', f: f, deployment_environment: 'dev' %>
 
-  <div class="govuk-form-group">
-    <%= f.check_box :require_authentication %>
-    <%= f.label :require_authentication %>
-  </div>
-
-  <div class="govuk-form-group">
-    <%= f.label :username %>
-    <%= f.text_field :username %>
-  </div>
-
-  <div class="govuk-form-group">
-    <%= f.label :password %>
-    <%= f.text_field :password %>
-  </div>
-
   <%= f.submit t('actions.publish_to_test'), class: 'govuk-button editor-button' %>
 <% end %>
 

--- a/config/publisher/cloud_platform/config_map.yaml.erb
+++ b/config/publisher/cloud_platform/config_map.yaml.erb
@@ -4,5 +4,9 @@ metadata:
   name: <%= config_map_name %>
   namespace: <%= namespace %>
 data: <% config_map.each do |configuration|  %>
-  <%= configuration.name %>: "<%= configuration.value %>"
+  <% if configuration.name == 'ENCODED_PUBLIC_KEY' %>
+    <%= configuration.name %>: "<%= configuration.encode64 %>"
+  <% else %>
+    <%= configuration.name %>: "<%= configuration.decrypt_value %>"
+  <% end %>
 <% end %>

--- a/config/publisher/cloud_platform/secrets.yaml.erb
+++ b/config/publisher/cloud_platform/secrets.yaml.erb
@@ -4,5 +4,5 @@ metadata:
   name: <%= secret_name %>
   namespace: <%= namespace %>
 data: <% secrets.each do |secret|  %>
-  <%= secret.name.downcase %>: "<%= secret.value %>"
+  <%= secret.name.downcase %>: "<%= secret.encode64 %>"
 <% end %>

--- a/deploy/fb-editor-chart/templates/deployment.yaml
+++ b/deploy/fb-editor-chart/templates/deployment.yaml
@@ -148,6 +148,16 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: encoded_private_key
+          - name: ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: encryption_key
+          - name: ENCRYPTION_SALT
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: encryption_salt
           # secrets created by terraform
           # which may or may not depend on values
           # canonically defined in secrets.tfvars

--- a/deploy/fb-editor-chart/templates/secrets.yaml
+++ b/deploy/fb-editor-chart/templates/secrets.yaml
@@ -9,3 +9,5 @@ data:
   auth0_client_id: {{ .Values.auth0_client_id }}
   auth0_client_secret: {{ .Values.auth0_client_secret }}
   encoded_private_key: {{ .Values.encoded_private_key}}
+  encryption_key: {{ .Values.encryption_key }}
+  encryption_salt: {{ .Values.encryption_salt }}

--- a/spec/models/service_configuration_spec.rb
+++ b/spec/models/service_configuration_spec.rb
@@ -60,4 +60,34 @@ RSpec.describe ServiceConfiguration, type: :model do
       end
     end
   end
+
+  context 'encrypting and decrypting values' do
+    let(:service_configuration) do
+      create(:service_configuration, :dev, :username, value: 'r2d2')
+    end
+
+    describe '#before_save' do
+      context 'encrypting value' do
+        it 'saves a encrypted value' do
+          expect(service_configuration.value).not_to eq('r2d2')
+        end
+      end
+    end
+
+    describe '#decrypt_value' do
+      context 'decrypting value' do
+        it 'decrypts a value from the db' do
+          expect(service_configuration.decrypt_value).to eq('r2d2')
+        end
+      end
+    end
+
+    describe '#encode64' do
+      context 'base64 encoded value' do
+        it 'base64 encodes the value' do
+          expect(service_configuration.encode64).to eq(Base64.strict_encode64('r2d2'))
+        end
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,8 @@
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 ENV['PLATFORM_ENV'] = 'test'
+ENV['ENCRYPTION_KEY'] = 'darth'
+ENV['ENCRYPTION_SALT'] = 'vader'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/spec/services/default_configuration_spec.rb
+++ b/spec/services/default_configuration_spec.rb
@@ -6,19 +6,14 @@ RSpec.describe DefaultConfiguration do
     before { default_configuration.create }
 
     context 'generates private/public keys' do
-      let(:decode) do
-        lambda do |value|
-          Base64.decode64(value)
-        end
-      end
       let(:created_configuration) do
         ServiceConfiguration.where(service_id: service.service_id)
       end
       let(:private_keys) do
-        created_configuration.where(name: 'ENCODED_PRIVATE_KEY').pluck(:value).map(&decode)
+        created_configuration.where(name: 'ENCODED_PRIVATE_KEY').map(&:decrypt_value)
       end
       let(:public_keys) do
-        created_configuration.where(name: 'ENCODED_PUBLIC_KEY').pluck(:value).map(&decode)
+        created_configuration.where(name: 'ENCODED_PUBLIC_KEY').map(&:decrypt_value)
       end
       let(:service_configuration) do
         created_configuration.map do |service_configuration|

--- a/spec/services/publish_service_creation_spec.rb
+++ b/spec/services/publish_service_creation_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PublishServiceCreation, type: :model do
 
     context 'when configuration exists' do
       let!(:username_config) do
-        create(:service_configuration, :dev, :username, service_id: service_id)
+        create(:service_configuration, :dev, :username, value: 'x-wing', service_id: service_id)
       end
 
       it 'returns the value decoded' do
@@ -141,10 +141,10 @@ RSpec.describe PublishServiceCreation, type: :model do
     context 'when require authentication' do
       context 'when existing username and password' do
         let!(:username_config) do
-          create(:service_configuration, :dev, :username, service_id: service_id)
+          create(:service_configuration, :dev, :username, value: 'executor', service_id: service_id)
         end
         let!(:password_config) do
-          create(:service_configuration, :dev, :password, service_id: service_id)
+          create(:service_configuration, :dev, :password, value: 'vader-ship', service_id: service_id)
         end
         let(:attributes) do
           {
@@ -161,11 +161,11 @@ RSpec.describe PublishServiceCreation, type: :model do
         end
 
         it 'updates username in base64' do
-          expect(username_config.reload.value).to eq(Base64.strict_encode64('executor'))
+          expect(username_config.reload.decrypt_value).to eq('executor')
         end
 
         it 'updates password in base64' do
-          expect(password_config.reload.value).to eq(Base64.strict_encode64('vader-ship'))
+          expect(password_config.reload.decrypt_value).to eq('vader-ship')
         end
       end
 
@@ -197,12 +197,12 @@ RSpec.describe PublishServiceCreation, type: :model do
 
         it 'creates username in base64' do
           expect(username_config).to be_present
-          expect(username_config.value).to eq(Base64.strict_encode64('executor'))
+          expect(username_config.decrypt_value).to eq('executor')
         end
 
         it 'creates password in base64' do
           expect(password_config).to be_present
-          expect(password_config.reload.value).to eq(Base64.strict_encode64('vader-ship'))
+          expect(password_config.reload.decrypt_value).to eq('vader-ship')
         end
       end
     end

--- a/spec/services/publisher/utils/kubernetes_configuration_spec.rb
+++ b/spec/services/publisher/utils/kubernetes_configuration_spec.rb
@@ -8,22 +8,28 @@ RSpec.describe Publisher::Utils::KubernetesConfiguration do
       platform_environment: 'test',
       deployment_environment: 'dev',
       service_configuration: [
-        build(:service_configuration, name: 'ENCODED_PRIVATE_KEY', value: encoded_private_key),
-        build(:service_configuration, name: 'ENCODED_PUBLIC_KEY', value: encoded_public_key),
-        build(:service_configuration, name: 'BASIC_AUTH_USER', value: 'ZHJvaWQ='),
-        build(:service_configuration, name: 'BASIC_AUTH_PASS', value: 'cjJkMg=='),
+        build(:service_configuration, name: 'ENCODED_PRIVATE_KEY', value: private_key),
+        build(:service_configuration, name: 'ENCODED_PUBLIC_KEY', value: public_key),
+        build(:service_configuration, name: 'BASIC_AUTH_USER', value: basic_auth_user),
+        build(:service_configuration, name: 'BASIC_AUTH_PASS', value: basic_auth_pass),
       ]
     )
   end
-  let(:encoded_private_key) do
-    Base64.strict_encode64(
+  let(:private_key) do
+    EncryptionService.new.encrypt(
       File.read(Rails.root.join('spec', 'fixtures', 'private_key'))
     )
   end
-  let(:encoded_public_key) do
-    Base64.strict_encode64(
+  let(:public_key) do
+    EncryptionService.new.encrypt(
       File.read(Rails.root.join('spec', 'fixtures', 'public_key'))
     )
+  end
+  let(:basic_auth_user) do
+    EncryptionService.new.encrypt('droid')
+  end
+  let(:basic_auth_pass) do
+    EncryptionService.new.encrypt('r2d2')
   end
 
   before do


### PR DESCRIPTION
This adds the username and password for basic authentication as well as
encrypting all the service configuration values in the DB.

This includes the private and public keys. However the public key which
resides in the config still needs to be base64 encoded when written to
the config_map.yaml. This is because the datastore ServiceTokenCacheClient
does a base64 decode after retrieving the key. The service token cache
just looks for the key 'ENCODED_PUBLIC_KEY' in the config map and passes
back to the requesting app.

The 'ENCODED_' part of both keys relates to the time they are written to
the yaml files, _not_ when they are written to the DB.

https://trello.com/c/9BnRRaD5/1228-publish-mechanism-add-username-and-password

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>