### PR TITLE
Fix/check answers page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'delayed_job_active_record'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'default-text'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '0.28.5'
+gem 'metadata_presenter', '0.28.8'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    metadata_presenter (0.28.5)
+    metadata_presenter (0.28.8)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -371,7 +371,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.6.0)
   hashie
   listen (~> 3.5)
-  metadata_presenter (= 0.28.5)
+  metadata_presenter (= 0.28.8)
   omniauth-auth0 (~> 2.6.0)
   omniauth-rails_csrf_protection (~> 0.1.2)
   pg (>= 0.18, < 2.0)

--- a/acceptance/features/edit_check_answers_page_spec.rb
+++ b/acceptance/features/edit_check_answers_page_spec.rb
@@ -1,0 +1,96 @@
+require_relative '../spec_helper'
+
+feature 'Edit check your answers page' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:url) { 'check-your-answers' }
+  let(:heading) { 'Become a sith' }
+  let(:send_heading) { 'Welcome to the Dark side of the force' }
+  let(:send_body) do
+    'Come to the Dark side, we have cookies'
+  end
+  let(:content_component) do
+    'You underestimate the power of the Dark Side.'
+  end
+  let(:content_extra_component) do
+    'If you only knew the power of the dark side'
+  end
+  let(:optional_content) do
+    '[Optional content]'
+  end
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'editing page info' do
+    given_I_have_a_check_your_answers_page
+    and_I_change_the_page_heading(heading)
+    and_I_change_the_send_heading(send_heading)
+    and_I_change_the_send_body(send_body)
+    when_I_save_my_changes
+    and_I_return_to_flow_page
+    and_I_edit_the_page(url: url)
+    then_I_should_see_the_page_heading(heading)
+    then_I_should_see_the_page_send_heading(send_heading)
+    then_I_should_see_the_page_send_body(send_body)
+  end
+
+  scenario 'adding components' do
+    given_I_have_a_check_your_answers_page
+    and_I_add_a_content_component(
+      content: content_component
+    )
+    and_I_add_a_content_extra_component(
+      content: content_extra_component
+    )
+    when_I_save_my_changes
+    and_I_return_to_flow_page
+    and_I_edit_the_page(url: url)
+    then_I_should_see_the_first_component(content_component)
+    then_I_should_see_the_first_extra_component(content_extra_component)
+  end
+
+  def given_I_have_a_check_your_answers_page
+    given_I_add_a_check_answers_page
+    and_I_add_a_page_url(url)
+    when_I_add_the_page
+  end
+
+  def and_I_change_the_send_heading(send_heading)
+    editor.page_send_heading.set(send_heading)
+  end
+
+  def and_I_change_the_send_body(send_body)
+    editor.page_send_body.set(send_body)
+  end
+
+  def and_I_add_a_content_component(content:)
+    editor.add_content_area_buttons.last.click
+    expect(editor.first_component.text).to eq(optional_content)
+    editor.first_component.set(content)
+  end
+
+  def and_I_add_a_content_extra_component(content:)
+    editor.add_content_area_buttons.first.click
+    expect(editor.first_extra_component.text).to eq(optional_content)
+    editor.first_extra_component.set(content)
+  end
+
+  def then_I_should_see_the_page_send_heading(send_heading)
+    expect(editor.page_send_heading.text).to eq(send_heading)
+  end
+
+  def then_I_should_see_the_page_send_body(send_body)
+    expect(editor.page_send_body.text).to eq(send_body)
+  end
+
+  def then_I_should_see_the_first_component(content)
+    expect(editor.first_component.text).to eq(content)
+  end
+
+  def then_I_should_see_the_first_extra_component(content)
+    expect(editor.first_extra_component.text).to eq(content)
+  end
+end

--- a/acceptance/features/edit_confirmation_page_spec.rb
+++ b/acceptance/features/edit_confirmation_page_spec.rb
@@ -40,10 +40,6 @@ feature 'Edit confirmation pages' do
     editor.page_body.set(body)
   end
 
-  def then_I_should_see_the_confirmation_heading(heading)
-    expect(editor.page_heading.text).to eq(heading)
-  end
-
   def then_I_should_see_the_confirmation_lede(lede)
     expect(editor.page_lede.text).to eq(lede)
   end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -73,6 +73,12 @@ class EditorApp < SitePrism::Page
   element :page_heading, :xpath, '//*[@data-fb-content-id="page[heading]"]'
   element :page_lede, :xpath, '//*[@data-fb-content-id="page[lede]"]'
   element :page_body, :xpath, '//*[@data-fb-content-id="page[body]"]'
