### PR TITLE
Allow footer to move dynamically with page content

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,19 +15,11 @@
  */
 
 html {
-  min-height: 100%;
-  position: relative;
+  background-color: #F3F2F1;
 }
 
 #main-content {
-  margin-bottom: 220px; /* approx height of footer - prevents visual overlap */
-  position: relative;
-}
-
-.fb-footer {
-  position: absolute;
-  width: 100%;
-  bottom: 0;
+  min-height: 55vh;
 }
 
 .editor-button {

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -17,6 +17,7 @@ body {
 }
 
 html {
+  background-color: govuk-colour("light-grey");
   min-height: 100%;
   position: relative;
 }
@@ -49,8 +50,8 @@ html {
 }
 
 #main-content {
-  margin-bottom: 220px; /* approx height of footer - prevents visual overlap */
   position: relative;
+  min-height: 55vh;
 }
 
 
@@ -60,12 +61,6 @@ html {
   // Trying to compensate for inherit GovUK maring-top settings
   // (or lack of them) on <p> tags and things that should be in them.
   margin-bottom: 1.2em;
-}
-
-.fb-editor-footer {
-  position: absolute;
-  width: 100%;
-  bottom: 0;
 }
 
 .fb-editor-list,

--- a/app/views/partials/_footer.html.erb
+++ b/app/views/partials/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="govuk-footer fb-editor-footer" role="contentinfo">
+<footer class="govuk-footer" role="contentinfo">
   <div class="govuk-width-container ">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">


### PR DESCRIPTION
We previously stuck the footer to the bottom of the page. While this looked nice it did also create an issue for any user that would zoom into the page a little too much.

Therefore, remove the CSS which makes the footer stick and instead allow it to move dynamically based on the content of a page. We then make the background html element the same colour as the footer for the times when there is not very much content on the page.

Users should now be able to zoom in and the content won't be obscured by the footer.

## Before

![Screenshot 2021-05-04 at 14 17 26](https://user-images.githubusercontent.com/3466862/117021074-eccd3f00-acee-11eb-8bd5-bdea60091299.png)


## After

![Screenshot 2021-05-04 at 14 31 54](https://user-images.githubusercontent.com/3466862/117021093-f22a8980-acee-11eb-9571-8708ea21552c.png)

![Screenshot 2021-05-04 at 16 43 31](https://user-images.githubusercontent.com/3466862/117030838-eee7cb80-acf7-11eb-8d83-cb097072b216.png)

![Screenshot 2021-05-04 at 16 43 19](https://user-images.githubusercontent.com/3466862/117030859-f27b5280-acf7-11eb-861a-79499d043be2.png)




