### PR TITLE
Alerts live publish

### DIFF
--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,0 +1,21 @@
+require "net/http"
+require "uri"
+
+class NotificationService
+  def self.notify(message)
+    body = {
+      text: message,
+      username: 'MOJ Forms Editor',
+      icon_emoji: ':rockon:'
+    }
+
+    uri = URI.parse(ENV['SLACK_PUBLISH_WEBHOOK'])
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request.body = body.to_json
+
+    http.request(request)
+  end
+end

--- a/app/services/publisher/adapters/cloud_platform.rb
+++ b/app/services/publisher/adapters/cloud_platform.rb
@@ -3,7 +3,14 @@ class Publisher
     class CloudPlatform
       class ConfigFilesNotFound < StandardError; end
       attr_reader :service_provisioner
-      delegate :service_id, :namespace, :service_slug, to: :service_provisioner
+      delegate :service_id,
+               :namespace,
+               :service_slug,
+               :hostname,
+               :service_name,
+               :deployment_environment,
+               :live_production?,
+               to: :service_provisioner
 
       def initialize(service_provisioner)
         @service_provisioner = service_provisioner
@@ -37,9 +44,24 @@ class Publisher
       end
 
       def completed
+        if live_production? && first_published?
+          NotificationService.notify(message)
+        end
       end
 
       private
+
+      def first_published?
+        PublishService.completed
+        .where(
+          service_id: service_id,
+          deployment_environment: deployment_environment
+        ).count.zero?
+      end
+
+      def message
+        "#{service_name} has been published to #{namespace}.\n#{hostname}"
+      end
 
       def create_config_dir
         FileUtils.mkdir_p(config_dir)

--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -31,6 +31,10 @@ class Publisher
       service.service_slug
     end
 
+    def service_name
+      service.service_name
+    end
+
     def namespace
       Rails.application.config.platform_environments[:common][:namespace] % {
         platform_environment: platform_environment,
@@ -105,12 +109,16 @@ class Publisher
     end
 
     def service_sentry_dsn
-      if platform_deployment == LIVE_PRODUCTION
+      if live_production?
         ENV["SERVICE_SENTRY_DSN_LIVE"]
       else
         # test-dev, test-production and live-dev
         ENV["SERVICE_SENTRY_DSN_TEST"]
       end
+    end
+
+    def live_production?
+      platform_deployment == LIVE_PRODUCTION
     end
 
     def config_map

--- a/deploy/fb-editor-chart/templates/deployment.yaml
+++ b/deploy/fb-editor-chart/templates/deployment.yaml
@@ -102,6 +102,11 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: service_sentry_dsn_live
+          - name: SLACK_PUBLISH_WEBHOOK
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: slack_publish_webhook
       volumes:
         - name: tmp-files
           emptyDir: {}
@@ -205,6 +210,11 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: service_sentry_dsn_live
+          - name: SLACK_PUBLISH_WEBHOOK
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: slack_publish_webhook
       volumes:
         - name: tmp-files
           emptyDir: {}

--- a/deploy/fb-editor-chart/templates/secrets.yaml
+++ b/deploy/fb-editor-chart/templates/secrets.yaml
@@ -15,3 +15,4 @@ data:
   submission_encryption_key: {{ .Values.submission_encryption_key }}
   service_sentry_dsn_test: {{ .Values.service_sentry_dsn_test }}
   service_sentry_dsn_live: {{ .Values.service_sentry_dsn_live }}
+  slack_publish_webhook: {{ .Values.slack_publish_webhook }}

--- a/spec/requests/metrics_spec.rb
+++ b/spec/requests/metrics_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'MetricsController', type: :request do
   describe 'GET /metrics' do
     before do
+      ActiveRecord::SessionStore::Session.delete_all
       get '/metrics'
     end
 


### PR DESCRIPTION
## Context

Only when is live production and it is the first time publishing the service we will notify on our slack channel about it.

This adds one ENV var for slack webhook (see deploy repo for more info)
