### PR TITLE
Email Submission Configuration

### DIFF
--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -18,6 +18,9 @@ class EditorApp < SitePrism::Page
   element :form_name_field, :field, 'Form name'
   element :save_button, :button, 'Save'
 
+  element :submission_settings_link, :link, 'Submission settings'
+  element :send_by_email_link, :link, 'Send by email'
+
   element :page_url_field, :field, 'The page’s relative url - it must not contain any spaces', visible: false
   element :new_page_form, '#new_page', visible: false
 

--- a/app/controllers/settings/email_controller.rb
+++ b/app/controllers/settings/email_controller.rb
@@ -1,0 +1,50 @@
+class Settings::EmailController < FormController
+  before_action :assign_form_objects
+
+  def create
+    @email_settings = EmailSettings.new(
+      email_settings_params.merge(service: service)
+    )
+
+    if @email_settings.valid?
+      EmailSettingsUpdater.new(
+        email_settings: @email_settings,
+        service: service
+      ).create_or_update!
+
+      redirect_to settings_email_index_path(service_id: service.service_id)
+    else
+      if email_settings_params[:deployment_environment] == 'dev'
+        @email_settings_dev = @email_settings
+      else
+        @email_settings_production = @email_settings
+      end
+      render :index, status: 422
+    end
+  end
+
+  private
+
+  def email_settings_params
+    params.require(:email_settings).permit(
+      :deployment_environment,
+      :send_by_email,
+      :service_email_output,
+      :service_email_subject,
+      :service_email_body,
+      :service_email_pdf_heading,
+      :service_email_pdf_subheading
+    )
+  end
+
+  def assign_form_objects
+    @email_settings_dev = EmailSettings.new(
+      service: service,
+      deployment_environment: 'dev'
+    )
+    @email_settings_production = EmailSettings.new(
+      service: service,
+      deployment_environment: 'production'
+    )
+  end
+end

--- a/app/controllers/settings/form_information_controller.rb
+++ b/app/controllers/settings/form_information_controller.rb
@@ -1,0 +1,24 @@
+class Settings::FormInformationController < FormController
+  def index
+    @settings = Settings.new(service_name: service.service_name)
+  end
+
+  def create
+    @settings = Settings.new(service_params)
+
+    if @settings.update
+      redirect_to settings_form_information_index_path(service.service_id)
+    else
+      render :index
+    end
+  end
+
+  private
+
+  def service_params
+    params.require(:service).permit(:service_name).merge(
+      service_id: service.service_id,
+      latest_metadata: service.to_h
+    )
+  end
+end

--- a/app/controllers/settings/submission_controller.rb
+++ b/app/controllers/settings/submission_controller.rb
@@ -1,0 +1,5 @@
+class Settings::SubmissionController < FormController
+  def index
+    @settings = Settings.new(service_name: service.service_name)
+  end
+end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,24 +1,2 @@
 class SettingsController < FormController
-  def form_information
-    @settings = Settings.new(service_name: service.service_name)
-  end
-
-  def update_form_information
-    @settings = Settings.new(service_params)
-
-    if @settings.update
-      redirect_to form_information_settings_path(service.service_id)
-    else
-      render :form_information
-    end
-  end
-
-  private
-
-  def service_params
-    params.require(:service).permit(:service_name).merge(
-      service_id: service.service_id,
-      latest_metadata: service.to_h
-    )
-  end
 end

--- a/app/models/email_settings.rb
+++ b/app/models/email_settings.rb
@@ -1,0 +1,73 @@
+class EmailSettings
+  include ActiveModel::Model
+  attr_accessor :deployment_environment,
+                :service,
+                :send_by_email,
+                :service_email_output,
+                :service_email_subject,
+                :service_email_body,
+                :service_email_pdf_heading,
+                :service_email_pdf_subheading
+
+  validates :deployment_environment, inclusion: {
+    in: Rails.application.config.deployment_environments
+  }
+
+  validates :service_email_output, presence: true, if: :send_by_email?
+
+  validates :service_email_output, format: { with: URI::MailTo::EMAIL_REGEXP },
+    allow_blank: true
+
+  def send_by_email_checked?
+    send_by_email? || SubmissionSetting.find_by(
+      service_id: service.service_id,
+      deployment_environment: deployment_environment
+    ).try(:send_email?)
+  end
+
+  def send_by_email?
+    send_by_email == '1'
+  end
+
+  def service_email_output
+    settings_for(:service_email_output)
+  end
+
+  def service_email_subject
+    settings_for(:service_email_subject)
+  end
+
+  def service_email_body
+    settings_for(:service_email_body)
+  end
+
+  def service_email_pdf_heading
+    settings_for(:service_email_pdf_heading)
+  end
+
+  def service_email_pdf_subheading
+    settings_for(:service_email_pdf_subheading)
+  end
+
+  def settings_for(setting_name)
+    params(setting_name).presence ||
+      database(setting_name) ||
+        default_value(setting_name)
+  end
+
+  def database(setting_name)
+    ServiceConfiguration.find_by(
+      service_id: service.service_id,
+      deployment_environment: deployment_environment,
+      name: setting_name.upcase,
+    ).try(:decrypt_value)
+  end
+
+  def default_value(setting_name)
+    I18n.t("default_values.#{setting_name}", service_name: service.service_name)
+  end
+
+  def params(setting_name)
+    self.instance_variable_get(:"@#{setting_name}")
+  end
+end

--- a/app/models/email_settings_updater.rb
+++ b/app/models/email_settings_updater.rb
@@ -1,0 +1,85 @@
+class EmailSettingsUpdater
+  attr_reader :email_settings, :service
+
+  CONFIG_WITHOUT_DEFAULTS = %w(
+    SERVICE_EMAIL_OUTPUT
+    SERVICE_EMAIL_PDF_SUBHEADING
+  ).freeze
+
+  CONFIG_WITH_DEFAULTS = %w(
+    SERVICE_EMAIL_SUBJECT
+    SERVICE_EMAIL_BODY
+    SERVICE_EMAIL_PDF_HEADING
+  ).freeze
+
+  def initialize(email_settings:, service:)
+    @email_settings = email_settings
+    @service = service
+  end
+
+  def create_or_update!
+    ActiveRecord::Base.transaction do
+      save_submission_setting
+      save_config_without_defaults
+      save_config_with_defaults
+    end
+  end
+
+  def save_submission_setting
+    submission_setting = SubmissionSetting.find_or_initialize_by(
+      service_id: service.service_id,
+      deployment_environment: email_settings.deployment_environment
+    )
+    submission_setting.send_email = email_settings.send_by_email?
+    submission_setting.save!
+  end
+
+  def save_config_without_defaults
+    CONFIG_WITHOUT_DEFAULTS.each do |config|
+      if params(config).present?
+        create_or_update_the_service_configuration(config)
+      else
+        remove_the_service_configuration(config)
+      end
+    end
+  end
+
+  def save_config_with_defaults
+    CONFIG_WITH_DEFAULTS.each do |config|
+      if params(config).present?
+        create_or_update_the_service_configuration(config)
+      else
+        create_or_update_the_service_configuration_adding_default_value(config)
+      end
+    end
+  end
+
+  def params(config)
+    email_settings.params(config.downcase.to_sym)
+  end
+
+  def create_or_update_the_service_configuration(config)
+    setting = find_or_initialize_setting(config)
+    setting.value = params(config)
+    setting.save!
+  end
+
+  def create_or_update_the_service_configuration_adding_default_value(config)
+    setting = find_or_initialize_setting(config)
+    setting.value = email_settings.default_value(config.downcase.to_sym)
+    setting.save!
+  end
+
+  def remove_the_service_configuration(config)
+    setting = find_or_initialize_setting(config)
+    setting.destroy!
+  end
+
+  def find_or_initialize_setting(config)
+    ServiceConfiguration.find_or_initialize_by(
+      service_id: service.service_id,
+      deployment_environment: email_settings.deployment_environment,
+      name: config
+    )
+  end
+end

