### PR TITLE
Rename page answer presenter

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -71,14 +71,14 @@ class PagesController < FormController
   end
   helper_method :reserved_submissions_path
 
-  def page_answers_presenters
+  def pages_presenters
     MetadataPresenter::PageAnswersPresenter.map(
       view: view_context,
       pages: service.pages,
       answers: {}
     )
   end
-  helper_method :page_answers_presenters
+  helper_method :pages_presenters
 
   private
 


### PR DESCRIPTION
## Context

When you add a check your answers page the editor returns a 500 error. The reason is that the check your answers page renamed the method needed to render its answers.

So the editor needs to be renamed as well.