### PR TITLE
Add delete pages feature

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,6 @@
 class PagesController < FormController
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
-  before_action :assign_required_objects, only: [:edit, :update]
+  before_action :assign_required_objects, only: [:edit, :update, :destroy]
 
   def create
     @page_creation = PageCreation.new(page_creation_params)
@@ -20,6 +20,13 @@ class PagesController < FormController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @metadata_updater = MetadataUpdater.new(common_params.merge(id: @page.id))
+
+    @metadata_updater.destroy
+    redirect_to edit_service_path(service.service_id)
   end
 
   def page_creation_params

--- a/app/services/metadata_updater.rb
+++ b/app/services/metadata_updater.rb
@@ -2,37 +2,66 @@ class MetadataUpdater
   attr_reader :id, :latest_metadata, :service_id, :attributes
 
   def initialize(attributes)
-    @latest_metadata = attributes.delete(:latest_metadata).to_h
+    @latest_metadata = attributes.delete(:latest_metadata).to_h.deep_dup
     @service_id = attributes.delete(:service_id)
     @id = attributes.delete(:id)
     @attributes = attributes
   end
 
   def update
-    version = MetadataApiClient::Version.create(
-      service_id: service_id,
-      payload: metadata
-    )
+    version = new_version(:update)
 
     return version.metadata unless version.errors?
 
     false
   end
 
-  def metadata
-    @latest_metadata.extend Hashie::Extensions::DeepLocate
+  def destroy
+    version = new_version(:destroy)
 
-    object = @latest_metadata.deep_locate(find_id).first
-    new_object = object.merge(attributes)
+    version.metadata
+  end
+
+  def metadata(action)
+    object = find_node_attribute_by_id
     index = @latest_metadata['pages'].index(object)
-    @latest_metadata['pages'][index] = new_object
+
+    send("#{action}_node", object: object, index: index)
 
     @latest_metadata
+  end
+
+  private
+
+  def find_node_attribute_by_id
+    @latest_metadata.extend Hashie::Extensions::DeepLocate
+
+    @latest_metadata.deep_locate(find_id).first
   end
 
   def find_id
     lambda do |key, value, object|
       key == '_id' && value == @id
     end
+  end
+
+  def update_node(object:, index:)
+    new_object = object.merge(attributes)
+    @latest_metadata['pages'][index] = new_object
+  end
+
+  def destroy_node(object:, index:)
+    # Don't delete start pages
+    return @latest_metadata if object['_type'] == 'page.start'
+
+    @latest_metadata['pages'].delete_at(index)
+    @latest_metadata['pages'][0]['steps'].delete(@id)
+  end
+
+  def new_version(action)
+    @new_version ||= MetadataApiClient::Version.create(
+      service_id: service_id,
+      payload: metadata(action)
+    )
   end
 end

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -25,7 +25,9 @@
           target: '_blank' %>
         </li>
         <li><a href="#add-page-here">Add page here</a></li>
-        <li><a href="#delete-page" class="destructive">Delete page...</a></li>
+        <li>
+          <%= link_to t('actions.delete_page'), page_path(service.service_id, page.uuid), method: :delete, class: 'destructive', data: { confirm: 'Are you sure?' } %>
+        </li>
       </ul>
 
       <%= link_to page.url, edit_page_path(service.service_id, page.uuid), class: 'govuk-link' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,7 @@ en:
     edit_page: 'Edit Page'
     preview_page: 'Preview page'
     preview_form: 'Preview form'
+    delete_page: 'Delete page...'
   pages:
     form: 'Form flow'
     name: 'Pages'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   resources :services, only: [:index, :edit, :update, :create] do
     member do
       resources :publish, only: [:index, :create]
-      resources :pages, param: :page_uuid, only: [:create, :edit, :update]
+      resources :pages, param: :page_uuid, only: [:create, :edit, :update, :destroy]
 
       resources :settings, only: [:index]
       namespace :settings do

--- a/spec/services/metadata_updater_spec.rb
+++ b/spec/services/metadata_updater_spec.rb
@@ -62,4 +62,43 @@ RSpec.describe MetadataUpdater do
       end
     end
   end
+
+  describe '#destroy' do
+    context 'when deleting start page' do
+      let(:updated_metadata) do
+        service_metadata.deep_dup
+      end
+      let(:attributes) do
+        {
+          id: 'page.start',
+          service_id: service.service_id,
+          latest_metadata: service_metadata,
+        }
+      end
+
+      it 'creates new version with start page' do
+        expect(updater.destroy).to eq(updated_metadata)
+      end
+    end
+
+    context 'when deleting other pages' do
+      let(:updated_metadata) do
+        metadata = service_metadata.deep_dup
+        metadata['pages'].delete_at(1)
+        metadata['pages'][0]['steps'].delete('page.name')
+        metadata
+      end
+      let(:attributes) do
+        {
+          id: 'page.name',
+          service_id: service.service_id,
+          latest_metadata: service_metadata
+        }
+      end
+
+      it 'creates new version with page deleted' do
+        expect(updater.destroy).to eq(updated_metadata)
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/vWF85IUT/1371-user-can-delete-remove-a-page-backend-m)

## Context

The delete pages will delete the 'pages' node in the metadata and
the pages[0]['steps'] in metadata as well.

Example

id => 'page.name'

'page.name' will be deleted entirely from the 'pages' node and
the pages[0]['steps'] node too.

The exception is that we should not delete the start page
(see the discusssion here:
https://mojdt.slack.com/archives/CE78LKCU8/p1615481002253100)