### PR TITLE
Default text

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,10 @@ gem 'daemons'
 # one of these lines:
 # gem 'metadata_presenter',
 #     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'feature/preview'
-#gem 'metadata_presenter', path: '../fb-metadata-presenter'
+#     branch: 'default-text'
+# gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.18.4'
+gem 'metadata_presenter', '0.19.1'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.6.0'

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ gem 'daemons'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'default-text'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-#
-gem 'metadata_presenter', '0.19.1'
+
+gem 'metadata_presenter', '0.19.2'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     jwt (2.2.2)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -150,7 +150,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.18.4)
+    metadata_presenter (0.19.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -326,7 +326,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.6.0)
   hashie
   listen (~> 3.4)
-  metadata_presenter (= 0.18.4)
+  metadata_presenter (= 0.19.1)
   omniauth-auth0 (~> 2.5.0)
   omniauth-rails_csrf_protection (~> 0.1.2)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.19.1)
+    metadata_presenter (0.19.2)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -326,7 +326,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.6.0)
   hashie
   listen (~> 3.4)
-  metadata_presenter (= 0.19.1)
+  metadata_presenter (= 0.19.2)
   omniauth-auth0 (~> 2.5.0)
   omniauth-rails_csrf_protection (~> 0.1.2)
   pg (>= 0.18, < 2.0)

--- a/acceptance/features/default_text_spec.rb
+++ b/acceptance/features/default_text_spec.rb
@@ -1,0 +1,90 @@
+require_relative '../spec_helper'
+
+feature 'Default text' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:page_url) { 'star-wars-question' }
+  let(:question) do
+    'Which program do Jedi use to open PDF files?'
+  end
+  let(:editable_options) do
+    ['Adobe-wan Kenobi', 'PDFinn']
+  end
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'Text component with default text' do
+    given_I_have_a_single_question_page_with_text
+    then_I_should_see_default_text
+    and_I_return_to_flow_page
+    preview_page = when_I_preview_the_page
+    then_I_should_preview_the_page(preview_page) do
+      and_I_should_not_see_the_default_text
+    end
+  end
+
+  scenario 'Text component with custom hint from the user' do
+    given_I_have_a_single_question_page_with_text
+    when_I_customise_hint
+    when_I_save_my_changes
+    and_I_return_to_flow_page
+    preview_page = when_I_preview_the_page
+    then_I_should_preview_the_page(preview_page) do
+      and_I_see_the_custom_hint
+    end
+  end
+
+  scenario 'Radio component with default text' do
+    given_I_have_a_single_question_page_with_radio
+    then_I_should_see_default_text_in_label_and_options
+    and_I_return_to_flow_page
+    preview_page = when_I_preview_the_page
+    then_I_should_preview_the_page(preview_page) do
+      and_I_should_not_see_the_default_text
+    end
+  end
+
+  scenario 'Radio component with custom hint from the user' do
+    given_I_have_a_single_question_page_with_radio
+    when_I_customise_all_hints
+    when_I_save_my_changes
+    and_I_return_to_flow_page
+    preview_page = when_I_preview_the_page
+    then_I_should_preview_the_page(preview_page) do
+      and_I_see_all_custom_hints
+    end
+  end
+
+  def then_I_should_see_default_text
+    expect(editor.question_hint.text).to eq("[Optional hint text]")
+  end
+
+  def and_I_should_not_see_the_default_text
+    expect(page.text).to_not include(MetadataPresenter::DefaultText['hint'])
+  end
+
+  def when_I_customise_hint
+    editor.question_hint.set('This is where you add your name')
+  end
+
+  def and_I_see_the_custom_hint
+    expect(page.text).to include('This is where you add your name')
+  end
+
+  def then_I_should_see_default_text_in_label_and_options
+    expect(editor.all_hints.map(&:text)).to eq(["[Optional hint text]", "[Optional hint text]", "[Optional hint text]"])
+  end
+
+  def when_I_customise_all_hints
+    editor.all_hints.each do |hint|
+      hint.set('This is a radio button')
+    end
+  end
+
+  def and_I_see_all_custom_hints
+    expect(page.text).to include('This is a radio button')
+  end
+end

--- a/acceptance/features/edit_single_question_page_spec.rb
+++ b/acceptance/features/edit_single_question_page_spec.rb
@@ -80,12 +80,6 @@ feature 'Edit single question page' do
     when_I_add_the_page
   end
 
-  def given_I_have_a_single_question_page_with_radio
-    given_I_add_a_single_question_page_with_radio
-    and_I_add_a_page_url
-    when_I_add_the_page
-  end
-
   def given_I_have_a_single_question_page_with_checkboxes
     given_I_add_a_single_question_page_with_checkboxes
     and_I_add_a_page_url
