### PR TITLE
Add login steps when running for CI mode enabled

### DIFF
--- a/.env.acceptance_tests.ci
+++ b/.env.acceptance_tests.ci
@@ -1,1 +1,1 @@
-ACCEPTANCE_TESTS_EDITOR_APP='https://%{user}:%{password}@fb-editor-test.apps.live-1.cloud-platform.service.justice.gov.uk/'
+ACCEPTANCE_TESTS_EDITOR_APP='https://fb-editor-test.apps.live-1.cloud-platform.service.justice.gov.uk/'

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -12,6 +12,10 @@ class EditorApp < SitePrism::Page
   element :sign_in_email_field, :field, 'Email:'
   element :sign_in_submit, :button, 'Sign In'
 
+  element :email_address_field, :field, 'Email address'
+  element :password_field, :field, 'Password'
+  element :login_continue_button, :button, 'Continue'
+
   element :service_name, '#form-navigation-heading'
   element :name_field, :field, 'What is the name of this form?'
   element :create_service_button, :button, 'Create a new form'

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -2,8 +2,15 @@ module CommonSteps
   def given_I_am_logged_in
     editor.load
     editor.sign_in_button.click
-    editor.sign_in_email_field.set('form-builder-developers@digital.justice.gov.uk')
-    editor.sign_in_submit.click
+
+    if ENV['CI_MODE'].present?
+      editor.email_address_field.set(ENV['ACCEPTANCE_TESTS_USER'])
+      editor.password_field.set(ENV['ACCEPTANCE_TESTS_PASSWORD'])
+      editor.login_continue_button.click
+    else
+      editor.sign_in_email_field.set('form-builder-developers@digital.justice.gov.uk')
+      editor.sign_in_submit.click
+    end
   end
 
   def given_I_have_a_service(service = service_name)


### PR DESCRIPTION
## Context

This adds the authentication step when running in CI mode (pointing to the test environment)

The build passed here: https://app.circleci.com/pipelines/github/ministryofjustice/fb-editor/1070/workflows/1c51b0fb-2f38-4eb4-a1d1-032a56a16d68/jobs/1441