### PR TITLE
Add metrics endpoint for prometheus scraping

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,0 +1,63 @@
+class MetricsController < ActionController::Base
+  def show
+    response.set_header('Content-Type', 'text/plain; version=0.0.4')
+    @stats = [
+      delayed_jobs_stats,
+      users_stats,
+      active_sessions_stats
+    ].flatten
+
+    render 'metrics/show.text'
+  end
+
+  def filter_to_string(filter)
+    return '' if filter.blank?
+
+    filter.to_a.map { |k, v| "#{k}=\"#{v}\"" }.join(',').prepend('{').concat('}')
+  end
+  helper_method :filter_to_string
+
+  private
+
+  def delayed_jobs_stats
+    pending_job_count = Delayed::Job.where('attempts = 0').count
+    failed_job_count = Delayed::Job.where('attempts > 0').count
+
+    [
+      { name: :delayed_jobs_pending,
+        type: 'gauge',
+        docstring: 'Number of pending jobs',
+        value: pending_job_count
+      },
+      {
+        name: :delayed_jobs_failed,
+        type: 'gauge',
+        docstring: 'Number of jobs failed',
+        value: failed_job_count
+      }
+    ]
+  end
+
+  def users_stats
+    {
+      name: :users,
+      type: 'counter',
+      docstring: 'Number of registered users',
+      value: User.count
+    }
+  end
+
+  def active_sessions_stats
+    cutoff_period = 90.minutes.ago
+    count = ActiveRecord::SessionStore::Session.where(
+      "updated_at < ?", cutoff_period
+    ).count
+
+    {
+      name: :active_sessions,
+      type: 'counter',
+      docstring: 'Number of active sessions',
+      value: count
+    }
+  end
+end

--- a/app/views/metrics/show.text.erb
+++ b/app/views/metrics/show.text.erb
@@ -1,0 +1,5 @@
+<% @stats.each do |stat| %>
+# HELP <%= stat.fetch(:name) %> <%= stat.fetch(:docstring) %>
+# TYPE <%= stat.fetch(:name) %> <%= stat.fetch(:type) %>
+<%= stat.fetch(:name) %><%= filter_to_string(stat.fetch(:filter, nil)) %> <%= stat.fetch(:value) %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   get '/health', to: 'health#show'
+  get '/metrics', to: 'metrics#show'
 
   # Auth0 routes
   get "/auth/auth0/callback" => "auth0#callback", as: 'auth0_callback'

--- a/spec/requests/metrics_spec.rb
+++ b/spec/requests/metrics_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'MetricsController', type: :request do
+  describe 'GET /metrics' do
+    before do
+      get '/metrics'
+    end
+
+    it 'shows the required metrics' do
+      expected_response = <<~HEREDOC
+      # HELP delayed_jobs_pending Number of pending jobs
+      # TYPE delayed_jobs_pending gauge
+      delayed_jobs_pending 0
+      # HELP delayed_jobs_failed Number of jobs failed
+      # TYPE delayed_jobs_failed gauge
+      delayed_jobs_failed 0
+      # HELP users Number of registered users
+      # TYPE users counter
+      users 0
+      # HELP active_sessions Number of active sessions
+      # TYPE active_sessions counter
+      active_sessions 0
+      HEREDOC
+
+      expect(response.body).to eq(expected_response)
+    end
+  end
+end


### PR DESCRIPTION
This adds the metrics endpoint for prometheus to be able to scrape some
basic metrics. In this PR we expose:

- Number of pending delayed jobs (publishing)
- Number of failed delayed jobs (publishing)
- Total number of registered users
- Number of active sessions
- 
https://trello.com/c/9y7n4Njx/1378-monitoring

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>