### PR TITLE
Fix duplicated 'Add component' button isolating selector

### DIFF
--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -351,7 +351,7 @@ function editPageCheckAnswersViewCustomisations() {
 
 function editPageMultipleQuestionsViewCustomisations() {
   var $button1 = $("[data-component=add-component]");
-  var $target = $("#new_answers :submit");
+  var $target = $("#new_answers input:submit");
   $target.before($button1);
 }
 


### PR DESCRIPTION
Bug: Editor adds new checkbox item and sees extra (duplicated) button due to jQuery target selector not being specific enough. 

Stops this happening after adding a new checkbox item:

<img width="813" alt="Screenshot 2021-04-23 at 11 53 19" src="https://user-images.githubusercontent.com/76942244/115861598-ddb2db00-a42a-11eb-8d83-e747bf5d9690.png">

<img width="825" alt="Screenshot 2021-04-23 at 11 53 09" src="https://user-images.githubusercontent.com/76942244/115861549-d1c71900-a42a-11eb-9534-5fdd7009fe02.png">
