### PR TITLE
Fix/1477 bug radio checkboxes options are not editable

### DIFF
--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -177,14 +177,18 @@ function focusOnEditableComponent() {
  * TODO: Add more description on how this works.
  **/
 function bindEditableContentHandlers($area) {
-  var PAGE = this;
+  const SELECTOR_LABEL_STANDARD = "label h1, label h2";
+  const SELECTOR_HINT_STANDARD = ".govuk-hint";
+
+  var page = this;
   var $editContentForm = $("#editContentForm");
   var $saveButton = $editContentForm.find(":submit");
   if($editContentForm.length) {
     $saveButton.attr("disabled", true); // disable until needed.
     $(".fb-editable").each(function(i, node) {
       var $node = $(node);
-      PAGE.editableContent.push(editableComponent($node, {
+
+      page.editableContent.push(editableComponent($node, {
         editClassname: "active",
         data: $node.data("fb-content-data"),
         attributeDefaultText: "fb-default-text",
@@ -198,14 +202,22 @@ function bindEditableContentHandlers($area) {
         },
         form: $editContentForm,
         id: $node.data("fb-content-id"),
+
+        // Selectors for editable component labels/legends/hints, etc.
+        selectorTextFieldLabel: SELECTOR_LABEL_STANDARD, // Also used by Number
+        selectorTextFieldHint: SELECTOR_HINT_STANDARD,   // Also used by Number
+        selectorTextareaFieldLabel: SELECTOR_LABEL_STANDARD,
+        selectorTextareaFieldHint: SELECTOR_HINT_STANDARD,
+        selectorGroupFieldLabel: "legend > :first-child", // Used by Date
+        selectorGroupFieldHint: SELECTOR_HINT_STANDARD,   // Used by Date
+        selectorCollectionFieldLabel: "legend > :first-child", // Used by Radios
+        selectorCollectionFieldHint: "fieldset > .govuk-hint", // Used by Radios
+        selectorComponentCollectionItemLabel: "label",               // Used by Radio options
+        selectorComponentCollectionItemHint: SELECTOR_HINT_STANDARD, // Used by Radio options
+
+        // Other selectors
         selectorDisabled: "input:not(:hidden), textarea",
-        selectorQuestion: "label h1, label h2",
-        selectorHint: "span",
-        selectorGroupQuestion: "legend > :first-child",
-        selectorCollectionQuestion: "legend > :first-child",
-        selectorCollectionOption: "label",
-        selectorCollectionHint: "fieldset > .govuk-hint",
-        selectorCollectionItem: ".govuk-radios__item, .govuk-checkboxes__item",
+
         text: {
           addItem: app.text.actions.option_add,
           removeItem: app.text.actions.option_remove
@@ -244,11 +256,11 @@ function bindEditableContentHandlers($area) {
           // Runs before onItemRemove when removing an editable Collection item.
           // Currently not used but added for future option and consistency
           // with onItemAdd (provides an opportunity for clean up).
-          PAGE.dialogConfirmationDelete.content = {
+          page.dialogConfirmationDelete.content = {
             heading: app.text.dialogs.heading_delete_option.replace(/%{option label}/, item._elements.label.$node.text()),
             ok: app.text.dialogs.button_delete_option
           };
-          PAGE.dialogConfirmationDelete.confirm({}, function() {
+          page.dialogConfirmationDelete.confirm({}, function() {
             item.component.remove(item);
           });
         },
@@ -271,8 +283,8 @@ function bindEditableContentHandlers($area) {
 
     // Add handler to activate save functionality from the independent 'save' button.
     $editContentForm.on("submit", (e) => {
-      for(var i=0; i<PAGE.editableContent.length; ++i) {
-        PAGE.editableContent[i].save();
+      for(var i=0; i<page.editableContent.length; ++i) {
+        page.editableContent[i].save();
       }
     });
   }

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -203,6 +203,7 @@ function bindEditableContentHandlers($area) {
         selectorHint: "span",
         selectorGroupQuestion: "legend > :first-child",
         selectorCollectionQuestion: "legend > :first-child",
+        selectorCollectionOption: "label",
         selectorCollectionHint: "fieldset > .govuk-hint",
         selectorCollectionItem: ".govuk-radios__item, .govuk-checkboxes__item",
         text: {

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -239,8 +239,8 @@ class EditableComponentBase extends EditableBase {
     //        and any others...
     //      }
     this._elements = arguments.length > 2 && elements || {
-      label: new EditableElement($node.find(config.selectorQuestion), config),
-      hint: new EditableElement($node.find(config.selectorHint), config)
+      label: new EditableElement($node.find(config.selectorElementLabel), config),
+      hint: new EditableElement($node.find(config.selectorElementHint), config)
     };
 
     $node.find(config.selectorDisabled).attr("disabled", true); // Prevent input in editor mode.
@@ -310,7 +310,10 @@ class EditableTextFieldComponent extends EditableComponentBase {
     //       Maybe make this EditableAttribute instance when class is
     //       ready so we can edit attribute values, such as placeholder.
     //  {input: new EditableAttribute($node.find("input"), config)}
-    super($node, config);
+    super($node, mergeObjects({
+      selectorElementLabel: config.selectorTextFieldLabel,
+      selectorElementHint: config.selectorTextFieldHint
+    }, config));
     $node.addClass("EditableTextFieldComponent");
   }
 }
@@ -345,7 +348,10 @@ class EditableTextFieldComponent extends EditableComponentBase {
  **/
 class EditableTextareaFieldComponent extends EditableComponentBase {
   constructor($node, config) {
-    super($node, config);
+    super($node, mergeObjects({
+      selectorElementLabel: config.selectorTextareaFieldLabel,
+      selectorElementHint: config.selectorTextareaFieldHint
+    }, config));
     $node.addClass("EditableTextareaFieldComponent");
   }
 }
@@ -389,10 +395,10 @@ class EditableTextareaFieldComponent extends EditableComponentBase {
  **/
 class EditableGroupFieldComponent extends EditableComponentBase {
   constructor($node, config) {
-    super($node, config, {
-      label: new EditableElement($node.find(config.selectorGroupQuestion), config),
-      hint: new EditableElement($node.find(config.selectorHint), config)
-    });
+    super($node, mergeObjects({
+      selectorElementLabel: config.selectorGroupFieldLabel,
+      selectorElementHint: config.selectorGroupFieldHint
+    }, config));
     $node.addClass("EditableGroupFieldComponent");
   }
 
@@ -462,12 +468,10 @@ class EditableGroupFieldComponent extends EditableComponentBase {
  **/
 class EditableCollectionFieldComponent extends EditableComponentBase {
   constructor($node, config) {
-    super($node, config, {
-      // Be better for consistency if this was 'label' and not 'legend',
-      // but working with the JSON recognised by/sent from the  server.
-      label: new EditableElement($node.find(config.selectorCollectionQuestion), config),
-      hint: new EditableElement($node.find(config.selectorCollectionHint), config)
-    });
+    super($node, mergeObjects({
+      selectorElementLabel: config.selectorCollectionFieldLabel,
+      selectorElementHint: config.selectorCollectionFieldHint
+    }, config));
 
     var text = config.text || {}; // Make sure it exists to avoid errors later on.
 
@@ -636,9 +640,10 @@ EditableCollectionFieldComponent.applyFilters = function(filters, unique, data) 
  **/
 class EditableComponentCollectionItem extends EditableComponentBase {
   constructor(editableCollectionFieldComponent, $node, config) {
-    super($node, mergeObjects(config, {
-      label: new EditableElement($node.find(config.selectorCollectionOption), config)
-    }));
+    super($node, mergeObjects({
+      selectorElementLabel: config.selectorComponentCollectionItemLabel,
+      selectorElementHint: config.selectorComponentCollectionItemHint
+    }, config));
 
     if(!config.preserveItem) {
       new EditableCollectionItemRemover(this, editableCollectionFieldComponent, config);

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -636,7 +636,9 @@ EditableCollectionFieldComponent.applyFilters = function(filters, unique, data) 
  **/
 class EditableComponentCollectionItem extends EditableComponentBase {
   constructor(editableCollectionFieldComponent, $node, config) {
-    super($node, config);
+    super($node, mergeObjects(config, {
+      label: new EditableElement($node.find(config.selectorCollectionOption), config)
+    }));
 
     if(!config.preserveItem) {
       new EditableCollectionItemRemover(this, editableCollectionFieldComponent, config);


### PR DESCRIPTION
This PR changes the way Editable Components target the elements that need to have the editable mechanism applied. 
Previously, the config files passed in selectors that found and applied elements based on them. The found elements overrode those found by standard functionality of the parent class, EditableComponentBase. 

Essentially, instead of doing this kind of thing in a child class:
```
super($node, config, {
      label: new EditableElement($node.find(config.selectorGroupQuestion), config),
      hint: new EditableElement($node.find(config.selectorHint), config)
    });
```
we now just pass in new selectors to overwrite the values of used in parent class lookup.
    
e.g. Parent class has this:
```
    this._elements = arguments.length > 2 && elements || {
      label: new EditableElement($node.find(config.selectorElementLabel), config),
      hint: new EditableElement($node.find(config.selectorElementHint), config)
    };
```
    
and we're now passing those values from child components, like this:

 ```
   super($node, mergeObjects({
      selectorElementLabel: config.selectorTextFieldLabel,
      selectorElementHint: config.selectorTextFieldHint
    }, config));
```
    
(config keys obviously change depending on the type of child class).
    


