### PR TITLE
Update link standalone page links colour

### DIFF
--- a/app/views/partials/_standalone.html.erb
+++ b/app/views/partials/_standalone.html.erb
@@ -7,7 +7,7 @@
       <% service.standalone_pages.each do |page| %>
         <li class="standalone-pages govuk-!-padding-right-9 govuk-!-margin-top-5">
           <%= flow_thumbnail(page, service.service_id) %>
-          <%= link_to page.url, edit_page_path(service.service_id, page.uuid) %>
+          <%= link_to page.url, edit_page_path(service.service_id, page.uuid), class: 'govuk-link' %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
Trying to add the right class to the links to the the footer pages so they look like the other thumbnails links.
Just comparing the code for both, seems ", class: 'govuk-link'" was missing.