### PR TITLE
Add service Sentry DSN's during publishing

### DIFF
--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -17,6 +17,8 @@ class Publisher
 
     validates :service_configuration, private_public_key: true
 
+    LIVE_PRODUCTION = 'live-production'.freeze
+
     def service_metadata
       service.to_json
     end
@@ -102,6 +104,15 @@ class Publisher
       '128Mi'
     end
 
+    def service_sentry_dsn
+      if platform_deployment == LIVE_PRODUCTION
+        ENV["SERVICE_SENTRY_DSN_LIVE"]
+      else
+        # test-dev, test-production and live-dev
+        ENV["SERVICE_SENTRY_DSN_TEST"]
+      end
+    end
+
     def config_map
       service_configuration.reject(&:secrets?).reject(&:do_not_send_submission?)
     end
@@ -116,6 +127,10 @@ class Publisher
       @service ||= MetadataPresenter::Service.new(
         MetadataApiClient::Service.latest_version(service_id)
       )
+    end
+
+    def platform_deployment
+      "#{platform_environment}-#{deployment_environment}"
     end
   end
 end

--- a/config/publisher/cloud_platform/deployment.yaml.erb
+++ b/config/publisher/cloud_platform/deployment.yaml.erb
@@ -45,6 +45,8 @@ spec:
             value: <%= secret_key_base %>
           - name: SERVICE_METADATA
             value: '<%= service_metadata %>'
+          - name: SENTRY_DSN
+            value: '<%= service_sentry_dsn %>'
         <% secrets.each do |secret|  %>
           - name: <%= secret.name %>
             valueFrom:

--- a/deploy/fb-editor-chart/templates/deployment.yaml
+++ b/deploy/fb-editor-chart/templates/deployment.yaml
@@ -77,14 +77,6 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: encryption_salt
-          # secrets created by terraform
-          # which may or may not depend on values
-          # canonically defined in secrets.tfvars
-          # Some assets aren't loading properly yet
-          # ...maybe an issue with how they're referenced,
-          # maybe something else - re-enabled this later
-          #
-          # Created by cloud-platforms-environments
           - name: DATABASE_URL
             valueFrom:
               secretKeyRef:
@@ -100,6 +92,16 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: submission_encryption_key
+          - name: SERVICE_SENTRY_DSN_TEST
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: service_sentry_dsn_test
+          - name: SERVICE_SENTRY_DSN_LIVE
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: service_sentry_dsn_live
       volumes:
         - name: tmp-files
           emptyDir: {}
@@ -178,14 +180,6 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: encryption_salt
-          # secrets created by terraform
-          # which may or may not depend on values
-          # canonically defined in secrets.tfvars
-          # Some assets aren't loading properly yet
-          # ...maybe an issue with how they're referenced,
-          # maybe something else - re-enabled this later
-          #
-          # Created by cloud-platforms-environments
           - name: DATABASE_URL
             valueFrom:
               secretKeyRef:
@@ -201,6 +195,16 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: submission_encryption_key
+          - name: SERVICE_SENTRY_DSN_TEST
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: service_sentry_dsn_test
+          - name: SERVICE_SENTRY_DSN_LIVE
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: service_sentry_dsn_live
       volumes:
         - name: tmp-files
           emptyDir: {}

--- a/deploy/fb-editor-chart/templates/secrets.yaml
+++ b/deploy/fb-editor-chart/templates/secrets.yaml
@@ -13,3 +13,5 @@ data:
   encryption_key: {{ .Values.encryption_key }}
   encryption_salt: {{ .Values.encryption_salt }}
   submission_encryption_key: {{ .Values.submission_encryption_key }}
+  service_sentry_dsn_test: {{ .Values.service_sentry_dsn_test }}
+  service_sentry_dsn_live: {{ .Values.service_sentry_dsn_live }}

--- a/spec/fixtures/kubernetes_configuration/deployment.yaml
+++ b/spec/fixtures/kubernetes_configuration/deployment.yaml
@@ -45,6 +45,8 @@ spec:
             value: 'fdfdd491d611aa1abef54cbf24a709a1bb31ff881a487f8c58c69399202b08f77019920f481e17b40dd7452361055534b9f91f172719ed98a088498242f96f59'
           - name: SERVICE_METADATA
             value: '{"service_name":"acceptance-tests-date"}'
+          - name: SENTRY_DSN
+            value: 'sentry-dsn-test'
           - name: ENCODED_PRIVATE_KEY
             valueFrom:
               secretKeyRef:

--- a/spec/services/publisher/service_provisioner_spec.rb
+++ b/spec/services/publisher/service_provisioner_spec.rb
@@ -232,4 +232,40 @@ RSpec.describe Publisher::ServiceProvisioner do
       end
     end
   end
+
+  describe '#service_sentry_dsn' do
+    before do
+      allow(ENV).to receive(:[])
+      allow(ENV).to receive(:[]).with('SERVICE_SENTRY_DSN_TEST').and_return('test')
+      allow(ENV).to receive(:[]).with('SERVICE_SENTRY_DSN_LIVE').and_return('live')
+    end
+
+    context 'not live production' do
+      not_live_production = [
+        { platform_environment: 'test', deployment_environment: 'dev' },
+        { platform_environment: 'test', deployment_environment: 'production' },
+        { platform_environment: 'live', deployment_environment: 'dev' }
+      ]
+
+      not_live_production.each do |platform_deployment|
+        context "#{platform_deployment[:platform_environment]}-#{platform_deployment[:deployment_environment]}" do
+          let(:attributes) { platform_deployment }
+
+          it 'creates the correct platform deployment' do
+            expect(service_provisioner.service_sentry_dsn).to eq('test')
+          end
+        end
+      end
+    end
+
+    context 'live production' do
+      let(:attributes) do
+        { platform_environment: 'live', deployment_environment: 'production' }
+      end
+
+      it 'creates the correct platform deployment' do
+        expect(service_provisioner.service_sentry_dsn).to eq('live')
+      end
+    end
+  end
 end

--- a/spec/services/publisher/utils/kubernetes_configuration_spec.rb
+++ b/spec/services/publisher/utils/kubernetes_configuration_spec.rb
@@ -45,6 +45,9 @@ RSpec.describe Publisher::Utils::KubernetesConfiguration do
     allow(ENV).to receive(:[])
       .with('SUBMISSION_ENCRYPTION_KEY')
       .and_return('65a27a35-c475-48b9-9a20-30142f14')
+    allow(ENV).to receive(:[])
+      .with('SERVICE_SENTRY_DSN_TEST')
+      .and_return('sentry-dsn-test')
   end
 
   describe '#generate' do


### PR DESCRIPTION
We need to inject Sentry DSN's into the configuration for all the published services.

test-dev, test-production and live-dev all use the same DSN which sends exceptions to the test project in Sentry.

live-production has its' own project in Sentry.