### PR TITLE
Feature/add component and content all pages

### DIFF
--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -59,8 +59,14 @@ PagesController.edit = function(app) {
     case "page.singlequestion":
          console.log("page.singlequestion");
          break;
+
     case "page.content":
-         console.log("page.content");
+         let buttons = createAddContentButton($form);
+         let $target = $("#new_answers :submit");
+         if(buttons.length) {
+           $target.before(buttons[0].$node);
+         }
+
          break;
     case "page.confirmation":
          console.log("page.confirmation");
@@ -74,12 +80,6 @@ PagesController.edit = function(app) {
   $("[data-component=add-component]").each(function() {
     var $node = $(this);
     new AddComponent($node);
-  });
-
-  // Find and enhance the Add Content buttons.
-  $("[data-component=add-content]").each(function() {
-    var $node = $(this);
-    new AddContent($node, { $form: $form });
   });
 }
 
@@ -133,6 +133,7 @@ class AddContent {
   constructor($node, config) {
     var $button = $node.find("> a");
     this.$button = $button;
+    this.$node = $node;
 
     $button.on("click.AddContent", function() {
       updateHiddenInputOnForm(config.$form, "page[add_component]", "content");
@@ -141,6 +142,19 @@ class AddContent {
 
     $node.addClass("AddContent");
   }
+}
+
+
+/* Adds a button to allow editor control of new
+ * content components.
+ **/
+function createAddContentButton($form) {
+  var buttons = [];
+  $("[data-component=add-content]").each(function() {
+    var $node = $(this);
+    buttons.push(new AddContent($node, { $form: $form }));
+  });
+  return buttons;
 }
 
 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -52,12 +52,14 @@ PagesController.edit = function(app) {
   // Bind document event listeners.
   $(document).on("AddComponentMenuSelection", AddComponent.MenuSelection.bind(this) );
 
+  // Handle page-specific view customisations here.
   switch(this.type) {
     case "page.multiplequestions":
-         console.log("page.multiplequestions");
+         editPageMultipleQuestionsViewCustomisations.call(this);
          break;
+
     case "page.singlequestion":
-         console.log("page.singlequestion");
+         // No customisations required for this view.
          break;
 
     case "page.content":
@@ -65,7 +67,7 @@ PagesController.edit = function(app) {
          break;
 
     case "page.confirmation":
-         // Nothing required (yet?).
+         // No customisations required for this view.
          break;
 
     case "page.checkanswers":
@@ -79,7 +81,7 @@ PagesController.edit = function(app) {
     new AddContent($node, { $form: $form });
   });
 
-  // Find and enhance the Add Component buttons.
+  // Enhance any Add Component buttons.
   $("[data-component=add-component]").each(function() {
     var $node = $(this);
     new AddComponent($node);
@@ -328,6 +330,11 @@ function editPageCheckAnswersViewCustomisations() {
 }
 
 
+function editPageMultipleQuestionsViewCustomisations() {
+  var $button1 = $("[data-component=add-component]");
+  var $target = $("#new_answers :submit");
+  $target.before($button1);
+}
 
 
 export { PagesController }

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -198,7 +198,7 @@ function bindEditableContentHandlers($area) {
         form: $editContentForm,
         id: $node.data("fb-content-id"),
         selectorDisabled: "input:not(:hidden), textarea",
-        selectorQuestion: "label",
+        selectorQuestion: "label h1, label h2",
         selectorHint: "span",
         selectorGroupQuestion: "legend > :first-child",
         selectorCollectionQuestion: "legend > :first-child",

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -43,7 +43,6 @@ class PagesController extends DefaultPage {
  **/
 PagesController.edit = function(app) {
   var $form = $("#editContentForm");
-
   this.$form = $form;
   this.editableContent = [];
 
@@ -52,6 +51,24 @@ PagesController.edit = function(app) {
 
   // Bind document event listeners.
   $(document).on("AddComponentMenuSelection", AddComponent.MenuSelection.bind(this) );
+
+  switch(this.type) {
+    case "page.multiplequestions":
+         console.log("page.multiplequestions");
+         break;
+    case "page.singlequestion":
+         console.log("page.singlequestion");
+         break;
+    case "page.content":
+         console.log("page.content");
+         break;
+    case "page.confirmation":
+         console.log("page.confirmation");
+         break;
+    case "page.checkanswers":
+         console.log("page.checkanswers");
+         break;
+  }
 
   // Find and enhance the Add Component buttons.
   $("[data-component=add-component]").each(function() {
@@ -64,7 +81,6 @@ PagesController.edit = function(app) {
     var $node = $(this);
     new AddContent($node, { $form: $form });
   });
-
 }
 
 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -61,21 +61,23 @@ PagesController.edit = function(app) {
          break;
 
     case "page.content":
-         let buttons = createAddContentButton($form);
-         let $target = $("#new_answers :submit");
-         if(buttons.length) {
-           $target.before(buttons[0].$node);
-         }
+         editPageContentViewCustomisations.call(this);
          break;
 
     case "page.confirmation":
-         createAddContentButton($form);
+         // Nothing required (yet?).
          break;
 
     case "page.checkanswers":
-         console.log("page.checkanswers");
+         editPageCheckAnswersViewCustomisations.call(this);
          break;
   }
+
+  // Enhance any Add Content buttons
+  $("[data-component=add-content]").each(function() {
+    var $node = $(this);
+    new AddContent($node, { $form: $form });
+  });
 
   // Find and enhance the Add Component buttons.
   $("[data-component=add-component]").each(function() {
@@ -143,19 +145,6 @@ class AddContent {
 
     $node.addClass("AddContent");
   }
-}
-
-
-/* Adds a button to allow editor control of new
- * content components.
- **/
-function createAddContentButton($form) {
-  var buttons = [];
-  $("[data-component=add-content]").each(function() {
-    var $node = $(this);
-    buttons.push(new AddContent($node, { $form: $form }));
-  });
-  return buttons;
 }
 
 
@@ -315,6 +304,30 @@ function collectionItemControlsInActivatedMenu($item, config) {
     $item.data("ActivatedMenu", menu);
   }
 }
+
+
+/**************************************************************/
+/* View customisations for PageController.edit actions follow */
+/**************************************************************/
+
+
+function editPageContentViewCustomisations() {
+  var $button1 = $("[data-component=add-content]");
+  var $target = $("#new_answers :submit");
+  $target.before($button1);
+}
+
+
+function editPageCheckAnswersViewCustomisations() {
+  var $button1 = $("[data-component=add-content]");
+  var $target1 = $(".fb-editable").last();
+  var $button2 = $button1.clone();
+  var $target2 = $("#answers-form dl");
+  $target1.after($button1);
+  $target2.before($button2);
+}
+
+
 
 
 export { PagesController }

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -66,11 +66,12 @@ PagesController.edit = function(app) {
          if(buttons.length) {
            $target.before(buttons[0].$node);
          }
+         break;
 
-         break;
     case "page.confirmation":
-         console.log("page.confirmation");
+         createAddContentButton($form);
          break;
+
     case "page.checkanswers":
          console.log("page.checkanswers");
          break;

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -324,7 +324,7 @@ function editPageCheckAnswersViewCustomisations() {
   var $button1 = $("[data-component=add-content]");
   var $target1 = $(".fb-editable").last();
   var $button2 = $button1.clone();
-  var $target2 = $("#answers-form dl");
+  var $target2 = $("#answers-form dl").first();
   $target1.after($button1);
   $target2.before($button2);
 }

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -196,7 +196,7 @@ class EditableContent extends EditableElement {
   // Expects HTML or blank string to show HTML or default text in view.
   populate(content) {
     var defaultContent = this.defaultContent || this.originalContent;
-    this.$node.htmll(content == "" ? defaultContent : content);
+    this.$node.html(content == "" ? defaultContent : content);
   }
 }
 
@@ -711,6 +711,7 @@ class EditableCollectionItemRemover {
  * Includes clean up of HTML by stripping attributes and unwanted trailing spaces.
  **/
 function convertToMarkdown(html) {
+  html = html || ""; // make sure it's a string and not undefined
   html = html.trim();
   html = html.replace(/(<\w[\w\d]+)\s*[\w\d\s=\"-]*?(>)/mig, "$1$2");
   html = html.replace(/(?:\n\s*)/mig, "\n");

--- a/app/javascript/src/page_default.js
+++ b/app/javascript/src/page_default.js
@@ -23,6 +23,7 @@ import { post } from './utilities';
 
 class DefaultPage {
   constructor() {
+    this.type = $(".fb-main-grid-wrapper").data("fb-pagetype");
     this.dialog = createDialog.call(this);
     this.dialogConfirmation = createDialogConfirmation.call(this);
     this.dialogConfirmationDelete = createDialogConfirmationDelete.call(this);

--- a/app/javascript/styles/_component_activated_menu.scss
+++ b/app/javascript/styles/_component_activated_menu.scss
@@ -49,10 +49,10 @@
     &.destructive:hover {
       background-color: $govuk-error-colour;
     }
-  }
 
-  a:focus-visible {
-    outline: none;
+    &:focus-visible {
+      outline: none;
+    }
   }
 
   span {

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -141,6 +141,8 @@ html {
  * ------------------- */
 .AddComponent,
 .AddContent {
+  margin: govuk-spacing(9) 0;
+
   a {
     @include addition_icon;
 


### PR DESCRIPTION
Moves position of Add Component / Add Content buttons to reflect the prototype layouts. 

Some examples:

**Multiple Question Page**
<img width="745" alt="Screenshot 2021-04-09 at 18 17 35" src="https://user-images.githubusercontent.com/76942244/114217314-e7830b80-995f-11eb-8deb-d7da6d510995.png">

**Confirmation Page**
<img width="770" alt="Screenshot 2021-04-09 at 18 18 22" src="https://user-images.githubusercontent.com/76942244/114217398-01245300-9960-11eb-9f5c-cf391cbd7ee2.png">

**Check Answers Page**
<img width="832" alt="Screenshot 2021-04-09 at 18 25 26" src="https://user-images.githubusercontent.com/76942244/114218178-fcac6a00-9960-11eb-95a5-d8284a43fc52.png">
