### PR TITLE
Add all tests for editing single question pages

### DIFF
--- a/acceptance/features/create_page_spec.rb
+++ b/acceptance/features/create_page_spec.rb
@@ -3,6 +3,7 @@ require_relative '../spec_helper'
 feature 'Create page' do
   let(:editor) { EditorApp.new }
   let(:service_name) { generate_service_name }
+  let(:page_url) { 'phasma' }
 
   background do
     given_I_am_logged_in
@@ -81,81 +82,8 @@ feature 'Create page' do
     then_I_should_see_a_validation_error_message_that_page_url_exists
   end
 
-  def given_I_have_a_single_question_page_with_text
-    given_I_add_a_single_question_page_with_text
-    and_I_add_a_page_url
-    when_I_add_the_page
-  end
-
-  def given_I_add_a_single_question_page_with_text
-    given_I_want_to_add_a_single_question_page
-    editor.add_single_question_text.click
-  end
-
-  def given_I_add_a_single_question_page_with_text_area
-    given_I_want_to_add_a_single_question_page
-    editor.add_single_question_text_area.click
-  end
-
-  def given_I_add_a_single_question_page_with_number
-    given_I_want_to_add_a_single_question_page
-    editor.add_single_question_number.click
-  end
-
-  def given_I_add_a_single_question_page_with_date
-    given_I_want_to_add_a_single_question_page
-    editor.add_single_question_date.click
-  end
-
-  def given_I_add_a_single_question_page_with_radio
-    given_I_want_to_add_a_single_question_page
-    editor.add_single_question_radio.click
-  end
-
-  def given_I_add_a_single_question_page_with_checkboxes
-    given_I_want_to_add_a_single_question_page
-    editor.add_single_question_checkboxes.click
-  end
-
-  def given_I_add_a_check_answers_page
-    given_I_want_to_add_a_page
-    editor.add_check_answers.click
-  end
-
-  def given_I_add_a_multiple_question_page
-    given_I_want_to_add_a_page
-    editor.add_multiple_question.click
-  end
-
-  def given_I_add_a_confirmation_page
-    given_I_want_to_add_a_page
-    editor.add_confirmation.click
-  end
-
-  def given_I_want_to_add_a_single_question_page
-    given_I_want_to_add_a_page
-    editor.add_single_question.hover
-  end
-
-  def given_I_want_to_add_a_page
-    editor.add_page.click
-  end
-
-  def and_I_edit_the_service
-    visit '/services'
-    editor.edit_service_link(service_name).click
-  end
-
-  def and_I_add_a_page_url
-    editor.page_url_field.set('phasma')
-  end
-
   def and_I_add_an_existing_page_url
     and_I_add_a_page_url
-  end
-
-  def when_I_add_the_page
-    editor.add_page_submit_button.last.click
   end
 
   def then_I_should_see_a_validation_error_message_that_page_url_exists

