### PR TITLE
Move default text into en.yaml

### DIFF
--- a/app/controllers/api/pages_controller.rb
+++ b/app/controllers/api/pages_controller.rb
@@ -3,7 +3,7 @@ module Api
     def show
       render json: {
         meta: {
-          default_text: Rails.application.config.default_text
+          default_text: I18n.t('default_text')
         }
       }
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,12 @@
 en:
+  default_text:
+    section_heading: '[Optional section heading]'
+    lede: '[Optional lede paragraph]'
+    body: '[Optional content]'
+    content: '[Optional content]'
+    hint: '[Optional hint text]'
+    option: 'Option'
+    option_hint: '[Optional hint text]'
   default_values:
     service_email_output: ''
     service_email_from: 'moj-forms@digital.justice.gov.uk'


### PR DESCRIPTION
Default text should be used by the editor exclusively so should not have to live in the presenter at all