### PR TITLE
Use Metadata Presenter 0.18.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'daemons'
 #     branch: 'feature/preview'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.18.3'
+gem 'metadata_presenter', '0.18.4'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.18.3)
+    metadata_presenter (0.18.4)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -326,7 +326,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.6.0)
   hashie
   listen (~> 3.4)
-  metadata_presenter (= 0.18.3)
+  metadata_presenter (= 0.18.4)
   omniauth-auth0 (~> 2.5.0)
   omniauth-rails_csrf_protection (~> 0.1.2)
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
This prevents the use of raw HTML in section headings, headings, questions and ledes.