### PR TITLE
Format user display name based on connection type

### DIFF
--- a/app/services/asserted_identity.rb
+++ b/app/services/asserted_identity.rb
@@ -14,14 +14,23 @@ class AssertedIdentity
     new(
       uid: userinfo['uid'],
       provider: userinfo['provider'],
-      name: userinfo['info'].try(:[], 'name') || humanised_name(userinfo),
+      name: humanised_name(userinfo),
       email: userinfo['info'].try(:[], 'email')
     )
   end
 
   def self.humanised_name(userinfo)
-    email_address = userinfo['info'].try(:[], 'email')
-    email_address[/[^@]+/].split('.').map(&:capitalize).join(' ') if email_address
+    name = extract_name(userinfo)
+    name.split('.').map(&:capitalize).join(' ').tr('0-9', '') if name
+  end
+
+  def self.extract_name(userinfo)
+    userinfo['info'].try(:[], 'nickname') || from_email(userinfo)
+  end
+
+  def self.from_email(userinfo)
+    email = userinfo['info'].try(:[], 'email')
+    email[/[^@]+/] if email
   end
 
   def to_identity

--- a/spec/services/asserted_identity_spec.rb
+++ b/spec/services/asserted_identity_spec.rb
@@ -30,20 +30,55 @@ describe AssertedIdentity do
       end
     end
 
-    context 'with a name in the claims' do
+    context 'when google connection' do
       let(:user_info) do
         {
           'info' => {
-            'uuid' => SecureRandom.uuid,
-            'provider' => 'provider',
-            'name' => 'The Fonz',
-            'email' => 'arthur.fonzarelli@happy-days.com'
+            'uuid' => "google-oauth2|#{SecureRandom.uuid}",
+            'provider' => 'auth0',
+            'name' => 'Vanya Hargreeves',
+            'nickname' => 'vanya.hargreeves',
+            'email' => 'vanya.hargreeves@umbrella-academy.com'
           }
         }
       end
 
-      it 'uses the name from the claims' do
-        expect(subject.from_auth0_userinfo(user_info).name).to eq('The Fonz')
+      it 'it correctly formats the name' do
+        expect(subject.from_auth0_userinfo(user_info).name).to eq('Vanya Hargreeves')
+      end
+    end
+
+    context 'when azure connection' do
+      let(:user_info) do
+        {
+          'info' => {
+            'uuid' => "waad|#{SecureRandom.uuid}",
+            'provider' => 'auth0',
+            'name' => 'Hargreeves, Fei',
+            'nickname' => 'Fei.Hargreeves',
+            'email' => 'Fei.Hargreeves@sparrow-academy.com'
+          }
+        }
+      end
+
+      it 'correctly formats the name' do
+        expect(subject.from_auth0_userinfo(user_info).name).to eq('Fei Hargreeves')
+      end
+    end
+
+    context 'when there is a number in the name' do
+      let(:user_info) do
+        {
+          'info' => {
+            'uuid' => "google-oauth2|#{SecureRandom.uuid}",
+            'provider' => 'auth0',
+            'email' => 'Rey.Mysterio619@hurricanrana.com'
+          }
+        }
+      end
+
+      it 'removes numbers from the name' do
+        expect(subject.from_auth0_userinfo(user_info).name).to eq('Rey Mysterio')
       end
     end
   end


### PR DESCRIPTION
The google and azure user claim set have slightly different structures
to their names. The latter uses surname first.

However both their nicknames have similar structures of
first_name.last_name. So swap to use that and then fallback to the
email.

Also remove any numbers as some of the azure email addresses have
numbers at the end.