--- a/app/models/service_configuration.rb
+++ b/app/models/service_configuration.rb
@@ -1,5 +1,12 @@
 class ServiceConfiguration < ApplicationRecord
   SECRETS = %w(BASIC_AUTH_USER BASIC_AUTH_PASS ENCODED_PRIVATE_KEY).freeze
+  SUBMISSION = %w(
+    SERVICE_EMAIL_OUTPUT
+    SERVICE_EMAIL_SUBJECT
+    SERVICE_EMAIL_BODY
+    SERVICE_EMAIL_PDF_HEADING
+    SERVICE_EMAIL_PDF_SUBHEADING
+  )
   BASIC_AUTH_USER = 'BASIC_AUTH_USER'.freeze
   BASIC_AUTH_PASS = 'BASIC_AUTH_PASS'.freeze
 
@@ -17,6 +24,14 @@ class ServiceConfiguration < ApplicationRecord
 
   def secrets?
     name.in?(SECRETS)
+  end
+
+  def do_not_send_submission?
+    name.in?(SUBMISSION) &&
+      SubmissionSetting.find_by(
+        service_id: service_id,
+        deployment_environment: deployment_environment
+      ).try(:send_email?).blank?
   end
 
   def decrypt_value

--- a/app/models/submission_setting.rb
+++ b/app/models/submission_setting.rb
@@ -1,0 +1,6 @@
+class SubmissionSetting < ApplicationRecord
+  validates :service_id, :deployment_environment, presence: true
+  validates :deployment_environment, inclusion: {
+    in: Rails.application.config.deployment_environments
+  }
+end

--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -75,6 +75,17 @@ class Publisher
       }
     end
 
+    def submitter_url
+      Rails.application.config.platform_environments[:common][:submitter_url] % {
+        platform_environment: platform_environment,
+        deployment_environment: deployment_environment
+      }
+    end
+
+    def submission_encryption_key
+      ENV['SUBMISSION_ENCRYPTION_KEY']
+    end
+
     def resource_limits_cpu
       '150m'
     end
@@ -92,7 +103,7 @@ class Publisher
     end
 
     def config_map
-      service_configuration.reject(&:secrets?)
+      service_configuration.reject(&:secrets?).reject(&:do_not_send_submission?)
     end
 
     def secrets

--- a/app/views/settings/email/_form.html.erb
+++ b/app/views/settings/email/_form.html.erb
@@ -1,0 +1,59 @@
+<%= f.hidden_field :deployment_environment, value: deployment_environment %>
+
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text" id="configure-<%= deployment_environment %>">Configure</span>
+  </summary>
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h2 class="govuk-fieldset__heading">
+        <%= f.object.class.human_attribute_name :email_fieldset %>
+      </h2>
+    </legend>
+
+    <div class="govuk-form-group <%= !f.object.errors[:service_email_output].empty? ? 'govuk-form-group--error' : '' %> ">
+      <% f.object.errors[:service_email_output].each do |message| %>
+        <span class="govuk-error-message"><%= message %></span>
+      <% end %>
+      <%= f.label :service_email_output, class: "govuk-label" %>
+      <%= f.text_field :service_email_output, class: "govuk-input width-responsive-two-thirds" %>
+    </div>
+
+    <div class="govuk-form-group">
+      <%= f.label :service_email_subject, class: "govuk-label" %>
+      <%= f.text_field :service_email_subject, class: "govuk-input width-responsive-two-thirds" %>
+    </div>
+
+    <div class="govuk-form-group">
+      <%= f.label :service_email_body, class: "govuk-label" do %>
+        <%= f.object.class.human_attribute_name :service_email_body %>
+        <span class="govuk-hint"><%= f.object.class.human_attribute_name :service_email_body_hint %></span>
+    <% end %>
+      <%= f.text_area :service_email_body, class: "govuk-textarea width-responsive-two-thirds", rows: '5' %>
+    </div>
+  </fieldset>
+
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h2 class="govuk-fieldset__heading">
+        <%= f.object.class.human_attribute_name :pdf_fieldset %>
+      </h2>
+    </legend>
+
+    <a href="#" class="govuk-link">See sample PDF</a>
+
+    <div class="govuk-hint">
+      <%= f.object.class.human_attribute_name :pdf_hint %>
+    </div>
+
+    <div class="govuk-form-group">
+      <%= f.label :service_email_pdf_heading, class: "govuk-label" %>
+      <%= f.text_field :service_email_pdf_heading, class: "govuk-input width-responsive-two-thirds", rows: '5' %>
+    </div>
+
+    <div class="govuk-form-group">
+      <%= f.label :service_email_pdf_subheading, class: "govuk-label" %>
+      <%= f.text_field :service_email_pdf_subheading, class: "govuk-input width-responsive-two-thirds" %>
+    </div>
+  </fieldset>
+</details>

--- a/app/views/settings/email/index.html.erb
+++ b/app/views/settings/email/index.html.erb
@@ -1,0 +1,62 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('settings.submission.email.label') %></h1>
+    <p><%= t('settings.submission.email.help') %></p>
+
+    <%= form_for @email_settings_dev,
+      url: settings_email_index_path(service.service_id),
+      html: { id: 'email-submission-dev' } do |f| %>
+      <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h1 class="govuk-fieldset__heading">Test</h1>
+              </legend>
+            <div class="govuk-hint">Where others can view your form and you can ensure everything works before you launch.</div>
+            <div class="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <%= f.check_box :send_by_email, class: 'govuk-checkboxes__input',
+                  checked: f.object.send_by_email_checked? %>
+                <%= f.label :send_by_email,
+                  f.object.class.human_attribute_name(:send_by_email_dev),
+                  class: 'govuk-label govuk-checkboxes__label' %>
+              </div>
+            </div>
+          </fieldset>
+      </div>
+
+      <%= render 'form', f: f, deployment_environment: 'dev' %>
+
+      <button type="submit" class="govuk-button" data-module="govuk-button">
+        Save
+      </button>
+    <% end %>
+
+    <%= form_for @email_settings_production,
+      url: settings_email_index_path(service.service_id),
+      html: { id: 'email-submission-production' } do |f| %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h1 class="govuk-fieldset__heading">Live</h1>
+            </legend>
+          <div class="govuk-hint">Where your form is hosted publicly when your service is running.</div>
+          <div class="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <%= f.check_box :send_by_email, class: 'govuk-checkboxes__input',
+                checked: f.object.send_by_email_checked? %>
+              <%= f.label :send_by_email,
+                f.object.class.human_attribute_name(:send_by_email_production),
+                class: 'govuk-label govuk-checkboxes__label' %>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <%= render 'form', f: f, deployment_environment: 'production' %>
+
+      <button type="submit" class="govuk-button" data-module="govuk-button">
+        Save
+      </button>
+    <% end %>
+  </div>
+</div>

