### PR TITLE
Required Validation as default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,12 @@ gem 'daemons'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
- gem 'metadata_presenter',
-     github: 'ministryofjustice/fb-metadata-presenter',
-     branch: 'component/number'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'component/number'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-#gem 'metadata_presenter', '0.8.0'
+gem 'metadata_presenter', '0.8.2'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.5.0'

--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,12 @@ gem 'daemons'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'some-branch'
+ gem 'metadata_presenter',
+     github: 'ministryofjustice/fb-metadata-presenter',
+     branch: 'component/number'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.8.0'
+#gem 'metadata_presenter', '0.8.0'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.5.0'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'daemons'
 #     branch: 'some-branch'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.7.1'
+gem 'metadata_presenter', '0.8.0'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 35b42b658bdeba0198739481ee545caf17c5f6ef
+  branch: component/number
+  specs:
+    metadata_presenter (0.8.2)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (>= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 6.0.3.4, < 6.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -144,11 +155,6 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.8.0)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (>= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 6.0.3.4, < 6.2.0)
     method_source (1.0.0)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
@@ -319,7 +325,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.5.0)
   hashie
   listen (~> 3.4)
-  metadata_presenter (= 0.8.0)
+  metadata_presenter!
   omniauth
   omniauth-auth0 (~> 2.5.0)
   omniauth-rails_csrf_protection (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 35b42b658bdeba0198739481ee545caf17c5f6ef
-  branch: component/number
-  specs:
-    metadata_presenter (0.8.2)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (>= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 6.0.3.4, < 6.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -155,6 +144,11 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
+    metadata_presenter (0.8.2)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (>= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 6.0.3.4, < 6.2.0)
     method_source (1.0.0)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
@@ -325,7 +319,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.5.0)
   hashie
   listen (~> 3.4)
-  metadata_presenter!
+  metadata_presenter (= 0.8.2)
   omniauth
   omniauth-auth0 (~> 2.5.0)
   omniauth-rails_csrf_protection (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk_design_system_formbuilder (2.1.7)
+    govuk_design_system_formbuilder (2.1.8)
       actionview (>= 5.2)
       activemodel (>= 5.2)
       activesupport (>= 5.2)
@@ -144,7 +144,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.7.1)
+    metadata_presenter (0.8.0)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -319,7 +319,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.5.0)
   hashie
   listen (~> 3.4)
-  metadata_presenter (= 0.7.1)
+  metadata_presenter (= 0.8.0)
   omniauth
   omniauth-auth0 (~> 2.5.0)
   omniauth-rails_csrf_protection (~> 0.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   helper_method :service
 
   def editable?
-    true
+    !request.script_name.include?('preview')
   end
   helper_method :editable?
 

--- a/app/generators/new_component_generator.rb
+++ b/app/generators/new_component_generator.rb
@@ -1,4 +1,5 @@
 class NewComponentGenerator
+  DEFAULT_VALIDATION = { 'required' => true }.freeze
   attr_reader :component_type, :page_url, :components
 
   def initialize(component_type:, page_url:, components: [])
@@ -13,6 +14,12 @@ class NewComponentGenerator
     metadata.tap do
       metadata['_id'] = component_id
       metadata['name'] = component_id
+
+      if metadata['validation'].present?
+        metadata['validation'].merge!(DEFAULT_VALIDATION)
+      else
+        metadata['validation'] = DEFAULT_VALIDATION
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,9 @@ Rails.application.routes.draw do
           patch 'update_form_information'
         end
       end
+
+      mount MetadataPresenter::Engine => '/preview', as: :preview
     end
-    mount MetadataPresenter::Engine => '/preview', as: :preview
   end
 
   root to: 'services#index'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe ApplicationController do
+  describe '#editable?' do
+    before do
+      allow(
+        controller.request
+      ).to receive(:script_name).and_return(script_name)
+    end
+
+    context 'when editing a page' do
+      let(:script_name) { 'services/1/pages/2/edit' }
+
+      it 'returns true' do
+        expect(controller).to be_editable
+      end
+    end
+
+    context 'when previewing a page' do
+      let(:script_name) { 'services/1/preview' }
+
+      it 'returns true' do
+        expect(controller).to_not be_editable
+      end
+    end
+  end
+end

--- a/spec/generators/new_component_generator_spec.rb
+++ b/spec/generators/new_component_generator_spec.rb
@@ -1,29 +1,54 @@
 RSpec.describe NewComponentGenerator do
   subject(:generator) do
-    described_class.new(component_type: component_type, page_url: page_url, components: components)
+    described_class.new(
+      component_type: component_type,
+      page_url: page_url,
+      components: components
+    )
   end
 
   describe '#to_metadata' do
     context 'valid component metadata' do
-
       let(:valid) { true }
 
-      context 'text component' do
-        let(:component_type) { 'text' }
-        let(:page_url) { 'some-page' }
-        let(:components) { [] }
+      %w(text textarea number).each do |component|
+        context "when component '#{component}'" do
+          let(:component_type) { component }
+          let(:page_url) { 'some-page' }
+          let(:components) { [] }
 
-        it 'creates valid text field component metadata' do
-          expect(
-            MetadataPresenter::ValidateSchema.validate(
-              generator.to_metadata, "component.#{component_type}"
-            )
-          ).to be(valid)
-        end
+          it 'creates valid text field component metadata' do
+            expect(
+              MetadataPresenter::ValidateSchema.validate(
+                generator.to_metadata, "component.#{component_type}"
+              )
+            ).to be(valid)
+          end
 
-        it 'generates the component id' do
-          expect(generator.to_metadata['_id']).to eq('some-page_text_1')
+          it 'generates the component id' do
+            expect(
+              generator.to_metadata['_id']
+            ).to eq("some-page_#{component}_1")
+          end
+
+          it 'generates required validation as default' do
+            expect(
+              generator.to_metadata['validation']
+            ).to include('required' => true)
+          end
         end
+      end
+    end
+
+    context "when component has other default validation" do
+      let(:component_type) { 'number' }
+      let(:page_url) { 'some-page' }
+      let(:components) { [] }
+
+      it 'generates number validation as default' do
+        expect(
+          generator.to_metadata['validation']
+        ).to include('number' => true)
       end
     end
 


### PR DESCRIPTION
## Context

This moves the responsibility of making the components required by default on the editor instead of on the default metadata definitions.

I also made the preview works (but only accessible via URL `/services/:service_id/preview`)

## Do not merge

Do not merge until the PR is merged: https://github.com/ministryofjustice/fb-metadata-presenter/pull/59