### PR TITLE
Fix orphaned 'Delete' button when activator is clicked

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -206,6 +206,13 @@ html {
 
 /* Injected/dynamic components
  * --------------------------- */
+.ActivatedMenu_Activator {
+  &.active {
+    opacity: 1;
+  }
+}
+
+
 .EditableCollectionItemInjector {
   @include button_type_link;
   @include addition_icon;
@@ -285,10 +292,6 @@ html {
   opacity: 0;
   overflow: hidden;
   position: absolute;
-
-  &.active {
-    opacity: 1;
-  }
 }
 
 .form-step_thumbnail {


### PR DESCRIPTION
Issue in ticket appears to be fixed already as cannot replicate.
This change relates to orphaned Delete button issue noticed (and has previously been reported somewhere) during investigation ticket issue (see screenshots).

**Was**
<img width="605" alt="Screenshot 2021-04-20 at 18 29 46" src="https://user-images.githubusercontent.com/76942244/115439657-baa7e180-a206-11eb-846b-58673e951d6a.png">

**Now**
<img width="446" alt="Screenshot 2021-04-20 at 18 29 55" src="https://user-images.githubusercontent.com/76942244/115439683-c2678600-a206-11eb-864a-33dff962ffd0.png">
