### PR TITLE
Fix/update confirmation

### DIFF
--- a/acceptance/features/edit_confirmation_page_spec.rb
+++ b/acceptance/features/edit_confirmation_page_spec.rb
@@ -1,0 +1,58 @@
+require_relative '../spec_helper'
+
+feature 'Edit confirmation pages' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:confirmation_url) { 'confirmation' }
+  let(:confirmation_heading) { 'Updated confirmation heading' }
+  let(:confirmation_lede) { 'Updated confirmation lede' }
+  let(:confirmation_body) { 'Updated confirmation body' }
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'updates all fields' do
+    given_I_have_a_confirmation_page
+    and_I_change_the_confirmation_heading(confirmation_heading)
+    and_I_change_the_confirmation_lede(confirmation_lede)
+    and_I_change_the_confirmation_body(confirmation_body)
+    when_I_save_my_changes
+    and_I_return_to_flow_page
+    and_I_edit_the_page(url: confirmation_url)
+    then_I_should_see_the_confirmation_heading(confirmation_heading)
+    then_I_should_see_the_confirmation_lede(confirmation_lede)
+    then_I_should_see_the_confirmation_body(confirmation_body)
+  end
+
+  def given_I_have_a_confirmation_page
+    given_I_add_a_confirmation_page
+    and_I_add_a_page_url(confirmation_url)
+    when_I_add_the_page
+  end
+
+  def and_I_change_the_confirmation_heading(heading)
+    editor.page_heading.set(heading)
+  end
+
+  def and_I_change_the_confirmation_lede(lede)
+    editor.page_lede.set(lede)
+  end
+
+  def and_I_change_the_confirmation_body(body)
+    editor.page_body.set(body)
+  end
+
+  def then_I_should_see_the_confirmation_heading(heading)
+    expect(editor.page_heading.text).to eq(heading)
+  end
+
+  def then_I_should_see_the_confirmation_lede(lede)
+    expect(editor.page_lede.text).to eq(lede)
+  end
+
+  def then_I_should_see_the_confirmation_body(body)
+    expect(editor.page_body.text).to eq(body)
+  end
+end

--- a/acceptance/features/edit_confirmation_page_spec.rb
+++ b/acceptance/features/edit_confirmation_page_spec.rb
@@ -15,9 +15,9 @@ feature 'Edit confirmation pages' do
 
   scenario 'updates all fields' do
     given_I_have_a_confirmation_page
-    and_I_change_the_confirmation_heading(confirmation_heading)
-    and_I_change_the_confirmation_lede(confirmation_lede)
-    and_I_change_the_confirmation_body(confirmation_body)
+    and_I_change_the_page_heading(confirmation_heading)
+    and_I_change_the_page_lede(confirmation_lede)
+    and_I_change_the_page_body(confirmation_body)
     when_I_save_my_changes
     and_I_return_to_flow_page
     and_I_edit_the_page(url: confirmation_url)
@@ -32,15 +32,15 @@ feature 'Edit confirmation pages' do
     when_I_add_the_page
   end
 
-  def and_I_change_the_confirmation_heading(heading)
+  def and_I_change_the_page_heading(heading)
     editor.page_heading.set(heading)
   end
 
-  def and_I_change_the_confirmation_lede(lede)
+  def and_I_change_the_page_lede(lede)
     editor.page_lede.set(lede)
   end
 
-  def and_I_change_the_confirmation_body(body)
+  def and_I_change_the_page_body(body)
     editor.page_body.set(body)
   end
 

--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -38,10 +38,6 @@ feature 'Preview form' do
     when_I_add_the_page
   end
 
-  def and_I_add_a_page_url(page_url)
-    editor.page_url_field.set(page_url)
-  end
-
   def when_I_update_the_question_name(question_name)
     editor.question_heading.first.set(question_name)
     when_I_save_my_changes

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -67,6 +67,9 @@ class EditorApp < SitePrism::Page
   elements :all_hints, '.govuk-hint'
   elements :editable_options, '.EditableComponentCollectionItem label'
   element :question_hint, '.govuk-hint'
+  element :page_heading, :xpath, '//*[@data-fb-content-id="page[heading]"]'
+  element :page_lede, :xpath, '//*[@data-fb-content-id="page[lede]"]'
+  element :page_body, :xpath, '//*[@data-fb-content-id="page[body]"]'
 
   elements :form_pages, '.form-step'
   elements :form_urls, '.form-step a.govuk-link'

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -107,12 +107,12 @@ module CommonSteps
     editor.edit_service_link(service_name).click
   end
 
-  def and_I_return_to_flow_page
-    editor.pages_link.click
+  def and_I_edit_the_page(url:)
+    click_link url
   end
 
-  def and_I_add_a_page_url
-    editor.page_url_field.set(page_url)
+  def and_I_return_to_flow_page
+    editor.pages_link.click
   end
 
   def when_I_create_the_service
@@ -161,5 +161,15 @@ module CommonSteps
     window_opened_by do
       editor.preview_form_button.click
     end
+  end
+
+  def and_I_add_a_page_url(url = nil)
+    path = if url.present?
+      url
+    else
+      page_url # via let(:page_url) { }
+    end
+
+    editor.page_url_field.set(path)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -63,9 +63,7 @@ class PagesController < FormController
   end
 
   def page_attributes
-    params.require(:page).permit(
-      @page.editable_attributes.keys.push({ components: {} })
-    )
+    params.require(:page).permit!
   end
 
   def common_params

--- a/brakeman.ignore
+++ b/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/pages/edit.html.erb",
-      "line": 11,
+      "line": 22,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(template => service.find_page_by_uuid(params[:page_uuid]).template, {})",
       "render_path": [
@@ -15,7 +15,7 @@
           "type": "controller",
           "class": "PagesController",
           "method": "update",
-          "line": 21,
+          "line": 26,
           "file": "app/controllers/pages_controller.rb",
           "rendered": {
             "name": "pages/edit",
@@ -30,8 +30,28 @@
       "user_input": "params[:page_uuid]",
       "confidence": "Weak",
       "note": ""
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "ba68e127b85a916b749bd1f7fec20219b1cb3e27b40904106d2dce53193bb5dd",
+      "check_name": "MassAssignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
+      "file": "app/controllers/pages_controller.rb",
+      "line": 66,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.require(:page).permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "PagesController",
+        "method": "page_attributes"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
     }
   ],
-  "updated": "2021-02-15 09:49:44 -0300",
+  "updated": "2021-04-09 14:15:50 -0300",
   "brakeman_version": "5.0.0"
 }


### PR DESCRIPTION
[Trello card](https://trello.com/c/W2fTjLqf/1455-backend-does-not-appear-to-be-storing-value)

## Context

We are not saving the optional fields anymore.

## Why?

The reason confirmation page is not saving attributes is that the way we permit params on the editor

```ruby
# app/controllers/pages_controller.rb
      params.require(:page).permit(
         @page.editable_attributes.keys.push({ components: {} })
      )
```

The `@page.editable_attributes`  implementation  on the metadata presenter gem:

```ruby
  # app/models/metadata_presenter/page.rb
       def editable_attributes
         to_h.reject { |k, _| k.in?(%i[_id _type steps]) }
       end
```

The page only looks into your own attributes, then the *optional fields* aren't on metadata then the attribute is not permitted.

## Possible solutions

### Solution 1: Permit everything!

Very extreme, we permit everything and hope for metadata API to validate the schema.

### Solution 2: See the schemas what we permit

Then we need to pair.
