### PR TITLE
Fix preview bug

### DIFF
--- a/acceptance/features/edit_single_question_page_spec.rb
+++ b/acceptance/features/edit_single_question_page_spec.rb
@@ -90,12 +90,6 @@ feature 'Edit single question page' do
     editor.question_heading.first.set(question)
   end
 
-  def and_I_preview_the_form
-    window_opened_by do
-      editor.preview_form_button.click
-    end
-  end
-
   def and_I_go_to_the_page_that_I_edit(preview_form)
     within_window(preview_form) do
       page.click_button 'Start now'

--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -1,0 +1,74 @@
+require_relative '../spec_helper'
+
+feature 'Preview form' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'preview the whole form' do
+    given_I_add_all_pages_for_a_form
+    preview_form = when_I_preview_the_form
+    then_I_can_navigate_until_the_end_of_the_form(preview_form)
+  end
+
+  def given_I_add_all_pages_for_a_form
+    given_I_add_a_single_question_page_with_text
+    and_I_add_a_page_url('name')
+    when_I_add_the_page
+    when_I_update_the_question_name('Full name')
+    and_I_return_to_flow_page
+
+    given_I_add_a_single_question_page_with_date
+    and_I_add_a_page_url('date-of-birth')
+    when_I_add_the_page
+    when_I_update_the_question_name('Date of birth')
+    and_I_return_to_flow_page
+
+    given_I_add_a_check_answers_page
+    and_I_add_a_page_url('cya')
+    when_I_add_the_page
+    and_I_return_to_flow_page
+
+    given_I_add_a_confirmation_page
+    and_I_add_a_page_url('confirmation')
+    when_I_add_the_page
+  end
+
+  def and_I_add_a_page_url(page_url)
+    editor.page_url_field.set(page_url)
+  end
+
+  def when_I_update_the_question_name(question_name)
+    editor.question_heading.first.set(question_name)
+    when_I_save_my_changes
+  end
+
+  def when_I_preview_the_form
+    and_I_return_to_flow_page
+    and_I_preview_the_form
+  end
+
+  def then_I_can_navigate_until_the_end_of_the_form(preview_form)
+    within_window(preview_form) do
+      expect(page.text).to include('This is your start page')
+      page.click_button 'Start now'
+      expect(page.text).to include('Full name')
+      page.fill_in 'Full name', with: 'Charmy Pappitson'
+      page.click_button 'Continue'
+      expect(page.text).to include('Date of birth')
+      page.fill_in 'Day', with: '03'
+      page.fill_in 'Month', with: '06'
+      page.fill_in 'Year', with: '2002'
+      page.click_button 'Continue'
+      expect(page.text).to include('Check your answers')
+      expect(page.text).to include('Charmy Pappitson')
+      expect(page.text).to include('03 June 2002')
+      page.click_button 'Accept and send application'
+      expect(page.text).to include('Application complete')
+    end
+  end
+end

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -147,4 +147,10 @@ module CommonSteps
     and_I_add_a_page_url
     when_I_add_the_page
   end
+
+  def and_I_preview_the_form
+    window_opened_by do
+      editor.preview_form_button.click
+    end
+  end
 end

--- a/app/controllers/preview_controller.rb
+++ b/app/controllers/preview_controller.rb
@@ -1,3 +1,4 @@
 class PreviewController < PermissionsController
   layout 'metadata_presenter/application'
+  self.per_form_csrf_tokens = false
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/qN4cY6qU/1453-fix-preview-feature)

## Context

When the user tries to preview the form the application rejects when the user is going to submit an answer.

The reason is that Rails does two autenticity token verifications: One for the app and one per form. 
So we disable the per form verification because it is not needed for the preview feature.  We still have the authenticity token app verification so the app is still secure.