### PR TITLE
Move HotJar script tags to the footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,21 +8,6 @@
     <%= render partial: 'partials/properties' %>
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>
-
-    <!-- Hotjar Tracking Code for Private Beta Research Study -->
-    <% if live_platform? %>
-      <script>
-        (function(h,o,t,j,a,r){
-          h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-          h._hjSettings={hjid:2316310,hjsv:6};
-          a=o.getElementsByTagName('head')[0];
-          r=o.createElement('script');r.async=1;
-          r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-          a.appendChild(r);
-        })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-      </script>
-    <% end %>
-    <!-- Hotjar Tracking Code for Private Beta Research Study -->
   </head>
 
   <body class="govuk-template__body govuk-body">

--- a/app/views/partials/_footer.html.erb
+++ b/app/views/partials/_footer.html.erb
@@ -16,4 +16,19 @@
       </div>
     </div>
   </div>
+
+  <% if live_platform? %>
+    <!-- Hotjar Tracking Code for Private Beta Research Study -->
+      <script>
+        (function(h,o,t,j,a,r){
+          h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+          h._hjSettings={hjid:2316310,hjsv:6};
+          a=o.getElementsByTagName('head')[0];
+          r=o.createElement('script');r.async=1;
+          r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+          a.appendChild(r);
+        })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+      </script>
+    <!-- Hotjar Tracking Code for Private Beta Research Study -->
+    <% end %>
 </footer>


### PR DESCRIPTION
Something is overwriting the scripts tags in the header on any page
after the main Form List page.

For the moment put the HotJar script tags in the footer