### PR TITLE
Make add page after works

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -33,7 +33,7 @@ class PagesController < FormController
     params.require(
       :page
     ).permit(
-      :page_url, :page_type, :component_type
+      :page_url, :page_type, :component_type, :add_page_after
     ).merge(common_params)
   end
 

--- a/app/generators/new_page_generator.rb
+++ b/app/generators/new_page_generator.rb
@@ -1,11 +1,15 @@
 class NewPageGenerator
   include ActiveModel::Model
-  attr_accessor :page_type, :page_url, :component_type, :latest_metadata
+  attr_accessor :page_type,
+                :page_url,
+                :component_type,
+                :latest_metadata,
+                :add_page_after
 
   def to_metadata
     latest_metadata.tap do
-      latest_metadata['pages'].push(page_metadata)
-      latest_metadata['pages'][0]['steps'].push(page_name)
+      latest_metadata['pages'].insert(insert_page_at, page_metadata)
+      latest_metadata['pages'][0]['steps'].insert(insert_page_at, page_name)
     end
   end
 
@@ -33,5 +37,23 @@ class NewPageGenerator
       component_type: component_type,
       page_url: page_url
     ).to_metadata
+  end
+
+  INSERT_LAST = -1
+
+  def insert_page_at
+    if add_page_after.present?
+      index = find_page_index_to_be_inserted_after
+
+      return index + 1 if index
+    end
+
+    INSERT_LAST
+  end
+
+  def find_page_index_to_be_inserted_after
+    latest_metadata['pages'].index(
+      latest_metadata['pages'].find { |page| page['_uuid'] == add_page_after }
+    )
   end
 end

--- a/app/services/page_creation.rb
+++ b/app/services/page_creation.rb
@@ -5,7 +5,8 @@ class PageCreation
                 :component_type,
                 :latest_metadata,
                 :service_id,
-                :version
+                :version,
+                :add_page_after
   validates :page_url, :page_type, presence: true
   validates :page_url, format: { with: /\A[\sa-zA-Z0-9-]*\z/ }
 
@@ -38,7 +39,8 @@ class PageCreation
       page_type: page_type,
       page_url: page_url.strip,
       component_type: component_type,
-      latest_metadata: latest_metadata
+      latest_metadata: latest_metadata,
+      add_page_after: add_page_after
     ).to_metadata
   end
 end


### PR DESCRIPTION
## Context

Insert a page after a given page.

The way it works is:

Given a params from the form called `page[add_page_after]` with the uuid of the page, the new page will be add after the given page in the params as expected.