### PR TITLE
Add acceptance tests for the footer pages

### DIFF
--- a/acceptance/features/edit_confirmation_page_spec.rb
+++ b/acceptance/features/edit_confirmation_page_spec.rb
@@ -32,10 +32,6 @@ feature 'Edit confirmation pages' do
     when_I_add_the_page
   end
 
-  def and_I_change_the_page_heading(heading)
-    editor.page_heading.set(heading)
-  end
-
   def and_I_change_the_page_lede(lede)
     editor.page_lede.set(lede)
   end

--- a/acceptance/features/editing_standalone_page_spec.rb
+++ b/acceptance/features/editing_standalone_page_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../spec_helper'
+
+feature 'Edit standalone pages' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:cookies_heading) { 'Updated cookies heading' }
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'editing footer standalone pages' do
+    given_I_have_footer_pages
+    and_I_edit_the_cookies_page
+    and_I_change_the_page_heading(cookies_heading)
+    when_I_save_my_changes
+    then_I_should_see_the_new_cookies_heading
+  end
+
+  def given_I_have_footer_pages
+    editor.footer_pages_links.click
+  end
+
+  def and_I_edit_the_cookies_page
+    editor.cookies_link.click
+  end
+
+  def then_I_should_see_the_new_cookies_heading
+    expect(editor.page_heading.text).to eq(cookies_heading)
+  end
+end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -23,6 +23,9 @@ class EditorApp < SitePrism::Page
   element :name_field, :field, 'Give your form a name'
   element :create_service_button, :button, 'Create a new form'
 
+  element :footer_pages_links, 'summary'
+  element :cookies_link, :link, 'cookies'
+
   element :pages_link, :link, 'Pages'
   element :settings_link, :link, 'Settings'
   element :form_details_link, :link, 'Form details'

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -115,6 +115,10 @@ module CommonSteps
     editor.pages_link.click
   end
 
+  def and_I_change_the_page_heading(heading)
+    editor.page_heading.set(heading)
+  end
+
   def when_I_create_the_service
     editor.modal_create_service_button.click
   end


### PR DESCRIPTION
This adds an acceptance tests for the footer pages when a new service is
created