### PR TITLE
Add user authentication to preview feature

### DIFF
--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -1,3 +1,3 @@
-class PreviewController < ApplicationController
+class PreviewController < PermissionsController
   layout 'metadata_presenter/application'
 end

--- a/app/helpers/auth0_helper.rb
+++ b/app/helpers/auth0_helper.rb
@@ -7,7 +7,7 @@ module Auth0Helper
 
   # @return the path to the login page
   def login_path
-    root_path
+    FbEditor::Application.routes.url_helpers.root_path
   end
 
   private

--- a/spec/requests/preview_spec.rb
+++ b/spec/requests/preview_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe 'GET /services/:service_id/preview' do
+  let(:request) { get "/services/#{service.service_id}/preview" }
+  context 'when not authenticated' do
+    before { request }
+
+    it 'redirects to root path' do
+      expect(response).to redirect_to('/')
+    end
+  end
+
+  context 'when authenticated' do
+    before do
+      allow_any_instance_of(
+        PermissionsController
+      ).to receive(:require_user!).and_return(true)
+      expect_any_instance_of(
+        ApplicationController
+      ).to receive(:service).at_least(:once).and_return(service)
+      allow_any_instance_of(
+        ApplicationController
+      ).to receive(:current_user).and_return(double(id: '1'))
+      request
+    end
+
+    it 'responds successfully' do
+      expect(response.status).to be(200)
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/Ng5jvVI5/1414-add-auth-to-all-pages-for-using-the-editor)

## Context

This PR adds the authentication check on preview form/preview pages.

## Solution

The preview comes from the metadata presenter gem and has a superclass inside of the editor app (PreviewController).

So by making the preview controller to inherit from permission controller we make the user to be redirect to the login path

I had to chage the `root_path` because it makes the user to redirect to root path in the in the context of the metadata
presenter gem (/services/:id/preview) which creates a infinite redirection.

Adding the FbEditor::Application.url_helpers.root_path makes it return '/' which is what we want.