### PR TITLE
Reorganise schemas and bump metadata-presenter version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'daemons'
 #     branch: 'some-branch'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.6.1'
+gem 'metadata_presenter', '0.7.0'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.6.1)
+    metadata_presenter (0.7.0)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -319,7 +319,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.5.0)
   hashie
   listen (~> 3.4)
-  metadata_presenter (= 0.6.1)
+  metadata_presenter (= 0.7.0)
   omniauth
   omniauth-auth0 (~> 2.5.0)
   omniauth-rails_csrf_protection (~> 0.1)

--- a/spec/generators/new_component_generator_spec.rb
+++ b/spec/generators/new_component_generator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe NewComponentGenerator do
         it 'creates valid text field component metadata' do
           expect(
             MetadataPresenter::ValidateSchema.validate(
-              generator.to_metadata, component_type
+              generator.to_metadata, "component.#{component_type}"
             )
           ).to be(valid)
         end


### PR DESCRIPTION
Fix test due to reorganisation of schemas in the metadata-presenter

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>