@@ -94,13 +88,6 @@ feature 'Edit single question page' do
 
   def and_I_edit_the_question
     editor.question_heading.first.set(question)
-  end
-
-  def when_I_save_my_changes
-    # click outside of fields that will make save button re-enable
-    editor.service_name.click
-    expect(editor.save_page_button).to_not be_disabled
-    editor.save_page_button.click
   end
 
   def and_I_preview_the_form

--- a/acceptance/features/preview_page_spec.rb
+++ b/acceptance/features/preview_page_spec.rb
@@ -27,31 +27,10 @@ feature 'Preview page' do
     when_I_click_preview_page
   end
 
-  def when_I_preview_the_page
-    editor.preview_page_images.last.hover
-    when_I_click_preview_page
-  end
-
-  def when_I_click_preview_page
-    editor.three_dots_button.click
-
-    window_opened_by do
-      editor.preview_page_link.click
-    end
-  end
-
   def then_I_should_preview_the_start_page(preview_page)
     within_window(preview_page) do
       expect(page.find('button')).to_not be_disabled
       expect(page.text).to include('Before you start')
-    end
-  end
-
-  def then_I_should_preview_the_page(preview_page)
-    within_window(preview_page) do
-      expect(page.find('input[type="submit"]')).to_not be_disabled
-      expect(page.text).to include('Question')
-      expect(page.text).to include('[Optional hint text]')
     end
   end
 end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -61,7 +61,9 @@ class EditorApp < SitePrism::Page
   elements :checkboxes_options, :xpath, '//input[@type="checkbox"]', visible: false
 
   elements :question_heading, '.EditableElement'
+  elements :all_hints, '.govuk-hint'
   elements :editable_options, '.EditableCollectionItemComponent label'
+  element :question_hint, '.govuk-hint'
 
   elements :form_pages, '.form-step'
   elements :form_urls, '.form-step a.govuk-link'

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -113,4 +113,38 @@ module CommonSteps
   def when_I_add_the_page
     editor.add_page_submit_button.last.click
   end
+
+  def when_I_preview_the_page
+    editor.preview_page_images.last.hover
+    when_I_click_preview_page
+  end
+
+  def when_I_click_preview_page
+    editor.three_dots_button.click
+
+    window_opened_by do
+      editor.preview_page_link.click
+    end
+  end
+
+  def then_I_should_preview_the_page(preview_page)
+    within_window(preview_page) do
+      expect(page.find('input[type="submit"]')).to_not be_disabled
+      expect(page.text).to include('Question')
+      yield if block_given?
+    end
+  end
+
+  def when_I_save_my_changes
+    # click outside of fields that will make save button re-enable
+    editor.service_name.click
+    expect(editor.save_page_button).to_not be_disabled
+    editor.save_page_button.click
+  end
+
+  def given_I_have_a_single_question_page_with_radio
+    given_I_add_a_single_question_page_with_radio
+    and_I_add_a_page_url
+    when_I_add_the_page
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include Auth0Helper
 
   def service
-    @service ||= MetadataPresenter::Service.new(service_metadata)
+    @service ||= MetadataPresenter::Service.new(service_metadata, editor: editable?)
   end
   helper_method :service
 

--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -1,8 +1,3 @@
 class PreviewController < ApplicationController
   layout 'metadata_presenter/application'
-
-  def service
-    @service ||= MetadataPresenter::Service.new(service_metadata, editor: editable?)
-  end
-  helper_method :service
 end

--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -1,3 +1,8 @@
 class PreviewController < ApplicationController
   layout 'metadata_presenter/application'
+
+  def service
+    @service ||= MetadataPresenter::Service.new(service_metadata, editor: editable?)
+  end
+  helper_method :service
 end

--- a/spec/generators/new_page_generator_spec.rb
+++ b/spec/generators/new_page_generator_spec.rb
@@ -104,14 +104,14 @@ RSpec.describe NewPageGenerator do
           '_id' => 'page.home-one',
           '_type' => 'page.singlequestion',
           'heading' => 'Question',
-          'lede' => 'This is the lede',
+          'lede' => '',
           'body' => 'Body section',
           'components' => [
             {
               '_id'    => "#{page_url}_#{component_type}_1",
               '_type'  => 'text',
               'errors' => {},
-              'hint'   => '[Optional hint text]',
+              'hint'   => '',
               'label'  => 'Question',
               'name'   => "#{page_url}_#{component_type}_1",
               'validation' => {


### PR DESCRIPTION
Ensure the default text is editable and is only shown in preview mode when the user has customised it.

Story: https://trello.com/c/YSHgwzER/1382-placeholder-text

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>