### PR TITLE
Set send by email checkbox name per deployment environment

### DIFF
--- a/app/controllers/settings/email_controller.rb
+++ b/app/controllers/settings/email_controller.rb
@@ -23,10 +23,8 @@ class Settings::EmailController < FormController
     end
   end
 
-  private
-
   def email_settings_params
-    params.require(:email_settings).permit(
+    email_params.permit(
       :deployment_environment,
       :send_by_email,
       :service_email_output,
@@ -36,6 +34,18 @@ class Settings::EmailController < FormController
       :service_email_pdf_heading,
       :service_email_pdf_subheading
     )
+  end
+
+  private
+
+  def email_params
+    params.require(:email_settings).tap do |settings|
+      settings[:send_by_email] = settings[send_by_email(settings)]
+    end
+  end
+
+  def send_by_email(settings)
+    "send_by_email_#{settings[:deployment_environment]}"
   end
 
   def assign_form_objects

--- a/app/views/settings/email/index.html.erb
+++ b/app/views/settings/email/index.html.erb
@@ -11,7 +11,7 @@
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
               <h2 class="govuk-fieldset__heading"><%= t('publish.test.heading') %></h2>
             </legend>
-            <div class="govuk-hint">Where others can view your form and you can ensure everything works before you launch.</div>
+            <div class="govuk-hint"><%= t('publish.test.hint') %></div>
             <div class="govuk-checkboxes">
               <div class="govuk-checkboxes__item">
                 <%= f.check_box :send_by_email_dev, class: 'govuk-checkboxes__input',
@@ -39,7 +39,7 @@
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h2 class="govuk-fieldset__heading"><%= t('publish.live.heading') %></h2>
           </legend>
-          <div class="govuk-hint">Where your form is hosted publicly when your service is running.</div>
+          <div class="govuk-hint"><%= t('publish.live.hint') %></div>
           <div class="govuk-checkboxes">
             <div class="govuk-checkboxes__item">
               <%= f.check_box :send_by_email_production, class: 'govuk-checkboxes__input',

--- a/app/views/settings/email/index.html.erb
+++ b/app/views/settings/email/index.html.erb
@@ -14,9 +14,9 @@
             <div class="govuk-hint">Where others can view your form and you can ensure everything works before you launch.</div>
             <div class="govuk-checkboxes">
               <div class="govuk-checkboxes__item">
-                <%= f.check_box :send_by_email, class: 'govuk-checkboxes__input',
+                <%= f.check_box :send_by_email_dev, class: 'govuk-checkboxes__input',
                   checked: f.object.send_by_email_checked? %>
-                <%= f.label :send_by_email,
+                <%= f.label :send_by_email_dev,
                   f.object.class.human_attribute_name(:send_by_email_dev),
                   class: 'govuk-label govuk-checkboxes__label' %>
               </div>
@@ -42,9 +42,9 @@
           <div class="govuk-hint">Where your form is hosted publicly when your service is running.</div>
           <div class="govuk-checkboxes">
             <div class="govuk-checkboxes__item">
-              <%= f.check_box :send_by_email, class: 'govuk-checkboxes__input',
+              <%= f.check_box :send_by_email_production, class: 'govuk-checkboxes__input',
                 checked: f.object.send_by_email_checked? %>
-              <%= f.label :send_by_email,
+              <%= f.label :send_by_email_production,
                 f.object.class.human_attribute_name(:send_by_email_production),
                 class: 'govuk-label govuk-checkboxes__label' %>
             </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,7 +70,7 @@ en:
   settings:
     name: 'Settings'
     form_information: 'Form details'
-    form_information_hint: 'Set your form’s name, URL and phase (e.g. Alpha, Beta).'
+    form_information_hint: "Set your form's name, URL and phase (e.g. Alpha, Beta)."
     form_information_label: 'Form name'
     form_information_help: 'The visible name of your form'
     submission:
@@ -97,12 +97,14 @@ en:
       description: 'Forms on Test can be shared with colleagues and protected by password. They will not be listed on search engines.'
       version: 'Version: Latest  -'
       by: 'by %{name}'
+      hint: Where others can view your form and you can ensure everything works before you launch.
     live:
       button: Publish to Live
       heading: 'Live site'
       description: 'Forms on Live can be seen by anyone and can be listed on search engines if requested.'
       version: 'Version: Latest  -'
       by: 'by %{name}'
+      hint: Where your form is hosted publicly when your service is running.
   services:
     heading: 'Your forms'
     edit: 'Edit'

--- a/spec/controllers/email_controller_spec.rb
+++ b/spec/controllers/email_controller_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Settings::EmailController do
+  describe '#email_settings_params' do
+    let(:params) do
+      {
+        authenticity_token: 'some-token',
+        email_settings: {
+          "send_by_email_#{deployment_environment}": '1',
+          deployment_environment: deployment_environment,
+          service_email_output: '',
+          service_email_subject: 'Submission from Version Fixture',
+          service_email_body: 'Please find attached a submission sent from Version Fixture',
+          service_email_pdf_heading: 'Submission for Version Fixture',
+          service_email_pdf_subheading: ''
+        }
+      }
+    end
+    let(:expected_params) do
+      {
+        'send_by_email' => '1',
+        'deployment_environment' => deployment_environment,
+        'service_email_output' => '',
+        'service_email_subject' => 'Submission from Version Fixture',
+        'service_email_body' => 'Please find attached a submission sent from Version Fixture',
+        'service_email_pdf_heading' => 'Submission for Version Fixture',
+        'service_email_pdf_subheading' => ''
+      }
+    end
+
+    before do
+      allow(controller).to receive(:params).and_return(
+        ActionController::Parameters.new(params)
+      )
+    end
+
+    %w[dev production].each do |environment|
+      context "when #{environment} deployment environment" do
+        let(:deployment_environment) { environment }
+
+        it "sets send_by_email param and rejects send_by_email_#{environment} param" do
+          expect(controller.email_settings_params).to eq(expected_params)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
On the email settings page the "Send email by" checkbox in both the Test and Live forms had the same label and id. This resulted in the user being able to click on the label of a checkbox in a different environment and it would affect the checkbox of the other environments form.

Change the labels to be deployment environment specific so there is no longer any clash.

In order to make this work once it is posted we extract the environment specific parameter and set its value to the parameter expected by the EmailSettings model which is `send_by_email`; 0 when unticked and 1 when ticked.

This does mean that the Rails console output will complain about unpermitted params for `send_by_email_dev` and `send_by_email_production`.

Also move email settings hint text into the locales

https://trello.com/c/RdztpG5U/1499-bug-email-settings-checkbox