### PR TITLE
Interact with username and password fields using JS

### DIFF
--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -5,10 +5,16 @@ class EditorApp < SitePrism::Page
     set_url ENV['ACCEPTANCE_TESTS_EDITOR_APP']
   end
 
+  # landing page
   element :sign_in_button, :button, 'Sign in'
+
+  # localhost
   element :sign_in_email_field, :field, 'Email:'
   element :sign_in_submit, :button, 'Sign In'
 
+  # Auth0
+  # currently not used as we are interacting with the fields using JS
+  # these will be used again in the future
   element :email_address_field, :field, 'Email'
   element :password_field, :field, 'Password'
   element :login_continue_button, :button, 'Log In'

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -4,13 +4,22 @@ module CommonSteps
     editor.sign_in_button.click
 
     if ENV['CI_MODE'].present?
-      editor.email_address_field.set(ENV['ACCEPTANCE_TESTS_USER'])
-      editor.password_field.set(ENV['ACCEPTANCE_TESTS_PASSWORD'])
-      editor.login_continue_button.click
+      # Executing javascript directly as the fields and button are hidden on the
+      # login page for the moment
+      editor.execute_script(
+        "document.getElementById('email').value = '#{ENV['ACCEPTANCE_TESTS_USER']}'"
+      )
+      editor.execute_script(
+        "document.getElementById('password').value = '#{ENV['ACCEPTANCE_TESTS_PASSWORD']}'"
+      )
+      editor.execute_script(
+        "document.getElementById('btn-login').click()"
+      )
     else
       editor.sign_in_email_field.set('form-builder-developers@digital.justice.gov.uk')
       editor.sign_in_submit.click
     end
+    sleep(1)
   end
 
   def given_I_have_a_service(service = service_name)


### PR DESCRIPTION
As a result of only having a single tenant for the moment in Auth0 we need to be able to interact with the username and password field which are hidden on the login screen.

The live editor should not show these fields as they will not be used by an actual user, only by our acceptance tests. Unfortunately Auth0 does not provide the facility to turn the fields on and off _if_ you have chosen to use Universal Login, which we have.

Unfortunately the acceptance tests will still continue to fail as there is a bug with the Question label for collection components.