### PR TITLE
Fix add page in the middle of the flow spec

### DIFF
--- a/acceptance/features/add_page_in_the_middle_flow_spec.rb
+++ b/acceptance/features/add_page_in_the_middle_flow_spec.rb
@@ -23,7 +23,7 @@ feature 'Add page in the middle flow' do
     editor.three_dots_button.click
     editor.add_page_here_link.click
     editor.add_single_question.hover
-    editor.add_single_question_radio.click
+    editor.add_radio.click
     editor.page_url_field.set(url)
     when_I_add_the_page
     # expect to be on the page created (radio component page)


### PR DESCRIPTION
The method was renamed.

Passed [here](https://app.circleci.com/pipelines/github/ministryofjustice/fb-editor/1445/workflows/23c87f45-ae12-48c7-927b-7f885e2a055b/jobs/2064)