### PR TITLE
Feature/1239 add component button 2

### DIFF
--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -106,7 +106,7 @@ class AddContent {
     var $button = $node.find("> a");
     this.$button = $button;
 
-    $button.on("click", function() {
+    $button.on("click.AddContent", function() {
       updateHiddenInputOnForm(config.$form, "page[add_component]", "content");
       config.$form.submit();
     });
@@ -152,7 +152,7 @@ function bindEditableContentHandlers($area) {
       PAGE.editableContent.push(editableComponent($node, {
         editClassname: "active",
         data: $node.data("fb-content-data"),
-        defaultTextAttribute: "fb-default-text",
+        attributeDefaultText: "fb-default-text",
         filters: {
           _id: function(index) {
             return this.replace(/^(.*)?[\d]+$/, "$1" + index);

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -122,14 +122,17 @@ class AddContent {
 function focusOnEditableComponent() {
   var target = location.hash;
   if(target.match(/^[#\w\d_]+$/)) {
+    // Newly added component with fragment identifier so find first
+    // first editable item of last component.
     let $newComponent = $(target);
     if($newComponent.length) {
       $newComponent.data("instance").focus();
     }
-    else {
-      if(this.editableContent.length > 0) {
-        this.editableContent[0].focus();
-      }
+  }
+  else {
+    // Standard editable page so find first editable item.
+    if(this.editableContent.length > 0) {
+      this.editableContent[0].focus();
     }
   }
 }
@@ -164,7 +167,7 @@ function bindEditableContentHandlers($area) {
         selectorQuestion: "label",
         selectorHint: "span",
         selectorGroupQuestion: ".govuk-heading-xl",
-        selectorCollectionQuestion: ".govuk-heading-xl",
+        selectorCollectionQuestion: "legend > :first-child",
         selectorCollectionHint: "fieldset > .govuk-hint",
         selectorCollectionItem: ".govuk-radios__item, .govuk-checkboxes__item",
         text: {

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -40,7 +40,11 @@ class PagesController extends DefaultPage {
 PagesController.edit = function() {
   var $form = $("#editContentForm");
 
+  this.$form = $form;
+  this.editableContent = [];
+
   bindEditableContentHandlers.call(this, app);
+  focusOnEditableComponent.call(this);
 
   // Bind document event listeners.
   $(document).on("AddComponentMenuSelection", AddComponent.MenuSelection.bind(this) );
@@ -57,7 +61,6 @@ PagesController.edit = function() {
     new AddContent($node, { $form: $form });
   });
 
-  this.$form = $form;
 }
 
 
@@ -113,6 +116,25 @@ class AddContent {
 }
 
 
+/* Set focus on first editable component or, if a new component has been
+ * added, the first element with that new component.
+ **/
+function focusOnEditableComponent() {
+  var target = location.hash;
+  if(target.match(/^[#\w\d_]+$/)) {
+    let $newComponent = $(target);
+    if($newComponent.length) {
+      $newComponent.data("instance").focus();
+    }
+    else {
+      if(this.editableContent.length > 0) {
+        this.editableContent[0].focus();
+      }
+    }
+  }
+}
+
+
 /* Controls all the Editable Component setup for each page.
  * TODO: Add more description on how this works.
  **/
@@ -120,12 +142,11 @@ function bindEditableContentHandlers($area) {
   var PAGE = this;
   var $editContentForm = $("#editContentForm");
   var $saveButton = $editContentForm.find(":submit");
-  var editableContent = [];
   if($editContentForm.length) {
     $saveButton.attr("disabled", true); // disable until needed.
     $(".fb-editable").each(function(i, node) {
       var $node = $(node);
-      editableContent.push(editableComponent($node, {
+      PAGE.editableContent.push(editableComponent($node, {
         editClassname: "active",
         data: $node.data("fb-content-data"),
         defaultTextAttribute: "fb-default-text",
@@ -202,15 +223,10 @@ function bindEditableContentHandlers($area) {
       });
     });
 
-    // Set focus on first editable component for design requirement.
-    if(editableContent.length > 0) {
-      editableContent[0].focus();
-    }
-
     // Add handler to activate save functionality from the independent 'save' button.
     $editContentForm.on("submit", (e) => {
-      for(var i=0; i<editableContent.length; ++i) {
-        editableContent[i].save();
+      for(var i=0; i<PAGE.editableContent.length; ++i) {
+        PAGE.editableContent[i].save();
       }
     });
   }

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -166,7 +166,7 @@ function bindEditableContentHandlers($area) {
         selectorDisabled: "input:not(:hidden), textarea",
         selectorQuestion: "label",
         selectorHint: "span",
-        selectorGroupQuestion: ".govuk-heading-xl",
+        selectorGroupQuestion: "legend > :first-child",
         selectorCollectionQuestion: "legend > :first-child",
         selectorCollectionHint: "fieldset > .govuk-hint",
         selectorCollectionItem: ".govuk-radios__item, .govuk-checkboxes__item",

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -74,7 +74,7 @@ class EditableBase {
 class EditableElement extends EditableBase {
   constructor($node, config) {
     super($node, config);
-    this.defaultText = $node.data(config.defaultTextAttribute) || $node.html();
+    var originalContent = $node.html();
 
     $node.on("blur.editablecomponent", this.update.bind(this));
     $node.on("focus.editablecomponent", this.edit.bind(this) );
@@ -83,11 +83,14 @@ class EditableElement extends EditableBase {
 
     $node.attr("contentEditable", true);
     $node.addClass("EditableElement");
+
+    this.originalContent = originalContent;
+    this.defaultContent = $node.data(config.attributeDefaultText);
   }
 
   get content() {
     var content = this.$node.html();
-    return content == this.defaultText ? "" : content;
+    return content == this.defaultContent ? "" : content;
   }
 
   set content(content) {
@@ -106,7 +109,8 @@ class EditableElement extends EditableBase {
 
   // Expects HTML or blank string to show HTML or default text in view.
   populate(content) {
-    this.$node.html(content.replace(/\s/mig, "") == "" ? this.defaultText : content);
+    var defaultContent = this.defaultContent || this.originalContent;
+    this.$node.html(content.trim() == "" ? defaultContent : content);
   }
 
   focus() {
@@ -142,7 +146,7 @@ class EditableContent extends EditableElement {
   // Get content must always return HTML because that' what we save.
   get content() {
     var content = this.$node.html();
-    return content.replace(/\s/mig, "") == this.defaultText ? "" : content;
+    return content.replace(/\s/mig, "") == this.defaultContent ? "" : content;
   }
 
   // Set content takes markdown (because it should be called after editing).

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -37,7 +37,6 @@ var turndownService = new TurndownService();
 class EditableBase {
   constructor($node, config) {
     this._config = config || {};
-    this._content = $node.text();
     this.type = config.type;
     this.$node = $node;
     $node.data("instance", this);
@@ -48,7 +47,7 @@ class EditableBase {
   }
 
   get content() {
-    return this._content;
+    return $node.text();
   }
 
   save() {
@@ -87,15 +86,13 @@ class EditableElement extends EditableBase {
   }
 
   get content() {
-    var content = this.$node.text();
+    var content = this.$node.html();
     return content == this.defaultText ? "" : content;
   }
 
   set content(content) {
-    if(this._content != content) {
-      this._content = content;
-      safelyActivateFunction(this._config.onSaveRequired);
-    }
+    this.populate(content);
+    safelyActivateFunction(this._config.onSaveRequired);
   }
 
   edit() {
@@ -103,15 +100,13 @@ class EditableElement extends EditableBase {
   }
 
   update() {
-    this.content = this.content; // confusing ES6 syntax makes sense if you look closely
+    this.content = this.$node.text();
     this.$node.removeClass(this._config.editClassname);
-    this.populate();
   }
 
-  populate() {
-    if(this.content.replace(/\s/mig, "") == "") {
-      this.$node.html(this.defaultText);
-    }
+  // Expects HTML or blank string to show HTML or default text in view.
+  populate(content) {
+    this.$node.html(content.replace(/\s/mig, "") == "" ? this.defaultText : content);
   }
 
   focus() {
@@ -180,11 +175,6 @@ class EditableContent extends EditableElement {
   markdown() {
     var markdown = convertToMarkdown(this.content);
     return markdown;
-  }
-
-  // Expects HTML or blank string to show HTML or default text in view.
-  populate(content) {
-    this.$node.html(content.replace(/\s/mig, "") == "" ? this.defaultText : content);
   }
 }
 

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -144,9 +144,9 @@ class EditableContent extends EditableElement {
     $node.addClass("EditableContent");
   }
 
-  // Get content must always return HTML because that' what we save.
+  // Get content must always return Markdown because that's what we save.
   get content() {
-    var content = this._html;
+    var content = convertToMarkdown(this._html);
     var value = "";
     if(this._config.data) {
       this._config.data.content = content;

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -74,7 +74,7 @@ class EditableBase {
 class EditableElement extends EditableBase {
   constructor($node, config) {
     super($node, config);
-    var originalContent = $node.html();
+    var originalContent = $node.text().trim(); // Trim removes whitespace from template.
 
     $node.on("blur.editablecomponent", this.update.bind(this));
     $node.on("focus.editablecomponent", this.edit.bind(this) );
@@ -84,16 +84,18 @@ class EditableElement extends EditableBase {
     $node.attr("contentEditable", true);
     $node.addClass("EditableElement");
 
+    this._content = $node.text().trim();
     this.originalContent = originalContent;
     this.defaultContent = $node.data(config.attributeDefaultText);
   }
 
   get content() {
-    var content = this.$node.html();
+    var content = this._content;
     return content == this.defaultContent ? "" : content;
   }
 
   set content(content) {
+    this._content = content;
     this.populate(content);
     safelyActivateFunction(this._config.onSaveRequired);
   }
@@ -103,14 +105,14 @@ class EditableElement extends EditableBase {
   }
 
   update() {
-    this.content = this.$node.text();
+    this.content = this.$node.text().trim();
     this.$node.removeClass(this._config.editClassname);
   }
 
-  // Expects HTML or blank string to show HTML or default text in view.
+  // Expects content or blank string to show content or default text in view.
   populate(content) {
     var defaultContent = this.defaultContent || this.originalContent;
-    this.$node.html(content.trim() == "" ? defaultContent : content);
+    this.$node.text(content == "" ? defaultContent : content);
   }
 
   focus() {
@@ -132,8 +134,6 @@ class EditableElement extends EditableBase {
 class EditableContent extends EditableElement {
   constructor($node, config) {
     super($node, config);
-    this._editing = false;
-    this._html = $node.html();
 
     // Adjust event for multiple line input.
     $node.off("keydown.editablecomponent");
@@ -142,11 +142,14 @@ class EditableContent extends EditableElement {
     // Correct the class:
     $node.removeClass("EditableElement");
     $node.addClass("EditableContent");
+
+    this._editing = false;
+    this._content = $node.html().trim(); // trim removes whitespace from template.
   }
 
   // Get content must always return Markdown because that's what we save.
   get content() {
-    var content = convertToMarkdown(this._html);
+    var content = convertToMarkdown(this._content).trim();
     var value = "";
     if(this._config.data) {
       this._config.data.content = content;
@@ -163,7 +166,7 @@ class EditableContent extends EditableElement {
   set content(markdown) {
     var markdown = sanitiseMarkdown(markdown);
     var html = convertToHtml(markdown);
-    this._html = html;
+    this._content = html;
     this.populate(html);
     safelyActivateFunction(this._config.onSaveRequired);
   }
@@ -178,7 +181,7 @@ class EditableContent extends EditableElement {
 
   update() {
     if(this._editing) {
-      this.content = this.$node.html(); // Converts markdown back to HTML.
+      this.content = this.$node.html().trim(); // Converts markdown back to HTML.
       this.$node.removeClass(this._config.editClassname);
       this._editing = false;
     }
@@ -188,6 +191,12 @@ class EditableContent extends EditableElement {
   markdown() {
     var markdown = convertToMarkdown(this._html);
     return markdown;
+  }
+
+  // Expects HTML or blank string to show HTML or default text in view.
+  populate(content) {
+    var defaultContent = this.defaultContent || this.originalContent;
+    this.$node.htmll(content == "" ? defaultContent : content);
   }
 }
 

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -149,7 +149,7 @@ class EditableContent extends EditableElement {
     var content = this._html;
     var value = "";
     if(this._config.data) {
-      this._config.data.html = content;
+      this._config.data.content = content;
       value = JSON.stringify(this._config.data);
     }
     else {


### PR DESCRIPTION
Closed PR https://github.com/ministryofjustice/fb-editor/pull/307 due to issues with outdated branch code and corrupted history. This PR clones required work from previous and adds a couple extra fixes.

Main intentions:

Fix focus on newly added Radio and Checkbox components
Fix focus for Date components
Fix issue with blank default text on Content (was submitting empty values)
Fix for returning JSON or Simple string on content (attribute vs. component handling)
Fix for saving in correct (markdown) format
