### PR TITLE
Add label to session trim cronjob

### DIFF
--- a/deploy/fb-editor-chart/templates/sessions_trim.yaml
+++ b/deploy/fb-editor-chart/templates/sessions_trim.yaml
@@ -5,10 +5,13 @@ metadata:
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 spec:
   schedule: "*/30 * * * *"
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            sessions-trim: cronjob
         spec:
           containers:
           - name: "fb-editor-workers-{{ .Values.environmentName }}"


### PR DESCRIPTION
Just to make it a little easier to check for the status of completed
cronjobs add a label to the metatdata. Should then be possible to do
something like:

kubectl get pods -n formbuilder-saas-test -l sessions-trim

Also bump the successful job history to 1.