### PR TITLE
Fix incomplete previous attempt to remove errors on close

### DIFF
--- a/app/javascript/src/component_activated_dialog.js
+++ b/app/javascript/src/component_activated_dialog.js
@@ -48,7 +48,8 @@ class ActivatedDialog {
       closeOnEscape: true,
       height: "auto",
       modal: true,
-      resizable: false
+      resizable: false,
+      close: this._config.onClose
     });
   }
 
@@ -58,7 +59,6 @@ class ActivatedDialog {
 
   close() {
     this.$node.dialog("close");
-    executeFunction(this._config.onClose);
   }
 }
 


### PR DESCRIPTION
Errors were visible after closing and reopening a dialog.
Previous fix only solved when 'cancel' button was clicked.
This should fix the issue no matter how the dialog is closed.