--- a/app/views/settings/form_information/index.html.erb
+++ b/app/views/settings/form_information/index.html.erb
@@ -1,9 +1,9 @@
 <h1 class="govuk-heading-xl"><%= t('settings.form_information') %></h1>
 
-<%= form_for @settings, as: :service, url: update_form_information_settings_path(service.service_id), method: :patch do |f| %>
+<%= form_for @settings, as: :service, url: settings_form_information_index_path(service.service_id) do |f| %>
   <div class="govuk-form-group <%= !f.object.errors.empty? ? 'govuk-form-group--error' :'' %>">
     <%= f.label :service_name, class: "govuk-label" do %>
-      <%= t('settings.form_information_label') %>
+      <%= f.object.class.human_attribute_name :service_name %>
       <span class="govuk-hint"><%= t('settings.form_information_help') %></span>
     <% end %>
     <% f.object.errors.each do |error|  %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -2,7 +2,10 @@
   <h2 id="settings-navigation-heading" class="govuk-heading-xl"><%= t('settings.name') %></h2>
   <ul aria-labelledby="settings-navigation-heading">
     <li>
-      <%= link_to t('settings.form_information'), form_information_settings_path(service.service_id), class: 'govuk-link' %>
+      <%= link_to t('settings.form_information'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %>
+    </li>
+    <li>
+      <%= link_to t('settings.submission.name'), settings_submission_index_path(service.service_id), class: 'govuk-link' %>
     </li>
   </ul>
 </nav>

--- a/app/views/settings/submission/index.html.erb
+++ b/app/views/settings/submission/index.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('settings.submission.name') %></h1>
+      <p class="govuk-body"><%= t('settings.submission.sub_heading') %></p>
+      <%= link_to t('settings.submission.email.label'), settings_email_index_path(service.service_id), class: 'govuk-link' %>
+  </div>
+</div>

--- a/config/initializers/service_environments.rb
+++ b/config/initializers/service_environments.rb
@@ -12,6 +12,7 @@ Rails.application.config.platform_environments =
     common: {
       namespace: 'formbuilder-services-%{platform_environment}-%{deployment_environment}',
       user_datastore_url: "http://fb-user-datastore-api-svc-%{platform_environment}-%{deployment_environment}.formbuilder-platform-%{platform_environment}-%{deployment_environment}/",
+      submitter_url: "http://fb-submitter-api-svc-%{platform_environment}-%{deployment_environment}.formbuilder-platform-%{platform_environment}-%{deployment_environment}/",
       container_port: 3000
     }
   })

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,10 @@
 en:
+  default_values:
+    service_email_output: ''
+    service_email_subject: 'Submission from %{service_name}'
+    service_email_body: 'Please find attached a submission sent from %{service_name}'
+    service_email_pdf_heading: 'Submission for %{service_name}'
+    service_email_pdf_subheading: ''
   header:
     service_name: "MoJ Forms"
     home_link_text: "Back to Home"
@@ -32,6 +38,13 @@ en:
     form_information: 'Form information'
     form_information_label: 'Form name'
     form_information_help: 'The visible name of your form'
+    submission:
+      name: 'Submission settings'
+      sub_heading: 'Controls what will happen to the entered data when the form is submitted. This will take only effect when the form is filled while on Test or Live, not in the Editor preview.'
+      email:
+        label: 'Send by email'
+        help: 'Sends the form data via email'
+        configure_pdf_label: PDF attachment
   publish:
     name: 'Publish'
     heading: 'Editor'
@@ -54,6 +67,18 @@ en:
         service_name: 'What is the name of this form?'
       settings:
         service_name: 'Form name'
+      email_settings:
+        send_by_email_dev: Send by email on Test
+        send_by_email_production: Send by email on Live
+        service_email_output: Send email to
+        service_email_subject: Email subject
+        service_email_body: Email text
+        service_email_pdf_heading: Heading
+        service_email_pdf_subheading: Subheading
+        email_fieldset: Email
+        pdf_fieldset: PDF attachment
+        service_email_body_hint: The email text that will be sent
+        pdf_hint: All answers will be written in a pdf attached to the email
       page_creation:
         page_url: "The page’s relative url - it must not contain any spaces"
       publish_service_creation:

--- a/config/publisher/cloud_platform/deployment.yaml.erb
+++ b/config/publisher/cloud_platform/deployment.yaml.erb
@@ -31,6 +31,10 @@ spec:
             value: 'true'
           - name: USER_DATASTORE_URL
             value: <%= user_datastore_url %>
+          - name: SUBMITTER_URL
+            value: <%= submitter_url %>
+          - name: SUBMISSION_ENCRYPTION_KEY
+            value: <%= submission_encryption_key %>
           - name: SERVICE_SLUG
             value: <%= service_slug %>
           - name: PLATFORM_ENV

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,10 +17,15 @@ Rails.application.routes.draw do
     member do
       resources :publish, only: [:index, :create]
       resources :pages, param: :page_uuid, only: [:create, :edit, :update]
-      resources :settings, only: [:index] do
-        collection do
-          get 'form_information'
-          patch 'update_form_information'
+
+      resources :settings, only: [:index]
+      namespace :settings do
+        resources :form_information, only: [:index, :create]
+
+        resources :submission, only: [:index] do
+          collection do
+            resources :email, only: [:index, :create]
+          end
         end
       end
 

