### PR TITLE
Fix acceptance tests for login page

### DIFF
--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -9,9 +9,9 @@ class EditorApp < SitePrism::Page
   element :sign_in_email_field, :field, 'Email:'
   element :sign_in_submit, :button, 'Sign In'
 
-  element :email_address_field, :field, 'Email address'
+  element :email_address_field, :field, 'Email'
   element :password_field, :field, 'Password'
-  element :login_continue_button, :button, 'Continue'
+  element :login_continue_button, :button, 'Log In'
 
   element :service_name, '#form-navigation-heading'
   element :name_field, :field, 'Give your form a name'


### PR DESCRIPTION
Email address is now "Email"

Login is now "Log In"

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>