### PR TITLE
Escape service metadata

### DIFF
--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -20,7 +20,7 @@ class Publisher
     LIVE_PRODUCTION = 'live-production'.freeze
 
     def service_metadata
-      service.to_json
+      service.to_json.inspect
     end
 
     def get_binding

--- a/config/publisher/cloud_platform/deployment.yaml.erb
+++ b/config/publisher/cloud_platform/deployment.yaml.erb
@@ -44,7 +44,7 @@ spec:
           - name: SECRET_KEY_BASE
             value: <%= secret_key_base %>
           - name: SERVICE_METADATA
-            value: '<%= service_metadata %>'
+            value: <%= ERB::Util.json_escape(service_metadata) %>
           - name: SENTRY_DSN
             value: '<%= service_sentry_dsn %>'
         <% secrets.each do |secret|  %>

--- a/spec/fixtures/kubernetes_configuration/deployment.yaml
+++ b/spec/fixtures/kubernetes_configuration/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           - name: SECRET_KEY_BASE
             value: 'fdfdd491d611aa1abef54cbf24a709a1bb31ff881a487f8c58c69399202b08f77019920f481e17b40dd7452361055534b9f91f172719ed98a088498242f96f59'
           - name: SERVICE_METADATA
-            value: '{"service_name":"acceptance-tests-date"}'
+            value: "{\"service_name\":\"acceptance-tests-date\",\"test_escaping\":\"I don't know\"}"
           - name: SENTRY_DSN
             value: 'sentry-dsn-test'
           - name: ENCODED_PRIVATE_KEY

--- a/spec/services/publisher/utils/kubernetes_configuration_spec.rb
+++ b/spec/services/publisher/utils/kubernetes_configuration_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe Publisher::Utils::KubernetesConfiguration do
   before do
     allow(service_provisioner).to receive(:service).and_return(
       MetadataPresenter::Service.new(
-        'service_name' => 'acceptance-tests-date'
+        'service_name' => 'acceptance-tests-date',
+        'test_escaping' => "I don't know"
       )
     )
     allow(service_provisioner).to receive(:secret_key_base).and_return(


### PR DESCRIPTION
Story: https://trello.com/c/7FaYyHxY/1406-investigate-editor-publishing-failure

There is a publishing failure when the service metadata has a `'` character.
This PR addresses this issue by escaping the service metadata.

Co-authored by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>