### PR TITLE
Session duration for editor

### DIFF
--- a/deploy/fb-editor-chart/templates/sessions_trim.yaml
+++ b/deploy/fb-editor-chart/templates/sessions_trim.yaml
@@ -16,7 +16,7 @@ spec:
             args:
             - /bin/sh
             - -c
-            - bundle exec rails db:sessions:trim
+            - rake db:sessions:trim
             securityContext:
               runAsUser: 1001
             imagePullPolicy: Always

--- a/deploy/fb-editor-chart/templates/sessions_trim.yaml
+++ b/deploy/fb-editor-chart/templates/sessions_trim.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fb-editor-cron-sessions-trim-{{ .Values.environmentName }}
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 spec:
-  schedule: "0 3 * * *"
+  schedule: "*/30 * * * *"
   successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:

--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -1,0 +1,9 @@
+namespace 'db:sessions' do
+  desc "Trim old sessions from the table (> 90 minutes)"
+  task :trim => [:environment, 'db:load_config'] do
+    cutoff_period = 90.minutes.ago
+    ActiveRecord::SessionStore::Session.
+    where("updated_at < ?", cutoff_period).
+    delete_all
+  end
+end


### PR DESCRIPTION
Story: https://trello.com/c/0CceGvhN/1385-session-duration-for-editor

This PR adds a rake task that clears the database of sessions that have been inactive for more than 90 minutes. This rake task is run every 30minutes via a cron job.
