### PR TITLE
Don't show the delete page if is the start page

### DIFF
--- a/acceptance/features/deleting_page_spec.rb
+++ b/acceptance/features/deleting_page_spec.rb
@@ -10,13 +10,6 @@ feature 'Deleting page' do
     given_I_have_a_service
   end
 
-  scenario 'when deleting start page' do
-    given_I_want_to_delete_the_start_page
-    when_I_delete_the_page
-    and_I_return_to_flow_page
-    then_I_should_still_see_the_start_page # Do not delete precious start pages
-  end
-
   scenario 'when deleting other pages' do
     given_I_have_a_single_question_page_with_text
     and_I_return_to_flow_page
@@ -24,11 +17,6 @@ feature 'Deleting page' do
     when_I_delete_the_page
     and_I_return_to_flow_page
     then_I_should_not_see_the_deleted_page_anymore
-  end
-
-  def given_I_want_to_delete_the_start_page
-    editor.preview_page_images.first.hover
-    editor.three_dots_button.click
   end
 
   def and_I_want_to_delete_the_page_that_I_created
@@ -39,10 +27,6 @@ feature 'Deleting page' do
   def when_I_delete_the_page
     editor.delete_page_link.click
     editor.delete_page_modal_button.click
-  end
-
-  def then_I_should_still_see_the_start_page
-    expect(editor.form_urls.map(&:text)).to eq(['/'])
   end
 
   def then_I_should_not_see_the_deleted_page_anymore

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -11,11 +11,6 @@
 
       <%= flow_thumbnail(page, service.service_id) %>
 
-      <%# TODO: Backend to add dynamic data-driven values to this standard output %>
-      <%# Note: This would probably be more efficient if outside the loop so that %>
-      <%# we only generated one, with events and blah attached. However, since I  %>
-      <%# am currently unaware of exactly how we're going to use this element, it %>
-      <%# is in this one-for-each-step form, for now.                             %>
       <ul class="govuk-navigation component-activated-menu"
           data-activator-text="<%= t('pages.actions') %>"
           data-activator-classname="form-step_button"
@@ -32,7 +27,11 @@
         </li>
         <li data-action="add"><a href="#add-page-here">Add page here</a></li>
         <li data-action="delete">
-          <%= link_to t('actions.delete_page'), page_path(service.service_id, page.uuid), method: :delete, class: 'destructive delete' %>
+          <% unless page.type == 'page.start' %>
+            <%= link_to t('actions.delete_page'),
+              page_path(service.service_id, page.uuid),
+              method: :delete, class: 'destructive delete' %>
+          <% end %>
         </li>
       </ul>
 
@@ -40,7 +39,6 @@
     </div>
   <% end %>
 
-  <%# TODO: Backend to replace this with dynamic data-driven output %>
   <ul class="component-activated-menu govuk-navigation"
       data-activated-menu-container-id="ActivatedMenu_AddPage"
       data-activator-classname="form-overview_button"
@@ -78,7 +76,6 @@
     <li><a href="#add-page" data-page-type="confirmation">Confirmation page</a></li>
     <li><a href="#add-page" data-page-type="content">Content page</a></li>
   </ul>
-
 
   <div class="component-dialog-form"
        id="new-page-create-dialog"


### PR DESCRIPTION
[Trello card](https://trello.com/c/vFcrTNto/1412-remove-delete-function-from-3dot-menu-for-start-page)

## Context

On the backend we don't allow start pages to be deleted so the "Delete page" on start page is useless.