### PR TITLE
Always show service URL after publishing

### DIFF
--- a/app/presenters/publish_service_presenter.rb
+++ b/app/presenters/publish_service_presenter.rb
@@ -5,7 +5,7 @@ class PublishServicePresenter
   delegate :deployment_environment, to: :publish_service
 
   def self.hostname_for(deployment_environment:, view:)
-    publish_service = completed_published_service(
+    publish_service = last_published_service(
       service_id: view.service.service_id,
       deployment_environment: deployment_environment
     )
@@ -16,8 +16,8 @@ class PublishServicePresenter
     end
   end
 
-  def self.completed_published_service(service_id:, deployment_environment:)
-    PublishService.completed.where(
+  def self.last_published_service(service_id:, deployment_environment:)
+    PublishService.where(
       deployment_environment: deployment_environment,
       service_id: service_id
     ).desc.first

--- a/spec/presenters/publish_service_presenter_spec.rb
+++ b/spec/presenters/publish_service_presenter_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe PublishServicePresenter do
     end
 
     let(:params) { { id: service.service_id } }
+    let(:expected_hostname) do
+      %(<a target=\"_blank\" class=\"govuk-link\" rel=\"noopener\" href=\"https://service-name.dev.test.form.service.justice.gov.uk\">service-name.dev.test.form.service.justice.gov.uk</a>)
+    end
 
     before do
       allow(view).to receive(:service).and_return(service)
@@ -25,9 +28,7 @@ RSpec.describe PublishServicePresenter do
         end
 
         it 'returns hostname link' do
-          expect(hostname).to eq(
-            %(<a target=\"_blank\" class=\"govuk-link\" rel=\"noopener\" href=\"https://service-name.dev.test.form.service.justice.gov.uk\">service-name.dev.test.form.service.justice.gov.uk</a>)
-          )
+          expect(hostname).to eq(expected_hostname)
         end
       end
 
@@ -49,8 +50,8 @@ RSpec.describe PublishServicePresenter do
         create(:publish_service, :dev, :queued, service_id: service.service_id)
       end
 
-      it 'returns nil' do
-        expect(hostname).to be_nil
+      it 'always shows the hostname' do
+        expect(hostname).to eq(expected_hostname)
       end
     end
 


### PR DESCRIPTION
We need to show the service URL once the publishing job has reached the
`completed` step.

Therefore we check whether a PublishService exists in the DB. If so then
it has successfully published so we can show the URL.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>