### PR TITLE
Add page in middle of the flow should redirect to created page

### DIFF
--- a/acceptance/features/add_page_in_the_middle_flow_spec.rb
+++ b/acceptance/features/add_page_in_the_middle_flow_spec.rb
@@ -1,0 +1,36 @@
+require_relative '../spec_helper'
+
+feature 'Add page in the middle flow' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:page_url) { 'palpatine' }
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'adding page after first page and before last page' do
+    given_I_have_a_single_question_page_with_text
+    and_I_return_to_flow_page
+    when_I_add_a_single_question_page_with_radio_after_start(url: 'new-page-url')
+    and_I_return_to_flow_page
+    then_I_should_see_the_page_flow_in_order(order: ['/', 'new-page-url', 'palpatine'])
+  end
+
+  def when_I_add_a_single_question_page_with_radio_after_start(url:)
+    editor.preview_page_images.first.hover
+    editor.three_dots_button.click
+    editor.add_page_here_link.click
+    editor.add_single_question.hover
+    editor.add_single_question_radio.click
+    editor.page_url_field.set(url)
+    when_I_add_the_page
+    # expect to be on the page created (radio component page)
+    expect(editor.radio_options.size).to be(2)
+  end
+
+  def then_I_should_see_the_page_flow_in_order(order:)
+    expect(editor.form_urls.map(&:text)).to eq(order)
+  end
+end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -76,6 +76,7 @@ class EditorApp < SitePrism::Page
   elements :preview_page_images, '.form-step img.body'
   element :three_dots_button, '.form-step_button'
   element :preview_page_link, :link, 'Preview page'
+  element :add_page_here_link, :link, 'Add page here'
   element :delete_page_link, :link, 'Delete page...'
   element :delete_page_modal_button, :button, 'Delete page'
 

--- a/app/generators/new_page_generator.rb
+++ b/app/generators/new_page_generator.rb
@@ -4,7 +4,8 @@ class NewPageGenerator
                 :page_url,
                 :component_type,
                 :latest_metadata,
-                :add_page_after
+                :add_page_after,
+                :page_uuid
 
   def to_metadata
     latest_metadata.tap do
@@ -18,7 +19,7 @@ class NewPageGenerator
 
     metadata.tap do
       metadata['_id'] = page_name
-      metadata['_uuid'] = SecureRandom.uuid
+      metadata['_uuid'] = page_uuid
       metadata['url'] = page_url
       if component_type.present?
         metadata['components'].push(component)

--- a/app/services/page_creation.rb
+++ b/app/services/page_creation.rb
@@ -16,7 +16,7 @@ class PageCreation
   validates :page_url, metadata_url: { metadata_method: :latest_metadata }
 
   def page_uuid
-    version.metadata['pages'].last['_uuid'] if version
+    @page_uuid ||= SecureRandom.uuid
   end
 
   def create
@@ -41,7 +41,8 @@ class PageCreation
       page_url: page_url.strip,
       component_type: component_type,
       latest_metadata: latest_metadata,
-      add_page_after: add_page_after
+      add_page_after: add_page_after,
+      page_uuid: page_uuid
     ).to_metadata
   end
 end

--- a/spec/generators/new_page_generator_spec.rb
+++ b/spec/generators/new_page_generator_spec.rb
@@ -5,10 +5,12 @@ RSpec.describe NewPageGenerator do
       page_url: page_url,
       component_type: component_type,
       latest_metadata: latest_metadata,
-      add_page_after: add_page_after
+      add_page_after: add_page_after,
+      page_uuid: page_uuid
     )
   end
   let(:add_page_after) { nil }
+  let(:page_uuid) { SecureRandom.uuid }
 
   describe '#to_metadata' do
     let(:valid) { true }

--- a/spec/services/page_creation_spec.rb
+++ b/spec/services/page_creation_spec.rb
@@ -5,24 +5,9 @@ RSpec.describe PageCreation, type: :model do
   let(:attributes) { { latest_metadata: metadata_fixture(:version) } }
 
   describe '#page_uuid' do
-    context 'when version' do
-      let(:attributes) do
-        { version: double(metadata: service_metadata) }
-      end
-
-      it 'returns the last page uuid' do
-        expect(
-          page_creation.page_uuid
-        ).to eq('b238a22f-c180-48d0-a7d9-8aad2036f1f2')
-      end
-    end
-
-    context 'when version is blank' do
-      it 'returns nil' do
-        expect(
-          page_creation.page_uuid
-        ).to be_nil
-      end
+    it 'generates uuid' do
+      allow(SecureRandom).to receive(:uuid).and_return('my-uuid')
+      expect(page_creation.page_uuid).to eq('my-uuid')
     end
   end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/Xu8Mud0v/1451-add-page-in-the-middle-of-flow)

## Context

Before this commit, the app was redirecting the user to the last page always, so we change this to redirect the user to the page created. The way to do this is to centralize the generation of the page uuid to the page creation object instead of the page generation object.