--- a/acceptance/features/edit_single_question_page_spec.rb
+++ b/acceptance/features/edit_single_question_page_spec.rb
@@ -1,0 +1,159 @@
+require_relative '../spec_helper'
+
+feature 'Edit single question page' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:page_url) { 'star-wars-question' }
+  let(:question) do
+    'Which program do Jedi use to open PDF files?'
+  end
+  let(:editable_options) do
+    ['Adobe-wan Kenobi', 'PDFinn']
+  end
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'when editing text component' do
+    given_I_have_a_single_question_page_with_text
+    when_I_update_the_question_name
+    and_I_return_to_flow_page
+    then_I_should_see_my_changes_on_preview
+  end
+
+  scenario 'when editing textarea component' do
+    given_I_have_a_single_question_page_with_textarea
+    when_I_update_the_question_name
+    and_I_return_to_flow_page
+    then_I_should_see_my_changes_on_preview
+  end
+
+  scenario 'when editing number component' do
+    given_I_have_a_single_question_page_with_number
+    when_I_update_the_question_name
+    and_I_return_to_flow_page
+    then_I_should_see_my_changes_on_preview
+  end
+
+  scenario 'when editing date component' do
+    given_I_have_a_single_question_page_with_date
+    when_I_update_the_question_name
+    and_I_return_to_flow_page
+    then_I_should_see_my_changes_on_preview
+  end
+
+  scenario 'when editing radio component' do
+    given_I_have_a_single_question_page_with_radio
+    when_I_update_the_question_name
+    and_I_update_the_options
+    and_I_return_to_flow_page
+    preview_form = then_I_should_see_my_changes_on_preview
+    and_I_should_see_the_options_that_I_added(preview_form)
+  end
+
+  scenario 'when editing checkboxes component' do
+    given_I_have_a_single_question_page_with_checkboxes
+    when_I_update_the_question_name
+    and_I_update_the_options
+    and_I_return_to_flow_page
+    preview_form = then_I_should_see_my_changes_on_preview
+    and_I_should_see_the_options_that_I_added(preview_form)
+  end
+
+  def given_I_have_a_single_question_page_with_textarea
+    given_I_add_a_single_question_page_with_text_area
+    and_I_add_a_page_url
+    when_I_add_the_page
+  end
+
+  def given_I_have_a_single_question_page_with_number
+    given_I_add_a_single_question_page_with_number
+    and_I_add_a_page_url
+    when_I_add_the_page
+  end
+
+  def given_I_have_a_single_question_page_with_date
+    given_I_add_a_single_question_page_with_date
+    and_I_add_a_page_url
+    when_I_add_the_page
+  end
+
+  def given_I_have_a_single_question_page_with_radio
+    given_I_add_a_single_question_page_with_radio
+    and_I_add_a_page_url
+    when_I_add_the_page
+  end
+
+  def given_I_have_a_single_question_page_with_checkboxes
+    given_I_add_a_single_question_page_with_checkboxes
+    and_I_add_a_page_url
+    when_I_add_the_page
+  end
+
+  def and_I_edit_the_question
+    editor.question_heading.first.set(question)
+  end
+
+  def when_I_save_my_changes
+    # click outside of fields that will make save button re-enable
+    editor.service_name.click
+    expect(editor.save_page_button).to_not be_disabled
+    editor.save_page_button.click
+  end
+
+  def and_I_return_to_flow_page
+    editor.pages_link.click
+  end
+
+  def and_I_preview_the_form
+    window_opened_by do
+      editor.preview_form_button.click
+    end
+  end
+
+  def and_I_go_to_the_page_that_I_edit(preview_form)
+    within_window(preview_form) do
+      page.click_button 'Start now'
+    end
+  end
+
+  def when_I_update_the_question_name
+    and_I_edit_the_question
+    when_I_save_my_changes
+  end
+
+  def and_I_edit_the_options
+    editor.editable_options.first.set(editable_options.first)
+    editor.editable_options.last.set(editable_options.last)
+  end
+
+  def and_I_update_the_options
+    and_I_edit_the_options
+    when_I_save_my_changes
+  end
+
+  def then_I_should_see_my_changes_on_preview
+    preview_form = and_I_preview_the_form
+
+    and_I_go_to_the_page_that_I_edit(preview_form)
+    then_I_should_see_my_changes_in_the_form(preview_form)
+
+    preview_form
+  end
+
+  def then_I_should_see_my_changes_in_the_form(preview_form)
+    within_window(preview_form) do
+      expect(page.text).to include(question)
+    end
+  end
+
+  def and_I_should_see_the_options_that_I_added(preview_form)
+    within_window(preview_form) do
+      editable_options.each do |option|
+        expect(page.text).to include(option)
+      end
+    end
+  end
+end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 class EditorApp < SitePrism::Page
   if ENV['ACCEPTANCE_TESTS_USER'] && ENV['ACCEPTANCE_TESTS_PASSWORD']
     set_url ENV['ACCEPTANCE_TESTS_EDITOR_APP'] % {
@@ -17,10 +16,12 @@ class EditorApp < SitePrism::Page
   element :name_field, :field, 'What is the name of this form?'
   element :create_service_button, :button, 'Create a new form'
 
+  element :pages_link, :link, 'Pages'
   element :settings_link, :link, 'Settings'
   element :form_details_link, :link, 'Form details'
   element :form_name_field, :field, 'Form name'
   element :save_button, :button, 'Save'
+  element :preview_form_button, :link, 'Preview form'
 
   element :submission_settings_link, :link, 'Submission settings'
   element :send_by_email_link, :link, 'Send by email'
@@ -54,6 +55,9 @@ class EditorApp < SitePrism::Page
 
   elements :radio_options, :xpath, '//input[@type="radio"]', visible: false
   elements :checkboxes_options, :xpath, '//input[@type="checkbox"]', visible: false
+
+  elements :question_heading, '.EditableElement'
+  elements :editable_options, '.EditableCollectionItemComponent label'
 
   def edit_service_link(service_name)
     find("#service-#{service_name.parameterize} .edit")

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -26,7 +26,80 @@ module CommonSteps
     editor.create_service_button.click
   end
 
+  def given_I_have_a_single_question_page_with_text
+    given_I_add_a_single_question_page_with_text
+    and_I_add_a_page_url
+    when_I_add_the_page
+  end
+
+  def given_I_add_a_single_question_page_with_text
+    given_I_want_to_add_a_single_question_page
+    editor.add_single_question_text.click
+  end
+
+  def given_I_add_a_single_question_page_with_text_area
+    given_I_want_to_add_a_single_question_page
+    editor.add_single_question_text_area.click
+  end
+
+  def given_I_add_a_single_question_page_with_number
+    given_I_want_to_add_a_single_question_page
+    editor.add_single_question_number.click
+  end
+
+  def given_I_add_a_single_question_page_with_date
+    given_I_want_to_add_a_single_question_page
+    editor.add_single_question_date.click
+  end
+
+  def given_I_add_a_single_question_page_with_radio
+    given_I_want_to_add_a_single_question_page
+    editor.add_single_question_radio.click
+  end
+
+  def given_I_add_a_single_question_page_with_checkboxes
+    given_I_want_to_add_a_single_question_page
+    editor.add_single_question_checkboxes.click
+  end
+
+  def given_I_add_a_check_answers_page
+    given_I_want_to_add_a_page
+    editor.add_check_answers.click
+  end
+
+  def given_I_add_a_multiple_question_page
+    given_I_want_to_add_a_page
+    editor.add_multiple_question.click
+  end
+
+  def given_I_add_a_confirmation_page
+    given_I_want_to_add_a_page
+    editor.add_confirmation.click
+  end
+
+  def given_I_want_to_add_a_single_question_page
+    given_I_want_to_add_a_page
+    editor.add_single_question.hover
+  end
+
+  def given_I_want_to_add_a_page
+    editor.add_page.click
+  end
+
+  def and_I_edit_the_service
+    visit '/services'
+    editor.edit_service_link(service_name).click
+  end
+
+  def and_I_add_a_page_url
+    editor.page_url_field.set(page_url)
+  end
+
   def when_I_create_the_service
     editor.modal_create_service_button.click
+  end
+
+  def when_I_add_the_page
+    editor.add_page_submit_button.last.click
   end
 end


### PR DESCRIPTION
## Context

This adds the edit the single question acceptance tests

## What these tests do not cover yet?

* The add option on radio and checkboxes is not covered because is in progress at the moment.