### PR TITLE
Fix duplicated Editable Collection Item text by using default text

### DIFF
--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -493,19 +493,23 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
  * because it would alert us to something very wrong.
  **/
 EditableCollectionFieldComponent.createCollectionItemTemplate = function(config) {
-  var $item = this.$node.find(config.selectorCollectionItem).eq(0);
+  var $clone = this.$node.find(config.selectorCollectionItem).eq(0).clone();
   var data = mergeObjects({}, config.data, ["items"]); // pt.1 Copy without items.
   var itemConfig = mergeObjects({}, config, ["data"]); // pt.2 Copy without data.
   itemConfig.data = mergeObjects(data, config.data.items[0]); // Bug fix response to JS reference handling.
 
   // Filters could be changing the blah_1 values to blah_0, depending on filters in play.
   itemConfig.data = EditableCollectionFieldComponent.applyFilters(config.filters, 0, itemConfig.data);
-  $item.data("config", itemConfig);
+
+  // In case we need some custom actions on element.
+  safelyActivateFunction(config.onCollectionItemClone, $clone);
+
+  $clone.data("config", itemConfig);
 
   // Note: If we need to strip out some attributes or alter the template
   //       in some way, do that here.
 
-  this.$itemTemplate = $item;
+  this.$itemTemplate = $clone;
 }
 
 /* Private function

--- a/app/javascript/src/page_editable_content.js
+++ b/app/javascript/src/page_editable_content.js
@@ -66,6 +66,13 @@ function bindEditableContentHandlers($area) {
           addItem: app.text.actions.option_add,
           removeItem: app.text.actions.option_remove
         },
+        onCollectionItemClone: function($node) {
+           // @node is the collection item (e.g. <div> wrapping <input type=radio> and <label> elements)
+           // Runs after the collection item has been cloned, so further custom manipulation can be
+           // carried out on the element.
+           $node.find("label").text(app.text.default_option);
+           $node.find("span").text(app.text.default_option_hint);
+        },
         onItemAdd: function($node) {
           // @$node (jQuery node) Node (instance.$node) that has been added.
           // Runs after adding a new Collection item.

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -5,6 +5,8 @@
       controller:  "<%= controller_name %>"
     },
     text: {
+      default_option: "<%= t('default_text.option') %>",
+      default_option_hint: "<%= t('default_text.option_hint') %>",
       dialogs: {
         button_cancel: "<%= t('dialogs.button_cancel') %>",
         button_delete: "<%= t('dialogs.button_delete') %>",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,9 @@ en:
     service_email_body: 'Please find attached a submission sent from %{service_name}'
     service_email_pdf_heading: 'Submission for %{service_name}'
     service_email_pdf_subheading: ''
+  default_text:
+    option: '[Required option text]'
+    option_hint: '[Optional hint text]'
   dialogs:
     button_cancel: 'Cancel'
     button_delete: 'Delete'


### PR DESCRIPTION
Fixes the current clone issue (duplicated text) when adding Radio options and Checkboxes.

Previously we saw duplicated text from first (cloned) element:
<img width="517" alt="Screenshot 2021-04-01 at 10 10 50" src="https://user-images.githubusercontent.com/76942244/113271716-b9078f80-92d2-11eb-8dbc-9a4a6ef71714.png">


New items will look like this (checkbox example, radios are same text):
<img width="392" alt="Screenshot 2021-03-31 at 23 31 48" src="https://user-images.githubusercontent.com/76942244/113219562-83828800-9279-11eb-960e-562f92a8b6cc.png">
