### PR TITLE
Fix to option labels incorrectly sharing data (causes label duplication)

### DIFF
--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -600,8 +600,12 @@ EditableCollectionFieldComponent.createCollectionItemTemplate = function(config)
  **/
 EditableCollectionFieldComponent.createEditableCollectionItems = function(config) {
   var component = this;
-  var data = mergeObjects({}, config.data, ["items", "_uuid"]); // pt.1 Copy without items and component uuid.
   component.$node.find(config.selectorCollectionItem).each(function(i) {
+    // WARNING! DO NOT MOVE data or itemConfig OUTSIDE OF THIS LOOP
+    // Due to JS reference handling of objects we need to make sure data and itemConfig are
+    // inside the loop to instantiate two completely different variables. JS will not pass
+    // by value so the alternative is creating EditableCollectionItems that share these objects.
+    var data = mergeObjects({}, config.data, ["items", "_uuid"]); // pt.1 Copy without items and component uuid.
     var itemConfig = mergeObjects({ preserveItem: (i < component._preservedItemCount) }, config, ["data"]); // pt.2 Without data
     itemConfig.data = mergeObjects(data, config.data.items[i]); // Bug fix response to JS reference handling.
 


### PR DESCRIPTION
**Was causing this issue:**
<img width="692" alt="Screenshot 2021-04-27 at 13 10 13" src="https://user-images.githubusercontent.com/76942244/116238972-ff2d0300-a759-11eb-8172-1baa1daf1078.png">

**Now back to correct handling:**
<img width="567" alt="Screenshot 2021-04-27 at 13 10 30" src="https://user-images.githubusercontent.com/76942244/116239003-094f0180-a75a-11eb-80c8-96de5674f7d3.png">
