### PR TITLE
Add live step to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,33 @@ jobs:
           name: Run acceptance tests
           command: 'make acceptance-ci -s'
       - slack/status: *slack_status
+  build_and_deploy_to_live:
+    working_directory: ~/circle/git/fb-editor
+    docker: *ecr_image
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 19.03.13
+      - add_ssh_keys: *ssh_keys
+      - run: *base_environment_variables
+      - run: *deploy_scripts
+      - run:
+          name: build and push docker images
+          environment:
+            ENVIRONMENT_NAME: live
+          command: './deploy-scripts/bin/build'
+      - run:
+          name: deploy to live
+          environment:
+            APPLICATION_NAME: fb-editor
+            PLATFORM_ENV: live
+            K8S_NAMESPACE: formbuilder-saas-live
+          command: './deploy-scripts/bin/deploy'
+      - slack/status:
+          only_for_branches: main
+          success_message: ":rocket:  Successfully deployed to Live  :guitar:"
+          failure_message: ":alert:  Failed to deploy to Live  :try_not_to_cry:"
+          include_job_number_field: false
 
 workflows:
   version: 2
@@ -87,6 +114,14 @@ workflows:
             branches:
               only:
                 - main
+                - deploy/live
       - acceptance_tests:
           requires:
             - build_and_deploy_to_test
+      - confirm_live_deploy:
+          type: approval
+          requires:
+            - build_and_deploy_to_test
+      - build_and_deploy_to_live:
+          requires:
+            - confirm_live_deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,14 +114,13 @@ workflows:
             branches:
               only:
                 - main
-                - deploy/live
       - acceptance_tests:
           requires:
             - build_and_deploy_to_test
       - confirm_live_deploy:
           type: approval
           requires:
-            - build_and_deploy_to_test
+            - acceptance_tests
       - build_and_deploy_to_live:
           requires:
             - confirm_live_deploy

--- a/deploy/fb-editor-chart/templates/config_map.yaml
+++ b/deploy/fb-editor-chart/templates/config_map.yaml
@@ -9,6 +9,6 @@ data:
   PLATFORM_ENV: {{ .Values.environmentName }}
   RAILS_SERVE_STATIC_FILES: "true"
   AUTH0_DOMAIN: mojds-trial.eu.auth0.com
-  EDITOR_FULL_URL_ROOT: https://fb-editor-{{ .Values.environmentName }}.apps.live-1.cloud-platform.service.justice.gov.uk
+  EDITOR_FULL_URL_ROOT: https://{{ .Values.editor_host }}
   ENCODED_PUBLIC_KEY: {{ .Values.encoded_public_key }}
   METADATA_API_URL: http://fb-metadata-api-svc-{{ .Values.environmentName }}

--- a/deploy/fb-editor-chart/templates/ingress.yaml
+++ b/deploy/fb-editor-chart/templates/ingress.yaml
@@ -9,6 +9,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.editor_host }}
+    secretName: editor-tls-certificate
   rules:
   - host: {{ .Values.editor_host }}
     http:

--- a/deploy/fb-editor-chart/templates/ingress.yaml
+++ b/deploy/fb-editor-chart/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   tls:
   - hosts:
-    {{ .Values.editor_host }}
+    - {{ .Values.editor_host }}
   rules:
   - host: {{ .Values.editor_host }}
     http:

--- a/deploy/fb-editor-chart/templates/ingress.yaml
+++ b/deploy/fb-editor-chart/templates/ingress.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   tls:
   - hosts:
-    - fb-editor-{{ .Values.environmentName }}.apps.live-1.cloud-platform.service.justice.gov.uk
+    {{ .Values.editor_host }}
   rules:
-  - host: fb-editor-{{ .Values.environmentName }}.apps.live-1.cloud-platform.service.justice.gov.uk
+  - host: {{ .Values.editor_host }}
     http:
       paths:
       - path: /


### PR DESCRIPTION
## Context

Adds the deploy to live step to the CircleCI config.

The hostname will be different from the test and live so I decided to move this config to the *-deploy repo. See https://github.com/ministryofjustice/fb-editor-deploy/pull/5 for more info.
