### PR TITLE
Rework Editable Content to use textarea instead of contentEditable DIV

### DIFF
--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -20,6 +20,8 @@ var converter = new showdown.Converter({
                   noHeaderId: true,
                   strikethrough: true,
                   omitExtraWLInCodeBlocks: true,
+                  simplifiedAutoLink: false,
+                  tables: true,
                   disableForced4SpacesIndentedSublists: true
                 });
 
@@ -146,29 +148,63 @@ class EditableElement extends EditableBase {
 class EditableContent extends EditableElement {
   constructor($node, config) {
     super($node, config);
+    var $input = $("<textarea class=\"input\"></textarea>");
+    var $output = $("<div class=\"output\"></div>");
+    var $span = $("<span>measure</span>");
+    var lineHeight;
 
-    if(config.text.default_content) {
-      this._defaultContent = config.text.default_content;
-    }
+    // ??
+    $span.css({
+      font: "inherit",
+      visibility: "hidden"
+    });
 
-    // Adjust event for multiple line input.
+    $node.append($span);
+    lineHeight = $span.height();
+    $span.remove();
+
+    // Use a textarea for input because it is more predictable than
+    // using a div with contentEditable attribute.
+    $output.append($node.html());
+    $node.empty();
+    $node.append($input);
+    $node.append($output);
+
+    // Clear inherited events
+    $node.off("blur.editablecomponent");
+    $node.off("focus.editablecomponent");
+    $node.off("paste.editablecomponent");
     $node.off("keydown.editablecomponent");
-    $node.on("keydown.editablecontent", e => multipleLineInputRestrictions(e) );
+
+    // Add event to required element
+    $output.on("click.editablecontent, focus.editablecontent", this.edit.bind(this) );
+    $input.on("blur.editablecontent", this.update.bind(this) );
+    // TODO: Experimental and not quite working properly auto-resizing effort.
+    //       Disabled for MVP unless there is time to get it right.
+    //$input.on("keydown.editablecontent, paste.editablecontent", EditableContent.inputResizer.bind(this) );
 
     // Correct the class:
     $node.removeClass("EditableElement");
     $node.addClass("EditableContent");
 
+    if(config.text.default_content) {
+      this._defaultContent = config.text.default_content;
+    }
+
     this._editing = false;
-    this._content = $node.html().trim(); // trim removes whitespace from template.
+    this._content = convertToMarkdown($output.html().trim()); // trim removes whitespace from template.
+    this._lineHeight = lineHeight;
+    this.$input = $input;
+    this.$output = $output;
   }
 
   // Get content must always return Markdown because that's what we save.
   get content() {
-    var content = convertToMarkdown(this._content);
+    var content = this._content;
     var contentWithoutWhitespace = content.replace(/\s/mig, "");
     var defaultWithoutWhitespace = this._defaultContent.replace(/\s/mig, "");
 
+    // Remove whitespace for better comparison
     content = (contentWithoutWhitespace == defaultWithoutWhitespace ? "" : content);
 
     // Bit hacky but we handle one type of content value as a string (see above),
@@ -181,57 +217,38 @@ class EditableContent extends EditableElement {
     return content;
   }
 
-  // Set content takes markdown (because it should be called after editing).
-  // It should convert the markdown to HTML and put back as DOM node content.
   set content(markdown) {
-    this._content = convertToHtml(markdown);
+    this._content = markdown;
     safelyActivateFunction(this._config.onSaveRequired);
   }
 
   edit() {
-    if(!this._editing) {
-      EditableContent.displayMarkdownInBrowser.call(this);
-      this._editing = true;
-      super.edit();
-    }
+    this.$node.addClass(this._config.editClassname);
+    this.$input.val(this._content); // Adds latest stored content to input area
+    this.$input.focus();
+    this.$input.select();
   }
 
   update() {
-    if(this._editing) {
-      // Get the content which should be markdown mixed with
-      // some HTML due to browser contentEditable handling.
-      this.content = this.$node.html();
-      EditableContent.displayHtmlInBrowser.call(this);
-      this.$node.removeClass(this._config.editClassname);
-      this._editing = false;
-    }
-  }
+    this.content = this.$input.val().trim(); // Get the latest markdown
+    this.$node.removeClass(this._config.editClassname);
 
-  markdown() {
-    return convertToMarkdown(this._content);
+    // Figure out what content to show
+    let defaultContent = this._defaultContent || this._originalContent;
+    let content = (this._content == "" ? defaultContent : this._content);
+
+    // Add latest content to output area
+    this.$output.html(convertToHtml(content));
   }
 }
 
-/* Function to display the content as markdown in browser.
- * Had own function because we need to manipulate the content to
- * make sure it displays correctly formatted (visually), and
- * for clarity of where the display action happens.
+/* Experimental effort to auto-resize input area.
+ * Currently not used as not working 100%.
  **/
-EditableContent.displayMarkdownInBrowser = function() {
-  var markdown = this.markdown();
-  this.$node.html(markdown.replace(/\n/g,"<br>")); // Displays on one line without this.
-}
-
-
-/* Function to display the content as markdown in browser.
- * Had own function because we need to manipulate the content to
- * make sure it displays correctly formatted (visually), and
- * for clarity of where the display action happens.
- **/
-EditableContent.displayHtmlInBrowser = function() {
-  var defaultContent = this._defaultContent || this._originalContent;
-  var content = (this._content == "" ? defaultContent : this._content);
-  this.$node.html(content);
+EditableContent.inputResizer = function(e) {
+  if(e.which == 13) {
+    this.$input.height(this.$input.height() + this._lineHeight);
+  }
 }
 
 
@@ -733,7 +750,7 @@ class EditableCollectionItemRemover {
       editableCollectionItem.remove();
     });
 
-    // Close on SPACE and ENTER
+    // Close on ENTER || SPACE
     $node.on("keydown.EditableCollectionItemRemover", function(e) {
       e.preventDefault();
       if(e.which == 13 || e.which == 32) {
@@ -754,11 +771,7 @@ class EditableCollectionItemRemover {
  * Includes clean up of HTML by stripping attributes and unwanted trailing spaces.
  **/
 function convertToMarkdown(html) {
-  html = html.trim();
-  html = html.replace(/<!-- -->/mig, "");
-  html = html.replace(/(<\/p>)/mig, "$1\n\n");
-  html = html.replace(/(<\w[\w\d]+)\s*[\w\d\s=\"-]*?(>)/mig, "$1$2");
-  return converter.makeMarkdown(html).trim();
+  return converter.makeMarkdown(html);
 }
 
 
@@ -766,19 +779,8 @@ function convertToMarkdown(html) {
  * Includes clean up of both Markdown and resulting HTML to fix noticed issues.
  **/
 function convertToHtml(markdown) {
-  // First clean up what we got as it will probably contain
-  // some nonsense due to browser contentEditabl handling. 
-  markdown = markdown.trim();
-  markdown = markdown.replace(/&nbsp;/mig, " "); // Entity spaces mess things up.
-  markdown = markdown.replace(/<br>/mig, "\n");  // Revert any we added for visual purpose.
-  markdown = markdown.replace(/<\/div><div>/mig, "\n");
-  markdown = markdown.replace(/<[\/]?div>/mig, "");
-  markdown = markdown.replace(/&gt;/mig, ">"); // Fix blockquotes.
-
-  // Next do the conversion and correct some things to display properly.
-  let html = converter.makeHtml(markdown);
-  html = html.replace(/<li><p>(.*)?<\/p>/mig, "<li>$1");  // Don't want <p> tags in there.
-  return html;
+console.log("markdown: ", markdown);
+  return converter.makeHtml(markdown);
 }
 
 
@@ -788,14 +790,7 @@ function convertToHtml(markdown) {
  * editing as plain text and markdown for all elements so try to
  * prevent unwanted entry with this function.
  **/
-function multipleLineInputRestrictions(event) {
-
-  // Prevent ENTER adding <div><br></div> nonsense.
-  if(event.which == 13) {
-    event.preventDefault();
-    document.execCommand("insertText", false, "\n");
-  }
-}
+function multipleLineInputRestrictions(event) {}
 
 
 /* Single Line Input Restrictions

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -157,11 +157,23 @@ html {
   }
 }
 
-.EditableContent,
-.EditableElement {
-  &:focus,
+.EditableContent {
+  .input {
+    border: none;
+    display: none;
+    min-height: 200px; // Arbitrary
+    width: 100%;
+  }
+
   &.active {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
+    .input {
+      display: block;
+      outline: $govuk-focus-width solid $govuk-focus-colour;
+    }
+
+    .output {
+      display: none;
+    }
   }
 }
 
@@ -191,6 +203,13 @@ html {
     .ActivatedMenu_Activator {
       opacity: 1;
     }
+  }
+}
+
+.EditableElement {
+  &:focus,
+  &.active {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
   }
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -161,6 +161,7 @@ html {
   .input {
     border: none;
     display: none;
+    font: inherit;
     min-height: 200px; // Arbitrary
     width: 100%;
   }


### PR DESCRIPTION
Rework because DIV[contentEditable] method just wasn't working properly. Using browsers native content editable feature is hard enough but, using that with the format switching between HTML and Markdown was causing too many, hard to detect, issues.

For the sake of saving time and have a more robust solution, better suited to the format switching, I have taken out the original approach and replaced with a <textarea> element. 

The trade off in making this change is swapping a better visual for the sake of better functionality, since a textarea does not auto resize in the same way a DIV[contentEditable] element would. There is some experimental code that can auto resize up but, since it cannot yet resize down, it is currently disable waiting time to finish. 