+  element :page_send_heading, :xpath, '//*[@data-fb-content-id="page[send_heading]"]'
+  element :page_send_body, :xpath, '//*[@data-fb-content-id="page[send_body]"]'
+
+  elements :add_content_area_buttons, :link, 'Add content area'
+  element :first_component, :xpath, '//*[@data-fb-content-id="page[components[0]]"]'
+  element :first_extra_component, :xpath, '//*[@data-fb-content-id="page[extra_components[0]]"]'
 
   elements :form_pages, '.form-step'
   elements :form_urls, '.form-step a.govuk-link'

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -176,4 +176,13 @@ module CommonSteps
 
     editor.page_url_field.set(path)
   end
+
+  def and_I_change_the_page_heading(heading)
+    editor.page_heading.set(heading)
+  end
+
+  def then_I_should_see_the_confirmation_heading(heading)
+    expect(editor.page_heading.text).to eq(heading)
+  end
+  alias_method :then_I_should_see_the_page_heading, :then_I_should_see_the_confirmation_heading
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,6 +2,9 @@ class PagesController < FormController
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
   before_action :assign_required_objects, only: %i[edit update destroy]
 
+  COMPONENTS = 'components'.freeze
+  EXTRA_COMPONENTS = 'extra_components'.freeze
+
   def create
     @page_creation = PageCreation.new(page_creation_params)
 
@@ -47,9 +50,10 @@ class PagesController < FormController
       id: @page.id
     }.merge(common_params).merge(page_attributes))
 
-    if params[:page] && params[:page][:add_component]
+    if params[:page] && additional_component
       update_params[:actions] = {
-        add_component: params[:page][:add_component]
+        add_component: additional_component,
+        component_collection: component_collection
       }
     end
 
@@ -101,5 +105,21 @@ class PagesController < FormController
   def assign_required_objects
     @page = service.find_page_by_uuid(params[:page_uuid])
     @page_answers = MetadataPresenter::PageAnswers.new(@page, {})
+  end
+
+  def additional_component
+    @additional_component ||= add_component || add_extra_component
+  end
+
+  def add_component
+    @add_component ||= params[:page][:add_component]
+  end
+
+  def add_extra_component
+    @add_extra_component ||= params[:page][:add_extra_component]
+  end
+
+  def component_collection
+    add_extra_component ? EXTRA_COMPONENTS : COMPONENTS
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -57,12 +57,17 @@ class PagesController < FormController
       }
     end
 
-    if update_params[:components]
-      update_params[:components] = update_params[:components].each.map do |_, value|
+    parse_components(update_params)
+  end
+
+  def parse_components(update_params)
+    %i[components extra_components].each do |collection|
+      next if update_params[collection].blank?
+
+      update_params[collection] = update_params[collection].each.map do |_, value|
         JSON.parse(value)
       end
     end
-
     update_params
   end
 

--- a/app/generators/new_component_generator.rb
+++ b/app/generators/new_component_generator.rb
@@ -12,6 +12,7 @@ class NewComponentGenerator
     metadata = DefaultMetadata["component.#{component_type}"]
 
     metadata.tap do
+      metadata['_uuid'] = SecureRandom.uuid
       metadata['_id'] = component_id
       metadata['name'] = component_id
 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -84,7 +84,7 @@ PagesController.edit = function(app) {
   // Enhance any Add Component buttons.
   $("[data-component=add-component]").each(function() {
     var $node = $(this);
-    new AddComponent($node);
+    new AddComponent($node, { $form: $form });
   });
 }
 
