### PR TITLE
Add Sentry Configuration 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem 'rails', '~> 6.1.3'
 gem 'sass-rails', '>= 6'
 gem 'tzinfo-data'
 gem 'webpacker', '~> 5.2'
+gem 'sentry-ruby', '~> 4.3.0'
+gem 'sentry-rails', '~> 4.3.1'
+gem 'sentry-delayed_job', '~> 4.3.0'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,18 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
+    sentry-delayed_job (4.3.0)
+      sentry-ruby-core (~> 4.3.0)
+    sentry-rails (4.3.1)
+      rails (>= 5.0)
+      sentry-ruby-core (~> 4.3.0)
+    sentry-ruby (4.3.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      faraday (>= 1.0)
+      sentry-ruby-core (= 4.3.0)
+    sentry-ruby-core (4.3.0)
+      concurrent-ruby
+      faraday
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
     site_prism (3.7.1)
@@ -335,6 +347,9 @@ DEPENDENCIES
   rspec-rails
   sass-rails (>= 6)
   selenium-webdriver (= 3.142.7)
+  sentry-delayed_job (~> 4.3.0)
+  sentry-rails (~> 4.3.1)
+  sentry-ruby (~> 4.3.0)
   shoulda-matchers
   site_prism
   spring

--- a/app/services/metadata_api_client/service.rb
+++ b/app/services/metadata_api_client/service.rb
@@ -15,6 +15,7 @@ module MetadataApiClient
       response = connection.post('/services', metadata)
       new(response.body)
     rescue Faraday::UnprocessableEntityError => exception
+      Sentry.capture_exception(exception)
       error_messages(exception)
     end
   end

--- a/app/services/metadata_api_client/version.rb
+++ b/app/services/metadata_api_client/version.rb
@@ -7,6 +7,7 @@ module MetadataApiClient
         ).body
       )
     rescue Faraday::UnprocessableEntityError => exception
+      Sentry.capture_exception(exception)
       error_messages(exception)
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,3 +33,13 @@ module FbEditor
     config.generators.system_tests = nil
   end
 end
+
+Sentry.init do |config|
+  config.breadcrumbs_logger = [:active_support_logger]
+
+  config.before_send = lambda do |event, _hint|
+    filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+    event.request.data = filter.filter(event.request.data)
+    event
+  end
+end

--- a/deploy/fb-editor-chart/templates/deployment.yaml
+++ b/deploy/fb-editor-chart/templates/deployment.yaml
@@ -42,8 +42,6 @@ spec:
           - configMapRef:
               name: fb-editor-config-map
         env:
-          - name: SENTRY_CURRENT_ENV
-            value: {{ .Values.environmentName }}
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:
@@ -145,8 +143,6 @@ spec:
           - configMapRef:
               name: fb-editor-config-map
         env:
-          - name: SENTRY_CURRENT_ENV
-            value: {{ .Values.environmentName }}
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:

--- a/deploy/fb-editor-chart/templates/deployment.yaml
+++ b/deploy/fb-editor-chart/templates/deployment.yaml
@@ -49,6 +49,11 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: secret_key_base
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: sentry_dsn
           - name: AUTH0_CLIENT_ID
             valueFrom:
               secretKeyRef:
@@ -147,6 +152,11 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: secret_key_base
+          - name: SENTRY_DSN
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: sentry_dsn
           - name: AUTH0_CLIENT_ID
             valueFrom:
               secretKeyRef:

--- a/deploy/fb-editor-chart/templates/secrets.yaml
+++ b/deploy/fb-editor-chart/templates/secrets.yaml
@@ -6,6 +6,7 @@ metadata:
 type: Opaque
 data:
   secret_key_base: {{ .Values.secret_key_base }}
+  sentry_dsn: {{ .Values.sentry_dsn }}
   auth0_client_id: {{ .Values.auth0_client_id }}
   auth0_client_secret: {{ .Values.auth0_client_secret }}
   encoded_private_key: {{ .Values.encoded_private_key}}

--- a/deploy/fb-editor-chart/templates/sessions_trim.yaml
+++ b/deploy/fb-editor-chart/templates/sessions_trim.yaml
@@ -26,6 +26,11 @@ spec:
             env:
               - name: SENTRY_CURRENT_ENV
                 value: {{ .Values.environmentName }}
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: sentry_dsn
               - name: SECRET_KEY_BASE
                 valueFrom:
                   secretKeyRef:

--- a/deploy/fb-editor-chart/templates/sessions_trim.yaml
+++ b/deploy/fb-editor-chart/templates/sessions_trim.yaml
@@ -24,8 +24,6 @@ spec:
               - configMapRef:
                   name: fb-editor-config-map
             env:
-              - name: SENTRY_CURRENT_ENV
-                value: {{ .Values.environmentName }}
               - name: SENTRY_DSN
                 valueFrom:
                   secretKeyRef:

--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -1,9 +1,13 @@
 namespace 'db:sessions' do
   desc "Trim old sessions from the table (> 90 minutes)"
   task :trim => [:environment, 'db:load_config'] do
-    cutoff_period = 90.minutes.ago
-    ActiveRecord::SessionStore::Session.
-    where("updated_at < ?", cutoff_period).
-    delete_all
+    begin
+      cutoff_period = 90.minutes.ago
+      ActiveRecord::SessionStore::Session.
+      where("updated_at < ?", cutoff_period).
+      delete_all
+    rescue StandardError => e
+      Sentry.capture_exception(e)
+    end
   end
 end


### PR DESCRIPTION
## Add Sentry configuration

This requires three gems as we also have delayed job queues for publishing.

## Remove SENTRY_CURRENT_ENV 

As a result of having 4 different namespace environments as opposed to the regular 2 we structure our sentry projects differently.

We have 2 sentry projects per app, one for test and one for live. The test one covers anything in the test-dev, test-production and live-dev namespaces whereas live is exclusively for live-production only. Therefore it's fine to let SENTRY_CURRENT_ENV use whatever RAILS_ENV is set to as it does by default.

## Send alerts to sentry 

Currently just set to capture errors when creating services or versions or when an error occurs in the rake task that cleans inactive sessions.