### PR TITLE
Turn on Sentry performance monitoring

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,16 +33,3 @@ module FbEditor
     config.generators.system_tests = nil
   end
 end
-
-Sentry.init do |config|
-  config.breadcrumbs_logger = [:active_support_logger]
-  config.logger =  Logger.new(STDOUT)
-
-  config.before_send = lambda do |event, _hint|
-    if event.request && event.request.data
-      filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
-      event.request.data = filter.filter(event.request.data)
-    end
-    event
-  end
-end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,13 @@
+Sentry.init do |config|
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+  config.logger =  Logger.new(STDOUT)
+
+  config.traces_sample_rate = 1
+  config.before_send = lambda do |event, _hint|
+    if event.request && event.request.data
+      filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+      event.request.data = filter.filter(event.request.data)
+    end
+    event
+  end
+end


### PR DESCRIPTION
This turns on the Sentry performance monitoring.

Also add the http_logger to the breadcrumbs