### PR TITLE
Additional tests for collection component item IDs

### DIFF
--- a/spec/generators/new_component_generator_spec.rb
+++ b/spec/generators/new_component_generator_spec.rb
@@ -65,25 +65,101 @@ RSpec.describe NewComponentGenerator do
     end
 
     context 'auto generated text component id and name' do
-      let(:component_type) { 'text' }
       let(:page_url) { 'another-page' }
-      let(:components) do
-        [
-          {
-            '_id' => 'another-page_text_1',
-            '_type' => 'text',
-            'name' => 'another-page_text_1'
-          },
-          {
-            '_id' => 'another-page_text_2',
-            '_type' => 'text',
-            'name' => 'another-page_text_2'
-          }
-        ]
+
+      context 'non collection input components' do
+        %w[text textarea date number].each do |component|
+          context "when #{component} component" do
+            let(:component_type) { component }
+            let(:components) do
+              [
+                {
+                  '_id' => "#{page_url}_#{component}_1",
+                  '_type' => component,
+                  'name' => "#{page_url}_#{component}_1"
+                },
+                {
+                  '_id' => "#{page_url}_#{component}_2",
+                  '_type' => component,
+                  'name' => "#{page_url}_#{component}_2"
+                }
+              ]
+            end
+
+            it 'should increment the newly created component id' do
+              expect(generator.to_metadata['_id']).to eq("#{page_url}_#{component}_3")
+            end
+          end
+        end
       end
 
-      it 'should increment the newly created component id' do
-        expect(generator.to_metadata['_id']).to eq('another-page_text_3')
+      context 'collection input components' do
+        let(:components) { [] }
+
+        %w[radios checkboxes].each do |component|
+          context "when #{component} component" do
+            let(:component_type) { component }
+            let(:expected_metadata) do
+              {
+                '_id' => "#{page_url}_#{component}_1",
+                '_type' => component,
+                'errors' => {},
+                'hint' => '',
+                'items' => [
+                  {
+                    '_id' => "#{page_url}_#{component}_1_item_1",
+                    '_type' => component.singularize,
+                    'hint' => '',
+                    'label' => 'Option',
+                    'value' => 'value-1'
+                  },
+                  {
+                    '_id' => "#{page_url}_#{component}_1_item_2",
+                    '_type' => component.singularize,
+                    'hint' => '',
+                    'label' => 'Option',
+                    'value' => 'value-2'
+                  }
+                ],
+                'legend' => 'Question',
+                'name' => "#{page_url}_#{component}_1",
+                'validation' => {
+                  'required' => true
+                }
+              }
+            end
+
+            it 'should generate default metadata with correct item ids' do
+              expect(generator.to_metadata).to eq(expected_metadata)
+            end
+          end
+        end
+      end
+
+      context 'content components' do
+        %w[content].each do |component|
+          context "when #{component} component" do
+            let(:component_type) { component }
+            let(:components) do
+              [
+                {
+                  '_id' => "#{page_url}_#{component}_1",
+                  '_type' => component,
+                  'name' => "#{page_url}_#{component}_1"
+                },
+                {
+                  '_id' => "#{page_url}_#{component}_2",
+                  '_type' => component,
+                  'name' => "#{page_url}_#{component}_2"
+                }
+              ]
+            end
+
+            it 'should increment the newly created component id' do
+              expect(generator.to_metadata['_id']).to eq("#{page_url}_#{component}_3")
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
We recently changed the structure of the Item model IDs a little bit. This adds some tests to check for those changes.

Also break the tests out into all the different possible components.