### PR TITLE
Add HotJar configuration scripts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,4 +31,10 @@ module ApplicationHelper
   def strip_url(url)
     url.to_s.chomp('/').reverse.chomp('/').reverse
   end
+
+  # Remove once hotjar testing is complete
+  def live_platform?
+    ENV['PLATFORM_ENV'] == 'live'
+  end
+  # Remove once hotjar testing is complete
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,21 @@
     <%= render partial: 'partials/properties' %>
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>
+
+    <!-- Hotjar Tracking Code for Private Beta Research Study -->
+    <% if live_platform? %>
+      <script>
+        (function(h,o,t,j,a,r){
+          h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+          h._hjSettings={hjid:2316310,hjsv:6};
+          a=o.getElementsByTagName('head')[0];
+          r=o.createElement('script');r.async=1;
+          r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+          a.appendChild(r);
+        })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+      </script>
+    <% end %>
+    <!-- Hotjar Tracking Code for Private Beta Research Study -->
   </head>
 
   <body class="govuk-template__body govuk-body">


### PR DESCRIPTION
This adds the necessary JS scripts for HotJar to work during the
upcoming private beta testing.

We only want it to appear in the Live editor.

## Screenshots

![Screenshot 2021-04-13 at 17 47 21](https://user-images.githubusercontent.com/3466862/114590254-6ccc3000-9c80-11eb-9130-710a33ec727c.png)

![Screenshot 2021-04-13 at 17 47 31](https://user-images.githubusercontent.com/3466862/114590266-6fc72080-9c80-11eb-85e9-914049994def.png)


Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>