### PR TITLE
Feature/preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,12 @@ gem 'daemons'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-#gem 'metadata_presenter',
-#    github: 'ministryofjustice/fb-metadata-presenter',
-#    branch: 'radio-buttons-default-items'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'feature/preview'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.13.2'
+gem 'metadata_presenter', '0.13.3'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.13.2)
+    metadata_presenter (0.13.3)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -319,7 +319,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.5.0)
   hashie
   listen (~> 3.4)
-  metadata_presenter (= 0.13.2)
+  metadata_presenter (= 0.13.3)
   omniauth
   omniauth-auth0 (~> 2.5.0)
   omniauth-rails_csrf_protection (~> 0.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,9 +16,9 @@ class ApplicationController < ActionController::Base
   helper_method :back_link
 
   def save_user_data
-    return {} if params[:answers].blank? || params[:service_id].blank?
+    return {} if params[:answers].blank? || params[:id].blank?
 
-    service_id = params[:service_id]
+    service_id = params[:id]
     session[service_id] ||= {}
     session[service_id]['user_data'] ||= {}
 
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
   end
 
   def load_user_data
-    user_data = session[params[:service_id]] || {}
+    user_data = session[params[:id]] || {}
 
     user_data['user_data'] || {}
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -71,6 +71,15 @@ class PagesController < FormController
   end
   helper_method :reserved_submissions_path
 
+  def page_answers_presenters
+    MetadataPresenter::PageAnswersPresenter.map(
+      view: view_context,
+      pages: service.pages,
+      answers: {}
+    )
+  end
+  helper_method :page_answers_presenters
+
   private
 
   # The metadata presenter gem requires this objects to render a page

--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -1,0 +1,3 @@
+class PreviewController < ApplicationController
+  layout 'metadata_presenter/application'
+end

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -1,3 +1,7 @@
+<%= link_to t('actions.preview_form'),
+  preview_service_path(service.service_id),
+  class: 'govuk-button editor-button',
+  target: '_blank' %>
 <h1><%= t('pages.form') %></h1>
 
 <div class="form-overview">
@@ -14,8 +18,15 @@
           data-activator-text="<%= t('pages.actions') %>"
           data-activator-classname="form-step_button"
           data-document-event="FormStepContextMenuSelection">
-        <li><a href="#edit-page">Edit page</a></li>
-        <li><a href="#preview-page">Preview page</a></li>
+          <li>
+            <%= link_to t('actions.edit_page'),
+              edit_page_path(service.service_id, page.id) %>
+          </li>
+          <li>
+            <%= link_to t('actions.preview_page'),
+              File.join(preview_service_path(service.service_id), page.url),
+              target: '_blank' %>
+          </li>
         <li><a href="#add-page-here">Add page here</a></li>
         <li><a href="#delete-page" class="destructive">Delete page...</a></li>
       </ul>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -13,6 +13,7 @@
             </span>
             <span class="actions">
               <%= link_to t('services.edit'), edit_service_path(service.id), class: "govuk-link edit" %>
+              <%= link_to t('services.preview'), preview_service_path(service.id), class: "govuk-link", target: '_blank' %>
             </span>
           </li>
         <% end %>

--- a/config/initializers/metadata_presenter.rb
+++ b/config/initializers/metadata_presenter.rb
@@ -1,0 +1,1 @@
+MetadataPresenter.parent_controller = '::PreviewController'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,7 +8,7 @@ en:
     publish_to_test: 'Publish to Test'
     publish_to_live: 'Publish to Live'
     edit_page: 'Edit Page'
-    preview_page: 'Preview Page'
+    preview_page: 'Preview page'
     preview_form: 'Preview form'
   pages:
     form: 'Form pages'
@@ -32,6 +32,7 @@ en:
     live_sub_heading: 'Live is where your form is hosted publicly when your service is running.'
   services:
     edit: 'Edit'
+    preview: 'Preview'
     create: 'Create a new form'
     cancel: 'Cancel'
   activemodel:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,9 @@ en:
     save: 'Save'
     publish_to_test: 'Publish to Test'
     publish_to_live: 'Publish to Live'
+    edit_page: 'Edit Page'
+    preview_page: 'Preview Page'
+    preview_form: 'Preview form'
   pages:
     form: 'Form pages'
     name: 'Pages'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -22,4 +22,38 @@ RSpec.describe ApplicationController do
       end
     end
   end
+
+  describe '#save_user_data' do
+    context 'when saving user data to the session' do
+      let(:params) do
+        {
+          answers: { 'frodo' => 'samwise' },
+          id: '123456'
+        }
+      end
+
+      before do
+        allow(controller).to receive(:params).and_return(params)
+        controller.save_user_data
+      end
+
+      it 'saves it with the service id' do
+        expect(controller.session.to_h).to eq(
+          {
+            "123456" => {
+              "user_data" => {
+                "frodo" => "samwise"
+              }
+            }
+          }
+        )
+      end
+
+      it 'retrieves user data using the service id' do
+        expect(controller.load_user_data.to_h).to eq(
+          { "frodo" => "samwise" }
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds the preview functionality to the the page flow page as well as the forms list page.

It was necessary to swap the layout for the preview controller so that it uses the Presenters layout not the Editors.

Clicking the button or link will open the form in a new tab as if it was inside the runner.

User data is saved and loaded to and from the session.

Bump MetadataPresenter to 0.13.3

https://trello.com/c/opSQzaPH/1285-preview-form-from-button

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>

