### PR TITLE
Add acceptace tests for multiple questions page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,14 @@ copy-env-vars-local:
 .PHONY: setup
 setup: build seed-public-key copy-env-vars-local
 
+.PHONY: restart
+restart:
+	$(DOCKER_COMPOSE) restart
+
+.PHONY: logs
+logs:
+	$(DOCKER_COMPOSE) logs editor-app
+
 .PHONY: acceptance-specs
 acceptance: setup
 	bundle exec rspec acceptance

--- a/acceptance/features/edit_check_answers_page_spec.rb
+++ b/acceptance/features/edit_check_answers_page_spec.rb
@@ -52,12 +52,6 @@ feature 'Edit check your answers page' do
     then_I_should_see_the_first_extra_component(content_extra_component)
   end
 
-  def given_I_have_a_check_your_answers_page
-    given_I_add_a_check_answers_page
-    and_I_add_a_page_url(url)
-    when_I_add_the_page
-  end
-
   def and_I_change_the_send_heading(send_heading)
     editor.page_send_heading.set(send_heading)
   end

--- a/acceptance/features/edit_multiple_questions_page_spec.rb
+++ b/acceptance/features/edit_multiple_questions_page_spec.rb
@@ -1,0 +1,143 @@
+require_relative '../spec_helper'
+
+feature 'Edit multiple questions page' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:url) { 'hakuna-matata' }
+  let(:page_heading) { 'Star wars questions' }
+  let(:text_component_question) do
+    'C-3P0 is fluent in how many languages?'
+  end
+  let(:textarea_component_question) do
+    'How Did Maz Kanata End Up With Luke`s Lightsaber?'
+  end
+  let(:radio_component_question) do
+    'How old is Yoda when he dies?'
+  end
+  let(:radio_component_options) { ['900 years old'] }
+  let(:checkboxes_component_question) do
+    'Tell us what are the star wars movies called'
+  end
+  let(:checkboxes_component_options) do
+    ['Prequels']
+  end
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'adding and updating components' do
+    given_I_have_a_multiple_questions_page
+    and_I_add_a_text_component
+    and_I_add_a_textarea_component
+    and_I_add_a_radio_component
+    and_I_add_a_checkbox_component
+    and_I_update_the_components
+    when_I_save_my_changes
+    and_I_return_to_flow_page
+    preview_form = and_I_preview_the_form
+    then_I_can_answer_the_questions_in_the_page(preview_form)
+  end
+
+  def given_I_have_a_multiple_questions_page
+    given_I_add_a_multiple_question_page
+    and_I_add_a_page_url(url)
+    when_I_add_the_page
+  end
+
+  def and_I_add_a_text_component
+    and_I_add_a_component
+    and_I_add_a_question
+    editor.add_text.click
+  end
+
+  def and_I_add_a_component
+    editor.add_a_component_button.click
+  end
+
+  def and_I_add_a_question
+    editor.question_component.hover
+  end
+
+  def and_I_add_a_textarea_component
+    and_I_add_a_component
+    and_I_add_a_question
+    editor.add_text_area.click
+  end
+
+  def and_I_add_a_radio_component
+    and_I_add_a_component
+    and_I_add_a_question
+    editor.add_radio.click
+  end
+
+  def and_I_add_a_checkbox_component
+    and_I_add_a_component
+    and_I_add_a_question
+    editor.add_checkboxes.click
+  end
+
+  def and_I_update_the_components
+    and_I_change_the_page_heading(page_heading)
+    and_I_change_the_text_component(text_component_question)
+    and_I_change_the_textarea_component(textarea_component_question)
+    and_I_change_the_radio_component(
+      radio_component_question,
+      options: radio_component_options
+    )
+    and_I_change_the_checkboxes_component(
+      checkboxes_component_question,
+      options: checkboxes_component_options
+    )
+  end
+
+  def and_I_change_the_text_component(question)
+    and_I_change_the_component(question, component: 0, tag: 'label')
+  end
+
+  def and_I_change_the_textarea_component(question)
+    and_I_change_the_component(question, component: 1, tag: 'label')
+  end
+
+  def and_I_change_the_radio_component(question, options:)
+    and_I_change_the_component(question, component: 2, tag: 'legend', options: options)
+  end
+
+  def and_I_change_the_checkboxes_component(question, options:)
+    and_I_change_the_component(question, component: 3, tag: 'legend', options: options)
+  end
+
+  def and_I_change_the_component(question, component:, tag:, options: nil)
+    element = editor.find(
+      :xpath,
+      "//*[@data-fb-content-id='page[components[#{component}]]']")
+    question_name = element.find("#{tag} .EditableElement")
+    question_name.set(question)
+
+    if options
+      options.each_with_index do |option, index|
+        element.all('label')[index].set(option)
+      end
+    end
+  end
+
+  def then_I_can_answer_the_questions_in_the_page(preview_form)
+    within_window(preview_form) do
+      expect(page.text).to include('Service name goes here')
+      page.click_button 'Start now'
+      page.fill_in 'C-3P0 is fluent in how many languages?',
+        with: 'Fluent in over six million forms of communication.'
+      page.fill_in 'How Did Maz Kanata End Up With Luke`s Lightsaber?',
+        with: 'Who knows?'
+      page.choose '900 years old', visible: false
+      page.check 'Prequels', visible: false
+      page.click_button 'Continue'
+
+      # There are no next pages but it means that the continue work and the
+      # multiple question is working since filling the form above worked
+      # gracefully.
+      expect(page.text).to include("The page you were looking for doesn't exist.")
+    end
+  end
+end

