### PR TITLE
Fix/1426 bug markdown parsing in body element

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,7 @@
 // Scripts called by javascript_pack_tag
 require("jquery")
 require("jquery-ui")
+require("showdown")
 require("../src/index")
 
 // Entry point for fb-editor stylesheets

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -23,7 +23,7 @@ var converter = new showdown.Converter({
                   disableForced4SpacesIndentedSublists: true
                 });
 
-
+showdown.setFlavor('github');
 
 /* Editable Base:
  * Shared code across the editable component types.

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -734,8 +734,6 @@ function convertToMarkdown(html) {
   html = html.replace(/<!-- -->/mig, "");
   html = html.replace(/(<\/p>)/mig, "$1\n\n");
   html = html.replace(/(<\w[\w\d]+)\s*[\w\d\s=\"-]*?(>)/mig, "$1$2");
-  //html = html.replace(/(?:\n\s*)/mig, "\n");
-  //html = html.replace(/[ ]{2,}/mig, " ");
   return converter.makeMarkdown(html).trim();
 }
 
@@ -751,12 +749,11 @@ function convertToHtml(markdown) {
   markdown = markdown.replace(/<br>/mig, "\n");  // Revert any we added for visual purpose.
   markdown = markdown.replace(/<\/div><div>/mig, "\n");
   markdown = markdown.replace(/<[\/]?div>/mig, "");
+  markdown = markdown.replace(/&gt;/mig, ">"); // Fix blockquotes.
 
   // Next do the conversion and correct some things to display properly.
   let html = converter.makeHtml(markdown);
   html = html.replace(/<li><p>(.*)?<\/p>/mig, "<li>$1");  // Don't want <p> tags in there.
-  //html = html.replace(/<\/li><\/ul>/mig, "</li>\n</ul>"); // Require line-break;
-  //html = html.replace(/(\W)<ul>/mig, "$1  \n<ul>");       // Require line-break;
   return html;
 }
 

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -19,7 +19,8 @@ var showdown  = require('showdown');
 var converter = new showdown.Converter({
                   noHeaderId: true,
                   strikethrough: true,
-                  omitExtraWLInCodeBlocks: true
+                  omitExtraWLInCodeBlocks: true,
+                  disableForced4SpacesIndentedSublists: true
                 });
 
 
@@ -754,8 +755,8 @@ function convertToHtml(markdown) {
   // Next do the conversion and correct some things to display properly.
   let html = converter.makeHtml(markdown);
   html = html.replace(/<li><p>(.*)?<\/p>/mig, "<li>$1");  // Don't want <p> tags in there.
-  html = html.replace(/<\/li><\/ul>/mig, "</li>\n</ul>"); // Require line-break;
-  html = html.replace(/(\W)<ul>/mig, "$1  \n<ul>");       // Require line-break;
+  //html = html.replace(/<\/li><\/ul>/mig, "</li>\n</ul>"); // Require line-break;
+  //html = html.replace(/(\W)<ul>/mig, "$1  \n<ul>");       // Require line-break;
   return html;
 }
 

--- a/package.json
+++ b/package.json
@@ -6,12 +6,10 @@
     "@rails/activestorage": "^6.1.3",
     "@rails/ujs": "^6.1.3",
     "@rails/webpacker": "^5.2.1",
-    "dompurify": "^2.2.7",
     "govuk-frontend": "^3.11.0",
     "jquery": "^3.6.0",
     "jquery-ui-dist": "^1.12.1",
-    "marked": "^2.0.3",
-    "turndown": "^7.0.0"
+    "showdown": "^1.9.1",
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "govuk-frontend": "^3.11.0",
     "jquery": "^3.6.0",
     "jquery-ui-dist": "^1.12.1",
-    "showdown": "^1.9.1",
+    "showdown": "^1.9.1"
   },
   "version": "0.1.0",
   "devDependencies": {


### PR DESCRIPTION
Hopefully some improvement to Markdown -> Html handling.
(note: one bug remains in that nested list have their first item appended to the parent list item - this appears to be a bug with the translation service that I have yet to find a workaround)

**From markdown:**
<img width="779" alt="Screenshot 2021-04-14 at 13 10 24" src="https://user-images.githubusercontent.com/76942244/114708278-0cda9580-9d23-11eb-81ae-f838e1277b7c.png">

**To Html:**
<img width="815" alt="Screenshot 2021-04-14 at 13 10 07" src="https://user-images.githubusercontent.com/76942244/114708310-182dc100-9d23-11eb-8404-53477cbdf498.png">
