### PR TITLE
Deny access to metrics endpoint

### DIFF
--- a/deploy/fb-editor-chart/templates/ingress.yaml
+++ b/deploy/fb-editor-chart/templates/ingress.yaml
@@ -2,6 +2,14 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: "fb-editor-ing-{{ .Values.environmentName }}"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      server_tokens off;
+      location /metrics {
+        deny all;
+        return 401;
+      }
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
We do not want unauthorised access to the metrics endpoint. There is no need for the request to even get as far as the application.

Prometheus seems to go directly to the container instead of using the ingress.