### PR TITLE
Style the preview button correctly

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -373,3 +373,7 @@
     width: 100%;
   }
 }
+
+.fb-preview-button {
+  float: right;
+}

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -1,6 +1,6 @@
 <%= link_to t('actions.preview_form'),
   preview_service_path(service.service_id),
-  class: 'govuk-button editor-button',
+  class: 'govuk-button editor-button fb-govuk-button fb-preview-button',
   target: '_blank' %>
 <h1 class="govuk-heading-xl"><%= t('pages.form') %></h1>
 


### PR DESCRIPTION
Interactive buttons relating to editor functionality are blue. The preview button should also be on the right hand side of the flow page.

![Screenshot 2021-03-03 at 15 06 58](https://user-images.githubusercontent.com/3466862/109829101-245b3480-7c35-11eb-9099-2914733bcc1c.png)
