### PR TITLE
Fix notification when it is first published on live production

### DIFF
--- a/app/services/publisher/adapters/cloud_platform.rb
+++ b/app/services/publisher/adapters/cloud_platform.rb
@@ -57,7 +57,7 @@ class Publisher
         .where(
           service_id: service_id,
           deployment_environment: deployment_environment
-        ).count.zero?
+        ).count == 1
       end
 
       def message

--- a/spec/services/publisher/adapters/cloud_platform_spec.rb
+++ b/spec/services/publisher/adapters/cloud_platform_spec.rb
@@ -120,6 +120,10 @@ RSpec.describe Publisher::Adapters::CloudPlatform do
       let(:deployment_environment) { 'production' }
 
       context 'when first published' do
+        let!(:publish_service_production) do
+          create(:publish_service, :completed, :production, service_id: service_id)
+        end
+
         context 'when there is a published for development' do
           let!(:publish_service) do
             create(:publish_service, :completed, :dev, service_id: service_id)
@@ -141,6 +145,9 @@ RSpec.describe Publisher::Adapters::CloudPlatform do
 
       context 'when not on first publish' do
         let!(:publish_service) do
+          create(:publish_service, :completed, :production, service_id: service_id)
+        end
+        let!(:publish_service_two) do
           create(:publish_service, :completed, :production, service_id: service_id)
         end
 


### PR DESCRIPTION
The Publisher class updates the publish service db BEFORE calling
the completed method which leaves the db with ONE published
service completed so in order to check if is first published
we need to check if is one.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>