### PR TITLE
Add acceptance tests for section heading

### DIFF
--- a/acceptance/features/default_text_spec.rb
+++ b/acceptance/features/default_text_spec.rb
@@ -23,6 +23,7 @@ feature 'Default text' do
     preview_page = when_I_preview_the_page
     then_I_should_preview_the_page(preview_page) do
       and_I_should_not_see_the_default_text
+      and_I_should_not_see_the_optional_section_heading_text
     end
   end
 
@@ -64,6 +65,10 @@ feature 'Default text' do
 
   def and_I_should_not_see_the_default_text
     expect(page.text).to_not include('[Optional hint text]')
+  end
+
+  def and_I_should_not_see_the_optional_section_heading_text
+    expect(page.text).to_not include('[Optional section heading]')
   end
 
   def when_I_customise_hint

--- a/acceptance/features/edit_single_question_page_spec.rb
+++ b/acceptance/features/edit_single_question_page_spec.rb
@@ -18,6 +18,7 @@ feature 'Edit single question page' do
 
   scenario 'when editing text component' do
     given_I_have_a_single_question_page_with_text
+    and_I_have_optional_section_heading_text
     when_I_update_the_question_name
     and_I_return_to_flow_page
     then_I_should_see_my_changes_on_preview
@@ -25,6 +26,7 @@ feature 'Edit single question page' do
 
   scenario 'when editing textarea component' do
     given_I_have_a_single_question_page_with_textarea
+    and_I_have_optional_section_heading_text
     when_I_update_the_question_name
     and_I_return_to_flow_page
     then_I_should_see_my_changes_on_preview
@@ -32,6 +34,7 @@ feature 'Edit single question page' do
 
   scenario 'when editing number component' do
     given_I_have_a_single_question_page_with_number
+    and_I_have_optional_section_heading_text
     when_I_update_the_question_name
     and_I_return_to_flow_page
     then_I_should_see_my_changes_on_preview
@@ -39,6 +42,7 @@ feature 'Edit single question page' do
 
   scenario 'when editing date component' do
     given_I_have_a_single_question_page_with_date
+    and_I_have_optional_section_heading_text
     when_I_update_the_question_name
     and_I_return_to_flow_page
     then_I_should_see_my_changes_on_preview
@@ -46,6 +50,7 @@ feature 'Edit single question page' do
 
   scenario 'when editing radio component' do
     given_I_have_a_single_question_page_with_radio
+    and_I_have_optional_section_heading_text
     when_I_update_the_question_name
     and_I_update_the_options
     and_I_return_to_flow_page
@@ -55,6 +60,7 @@ feature 'Edit single question page' do
 
   scenario 'when editing checkboxes component' do
     given_I_have_a_single_question_page_with_checkboxes
+    and_I_have_optional_section_heading_text
     when_I_update_the_question_name
     and_I_update_the_options
     and_I_return_to_flow_page
@@ -132,5 +138,9 @@ feature 'Edit single question page' do
         expect(page.text).to include(option)
       end
     end
+  end
+
+  def and_I_have_optional_section_heading_text
+    expect(page.text).to include('[Optional section heading]')
   end
 end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -81,10 +81,11 @@ class EditorApp < SitePrism::Page
   elements :radio_options, :xpath, '//input[@type="radio"]', visible: false
   elements :checkboxes_options, :xpath, '//input[@type="checkbox"]', visible: false
 
-  elements :question_heading, '.EditableElement'
+  elements :question_heading, 'h1'
   elements :all_hints, '.govuk-hint'
   elements :editable_options, '.EditableComponentCollectionItem label'
   element :question_hint, '.govuk-hint'
+  data_content_id :section_heading, 'page[section_heading]'
   data_content_id :page_heading, 'page[heading]'
   data_content_id :page_lede, 'page[lede]'
   data_content_id :page_body, 'page[body]'


### PR DESCRIPTION
Optional section headings should be seen on the page in the editor but
not in the runner unless a user changes the text to something other than
the default text