### PR TITLE
Add script to remove service configurations from a namespace

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ AllCops:
     - "tmp/**/*"
     - "node_modules/**/*"
     - "acceptance/**/*"
+    - 'lib/scripts/remove_services.rb'
 
 Style/StringLiterals:
   EnforcedStyle: single_quotes

--- a/README.md
+++ b/README.md
@@ -92,3 +92,15 @@ There is a rake task that removes any sessions that have been inactive for more 
 This rake task is found in `lib/tasks/database.rake`.
 
 We could not use the [built in rails session trim task](https://github.com/rails/activerecord-session_store/blob/master/lib/tasks/database.rake) as this could only be modified in days.
+
+### Remove services script
+
+This is for removing all services and their configuration in a given namespace.
+
+`ruby ./lib/scripts/remove_services.rb <namespace> <target>`
+
+For example, if the pod name for a service is `awesome-form-78b47fc858-cxgfl` and you wanted to remove it from `formbuilder-services-test-dev`:
+
+`ruby ./lib/scripts/remove_services.rb formbuilder-services-test-dev awesome-form`
+
+If target is not provided it will attempt to remove all services within the supplied namespace. This is temporary for now until we have a proper mechanism for removing a service and its configuration. It will not work in production namespaces, developers will need to do those by hand if required.

--- a/lib/scripts/remove_services.rb
+++ b/lib/scripts/remove_services.rb
@@ -1,0 +1,83 @@
+def kubectl(namespace:, config:, target:)
+  result = `$(which kubectl) delete #{config} #{target} -n #{namespace}`
+
+  if result.empty?
+    puts "Failed to delete #{target} from #{config}"
+  else
+    puts "Successfully deleted #{target} from #{config}"
+  end
+end
+
+def delete_deployment(target:, namespace:)
+  kubectl(namespace: namespace, config: 'deployment', target: target)
+end
+
+def delete_ingress(target:, namespace:)
+  kubectl(namespace: namespace, config: 'ingress', target: "#{target}-ingress")
+end
+
+def delete_service(target:, namespace:)
+  kubectl(namespace: namespace, config: 'service', target: target)
+end
+
+def delete_configmaps(target:, namespace:)
+  kubectl(namespace: namespace, config: 'configmaps', target: "fb-#{target}-config-map")
+end
+
+def delete_secrets(target:, namespace:)
+  kubectl(namespace: namespace, config: 'secrets', target: "fb-#{target}-secrets")
+end
+
+def delete_service_configurations(target:, namespace:)
+  puts '-----------------------------------------'
+  delete_deployment(target: target, namespace: namespace)
+  delete_ingress(target: target, namespace: namespace)
+  delete_service(target: target, namespace: namespace)
+  delete_configmaps(target: target, namespace: namespace)
+  delete_secrets(target: target, namespace: namespace)
+  puts '-----------------------------------------'
+end
+
+if ARGV.count > 2
+  puts "Too many arguments"
+  exit 0
+end
+
+namespace, service_to_remove = ARGV
+
+if namespace.nil?
+  puts "Namespace is required"
+  exit 0
+end
+
+if namespace.include?('live-production')
+  puts "Nope!"
+  exit 0
+end
+
+services = `kubectl get pods -n #{namespace}`.split("\n")
+services.shift # remove the column names
+
+non_acceptance_tests_services = services.map do |service|
+  next if service.include?('acceptance-tests')
+  service.split('-')[0...-2].join('-')
+end.compact
+
+if service_to_remove
+  if non_acceptance_tests_services.include?(service_to_remove)
+    delete_service_configurations(target: service_to_remove, namespace: namespace)
+  else
+    puts "#{service_to_remove} does not exist in #{namespace}"
+    exit 0
+  end
+else
+  if services.empty?
+    puts "No services to remove in #{namespace}"
+  else
+    puts "Removing #{non_acceptance_tests_services.count} services"
+
+    non_acceptance_tests_services.each do |target|
+      delete_service_configurations(target: target, namespace: namespace)
+    end
+  end
+end


### PR DESCRIPTION
This is a temporary script to remove services and their configurations within a given namespace.

This will not work in prod.

Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>