--- a/db/migrate/20210304150513_create_submission_settings.rb
+++ b/db/migrate/20210304150513_create_submission_settings.rb
@@ -1,0 +1,15 @@
+class CreateSubmissionSettings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :submission_settings do |t|
+      t.boolean :send_email, default: false
+      t.string :deployment_environment
+      t.uuid :service_id
+
+      t.timestamps
+    end
+
+    add_index :submission_settings, :service_id
+    add_index :submission_settings, [:service_id, :deployment_environment],
+      name: :submission_settings_id_and_environment
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_04_154652) do
+ActiveRecord::Schema.define(version: 2021_03_04_150513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -63,6 +63,16 @@ ActiveRecord::Schema.define(version: 2021_02_04_154652) do
     t.index ["service_id", "deployment_environment", "name"], name: "index_service_configurations_on_service_deployment_name"
     t.index ["service_id", "deployment_environment"], name: "index_service_configurations_on_service_id_and_deployment_env"
     t.index ["service_id"], name: "index_service_configurations_on_service_id"
+  end
+
+  create_table "submission_settings", force: :cascade do |t|
+    t.boolean "send_email", default: false
+    t.string "deployment_environment"
+    t.uuid "service_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["service_id", "deployment_environment"], name: "submission_settings_id_and_environment"
+    t.index ["service_id"], name: "index_submission_settings_on_service_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/deploy/fb-editor-chart/templates/deployment.yaml
+++ b/deploy/fb-editor-chart/templates/deployment.yaml
@@ -92,10 +92,14 @@ spec:
               secretKeyRef:
                 name: {{ .Values.editor_service_account_token }}
                 key: token
+          - name: SUBMISSION_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: submission_encryption_key
       volumes:
         - name: tmp-files
           emptyDir: {}
-
 ---
 # workers
 apiVersion: apps/v1
@@ -186,6 +190,11 @@ spec:
               secretKeyRef:
                 name: {{ .Values.editor_service_account_token }}
                 key: token
+          - name: SUBMISSION_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: submission_encryption_key
       volumes:
         - name: tmp-files
           emptyDir: {}

--- a/deploy/fb-editor-chart/templates/secrets.yaml
+++ b/deploy/fb-editor-chart/templates/secrets.yaml
@@ -11,3 +11,4 @@ data:
   encoded_private_key: {{ .Values.encoded_private_key}}
   encryption_key: {{ .Values.encryption_key }}
   encryption_salt: {{ .Values.encryption_salt }}
+  submission_encryption_key: {{ .Values.submission_encryption_key }}

--- a/spec/factories/service_configurations.rb
+++ b/spec/factories/service_configurations.rb
@@ -19,5 +19,30 @@ FactoryBot.define do
       name { ServiceConfiguration::BASIC_AUTH_PASS }
       value { 'dGllLWZpZ2h0ZXIK' }
     end
+
+    trait :service_email_subject do
+      name { 'SERVICE_EMAIL_SUBJECT' }
+      value { "Aren’t you a little short for a Stormtrooper?" }
+    end
+
+    trait :service_email_output do
+      name { 'SERVICE_EMAIL_OUTPUT' }
+      value { "wookies@grrrrr.uk" }
+    end
+
+    trait :service_email_body do
+      name { 'SERVICE_EMAIL_BODY' }
+      value { 'Why, you stuck-up, half-witted, scruffy-looking nerf herder' }
+    end
+
+    trait :service_email_pdf_heading do
+      name { 'SERVICE_EMAIL_PDF_HEADING' }
+      value { 'Star killer complaints' }
+    end
+
+    trait :service_email_pdf_subheading do
+      name { 'SERVICE_EMAIL_PDF_SUBHEADING' }
+      value { 'Star killer HR' }
+    end
   end
 end

--- a/spec/factories/submission_settings.rb
+++ b/spec/factories/submission_settings.rb
@@ -1,0 +1,21 @@
+FactoryBot.define do
+  factory :submission_setting do
+    service_id { SecureRandom.uuid }
+
+    trait :dev do
+      deployment_environment { 'dev' }
+    end
+
+    trait :production do
+      deployment_environment { 'production' }
+    end
+
+    trait :send_email do
+      send_email { true }
+    end
+
+    trait :do_not_send_email do
+      send_email { false }
+    end
+  end
+end

--- a/spec/fixtures/kubernetes_configuration/deployment.yaml
+++ b/spec/fixtures/kubernetes_configuration/deployment.yaml
@@ -31,6 +31,10 @@ spec:
             value: 'true'
           - name: USER_DATASTORE_URL
             value: http://fb-user-datastore-api-svc-test-dev.formbuilder-platform-test-dev/
+          - name: SUBMITTER_URL
+            value: http://fb-submitter-api-svc-test-dev.formbuilder-platform-test-dev/
+          - name: SUBMISSION_ENCRYPTION_KEY
+            value: 65a27a35-c475-48b9-9a20-30142f14
           - name: SERVICE_SLUG
             value: acceptance-tests-date
           - name: PLATFORM_ENV

--- a/spec/models/email_settings_spec.rb
+++ b/spec/models/email_settings_spec.rb
@@ -1,0 +1,484 @@
+RSpec.describe EmailSettings do
+  subject(:email_settings) do
+    described_class.new(
+      params.merge(service: service)
+    )
+  end
+  let(:params) { {} }
+
+  describe '#valid?' do
+    context 'when send by email is ticked' do
+      before do
+        allow(email_settings).to receive(:send_by_email).and_return('1')
+      end
+
+      it 'allow emails' do
+        should allow_values(
+          'frodo@shire.uk'
+        ).for(:service_email_output)
+      end
+
+      it 'do not allow malformed emails' do
+        should_not allow_values(
+          'organa', 'leia'
+        ).for(:service_email_output)
+      end
+
+      it 'do not allow blanks' do
+        should_not allow_values(
+          nil, ''
+        ).for(:service_email_output)
+      end
+    end
+
+    context 'when send by email is unticked' do
+      before do
+        allow(email_settings).to receive(:send_by_email).and_return('0')
+      end
+
+      it 'do not allow malformed emails' do
+        should_not allow_values(
+          'organa', 'leia'
+        ).for(:service_email_output)
+      end
+
+      it 'allow blanks' do
+        should allow_values(
+          nil, ''
+        ).for(:service_email_output)
+      end
+    end
+
+    context 'deployment environment' do
+      it 'allow dev and production' do
+        should allow_values('dev', 'production').for(:deployment_environment)
+      end
+
+      it 'do not allow enything else' do
+        should_not allow_values(
+          nil, '', 'something-else', 'staging', 'live', 'test'
+        ).for(:deployment_environment)
+      end
+    end
+  end
+
+  describe '#service_email_output' do
+    context 'when email is empty' do
+      it 'returns nil' do
+        expect(email_settings.service_email_output).to eq('')
+      end
+    end
+
+    context 'when user submits a value' do
+      let(:params) do
+        {
+          deployment_environment: 'dev',
+          service_email_output: 'han.solo@milleniumfalcon.uk'
+        }
+      end
+
+      it 'shows the submitted value' do
+        expect(
+          email_settings.service_email_output
+        ).to eq('han.solo@milleniumfalcon.uk')
+      end
+    end
+
+    context 'when a value already exists in the db' do
+      let(:params) { {deployment_environment: 'dev'} }
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :dev,
+          :service_email_output,
+          service_id: service.service_id
+        )
+      end
+
+      it 'shows the value in the db' do
+        expect(
+          email_settings.service_email_output
+        ).to eq(service_configuration.decrypt_value)
+      end
+    end
+  end
+
+  describe '#service_email_output' do
+    context 'when email is empty' do
+      it 'returns nil' do
+        expect(email_settings.service_email_output).to eq('')
+      end
+    end
+
+    context 'when user submits a value' do
+      let(:params) do
+        { deployment_environment: 'production',
+          service_email_output: 'han.solo@milleniumfalcon.uk'
+        }
+      end
+
+      it 'shows the submitted value' do
+        expect(
+          email_settings.service_email_output
+        ).to eq('han.solo@milleniumfalcon.uk')
+      end
+    end
+
+    context 'when a value already exists in the db' do
+      let(:params) { {deployment_environment: 'production'} }
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :production,
+          :service_email_output,
+          service_id: service.service_id
+        )
+      end
+
+      it 'shows the value in the db' do
+        expect(
+          email_settings.service_email_output
+        ).to eq(service_configuration.decrypt_value)
+      end
+    end
+  end
+
+  describe '#service_email_subject' do
+    context 'when subject is empty' do
+      it 'shows the default value' do
+        expect(email_settings.service_email_subject).to eq(
+          "Submission from #{service.service_name}"
+        )
+      end
+    end
+
+    context 'when user submits a value' do
+      let(:params) do
+        {
+          deployment_environment: 'dev',
+          service_email_subject: 'Never tell me the odds.'
+        }
+      end
+
+      it 'shows the submitted value' do
+        expect(
+          email_settings.service_email_subject
+        ).to eq('Never tell me the odds.')
+      end
+    end
+
+    context 'when a value already exists in the db' do
+      let(:params) { {deployment_environment: 'dev'} }
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :dev,
+          :service_email_subject,
+          service_id: service.service_id
+        )
+      end
+
+      it 'shows the value in the db' do
+        expect(
+          email_settings.service_email_subject
+        ).to eq(service_configuration.decrypt_value)
+      end
+    end
+  end
+
+  describe '#service_email_subject' do
+    context 'when subject is empty' do
+      it 'shows the default value' do
+        expect(email_settings.service_email_subject).to eq(
+          "Submission from #{service.service_name}"
+        )
+      end
+    end
+
+    context 'when user submits a value' do
+      let(:params) do
+        { deployment_environment: 'production',
+          service_email_subject: 'Never tell me the odds.'
+        }
+      end
+
+      it 'shows the submitted value' do
+        expect(
+          email_settings.service_email_subject
+        ).to eq('Never tell me the odds.')
+      end
+    end
+
+    context 'when a value already exists in the db' do
+      let(:params) { {deployment_environment: 'production'} }
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :production,
+          :service_email_subject,
+          service_id: service.service_id
+        )
+      end
+
+      it 'shows the value in the db' do
+        expect(
+          email_settings.service_email_subject
+        ).to eq(service_configuration.decrypt_value)
+      end
+    end
+  end
+
+  describe '#service_email_body' do
+    context 'when body is empty' do
+      it 'shows the default value' do
+        expect(email_settings.service_email_body).to eq(
+          "Please find attached a submission sent from #{service.service_name}"
+        )
+      end
+    end
+
+    context 'when user submits a value' do
+      let(:params) do
+        {
+          deployment_environment: 'dev',
+          service_email_body: 'Please find attached the Death star plans'
+          }
+      end
+
+      it 'shows the submitted value' do
+        expect(
+          email_settings.service_email_body
+        ).to eq('Please find attached the Death star plans')
+      end
+    end
+
+    context 'when a value already exists in the db' do
+      let(:params) { {deployment_environment: 'dev'} }
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :dev,
+          :service_email_body,
+          service_id: service.service_id
+        )
+      end
+
+      it 'shows the value in the db' do
+        expect(
+          email_settings.service_email_body
+        ).to eq(service_configuration.decrypt_value)
+      end
+    end
+  end
+
+  describe '#service_email_body' do
+    context 'when body is empty' do
+      it 'shows the default value' do
+        expect(email_settings.service_email_body).to eq(
+          "Please find attached a submission sent from #{service.service_name}"
+        )
+      end
+    end
+
+    context 'when user submits a value' do
+      let(:params) do
+        {
+          deployment_environment: 'production',
+          service_email_body: 'Please find attached the Death star plans'
+        }
+      end
+
+      it 'shows the submitted value' do
+        expect(
+          email_settings.service_email_body
+        ).to eq('Please find attached the Death star plans')
+      end
+    end
+
+    context 'when a value already exists in the db' do
+      let(:params) { {deployment_environment: 'production'} }
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :production,
+          :service_email_body,
+          service_id: service.service_id
+        )
+      end
+
+      it 'shows the value in the db' do
+        expect(
+          email_settings.service_email_body
+        ).to eq(service_configuration.decrypt_value)
+      end
+    end
+  end
+
+  describe '#service_email_pdf_heading' do
+    context 'when body is empty' do
+      it 'shows the default value' do
+        expect(email_settings.service_email_pdf_heading).to eq(
+          "Submission for #{service.service_name}"
+        )
+      end
+    end
+
+    context 'when user submits a value' do
+      let(:params) do
+        {
+          deployment_environment: 'dev',
+          service_email_pdf_heading: 'Death star plans'
+        }
+      end
+
+      it 'shows the submitted value' do
+        expect(
+          email_settings.service_email_pdf_heading
+        ).to eq('Death star plans')
+      end
+    end
+
+    context 'when a value already exists in the db' do
+      let(:params) { {deployment_environment: 'dev'} }
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :dev,
+          :service_email_pdf_heading,
+          service_id: service.service_id
+        )
+      end
+
+      it 'shows the value in the db' do
+        expect(
+          email_settings.service_email_pdf_heading
+        ).to eq(service_configuration.decrypt_value)
+      end
+    end
+  end
+
+  describe '#service_email_pdf_heading' do
+    context 'when body is empty' do
+      it 'shows the default value' do
+        expect(email_settings.service_email_pdf_heading).to eq(
+          "Submission for #{service.service_name}"
+        )
+      end
+    end
+
+    context 'when user submits a value' do
+      let(:params) do
+        {
+          deployment_environment: 'production',
+          service_email_pdf_heading: 'Death star plans'
+        }
+      end
+
+      it 'shows the submitted value' do
+        expect(
+          email_settings.service_email_pdf_heading
+        ).to eq('Death star plans')
+      end
+    end
+
+    context 'when a value already exists in the db' do
+      let(:params) { {deployment_environment: 'production'} }
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :production,
+          :service_email_pdf_heading,
+          service_id: service.service_id
+        )
+      end
+
+      it 'shows the value in the db' do
+        expect(
+          email_settings.service_email_pdf_heading
+        ).to eq(service_configuration.decrypt_value)
+      end
+    end
+  end
+
+  describe '#service_email_pdf_subheading' do
+    context 'when body is empty' do
+      it 'shows the default value' do
+        expect(email_settings.service_email_pdf_subheading).to eq('')
+      end
+    end
+
+    context 'when user submits a value' do
+      let(:params) do
+        {
+          deployment_environment: 'dev',
+          service_email_pdf_subheading: 'Rebellion ships'
+        }
+      end
+
+      it 'shows the submitted value' do
+        expect(
+          email_settings.service_email_pdf_subheading
+        ).to eq('Rebellion ships')
+      end
+    end
+
+    context 'when a value already exists in the db' do
+      let(:params) { {deployment_environment: 'dev'} }
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :dev,
+          :service_email_pdf_subheading,
+          service_id: service.service_id
+        )
+      end
+
+      it 'shows the value in the db' do
+        expect(
+          email_settings.service_email_pdf_subheading
+        ).to eq(service_configuration.decrypt_value)
+      end
+    end
+  end
+
+  describe '#service_email_pdf_subheading' do
+    context 'when body is empty' do
+      it 'shows the default value' do
+        expect(email_settings.service_email_pdf_subheading).to eq('')
+      end
+    end
+
+    context 'when user submits a value' do
+      let(:params) do
+        {
+          deployment_environment: 'production',
+          service_email_pdf_subheading: 'Rebellion ships'
+        }
+      end
+
+      it 'shows the submitted value' do
+        expect(
+          email_settings.service_email_pdf_subheading
+        ).to eq('Rebellion ships')
+      end
+    end
+
+    context 'when a value already exists in the db' do
+      let(:params) { {deployment_environment: 'production'} }
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :production,
+          :service_email_pdf_subheading,
+          service_id: service.service_id
+        )
+      end
+
+      it 'shows the value in the db' do
+        expect(
+          email_settings.service_email_pdf_subheading
+        ).to eq(service_configuration.decrypt_value)
+      end
+    end
+  end
+end

