### PR TITLE
Fix text movement

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -371,6 +371,7 @@ html {
     &,
     &:hover {
       @include govuk-font($size: 19);
+      border-bottom:  govuk-colour("light-grey") solid 4px;
       color: $govuk-link-colour;
       display: block;
       font: inherit;
@@ -397,7 +398,7 @@ html {
 
     &.current {
       a {
-        border-bottom:  govuk-colour("blue") solid 4px;
+        border-color:  govuk-colour("blue");
 
         &:focus {
           border-color: $govuk-text-colour;


### PR DESCRIPTION
Less space below:
<img width="366" alt="Screenshot 2021-03-19 at 17 17 17" src="https://user-images.githubusercontent.com/76942244/111818355-fdf4f480-88d6-11eb-93bc-b16d783f2155.png">

More space with border:
<img width="365" alt="Screenshot 2021-03-19 at 17 03 07" src="https://user-images.githubusercontent.com/76942244/111818388-06e5c600-88d7-11eb-951d-c70a48fe85fd.png">

Now same space with or without.