### PR TITLE
Make acceptance tests to pass again

### DIFF
--- a/acceptance/features/create_page_spec.rb
+++ b/acceptance/features/create_page_spec.rb
@@ -88,7 +88,7 @@ feature 'Create page' do
 
   def then_I_should_see_a_validation_error_message_that_page_url_exists
     expect(editor.text).to include(
-      "Your answer for ‘The page’s relative url - it must not contain any spaces' is already used by another page. Please modify it."
+      "Your answer for ‘What will be the URL for this page?' is already used by another page. Please modify it"
     )
   end
 

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -62,7 +62,7 @@ class EditorApp < SitePrism::Page
 
   elements :question_heading, '.EditableElement'
   elements :all_hints, '.govuk-hint'
-  elements :editable_options, '.EditableCollectionItemComponent label'
+  elements :editable_options, '.EditableComponentCollectionItem label'
   element :question_hint, '.govuk-hint'
 
   elements :form_pages, '.form-step'

--- a/acceptance/spec_helper.rb
+++ b/acceptance/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'capybara/rspec'
 require 'selenium/webdriver'
 require 'site_prism'
+require 'metadata_presenter'
 require 'dotenv'
 Dotenv.load('.env.acceptance_tests')
 require 'rails/all'


### PR DESCRIPTION
The radio/checkboxes js component changed name so we
had to change.

The metadata presenter is not included in the spec helper
so we had to add the require