### PR TITLE
Login page and Footer

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,2 +1,5 @@
 class HomeController < ApplicationController
+  def show
+    @sign_in_url = '/services'
+  end
 end

--- a/app/helpers/auth0_helper.rb
+++ b/app/helpers/auth0_helper.rb
@@ -15,7 +15,8 @@ module Auth0Helper
   # Is the user signed in?
   # @return [Boolean]
   def user_signed_in?
-    session.try(:[],:user_id).present?
+    request.path != '/'
+    # session.try(:[],:user_id).present?
   end
 
   def identify_user(user_id = session[:user_id])

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -1,4 +1,4 @@
-/* Note: 
+/* Note:
  * These style rely on some sass code from the govuk design files
  **/
 
@@ -356,6 +356,33 @@
   }
 }
 
+// For when a user is signed in
+.govuk-navigation-header {
+  float: right;
+  color:  govuk-colour("white");
+
+  a {
+    &:link {
+      text-decoration: none;
+    }
+
+    &,
+    &:hover {
+      color:  govuk-colour("white");
+      font: inherit;
+      text-decoration: underline;
+    }
+
+    &:hover {
+      color:  govuk-colour("white");
+    }
+  }
+
+  li {
+    display: inline;
+    margin-left: govuk-spacing(2);
+  }
+}
 
 /* Override GovUK styles
  * --------------------- */

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -404,3 +404,9 @@
 .fb-preview-button {
   float: right;
 }
+
+.fb-editor-footer {
+  position: absolute;
+  width: 100%;
+  bottom: 0;
+}

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,7 +1,31 @@
-  <div>
-    <% if Rails.env.development? %>
-      <%= link_to t('.sign_in'), '/auth/developer', method: :post, class: 'button button-start' %>
-    <% else %>
-      <%= link_to t('.sign_in'), '/auth/auth0', method: :post, class: 'button button-start' %>
-    <% end %>
+<div class="fb-main-grid-wrapper" data-block-id="home" data-block-type="page" data-block-pagetype="home">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-panel__title govuk-heading-xl" data-block-id="title" data-block-property="heading">
+        <%= t('.title') %>
+      </h1>
+
+    <div class="govuk-panel__body">
+      <p><%= t('.lede')%></p>
+    </div>
+
+      <div>
+        <p><%= t('.body', formbuilder_slack: "#{ENV['SLACK_CHANNEL']}").html_safe %></p>
+      </div>
+
+      <div class="govuk-inset-text">
+        <p><%= t('.callout') %></p>
+      </div>
+
+      <%= form_tag(@sign_in_url, method: :get) do %>
+        <button class='editor-button govuk-button fb-govuk-button  govuk-!-margin-top-2'>
+          <%= t('.sign_in') %>
+          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+          </svg>
+        </button>
+      <% end %>
+    </div>
   </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,9 +13,6 @@
     <%= render partial: 'partials/header' %>
 
     <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing govuk-width-container govuk-body-m" id="main-content" role="main">
-      <% if user_signed_in? %>
-        <%= link_to t('.sign_out'), user_session_path, method: :delete %>
-      <% end %>
 
       <%= yield %>
     </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,5 +16,7 @@
 
       <%= yield %>
     </main>
+
+    <%= render partial: 'partials/footer' %>
   </body>
 </html>

--- a/app/views/layouts/form.html.erb
+++ b/app/views/layouts/form.html.erb
@@ -17,5 +17,7 @@
 
       <%= yield %>
     </main>
+
+    <%= render partial: 'partials/footer' %>
   </body>
 </html>

--- a/app/views/layouts/form.html.erb
+++ b/app/views/layouts/form.html.erb
@@ -14,9 +14,6 @@
     <%= render partial: 'partials/form-navigation' %>
 
     <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing govuk-width-container govuk-body-m" id="main-content" role="main">
-      <% if user_signed_in? %>
-        <%= link_to t('.sign_out'), user_session_path, method: :delete %>
-      <% end %>
 
       <%= yield %>
     </main>

--- a/app/views/partials/_footer.html.erb
+++ b/app/views/partials/_footer.html.erb
@@ -1,0 +1,19 @@
+<footer class="govuk-footer fb-editor-footer" role="contentinfo">
+  <div class="govuk-width-container ">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+        <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+          <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+        </svg>
+        <span class="govuk-footer__licence-description">
+          All content is available under the
+          <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -7,5 +7,17 @@
     <a href="/" class="govuk-header__link govuk-header__link--service-name">
       <%= t('header.service_name') %>
     </a>
+
+    <% if user_signed_in? %>
+      <ul class="govuk-navigation govuk-navigation-header govuk-!-font-size-19" aria-labelledby="editor-navigation-header">
+        <li>
+          <%= link_to t('.forms'), services_path %>
+        </li>
+
+        <li>
+          <%= link_to t('.sign_out'), user_session_path, method: :delete %>
+        </li>
+      </ul>
+    <% end %>
   </div>
 </header>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,13 @@ en:
     service_name: "MoJ Forms"
     home_link_text: "Back to Home"
     home_link_alt: "Ministry of Justice Logo - homepage"
+  home:
+    show:
+      title: MoJ Forms
+      lede: Prototype, test and publish online forms quickly and easily
+      body: 'To find out more about MoJ Forms, please email us at <a href="mailto:moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a>, or you can also <a href="%{formbuilder_slack}">ask us a question on Slack</a>.'
+      callout: You will need a @digital.justice.gov.uk or @justice.gov.uk email address to use MoJ Forms.
+      sign_in: Sign in
   actions:
     save: 'Save'
     publish_to_test: 'Publish to Test'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,10 @@ en:
     service_name: "MoJ Forms"
     home_link_text: "Back to Home"
     home_link_alt: "Ministry of Justice Logo - homepage"
+  partials:
+    header:
+      forms: Forms
+      sign_out: Sign out
   home:
     show:
       title: MoJ Forms

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,5 +28,5 @@ Rails.application.routes.draw do
     end
   end
 
-  root to: 'services#index'
+  root to: 'home#show'
 end


### PR DESCRIPTION
## Login page

Created the login page layout and content. Slack channel will be injected later. The sign in link just takes the user to the services page currently since they have already gotten passed basic auth.

## Header navigation

The forms link and sign out link are now there. The latter does a faux session destroy before redirecting to the login page. It only appears if not on the login page but will later be changed to check whether a user is logged in or not.

## Add footer

This currently does not contain any accessibility, privacy or cookies links. These will be added later.

## Screenshots


![Screenshot 2021-03-08 at 21 49 41](https://user-images.githubusercontent.com/3466862/110451280-f4d87c00-80bb-11eb-9e86-f08a325c15c8.png)


![Screenshot 2021-03-08 at 21 49 52](https://user-images.githubusercontent.com/3466862/110451292-f7d36c80-80bb-11eb-87c8-091b9eda25ac.png)
