### PR TITLE
Remove sentry alerting when creating a service

### DIFF
--- a/app/services/metadata_api_client/service.rb
+++ b/app/services/metadata_api_client/service.rb
@@ -15,7 +15,6 @@ module MetadataApiClient
       response = connection.post('/services', metadata)
       new(response.body)
     rescue Faraday::UnprocessableEntityError => exception
-      Sentry.capture_exception(exception)
       error_messages(exception)
     end
   end


### PR DESCRIPTION
When someone tries to create a service with the same name of a
existing one, the sentry is alerted without need. So removing on this
commit.