@@ -137,11 +137,12 @@ AddComponent.MenuSelection = function(event, data) {
 class AddContent {
   constructor($node, config) {
     var $button = $node.find("> a");
+    var fieldname = $node.data("fb-field-name") || "page[add_component]";
     this.$button = $button;
     this.$node = $node;
 
     $button.on("click.AddContent", function() {
-      updateHiddenInputOnForm(config.$form, "page[add_component]", "content");
+      updateHiddenInputOnForm(config.$form, fieldname, "content");
       config.$form.submit();
     });
 
@@ -327,6 +328,7 @@ function editPageCheckAnswersViewCustomisations() {
   var $target2 = $("#answers-form dl").first();
   $target1.after($button1);
   $target2.before($button2);
+  $button2.attr("data-fb-field-name", "page[add_extra_component]");
 }
 
 

--- a/app/services/metadata_updater.rb
+++ b/app/services/metadata_updater.rb
@@ -69,11 +69,8 @@ class MetadataUpdater
 
     if @actions && @actions[:add_component].present?
       new_object[component_collection] ||= []
-      component = NewComponentGenerator.new(
-        component_type: @actions[:add_component],
-        page_url: new_object['url'].gsub(/^\//, ''),
-        components: new_object[component_collection]
-      ).to_metadata
+
+      component = new_component(new_object)
       new_object[component_collection].push(component)
       @component_added = component
     end
@@ -98,11 +95,23 @@ class MetadataUpdater
     )
   end
 
+  def new_component(new_object)
+    NewComponentGenerator.new(
+      component_type: @actions[:add_component],
+      page_url: new_object['url'].gsub(/^\//, ''),
+      components: all_components(new_object)
+    ).to_metadata
+  end
+
   def flow_page?(page_collection)
     page_collection == PAGES
   end
 
   def component_collection
     @component_collection ||= @actions[:component_collection]
+  end
+
+  def all_components(obj)
+    [obj['components'], obj['extra_components']].flatten.compact
   end
 end

--- a/app/services/metadata_updater.rb
+++ b/app/services/metadata_updater.rb
@@ -27,9 +27,14 @@ class MetadataUpdater
 
   def metadata(action)
     object = find_node_attribute_by_id
-    collection, index = find_collection_and_index(object)
+    page_collection, index = find_page_collection_and_index(object)
 
-    send("#{action}_node", object: object, index: index, collection: collection)
+    send(
+      "#{action}_node",
+      object: object,
+      index: index,
+      page_collection: page_collection
+    )
 
     @latest_metadata
   end
@@ -40,7 +45,7 @@ class MetadataUpdater
 
   private
 
-  def find_collection_and_index(object)
+  def find_page_collection_and_index(object)
     %w[pages standalone_pages].each do |collection|
       index = @latest_metadata[collection].index(object)
       return collection, index if index.present?
@@ -59,7 +64,7 @@ class MetadataUpdater
     end
   end
 
-  def update_node(object:, index:, collection:)
+  def update_node(object:, index:, page_collection:)
     new_object = object.merge(attributes)
 
     if @actions && @actions[:add_component].present?
@@ -74,16 +79,16 @@ class MetadataUpdater
       @component_added = component
     end
 
-    @latest_metadata[collection][index] = new_object
+    @latest_metadata[page_collection][index] = new_object
     @latest_metadata
   end
 
-  def destroy_node(object:, index:, collection:)
+  def destroy_node(object:, index:, page_collection:)
     # Don't delete start pages
     return @latest_metadata if object['_type'] == 'page.start'
 
-    @latest_metadata[collection].delete_at(index)
-    @latest_metadata['pages'][0]['steps'].delete(@id) if flow_page?(collection)
+    @latest_metadata[page_collection].delete_at(index)
+    @latest_metadata['pages'][0]['steps'].delete(@id) if flow_page?(page_collection)
     @latest_metadata
   end
 
@@ -94,7 +99,7 @@ class MetadataUpdater
     )
   end
 
-  def flow_page?(collection)
-    collection == PAGES
+  def flow_page?(page_collection)
+    page_collection == PAGES
   end
 end

--- a/app/services/metadata_updater.rb
+++ b/app/services/metadata_updater.rb
@@ -68,14 +68,13 @@ class MetadataUpdater
     new_object = object.merge(attributes)
 
     if @actions && @actions[:add_component].present?
-      collection_name = 'components'
-      new_object[collection_name] ||= []
+      new_object[component_collection] ||= []
       component = NewComponentGenerator.new(
         component_type: @actions[:add_component],
         page_url: new_object['url'].gsub(/^\//, ''),
-        components: new_object[collection_name]
+        components: new_object[component_collection]
       ).to_metadata
-      new_object[collection_name].push(component)
+      new_object[component_collection].push(component)
       @component_added = component
     end
 
@@ -101,5 +100,9 @@ class MetadataUpdater
 
   def flow_page?(page_collection)
     page_collection == PAGES
+  end
+
+  def component_collection
+    @component_collection ||= @actions[:component_collection]
   end
 end

--- a/app/services/metadata_updater.rb
+++ b/app/services/metadata_updater.rb
@@ -63,13 +63,14 @@ class MetadataUpdater
     new_object = object.merge(attributes)
 
     if @actions && @actions[:add_component].present?
-      new_object['components'] ||= []
+      collection_name = 'components'
+      new_object[collection_name] ||= []
       component = NewComponentGenerator.new(
         component_type: @actions[:add_component],
         page_url: new_object['url'].gsub(/^\//, ''),
-        components: new_object['components']
+        components: new_object[collection_name]
       ).to_metadata
-      new_object['components'].push(component)
+      new_object[collection_name].push(component)
       @component_added = component
     end
 

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -8,9 +8,9 @@
 
 <%= form_for @page, as: :page, url: page_path(service.service_id, @page.uuid), html: { id: "editContentForm" }, method: :patch do |f| %>
   <% @page.editable_attributes.each do |key, value| %>
-    <% if key == :components %>
+    <% if key == :components || key == :extra_components %>
       <% value.each_with_index do |hash, index| %>
-        <%= f.hidden_field "components[#{index}]", value: hash.to_json %>
+        <%= f.hidden_field "#{key}[#{index}]", value: hash.to_json %>
       <% end %>
     <% else %>
       <%= f.hidden_field key, value: value %>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -19,7 +19,7 @@
 
   <%= f.submit t('actions.save'), class: 'editor-button govuk-button fb-govuk-button' %>
 <% end %>
+
 <%= render template: @page.template %>
 <%= render partial: 'partials/add_component_button' %>
 <%= render partial: 'partials/add_content_button' %>
-

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -59,14 +59,34 @@ RSpec.describe PagesController do
     end
 
     context 'when adding a new component' do
-      let(:params) do
-        { add_component: 'radios' }
+      context 'when adding a component' do
+        let(:params) do
+          { add_component: 'radios' }
+        end
+
+        it 'returns actions to add a component' do
+          expect(controller.page_update_params).to include(
+            'actions' => {
+              'add_component' => 'radios',
+              'component_collection' => 'components'
+            }
+          )
+        end
       end
 
-      it 'returns actions to add a component' do
-        expect(controller.page_update_params).to include(
-          'actions' => { 'add_component' => 'radios' }
-        )
+      context 'when adding an extra component' do
+        let(:params) do
+          { add_extra_component: 'radios', component_collection: 'extra_components' }
+        end
+
+        it 'returns actions to add a component' do
+          expect(controller.page_update_params).to include(
+            'actions' => {
+              'add_component' => 'radios',
+              'component_collection' => 'extra_components'
+            }
+          )
+        end
       end
     end
   end

--- a/spec/generators/new_component_generator_spec.rb
+++ b/spec/generators/new_component_generator_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe NewComponentGenerator do
   input_components = %w[text textarea number radios checkboxes]
   non_input_components = %w[content]
 
+  before do
+    allow(SecureRandom).to receive(:uuid).and_return('Get to the choppa')
+  end
+
   describe '#to_metadata' do
     context 'valid component metadata' do
       let(:valid) { true }
@@ -103,6 +107,7 @@ RSpec.describe NewComponentGenerator do
               {
                 '_id' => "#{page_url}_#{component}_1",
                 '_type' => component,
+                '_uuid' => 'Get to the choppa',
                 'errors' => {},
                 'hint' => '',
                 'items' => [

--- a/spec/generators/new_page_generator_spec.rb
+++ b/spec/generators/new_page_generator_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe NewPageGenerator do
         'url' => page_url,
         '_id' => 'page.home-one',
         '_type' => 'page.singlequestion',
+        '_uuid' => 'mandalorian-123',
         'heading' => 'Question',
         'lede' => '',
         'body' => 'Body section',
@@ -29,6 +30,7 @@ RSpec.describe NewPageGenerator do
           {
             '_id' => "#{page_url}_#{component_type}_1",
             '_type' => 'text',
+            '_uuid' => 'mandalorian-123',
             'errors' => {},
             'hint' => '',
             'label' => 'Question',

--- a/spec/services/metadata_updater_spec.rb
+++ b/spec/services/metadata_updater_spec.rb
@@ -64,47 +64,49 @@ RSpec.describe MetadataUpdater do
 
     context 'when updating attributes and adding new components' do
       context 'when there are no components on the page' do
-        let(:fixture) { metadata_fixture(:no_component_page) }
-        let(:page_url) { '/confirmation' }
-        let(:expected_created_component) do
-          ActiveSupport::HashWithIndifferentAccess.new({
-            '_id': 'confirmation_content_1',
-            '_type': 'content',
-            'content': '[Optional content]',
-            'name': 'confirmation_content_1'
-          })
-        end
-        let(:expected_updated_page) do
-          {
-            '_id' => 'page._confirmation',
-            '_type' => 'page.confirmation',
-            'body' => "You'll receive a confirmation email",
-            'heading' => 'Complaint sent',
-            'lede' => 'Updated lede',
-            'url' => '/confirmation',
-            'components' => [expected_created_component]
-          }
-        end
-        let(:updated_metadata) do
-          metadata = fixture.deep_dup
-          metadata['pages'][-1] = metadata['pages'][-1].merge(expected_updated_page)
-          metadata
-        end
-        let(:attributes) do
-          ActiveSupport::HashWithIndifferentAccess.new({
-            id: 'page._confirmation',
-            service_id: service.service_id,
-            latest_metadata: fixture,
-            actions: { add_component: 'content' },
-            lede: 'Updated lede'
-          })
-        end
+        context 'add to components collection' do
+          let(:fixture) { metadata_fixture(:no_component_page) }
+          let(:page_url) { '/confirmation' }
+          let(:expected_created_component) do
+            ActiveSupport::HashWithIndifferentAccess.new({
+              '_id': 'confirmation_content_1',
+              '_type': 'content',
+              'content': '[Optional content]',
+              'name': 'confirmation_content_1'
+            })
+          end
+          let(:expected_updated_page) do
+            {
+              '_id' => 'page._confirmation',
+              '_type' => 'page.confirmation',
+              'body' => "You'll receive a confirmation email",
+              'heading' => 'Complaint sent',
+              'lede' => 'Updated lede',
+              'url' => '/confirmation',
+              'components' => [expected_created_component]
+            }
+          end
+          let(:updated_metadata) do
+            metadata = fixture.deep_dup
+            metadata['pages'][-1] = metadata['pages'][-1].merge(expected_updated_page)
+            metadata
+          end
+          let(:attributes) do
+            ActiveSupport::HashWithIndifferentAccess.new({
+              id: 'page._confirmation',
+              service_id: service.service_id,
+              latest_metadata: fixture,
+              actions: { add_component: 'content', component_collection: 'components' },
+              lede: 'Updated lede'
+            })
+          end
 
-        it 'updates the page metadata' do
-          updater.update['pages'][-1]
-          expect(
-            updater.component_added.to_h.stringify_keys
-          ).to eq(expected_created_component)
+          it 'updates the page metadata' do
+            updater.update['pages'][-1]
+            expect(
+              updater.component_added.to_h.stringify_keys
+            ).to eq(expected_created_component)
+          end
         end
       end
 
@@ -136,7 +138,7 @@ RSpec.describe MetadataUpdater do
               service_id: service.service_id,
               latest_metadata: service_metadata,
               id: 'page.star-wars-knowledge',
-              actions: { add_component: 'number' }
+              actions: { add_component: 'number', component_collection: 'components' }
             })
           end
 
@@ -174,7 +176,7 @@ RSpec.describe MetadataUpdater do
               service_id: service.service_id,
               latest_metadata: service_metadata,
               id: 'page.star-wars-knowledge',
-              actions: { add_component: 'text' }
+              actions: { add_component: 'text', component_collection: 'components' }
             })
           end
 
@@ -228,7 +230,7 @@ RSpec.describe MetadataUpdater do
               service_id: service.service_id,
               latest_metadata: service_metadata,
               id: 'page.star-wars-knowledge',
-              actions: { add_component: 'radios' }
+              actions: { add_component: 'radios', component_collection: 'components' }
             })
           end
 
@@ -237,6 +239,44 @@ RSpec.describe MetadataUpdater do
             expect(
               updater.component_added.to_h.stringify_keys
             ).to eq(new_component)
+          end
+        end
+
+        context 'add to extra components collection' do
+          let(:fixture) { metadata_fixture(:version) }
+          let(:page_url) { '/check-answers' }
+          let(:expected_created_component) do
+            ActiveSupport::HashWithIndifferentAccess.new({
+              '_id': 'check-answers_content_1',
+              '_type': 'content',
+              'content': '[Optional content]',
+              'name': 'check-answers_content_1'
+            })
+          end
+          let(:expected_updated_page) do
+            metadata = fixture.deep_dup
+            metadata['pages'][-2]['extra_components'].push(expected_created_component)
+            metadata['pages'][-2]
+          end
+          let(:updated_metadata) do
+            metadata = fixture.deep_dup
+            metadata['pages'][-2] = metadata['pages'][-2].merge(expected_updated_page)
+            metadata
+          end
+          let(:attributes) do
+            ActiveSupport::HashWithIndifferentAccess.new({
+              id: 'page._check-answers',
+              service_id: service.service_id,
+              latest_metadata: fixture,
+              actions: { add_component: 'content', component_collection: 'extra_components' }
+            })
+          end
+
+          it 'updates the page metadata' do
+            updater.update['pages'][-2]
+            expect(
+              updater.component_added.to_h.stringify_keys
+            ).to eq(expected_created_component)
           end
         end
       end

--- a/spec/services/metadata_updater_spec.rb
+++ b/spec/services/metadata_updater_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe MetadataUpdater do
       service_id: service_id,
       payload: updated_metadata
     ).and_return(version)
+
+    allow(SecureRandom).to receive(:uuid).and_return(
+      "Dead or alive you're coming with me"
+    )
   end
 
   describe '#update' do
@@ -71,6 +75,7 @@ RSpec.describe MetadataUpdater do
             ActiveSupport::HashWithIndifferentAccess.new({
               '_id': 'confirmation_content_1',
               '_type': 'content',
+              '_uuid': "Dead or alive you're coming with me",
               'content': '[Optional content]',
               'name': 'confirmation_content_1'
             })
@@ -79,6 +84,7 @@ RSpec.describe MetadataUpdater do
             {
               '_id' => 'page._confirmation',
               '_type' => 'page.confirmation',
+              "_uuid"=> 'b238a22f-c180-48d0-a7d9-8aad2036f1f2',
               'body' => "You'll receive a confirmation email",
               'heading' => 'Complaint sent',
               'lede' => 'Updated lede',
@@ -116,6 +122,7 @@ RSpec.describe MetadataUpdater do
             {
               '_id' => 'star-wars-knowledge_number_1',
               '_type' => 'number',
+              '_uuid' => "Dead or alive you're coming with me",
               'errors' => {},
               'hint' => '',
               'label' => 'Question',
@@ -155,6 +162,7 @@ RSpec.describe MetadataUpdater do
             {
               '_id' => 'star-wars-knowledge_text_2',
               '_type' => 'text',
+              '_uuid' => "Dead or alive you're coming with me",
               'errors' => {},
               'hint' => '',
               'label' => 'Question',
@@ -193,6 +201,7 @@ RSpec.describe MetadataUpdater do
             {
               '_id' => 'star-wars-knowledge_radios_2',
               '_type' => 'radios',
+              '_uuid' => "Dead or alive you're coming with me",
               'errors' => {},
               'hint' => '',
               'items' => [
@@ -247,10 +256,11 @@ RSpec.describe MetadataUpdater do
           let(:page_url) { '/check-answers' }
           let(:expected_created_component) do
             ActiveSupport::HashWithIndifferentAccess.new({
-              '_id': 'check-answers_content_1',
+              '_id': 'check-answers_content_3',
               '_type': 'content',
+              '_uuid' => "Dead or alive you're coming with me",
               'content': '[Optional content]',
-              'name': 'check-answers_content_1'
+              'name': 'check-answers_content_3'
             })
           end
           let(:expected_updated_page) do

--- a/spec/services/metadata_updater_spec.rb
+++ b/spec/services/metadata_updater_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe MetadataUpdater do
             {
               '_id' => 'page._confirmation',
               '_type' => 'page.confirmation',
-              "_uuid"=> 'b238a22f-c180-48d0-a7d9-8aad2036f1f2',
+              '_uuid' => 'b238a22f-c180-48d0-a7d9-8aad2036f1f2',
               'body' => "You'll receive a confirmation email",
               'heading' => 'Complaint sent',
               'lede' => 'Updated lede',


### PR DESCRIPTION
## Context

This Pull request makes the edit check your answers to work properly.

All attributes like heading, send_heading, send_body and the two add component buttons are included on the fix.

## Unique identifiers

The components now has a `uuid` attribute just to guarantee uniqueness independently of the id (the ids are unique too but not using uuid format).

