### PR TITLE
Fix/1484 optional content still displayed on the form

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -20,9 +20,3 @@ import "../styles/application.scss"
 //
 const images = require.context('../images', true)
 const imagePath = (name) => images(name, true)
-
-
-// Something appears to have broken console.log so reinstating using console.debug
-if(window.console && console.debug) {
-  console.log = console.debug;
-}

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -185,9 +185,9 @@ function bindEditableContentHandlers($area) {
   var $saveButton = $editContentForm.find(":submit");
   if($editContentForm.length) {
     $saveButton.attr("disabled", true); // disable until needed.
+
     $(".fb-editable").each(function(i, node) {
       var $node = $(node);
-
       page.editableContent.push(editableComponent($node, {
         editClassname: "active",
         data: $node.data("fb-content-data"),
@@ -220,8 +220,12 @@ function bindEditableContentHandlers($area) {
 
         text: {
           addItem: app.text.actions.option_add,
-          removeItem: app.text.actions.option_remove
+          removeItem: app.text.actions.option_remove,
+
+          default_element: app.text.default_element,
+          default_content: app.text.default_content
         },
+
         onCollectionItemClone: function($node) {
            // @node is the collection item (e.g. <div> wrapping <input type=radio> and <label> elements)
            // Runs after the collection item has been cloned, so further custom manipulation can be

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -178,5 +178,35 @@ function updateHiddenInputOnForm($form, name, content) {
 }
 
 
+/* Function return specified namespace (creates if doesn't exist).
+ * This means you can safely do something like this:
+ * namespace("my.name.space").something = "foo";
+ * without having the 'space' object previously exist, for example.
+ *
+ * Also, it means you can avoid undefined errors by doing this:
+ * if(namespace("my.name.space").something) {
+ *   // something exists so use it
+ * }
+ *
+ * If 'space' did not exist this code would fall over when trying
+ * to see if 'something' has value. Instead, although 'something'
+ * would still not exist (because 'space' did not) the check should
+ * work but without having to write an alternative such as:
+ * if(my && my.name && my.name.space && my.name.space.something) {
+ *   // something exists so use it
+ * }
+ **/
+function namespace(namespace) {
+  var split = namespace.split(".");
+  var context = this;
+  var i = 0;
+  while( i < split.length) {
+    context = namespace.call(context, split(i));
+    ++i;
+  }
+  return context;
+}
+
+
 // Make available for importing.
 export { mergeObjects, createElement, safelyActivateFunction, isFunction, uniqueString, findFragmentIdentifier, meta, post, updateHiddenInputOnForm };

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -5,6 +5,7 @@
       controller:  "<%= controller_name %>"
     },
     text: {
+      default_content: "<%= MetadataPresenter::DefaultText[:content] %>",
       default_option: "<%= MetadataPresenter::DefaultText[:option] %>",
       default_option_hint: "<%= MetadataPresenter::DefaultText[:option_hint] %>",
       dialogs: {


### PR DESCRIPTION
- Removing window.console fix as no longer required
- Namespace function is to allow for safer `something.something.something.darkside` calls
- `this._required` change is first step to separating logic and allowing required fields to have default text
- `default_content` addition is to use the Metadata Presenter value in output validation
- `default_element` does not exist in Metadata Presenter yet, but adding to avoid later confusion when figuring out how to use same mechanism as content (there is a backlog issue that will use this).
- update to `get content()` uses the above to effect the main requirement for fixing the ticket issue. 