--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -55,11 +55,6 @@ feature 'Preview form' do
     when_I_save_my_changes
   end
 
-  def when_I_preview_the_form
-    and_I_return_to_flow_page
-    and_I_preview_the_form
-  end
-
   def then_I_can_navigate_until_the_end_of_the_form(preview_form)
     within_window(preview_form) do
       expect(page.text).to include('This is your start page')

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -53,12 +53,20 @@ class EditorApp < SitePrism::Page
           :xpath,
           "//a[@class='ui-menu-item-wrapper' and contains(.,'Confirmation page')]"
 
-  element :add_single_question_text, :link, 'Text', visible: false
-  element :add_single_question_text_area, :link, 'Textarea', visible: false
-  element :add_single_question_number, :link, 'Number', visible: false
-  element :add_single_question_date, :link, 'Date', visible: false
-  element :add_single_question_radio, :link, 'Radio buttons', visible: false
-  element :add_single_question_checkboxes, :link, 'Checkboxes', visible: false
+  element :add_a_component_button, :link, 'Add component'
+  element :question_component,
+          :xpath,
+          "//span[@class='ui-menu-item-wrapper' and contains(.,'Question')]"
+  element :content_component,
+          :xpath,
+          "//span[@class='ui-menu-item-wrapper' and contains(.,'Content area')]"
+
+  element :add_text, :link, 'Text', visible: false
+  element :add_text_area, :link, 'Textarea', visible: false
+  element :add_number, :link, 'Number', visible: false
+  element :add_date, :link, 'Date', visible: false
+  element :add_radio, :link, 'Radio buttons', visible: false
+  element :add_checkboxes, :link, 'Checkboxes', visible: false
 
   elements :add_page_submit_button, :button, 'Add page'
   element :save_page_button, :xpath, '//input[@value="Save"]'

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -50,32 +50,32 @@ module CommonSteps
 
   def given_I_add_a_single_question_page_with_text
     given_I_want_to_add_a_single_question_page
-    editor.add_single_question_text.click
+    editor.add_text.click
   end
 
   def given_I_add_a_single_question_page_with_text_area
     given_I_want_to_add_a_single_question_page
-    editor.add_single_question_text_area.click
+    editor.add_text_area.click
   end
 
   def given_I_add_a_single_question_page_with_number
     given_I_want_to_add_a_single_question_page
-    editor.add_single_question_number.click
+    editor.add_number.click
   end
 
   def given_I_add_a_single_question_page_with_date
     given_I_want_to_add_a_single_question_page
-    editor.add_single_question_date.click
+    editor.add_date.click
   end
 
   def given_I_add_a_single_question_page_with_radio
     given_I_want_to_add_a_single_question_page
-    editor.add_single_question_radio.click
+    editor.add_radio.click
   end
 
   def given_I_add_a_single_question_page_with_checkboxes
     given_I_want_to_add_a_single_question_page
-    editor.add_single_question_checkboxes.click
+    editor.add_checkboxes.click
   end
 
   def given_I_add_a_check_answers_page
@@ -185,4 +185,16 @@ module CommonSteps
     expect(editor.page_heading.text).to eq(heading)
   end
   alias_method :then_I_should_see_the_page_heading, :then_I_should_see_the_confirmation_heading
+
+  def given_I_have_a_check_your_answers_page
+    given_I_add_a_check_answers_page
+    and_I_add_a_page_url(url)
+    when_I_add_the_page
+  end
+  alias_method :and_I_have_a_check_your_answers_page, :given_I_have_a_check_your_answers_page
+
+  def when_I_preview_the_form
+    and_I_return_to_flow_page
+    and_I_preview_the_form
+  end
 end

--- a/app/views/partials/_add_component_button.html.erb
+++ b/app/views/partials/_add_component_button.html.erb
@@ -6,7 +6,11 @@
           <span><%= t('components.menu.question') %></span>
           <ul class="govuk-navigation">
             <% @page.input_components.each do |component| %>
-              <li data-action="<%= component %>"><a href="#add_component"><%= component.capitalize %></a></li>
+              <li data-action="<%= component %>">
+                <a href="#add_component">
+                  <%= t("components.list.#{component.underscore}") %>
+                </a>
+              </li>
             <% end %>
           </ul>
         </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,13 @@ en:
     actions: 'Actions'
     footer: 'Form footer'
   components:
+    list:
+      text: 'Text'
+      textarea: 'Textarea'
+      number: 'Number'
+      date: 'Date'
+      radios: 'Radio buttons'
+      checkboxes: 'Checkboxes'
     actions:
       add_component: 'Add component'
       add_content: 'Add content area'


### PR DESCRIPTION
## Context

This PR adds acceptance tests for multiple questions page.

Plus this PR adds the component names to the translation file. Talking with Fabien in the add page button is saying "Radio buttons" and it should be the same in the add component too.