--- a/spec/models/email_settings_updater_spec.rb
+++ b/spec/models/email_settings_updater_spec.rb
@@ -1,0 +1,722 @@
+RSpec.describe EmailSettingsUpdater do
+  subject(:email_settings_updater) do
+    described_class.new(
+      email_settings: EmailSettings.new(
+        params.merge(
+          service: service,
+          deployment_environment: 'dev'
+        )
+      ),
+      service: service
+    )
+  end
+  let(:params) { {} }
+
+  describe '#create_or_update' do
+    context 'email output' do
+      context 'when email output exists in the db' do
+        let!(:service_configuration) do
+          create(
+            :service_configuration,
+            :dev,
+            :service_email_output,
+            service_id: service.service_id
+          )
+        end
+
+        context 'when a user updates the value' do
+          let(:params) do
+            {
+              service_email_output: 'aragorn@middle-earth.uk'
+            }
+          end
+
+          it 'updates the service configuration subject' do
+            email_settings_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_output])
+          end
+        end
+
+        context 'when user removes the value' do
+          let(:params) do
+            {
+              service_email_output: ''
+            }
+          end
+
+          it 'removes from the database' do
+            email_settings_updater.create_or_update!
+
+            expect {
+              service_configuration.reload
+            }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
+      context 'when email output does not exist in the db' do
+        let(:service_configuration) do
+          ServiceConfiguration.find_by(
+            service_id: service.service_id,
+            name: 'SERVICE_EMAIL_OUTPUT'
+          )
+        end
+
+        context 'when an user adds the value' do
+          let(:params) do
+            {
+              service_email_output: 'aragorn@middle-earth.uk'
+            }
+          end
+          before { email_settings_updater.create_or_update! }
+
+          it 'updates the service configuration subject' do
+            expect(service_configuration).to be_persisted
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_output])
+          end
+        end
+
+        context 'when user removes the value' do
+          let(:params) do
+            {
+              service_email_output: ''
+            }
+          end
+          before { email_settings_updater.create_or_update! }
+
+          it 'updates the service configuration subject' do
+            expect(service_configuration).to be_blank
+          end
+        end
+      end
+    end
+
+    context 'email pdf subheading' do
+      context 'when email pdf subheading exists in the db' do
+        let!(:service_configuration) do
+          create(
+            :service_configuration,
+            :dev,
+            :service_email_pdf_subheading,
+            service_id: service.service_id
+          )
+        end
+
+        context 'when a user updates the value' do
+          let(:params) do
+            {
+              service_email_pdf_subheading: 'A subterranean subheading'
+            }
+          end
+
+          it 'updates the service configuration pdf subheading' do
+            email_settings_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_pdf_subheading])
+          end
+        end
+
+        context 'when user removes the value' do
+          let(:params) do
+            {
+              service_email_pdf_subheading: ''
+            }
+          end
+
+          it 'removes from the database' do
+            email_settings_updater.create_or_update!
+
+            expect {
+              service_configuration.reload
+            }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
+      context 'when email pdf subheading does not exist in the db' do
+        let(:service_configuration) do
+          ServiceConfiguration.find_by(
+            service_id: service.service_id,
+            name: 'SERVICE_EMAIL_PDF_SUBHEADING'
+          )
+        end
+
+        context 'when a user adds the value' do
+          let(:params) do
+            {
+              service_email_pdf_subheading: 'A subterranean subheading'
+            }
+          end
+          before { email_settings_updater.create_or_update! }
+
+          it 'updates the service configuration pdf subheading' do
+            expect(service_configuration).to be_persisted
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_pdf_subheading])
+          end
+        end
+
+        context 'when user removes the value' do
+          let(:params) do
+            {
+              service_email_pdf_subheading: ''
+            }
+          end
+          before { email_settings_updater.create_or_update! }
+
+          it 'updates the service configuration pdf subheading' do
+            expect(service_configuration).to be_blank
+          end
+        end
+      end
+    end
+
+    context 'email pdf subheading' do
+      context 'when email pdf subheading exists in the db' do
+        let!(:service_configuration) do
+          create(
+            :service_configuration,
+            :dev,
+            :service_email_pdf_subheading,
+            service_id: service.service_id
+          )
+        end
+
+        context 'when a user updates the value' do
+          let(:params) do
+            {
+              deployment_environment: 'dev',
+              service_email_pdf_subheading: 'A subterranean subheading'
+            }
+          end
+
+          it 'updates the service configuration pdf subheading' do
+            email_settings_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_pdf_subheading])
+          end
+        end
+
+        context 'when user removes the value' do
+          let(:params) do
+            {
+              deployment_environment: 'dev',
+              service_email_pdf_subheading: ''
+            }
+          end
+
+          it 'removes from the database' do
+            email_settings_updater.create_or_update!
+
+            expect {
+              service_configuration.reload
+            }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
+      context 'when email pdf subheading does not exist in the db' do
+        let(:service_configuration) do
+          ServiceConfiguration.find_by(
+            service_id: service.service_id,
+            name: 'SERVICE_EMAIL_PDF_SUBHEADING'
+          )
+        end
+
+        context 'when a user adds the value' do
+          let(:params) do
+            {
+              deployment_environment: 'dev',
+              service_email_pdf_subheading: 'A subterranean subheading'
+            }
+          end
+          before { email_settings_updater.create_or_update! }
+
+          it 'updates the service configuration pdf subheading' do
+            expect(service_configuration).to be_persisted
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_pdf_subheading])
+          end
+        end
+
+        context 'when user removes the value' do
+          let(:params) do
+            {
+              deployment_environment: 'dev',
+              service_email_pdf_subheading: ''
+            }
+          end
+          before { email_settings_updater.create_or_update! }
+
+          it 'updates the service configuration pdf subheading' do
+            expect(service_configuration).to be_blank
+          end
+        end
+      end
+    end
+
+    context 'email subject' do
+      context 'when email subject exists in the db' do
+        let!(:service_configuration) do
+          create(
+            :service_configuration,
+            :dev,
+            :service_email_subject,
+            service_id: service.service_id
+          )
+        end
+
+        context 'when a user updates the value' do
+          let(:params) do
+            {
+              service_email_subject: 'This is an awesome email subject'
+            }
+          end
+
+          it 'updates the service configuration subject' do
+            email_settings_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_subject])
+          end
+        end
+
+        context 'when a user removes the value' do
+          let(:params) do
+            {
+              service_email_subject: ''
+            }
+          end
+
+          it 'shows the default subject' do
+            email_settings_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value
+            ).to eq("Submission from #{service.service_name}")
+          end
+        end
+      end
+
+      context 'when email subject does not exist in db' do
+        let(:service_configuration) do
+          ServiceConfiguration.find_by(
+            service_id: service.service_id,
+            name: 'SERVICE_EMAIL_SUBJECT'
+          )
+        end
+
+        context 'when an user adds a value' do
+          let(:params) do
+            {
+              service_email_subject: 'This is an awesome email subject'
+            }
+          end
+
+          before do
+            email_settings_updater.create_or_update!
+          end
+
+          it 'creates the service configuration subject' do
+            expect(service_configuration).to be_persisted
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_subject])
+          end
+        end
+
+        context 'when a user removes the value' do
+          let(:params) do
+            {
+              service_email_subject: ''
+            }
+          end
+          before { email_settings_updater.create_or_update! }
+
+          it 'shows the default subject' do
+            expect(service_configuration).to be_persisted
+            expect(
+              service_configuration.decrypt_value
+            ).to eq("Submission from #{service.service_name}")
+          end
+        end
+      end
+    end
+
+    context 'email body' do
+      context 'when email body exists in the db' do
+        let!(:service_configuration) do
+          create(
+            :service_configuration,
+            :dev,
+            :service_email_body,
+            service_id: service.service_id
+          )
+        end
+
+        context 'when an user updates the value' do
+          let(:params) do
+            {
+              service_email_body: 'Heads and shoulders, knees and toes'
+            }
+          end
+
+          it 'updates the service configuration body' do
+            email_settings_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_body])
+          end
+        end
+
+        context 'when a user removes the value' do
+          let(:params) do
+            {
+              service_email_body: ''
+            }
+          end
+
+          it 'shows the default body' do
+            email_settings_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value
+            ).to eq("Please find attached a submission sent from #{service.service_name}")
+          end
+        end
+      end
+
+      context 'when email body does not exist in db' do
+        let(:service_configuration) do
+          ServiceConfiguration.find_by(
+            service_id: service.service_id,
+            name: 'SERVICE_EMAIL_BODY'
+          )
+        end
+
+        context 'when a user adds a value' do
+          let(:params) do
+            {
+              service_email_body: 'Heads and shoulders, knees and toes'
+            }
+          end
+
+          before do
+            email_settings_updater.create_or_update!
+          end
+
+          it 'creates the service configuration body' do
+            expect(service_configuration).to be_persisted
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_body])
+          end
+        end
+
+        context 'when a user removes the value' do
+          let(:params) do
+            {
+              service_email_body: ''
+            }
+          end
+          before { email_settings_updater.create_or_update! }
+
+          it 'shows the default subject' do
+            expect(service_configuration).to be_persisted
+            expect(
+              service_configuration.decrypt_value
+            ).to eq("Please find attached a submission sent from #{service.service_name}")
+          end
+        end
+      end
+    end
+
+    context 'email pdf heading' do
+      context 'when email pdf heading exists in the db' do
+        let!(:service_configuration) do
+          create(
+            :service_configuration,
+            :dev,
+            :service_email_pdf_heading,
+            service_id: service.service_id
+          )
+        end
+
+        context 'when a user updates the value' do
+          let(:params) do
+            {
+              service_email_pdf_heading: 'We love kakapos'
+            }
+          end
+
+          it 'updates the service configuration pdf heading' do
+            email_settings_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_pdf_heading])
+          end
+        end
+
+        context 'when a user removes the value' do
+          let(:params) do
+            {
+              service_email_pdf_heading: ''
+            }
+          end
+
+          it 'shows the default pdf heading' do
+            email_settings_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value
+            ).to eq("Submission for #{service.service_name}")
+          end
+        end
+      end
+
+      context 'when email pdf heading does not exist in db' do
+        let(:service_configuration) do
+          ServiceConfiguration.find_by(
+            service_id: service.service_id,
+            name: 'SERVICE_EMAIL_PDF_HEADING'
+          )
+        end
+
+        context 'when a user adds a value' do
+          let(:params) do
+            {
+              service_email_pdf_heading: 'We love kakapos'
+            }
+          end
+
+          before do
+            email_settings_updater.create_or_update!
+          end
+
+          it 'creates the service configuration pdf heading' do
+            expect(service_configuration).to be_persisted
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_pdf_heading])
+          end
+        end
+
+        context 'when a user removes the value' do
+          let(:params) do
+            {
+              service_email_pdf_heading: ''
+            }
+          end
+          before { email_settings_updater.create_or_update! }
+
+          it 'shows the default pdf heading' do
+            expect(service_configuration).to be_persisted
+            expect(
+              service_configuration.decrypt_value
+            ).to eq("Submission for #{service.service_name}")
+          end
+        end
+      end
+    end
+
+    context 'email body' do
+      context 'when email body exists in the db' do
+        let!(:service_configuration) do
+          create(
+            :service_configuration,
+            :dev,
+            :service_email_body,
+            service_id: service.service_id
+          )
+        end
+
+        context 'when an user updates the value' do
+          let(:params) do
+            {
+              deployment_environment: 'dev',
+              service_email_body: 'Heads and shoulders, knees and toes'
+            }
+          end
+
+          it 'updates the service configuration body' do
+            email_settings_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_body])
+          end
+        end
+
+        context 'when a user removes the value' do
+          let(:params) do
+            {
+              deployment_environment: 'dev',
+              service_email_body: ''
+            }
+          end
+
+          it 'shows the default body' do
+            email_settings_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value
+            ).to eq("Please find attached a submission sent from #{service.service_name}")
+          end
+        end
+      end
+
+      context 'when email body does not exist in db' do
+        let(:service_configuration) do
+          ServiceConfiguration.find_by(
+            service_id: service.service_id,
+            name: 'SERVICE_EMAIL_BODY'
+          )
+        end
+
+        context 'when a user adds a value' do
+          let(:params) do
+            {
+              deployment_environment: 'dev',
+              service_email_body: 'Heads and shoulders, knees and toes'
+            }
+          end
+
+          before do
+            email_settings_updater.create_or_update!
+          end
+
+          it 'creates the service configuration body' do
+            expect(service_configuration).to be_persisted
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_body])
+          end
+        end
+
+        context 'when a user removes the value' do
+          let(:params) do
+            {
+              deployment_environment: 'dev',
+              service_email_body: ''
+            }
+          end
+          before { email_settings_updater.create_or_update! }
+
+          it 'shows the default subject' do
+            expect(service_configuration).to be_persisted
+            expect(
+              service_configuration.decrypt_value
+            ).to eq("Please find attached a submission sent from #{service.service_name}")
+          end
+        end
+      end
+    end
+
+    context 'email pdf heading' do
+      context 'when email pdf heading exists in the db' do
+        let!(:service_configuration) do
+          create(
+            :service_configuration,
+            :dev,
+            :service_email_pdf_heading,
+            service_id: service.service_id
+          )
+        end
+
+        context 'when a user updates the value' do
+          let(:params) do
+            {
+              deployment_environment: 'dev',
+              service_email_pdf_heading: 'We love kakapos'
+            }
+          end
+
+          it 'updates the service configuration pdf heading' do
+            email_settings_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_pdf_heading])
+          end
+        end
+
+        context 'when a user removes the value' do
+          let(:params) do
+            {
+              deployment_environment: 'dev',
+              service_email_pdf_heading: ''
+            }
+          end
+
+          it 'shows the default pdf heading' do
+            email_settings_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value
+            ).to eq("Submission for #{service.service_name}")
+          end
+        end
+      end
+
+      context 'when email pdf heading does not exist in db' do
+        let(:service_configuration) do
+          ServiceConfiguration.find_by(
+            service_id: service.service_id,
+            name: 'SERVICE_EMAIL_PDF_HEADING'
+          )
+        end
+
+        context 'when a user adds a value' do
+          let(:params) do
+            {
+              deployment_environment: 'dev',
+              service_email_pdf_heading: 'We love kakapos'
+            }
+          end
+
+          before do
+            email_settings_updater.create_or_update!
+          end
+
+          it 'creates the service configuration pdf heading' do
+            expect(service_configuration).to be_persisted
+            expect(
+              service_configuration.decrypt_value
+            ).to eq(params[:service_email_pdf_heading])
+          end
+        end
+
+        context 'when a user removes the value' do
+          let(:params) do
+            {
+              deployment_environment: 'dev',
+              service_email_pdf_heading: ''
+            }
+          end
+          before { email_settings_updater.create_or_update! }
+
+          it 'shows the default pdf heading' do
+            expect(service_configuration).to be_persisted
+            expect(
+              service_configuration.decrypt_value
+            ).to eq("Submission for #{service.service_name}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/service_configuration_spec.rb
+++ b/spec/models/service_configuration_spec.rb
@@ -61,6 +61,91 @@ RSpec.describe ServiceConfiguration, type: :model do
     end
   end
 
+  describe '#do_not_send_submission?' do
+    subject(:service_configuration) do
+      described_class.new(name: 'SERVICE_EMAIL_OUTPUT')
+    end
+
+    context 'when submission setting exists' do
+      let!(:submission_setting) do
+        create(
+          :submission_setting,
+          :dev,
+          service_id: service.service_id,
+          send_email: send_email
+        )
+      end
+
+      context 'when send email flag is true' do
+        let(:send_email) { true }
+
+        %w(
+          SERVICE_EMAIL_OUTPUT
+          SERVICE_EMAIL_SUBJECT
+          SERVICE_EMAIL_BODY
+          SERVICE_EMAIL_PDF_HEADING
+          SERVICE_EMAIL_PDF_SUBHEADING
+        ).each do |configuration|
+          context "when configuration is #{configuration}" do
+            let(:service_configuration) do
+              described_class.new(
+                name: configuration,
+                service_id: service.service_id,
+                deployment_environment: 'dev'
+              )
+            end
+
+            it 'returns false' do
+              expect(service_configuration.do_not_send_submission?).to be_falsey
+            end
+          end
+        end
+
+        %w(OTHER_ENV_VARS ENCODED_PRIVATE_KEY).each do |configuration|
+          context "when configuration is #{configuration}" do
+            let(:service_configuration) do
+              described_class.new(
+                name: configuration,
+                service_id: service.service_id,
+                deployment_environment: 'dev'
+              )
+            end
+
+            it 'returns false' do
+              expect(service_configuration.do_not_send_submission?).to be_falsey
+            end
+          end
+        end
+      end
+
+      context 'when send email flag is false' do
+        let(:send_email) { false }
+
+        %w(OTHER_ENV_VARS ENCODED_PRIVATE_KEY).each do |configuration|
+          context "when configuration is #{configuration}" do
+            let(:service_configuration) do
+              described_class.new(
+                name: configuration,
+                service_id: service.service_id,
+                deployment_environment: 'dev'
+              )
+            end
+
+            it 'returns false' do
+              expect(service_configuration.do_not_send_submission?).to be_falsey
+            end
+          end
+        end
+      end
+    end
+
+    context 'when submission setting does not exist' do
+      it 'returns true' do
+        expect(service_configuration.do_not_send_submission?).to be_truthy
+      end
+    end
+  end
+
   context 'encrypting and decrypting values' do
     let(:service_configuration) do
       create(:service_configuration, :dev, :username, value: 'r2d2')

--- a/spec/models/submission_setting_spec.rb
+++ b/spec/models/submission_setting_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe SubmissionSetting, type: :model do
+  describe '#valid?' do
+    context 'service_id' do
+      it 'do not allow blank' do
+        should_not allow_values('').for(:service_id)
+      end
+    end
+
+    context 'deployment environment' do
+      it 'allow dev and production' do
+        should allow_values('dev', 'production').for(:deployment_environment)
+      end
+
+      it 'do not allow enything else' do
+        should_not allow_values(
+          nil, '', 'something-else', 'staging', 'live', 'test'
+        ).for(:deployment_environment)
+      end
+    end
+  end
+
+end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -3,12 +3,12 @@ RSpec.describe 'Settings' do
     MetadataPresenter::Service.new(service_id: SecureRandom.uuid)
   end
 
-  describe 'PATCH /services/:id/settings/update_form_information' do
+  describe 'POST /services/:id/settings/form_information' do
     before do
       expect_any_instance_of(ApplicationController).to receive(:service).at_least(:once).and_return(service)
       expect_any_instance_of(Settings).to receive(:update).and_return(valid)
 
-      patch "/services/#{service.service_id}/settings/update_form_information",
+      post "/services/#{service.service_id}/settings/form_information",
             params: { service: { service_name: 'R2-D2' } }
     end
 
@@ -16,7 +16,7 @@ RSpec.describe 'Settings' do
       let(:valid) { true }
 
       it 'redirects to form information index' do
-        expect(response).to redirect_to(form_information_settings_path(service.service_id))
+        expect(response).to redirect_to(settings_form_information_index_path(service.service_id))
       end
     end
 

--- a/spec/services/default_configuration_spec.rb
+++ b/spec/services/default_configuration_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe DefaultConfiguration do
       end
 
       it 'generates 2 keys per deployment environment' do
-        expect(service_configuration).to eq(
+        expect(service_configuration).to match_array(
           [
             {
               name: 'ENCODED_PRIVATE_KEY',

--- a/spec/services/publisher/utils/kubernetes_configuration_spec.rb
+++ b/spec/services/publisher/utils/kubernetes_configuration_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe Publisher::Utils::KubernetesConfiguration do
     allow(service_provisioner).to receive(:secret_key_base).and_return(
       'fdfdd491d611aa1abef54cbf24a709a1bb31ff881a487f8c58c69399202b08f77019920f481e17b40dd7452361055534b9f91f172719ed98a088498242f96f59'
     )
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[])
+      .with('SUBMISSION_ENCRYPTION_KEY')
+      .and_return('65a27a35-c475-48b9-9a20-30142f14')
   end
 
   describe '#generate' do


### PR DESCRIPTION
This PR relates to this story: https://trello.com/c/utAUt3qG/1253-add-submission-configuration-serviceoutputemail-to-editor

This PR contains changes including:
#### Adds layout of pages
Add html.erb files in `views/settings` folder and associated labels in `config/en.yml`

This allows the user to go to the Settings -> Submission settings -> Send by email -> Send by email forms page

#### Puts every setting into a specific controller
This meant moving logic out of `app/controllers/settings_controller.rb` and splitting it out into different controllers, `app/controllers/settings/email_controller.rb` `app/controllers/settings/form_information_controller.rb` `app/controllers/settings/submission_controller.rb`

The controllers now had their own index.html.erb files:
Settings -> index.html.erb

/settings/form_information
Controller: Settings - Form information -> index.html.erb

/settings/submission
Controller: Settings - Submission -> index.html.erb

/settings/submission/email
 Controller: Settings - Email -> index.html.erb

This meant changes to the `config/routes.rb` `spec/requests/settings_spec.rb` and paths in associated `index.html.erb` files.

#### Sends email service output value to database

#### Sets all 5 possible email setting configurations in both dev and production environments
`app/models/email_settings.rb`
This is because there are 3 fields (subject, heading pdf heading) that require a default, whereas the output and pdf subheading can be left blank.

#### Make inputs return from params, db or default
`app/controllers/settings/email_controller.rb`
`app/models/email_settings.rb`
And add associated tests
`spec/factories/service_configurations.rb`
`spec/models/email_settings_spec.rb`

#### Do not inject email env vars if send email flag is false
If the user unchecks the "Send by email on Test/Live" then a record in the db will be created (SubmissionSetting) then when we publish we should reject the email related env vars for those that doesn't have a send email flag as true.
`app/models/service_configuration.rb`
`app/services/publisher/service_provisioner.rb`
And associated tests:
`spec/models/service_configuration_spec.rb`

#### Add submission setting table
This table will be responsible to handle the flag that the service needs to send email or not.
Usually every service will have two rows on this table.
`app/models/submission_setting.rb`
`db/migrate/20210304150513_create_submission_settings.rb`
`db/schema.rb`
And spec files:
`spec/factories/submission_settings.rb`
`spec/models/submission_setting_spec.rb`

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>