### PR TITLE
Component/date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'daemons'
 #     branch: 'component/number'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.8.2'
+gem 'metadata_presenter', '0.12.0'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.8.2)
+    metadata_presenter (0.12.0)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -319,7 +319,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.5.0)
   hashie
   listen (~> 3.4)
-  metadata_presenter (= 0.8.2)
+  metadata_presenter (= 0.12.0)
   omniauth
   omniauth-auth0 (~> 2.5.0)
   omniauth-rails_csrf_protection (~> 0.1)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,6 @@
 class PagesController < FormController
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+  before_action :assign_required_objects, only: [:edit, :update]
 
   def create
     @page_creation = PageCreation.new(page_creation_params)
@@ -11,13 +12,7 @@ class PagesController < FormController
     end
   end
 
-  def edit
-    @page = service.find_page_by_uuid(params[:page_uuid])
-  end
-
   def update
-    @page = service.find_page_by_uuid(params[:page_uuid])
-
     @metadata_updater = MetadataUpdater.new(page_update_params)
 
     if @metadata_updater.update
@@ -65,4 +60,13 @@ class PagesController < FormController
     ''
   end
   helper_method :reserved_submissions_path
+
+  private
+
+  # The metadata presenter gem requires this objects to render a page
+  #
+  def assign_required_objects
+    @page = service.find_page_by_uuid(params[:page_uuid])
+    @page_answers = MetadataPresenter::PageAnswers.new(@page, {})
+  end
 end

--- a/brakeman.ignore
+++ b/brakeman.ignore
@@ -3,7 +3,7 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "e7a712bc09393b5494d0566c761eebfff983b805e29c590f886babe58a5370f9",
+      "fingerprint": "2f7dda0f37fc0343dc737277d31c3c3ce95d50274b8bf339f3bcdbd9235e7896",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/pages/edit.html.erb",
@@ -14,8 +14,8 @@
         {
           "type": "controller",
           "class": "PagesController",
-          "method": "edit",
-          "line": 16,
+          "method": "update",
+          "line": 21,
           "file": "app/controllers/pages_controller.rb",
           "rendered": {
             "name": "pages/edit",
@@ -29,9 +29,9 @@
       },
       "user_input": "params[:page_uuid]",
       "confidence": "Weak",
-      "note": "The template is chosen after finding the correct page using the UUID, so this is fine"
+      "note": ""
     }
   ],
-  "updated": "2021-01-25 17:11:13 +0000",
-  "brakeman_version": "4.10.1"
+  "updated": "2021-02-15 09:49:44 -0300",
+  "brakeman_version": "5.0.0"
 }


### PR DESCRIPTION
[Trello card](https://trello.com/c/l9QOuavK/1236-add-date-component-to-a-single-question-page)

## Context

This adds the date feature specs to the runner and bumps the version in relation to the work done on https://github.com/ministryofjustice/fb-metadata-presenter/pull/63/files

## Some points

The page answers object was introduced on 0.9.0 so we need to assign those objects in order for the edit and page preview to work.

