### PR TITLE
Feature/1429 default text for optional fields

### DIFF
--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -74,7 +74,7 @@ class EditableBase {
 class EditableElement extends EditableBase {
   constructor($node, config) {
     super($node, config);
-    this.defaultText = $node.data(config.defaultTextAttribute) || "[empty]";
+    this.defaultText = $node.data(config.defaultTextAttribute) || $node.html();
 
     $node.on("blur.editablecomponent", this.update.bind(this));
     $node.on("focus.editablecomponent", this.edit.bind(this) );
@@ -107,8 +107,8 @@ class EditableElement extends EditableBase {
   }
 
   populate() {
-    if(this.content == "") {
-      this.$node.text(this.defaultText);
+    if(this.content.replace(/\s/mig, "") == "") {
+      this.$node.html(this.defaultText);
     }
   }
 

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -74,6 +74,7 @@ class EditableBase {
 class EditableElement extends EditableBase {
   constructor($node, config) {
     super($node, config);
+    this.defaultText = $node.data(config.defaultTextAttribute) || "[empty]";
 
     $node.on("blur.editablecomponent", this.update.bind(this));
     $node.on("focus.editablecomponent", this.edit.bind(this) );
@@ -102,6 +103,13 @@ class EditableElement extends EditableBase {
   update() {
     this.content = this.content; // confusing ES6 syntax makes sense if you look closely
     this.$node.removeClass(this._config.editClassname);
+    this.populate();
+  }
+
+  populate() {
+    if(this.content == "") {
+      this.$node.text(this.defaultText);
+    }
   }
 
   focus() {
@@ -163,6 +171,7 @@ class EditableContent extends EditableElement {
       this.$node.removeClass(this._config.editClassname);
       this._editing = false;
     }
+    this.populate();
   }
 }
 

--- a/app/javascript/src/page_editable_content.js
+++ b/app/javascript/src/page_editable_content.js
@@ -44,6 +44,7 @@ function bindEditableContentHandlers($area) {
       editableContent.push(editableComponent($node, {
         editClassname: "active",
         data: $node.data("fb-content-data"),
+        defaultTextAttribute: "fb-default-text",
         filters: {
           _id: function(index) {
             return this.replace(/^(.*)?[\d]+$/, "$1" + index);


### PR DESCRIPTION
Adds support for non-empty elements on editing.
Uses default text attribute value if available, otherwise the text shown on page load (this is so headings cannot be left blank, for example).