### PR TITLE
Fix/1479 scrolling feature issues

### DIFF
--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -62,18 +62,7 @@ ServicesController.edit = function(app) {
   });
 
   // Create the menu for Add Page functionality.
-  let pageAdditionMenu = new PageActionMenu(this, $("[data-component='PageAdditionMenu']"), {
-    selection_event: "PageAdditionMenuSelection",
-    pageCreateDialog: pageCreateDialog,
-    menu: {
-      position: { at: "right+2 top-2" } // Position second-level menu in relation to first.
-    }
-  });
-
-  // Add handler for main 'Add page' button to clear any add_page_after values.
-  pageAdditionMenu.menu.activator.$node.on("click.servicescontrolleredit", function() {
-    updateHiddenInputOnForm(pageCreateDialog.$form, "page[add_page_after]", "");
-  });
+  createPageAdditionMenu(pageCreateDialog);
 
   // Fix for the scrolling of form overview.
   applyCustomOverviewWorkaround();
@@ -183,6 +172,23 @@ function pageActionMenuSelection(event, data) {
 }
 
 
+/* TODO
+ * Description here
+ **/
+function createPageAdditionMenu(pageCreateDialog) {
+  new PageActionMenu(this, $("[data-component='PageAdditionMenu']"), {
+      selection_event: "PageAdditionMenuSelection",
+      pageCreateDialog: pageCreateDialog,
+      menu: {
+        position: { at: "right+2 top-2" } // Position second-level menu in relation to first.
+      }
+    }).menu.activator.$node.on("click.servicescontrolleredit", function() {
+      // Add handler for main 'Add page' button to clear any add_page_after values.
+      updateHiddenInputOnForm(pageCreateDialog.$form, "page[add_page_after]", "");
+  });
+}
+
+
 /* Controls what happens when user selects a page type.
  * 1). Clear page_type & component_type values in hidden form.
  * (if we then have new values):
@@ -215,12 +221,32 @@ function pageAdditionMenuSelection(event, data) {
 function applyCustomOverviewWorkaround() {
   var $overview = $("#form-overview");
   var $container = $overview.find(" > .container");
+  var $button = $(".form-overview_button")
+  var containerWidth = $container.width();
+  var overviewWidth = $overview.width();
+  var offsetLeft = $overview.offset().left;
+  var margin = 30; // Arbitrary number based on common
+  var spacerForMenu = 250;
+  var maxWidth = window.innerWidth - (margin * 2) - spacerForMenu;
 
-  $overview.height($container.height());
-  $container.css({
-    right: ~($overview.offset().left) + 30
-  }); // + 30 is arbitrary extra spacing
+  if(containerWidth > overviewWidth) {
+    let left = ((containerWidth + spacerForMenu) - overviewWidth) / 2;
+    if(left < offsetLeft) {
+      $container.css("left", ~left);
+    }
+    else {
+      $container.css("left", ~(offsetLeft - margin));
+    }
 
+    // Make sure to limit so a scrollbar can kick in, if necessary.
+    $container.css({
+      "max-width": maxWidth,
+    });
+
+  }
+
+  $container.scrollLeft(containerWidth); // Align to right so Add page button is visible
+  $overview.height($container.outerHeight(true));
 }
 
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -66,6 +66,13 @@ ServicesController.edit = function(app) {
 
   // Fix for the scrolling of form overview.
   applyCustomOverviewWorkaround();
+  let scrollTimeout;
+  $(window).on("resize", function() {
+    scrollTimeout = setTimeout(function() {
+      clearTimeout(scrollTimeout);
+      applyCustomOverviewWorkaround();
+    }, 500);
+  });
 }
 
 
@@ -237,14 +244,9 @@ function applyCustomOverviewWorkaround() {
     else {
       $container.css("left", ~(offsetLeft - margin));
     }
-
-    // Make sure to limit so a scrollbar can kick in, if necessary.
-    $container.css({
-      "max-width": maxWidth,
-    });
-
   }
 
+  $container.css("max-width", maxWidth); // Make sure to limit so a scrollbar can kick in, if necessary.
   $container.scrollLeft(containerWidth); // Align to right so Add page button is visible
   $overview.height($container.outerHeight(true));
 }

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -337,11 +337,11 @@ html {
 }
 
 #form-overview {
-  overflow: auto;
+  overflow: visible;
 
   .container {
-    overflow: auto;
-    padding-bottom: 30px;
+    overflow: scroll;
+    padding: 60px 0px;
     position: absolute;
     left: 0;
     white-space: nowrap;


### PR DESCRIPTION
Now calculate whether we need scrolling and adjust the view for browser size.
- Will leave thumbnail aligned to Main container restriction if thumbnail area is small enough to fit.
- Will centre to browser window (with space for Add page menu) if thumbnail container is larger than Main container area
- Will add scrollbars to thumbnail container if too large even for the browser window
- Tries to align right so that Add page button is always visible if scrolling required (bit temperamental)
- Will reapply the above calculations if the browser window is manually resized

Some screenshots:

**Small enough to fit in main container**
<img width="2048" alt="Screenshot 2021-04-21 at 12 37 04" src="https://user-images.githubusercontent.com/76942244/115550886-415dcc80-a2a2-11eb-8f27-a369ccc6e6d1.png">

**Larger than main container but smaller than browser window**
<img width="2048" alt="Screenshot 2021-04-21 at 13 06 22" src="https://user-images.githubusercontent.com/76942244/115551003-65211280-a2a2-11eb-8950-941b6ddcd7aa.png">

**Larger than browser window so scrolling applied**
Note: due to mac system scrollbars are hidden until active on my browser - you can see the thumbnail have scrolled off to the left
<img width="2048" alt="Screenshot 2021-04-21 at 12 38 31" src="https://user-images.githubusercontent.com/76942244/115551123-87b32b80-a2a2-11eb-85ce-9edd0dc9f405.png">
