### PR TITLE
Use Node 14.16.1 LTS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 New editor from the MoJ online.
 
 ## Setup
-Ensure you are running on Node version 10.17.0:
-`nvm use 10.17.0`
+Ensure you are running on Node version 14.16.1:
+`nvm use 14.16.1`
 
 Compile the necessary assets and run webpack:
 `make assets`

--- a/acceptance/Dockerfile
+++ b/acceptance/Dockerfile
@@ -2,8 +2,10 @@ FROM ruby:2.7.2-alpine
 
 ARG UID=1001
 
-RUN apk add git nodejs yarn build-base postgresql-contrib postgresql-dev bash libcurl
+RUN apk add git yarn build-base postgresql-contrib postgresql-dev bash libcurl
 RUN apk add build-base bash tzdata chromium-chromedriver chromium zlib-dev xorg-server
+
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=14.16.1-r2 npm
 
 WORKDIR /usr/src/app
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -2,8 +2,10 @@ FROM ruby:2.7.2-alpine3.12
 
 ARG UID=1001
 
-RUN apk add git nodejs yarn build-base postgresql-contrib postgresql-dev \
+RUN apk add git yarn build-base postgresql-contrib postgresql-dev \
       bash libcurl curl
+
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=14.16.1-r2 npm
 
 RUN addgroup -g ${UID} -S appgroup && \
   adduser -u ${UID} -S appuser -G appgroup

--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -2,7 +2,9 @@ FROM ruby:2.7.2-alpine3.12
 
 ARG UID=1001
 
-RUN apk add git nodejs yarn build-base postgresql-contrib postgresql-dev bash libcurl curl
+RUN apk add git yarn build-base postgresql-contrib postgresql-dev bash libcurl curl
+
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=14.16.1-r2 npm
 
 ARG KUBE_VERSION="1.17.3"
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fb_editor",
   "private": true,
+  "engines" : { "node" : "14.16.1" },
   "dependencies": {
     "@rails/actioncable": "^6.1.3",
     "@rails/activestorage": "^6.1.3",


### PR DESCRIPTION
We have some descrepencies with node versions in our containers but also
when developing locally. The README says use version 10 but the
container is installing 12 . . .

Lock the Node version to 14.16.1 as that is the current LTS version
which will be end of life in 2023.

Update the dockerfiles to install the specific node version and also use
a .npmrc file to lock the node version to the one we want.