### PR TITLE
Generated page metadata validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'daemons'
 #     branch: 'feature/preview'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.16.2'
+gem 'metadata_presenter', '0.17.1'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.16.2)
+    metadata_presenter (0.17.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -326,7 +326,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.6.0)
   hashie
   listen (~> 3.4)
-  metadata_presenter (= 0.16.2)
+  metadata_presenter (= 0.17.1)
   omniauth-auth0 (~> 2.5.0)
   omniauth-rails_csrf_protection (~> 0.1.2)
   pg (>= 0.18, < 2.0)

--- a/spec/generators/new_page_generator_spec.rb
+++ b/spec/generators/new_page_generator_spec.rb
@@ -61,12 +61,40 @@ RSpec.describe NewPageGenerator do
     context 'when existing pages exist' do
       let(:latest_metadata) { metadata_fixture(:version) }
 
-      it 'creates a valid page metadata' do
-        expect(
-          MetadataPresenter::ValidateSchema.validate(
-            generator.page_metadata, "page.#{page_type}"
-          )
-        ).to be(valid)
+      context 'generating valid metadata' do
+        context 'pages with components' do
+          %w(singlequestion).each do |page|
+            context "when #{page} page" do
+              let(:page_type) { page }
+              let(:component_type) { 'text' }
+
+              it 'creates a valid page metadata' do
+                expect(
+                  MetadataPresenter::ValidateSchema.validate(
+                    generator.page_metadata, "page.#{page_type}"
+                  )
+                ).to be(valid)
+              end
+            end
+          end
+        end
+
+        context 'pages without components' do
+          %w(multiplequestions checkanswers confirmation).each do |page|
+            context "when #{page} page" do
+              let(:page_type) { page }
+              let(:component_type) { nil }
+
+              it 'creates a valid page metadata' do
+                expect(
+                  MetadataPresenter::ValidateSchema.validate(
+                    generator.page_metadata, "page.#{page_type}"
+                  )
+                ).to be(valid)
+              end
+            end
+          end
+        end
       end
 
       it 'generates page attributes' do


### PR DESCRIPTION
This adds tests to cover all the current pages and validate the generated metadata against the necessary schemas

Also adds the presenter 0.17.1 which has the content component metdata