### PR TITLE
Add skip link to main content

### DIFF
--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -1,4 +1,6 @@
 <header class="govuk-header govuk-header__container" role="banner" data-module="govuk-header">
+  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+
   <div class="govuk-width-container">
     <a href="/" aria-label="<%= t('header.home_link_text') %>" id="header-logo-link" class="page-header__logo">
       <span class="govuk-visually-hidden"><%= t('header.home_link_text') %></span>


### PR DESCRIPTION
This enables keyboard users to quickly access the main content of the
site