### PR TITLE
Remove properties from js

### DIFF
--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -2,8 +2,7 @@
   var app = {
     page: {
       action: "<%= action_name %>",
-      controller:  "<%= controller_name %>",
-      properties: JSON.parse('<%= yield(:properties).presence || "{}" %>')
+      controller:  "<%= controller_name %>"
     },
     text: {
       default_content: "<%= MetadataPresenter::DefaultText[:content] %>",


### PR DESCRIPTION
This is not being used and it is making the standalone pages (edit on the editor)
to break because the JSON is not escaped.