### PR TITLE
Make sure we are using the right names for editor service

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       kramdown (>= 2.3.0)
       rails (>= 6.0.3.4, < 6.2.0)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)

--- a/deploy/fb-editor-chart/templates/service_monitor.yaml
+++ b/deploy/fb-editor-chart/templates/service_monitor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: "fb-editor-{{ .Values.environmentName }}"
+      app: "fb-editor-web-{{ .Values.environmentName }}"
   endpoints:
   - port: http
     interval: 15s
@@ -19,7 +19,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: "fb-editor-{{ .Values.environmentName }}"
+      app: "fb-editor-web-{{ .Values.environmentName }}"
   policyTypes:
   - Ingress
   ingress:


### PR DESCRIPTION
For the service monitor it is best to make sure we are following [CP docs](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/application-metrics.html#applications-configured-to-use-multiple-processes)

We need to make sure that we are using the same pod definition name in other places. 

We do have the `fb-editor-web` and `fb-editor-workers` pods so let's use this everywhere.