### PR TITLE
Fix lost page type after error

### DIFF
--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -84,8 +84,8 @@
        data-activator-text="<%= t('pages.create') %>"
        data-cancel-text="<%= t('pages.cancel') %>">
     <%= form_for(@page_creation, as: :page, url: pages_path) do |f| %>
-      <%= f.hidden_field :page_type, value: 'singlequestion' %>
-      <%= f.hidden_field :component_type, value: 'text' %>
+      <%= f.hidden_field :page_type, value: f.object.page_type.nil? ? 'singlequestion' : f.object.page_type  %>
+      <%= f.hidden_field :component_type, value: f.object.component_type.nil? ? 'text' : f.object.component_type %>
       <div class="govuk-form-group <%= !f.object.errors.empty? ? 'govuk-form-group--error' :'' %>">
         <%= f.label :page_url, class: "govuk-label govuk-label--m" %>
         <% f.object.errors.each do |error|  %>


### PR DESCRIPTION
(copied from ticket)

On form 'flow' page, the default set type is Single Question (written in hidden form fields on page load). This default is overwrites the chosen type after user error.

Steps to replicate:

1. Visit form 'flow' page.
2. Click 'Add page' (but not Single Question type).
3. Enter incorrect information in Dialog.
4. Submit.
5. Page is sent to server and reloads with error.
6. Correct error and submit.
7. Page is created but of Single Question type, not the alternative you chose in step 2.
