### PR TITLE
Add link to ask form builder slack channel

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -11,7 +11,7 @@
     </div>
 
       <div>
-        <p><%= t('.body', formbuilder_slack: "#{ENV['SLACK_CHANNEL']}").html_safe %></p>
+        <p><%= t('.body').html_safe %></p>
       </div>
 
       <div class="govuk-inset-text">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,7 +19,7 @@ en:
     show:
       title: MoJ Forms
       lede: Prototype, test and publish online forms quickly and easily
-      body: 'To find out more about MoJ Forms, please email us at <a href="mailto:moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a>, or you can also <a href="%{formbuilder_slack}">ask us a question on Slack</a>.'
+      body: 'To find out more about MoJ Forms, please email us at <a href="mailto:moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a>, or you can also <a href="https://app.slack.com/client/T02DYEB3A/CE26QEL1Z">ask us a question on Slack</a>.'
       callout: You will need a @digital.justice.gov.uk or @justice.gov.uk email address to use MoJ Forms.
       sign_in: Sign in
   auth:


### PR DESCRIPTION
This was previously going to be injected as secret into the app, but actually the provided link requires people to authenticate before they can get to the channel so it's probably fine to just have in the locales.