### PR TITLE
Fix/reverse temporary disable question required feature

### DIFF
--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -426,7 +426,7 @@ function setQuestionRequiredFlag(question, $target, text) {
 
   // If we've changed the $target content, or the eitor has, we
   // need to check whether required flag needs to show, or not.
-  $target.data("instance").update(true); // passing true prevents onSaveRequired trigger to keep 'Save' button disabled.
+  $target.data("instance").update();
 }
 
 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -370,7 +370,8 @@ function createDialogConfiguration() {
 function setupQuestions() {
   var view = this;
   var questionMenuTemplate = $("[data-component-template=QuestionMenu]");
-  $("[data-fb-content-data]").each(function() {
+
+  $("[data-fb-content-data]").not("[data-fb-content-type='content']").each(function() {
 
     // Initialise the question as an object.
     var $node = $(this);

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -96,41 +96,11 @@ PagesController.edit = function() {
     var $node = $(this);
     new AddComponent($node, { $form: $form });
   });
-/*
+
   // Initialise questions
-  let questionMenuTemplate = $("[data-component-template=QuestionMenu]");
-  $("[data-fb-content-data]").each(function() {
+  setupQuestions.call(view);
 
-    // Initialise the question as an object.
-    var $node = $(this);
-    var question = new Question($node, {
-      data: $node.data("fb-content-data"),
-      view: view
-    });
-
-    // Create a menu for Question property editing.
-    var $ul = $(questionMenuTemplate.html());
-    var $target = $(SELECTOR_LABEL_HEADING, $node);
-    //var $optionalFlag = $("<span class=\"flag\">&nbsp;" + view.text.question_optional_flag + "</span>").css("font-size", $target.get(0).style.fontSize);
-
-    // Need to make sure $ul is added to body before we try to create a QuestionMenu out of it.
-    view.$body.append($ul);
-
-    new QuestionMenu($ul, {
-      activator_text: questionMenuTemplate.data("activator-text"),
-      $target: $target,
-      question: question,
-      view: view,
-      question_property_fields: $("[data-component-template=QuestionPropertyFields]").html(),
-      onSetRequired: function(questionMenu) {
-        setQuestionRequiredFlag(question, $target, view.text.question_optional_flag);
-      }
-    });
-
-    // Set initial view state
-    setQuestionRequiredFlag(question, $target, view.text.question_optional_flag);
-  });
-*/
+  // Setting focus for editing.
   focusOnEditableComponent.call(view);
 }
 
@@ -143,22 +113,6 @@ PagesController.create = function() {
   ServicesController.edit.call(this);
 }
 
-
-
-/* The design calls for a visual indicator that the question is optional.
- * This function is to handle the adding the extra element.
- **/
-function setQuestionRequiredFlag(question, $target, text) {
-  var regExpTextWithSpace = " " + text.replace(/(\(|\))/mig, "\\$1"); // Need to escape parenthesis for RegExp
-  var textWithSpace =  " " + text;
-  var re = new RegExp(regExpTextWithSpace + "$");
-
-  // Since we always remove first we can add knowing duplicates should not happen.
-  $target.text($target.text().replace(re, ""));
-  if(!question.data().validation.required) {
-    $target.text($target.text() + textWithSpace);
-  }
-}
 
 
 /* Gives add component buttons functionality to select a component type
@@ -407,6 +361,69 @@ function createDialogConfiguration() {
       "ui-dialog": $template.data("classes")
     }
   });
+}
+
+
+/* Apply functionality for Question Menu that handles the settings
+ * for the question and page view.
+ **/
+function setupQuestions() {
+  var view = this;
+  var questionMenuTemplate = $("[data-component-template=QuestionMenu]");
+  $("[data-fb-content-data]").each(function() {
+
+    // Initialise the question as an object.
+    var $node = $(this);
+    var question = new Question($node, {
+      data: $node.data("fb-content-data"),
+      view: view
+    });
+
+    // Create a menu for Question property editing.
+    var $ul = $(questionMenuTemplate.html());
+    var $target = $(SELECTOR_LABEL_HEADING, $node);
+    //var $optionalFlag = $("<span class=\"flag\">&nbsp;" + view.text.question_optional_flag + "</span>").css("font-size", $target.get(0).style.fontSize);
+
+    // Need to make sure $ul is added to body before we try to create a QuestionMenu out of it.
+    view.$body.append($ul);
+
+    new QuestionMenu($ul, {
+      activator_text: questionMenuTemplate.data("activator-text"),
+      $target: $target,
+      question: question,
+      view: view,
+      question_property_fields: $("[data-component-template=QuestionPropertyFields]").html(),
+      onSetRequired: function(questionMenu) {
+        setQuestionRequiredFlag(question, $target, view.text.question_optional_flag);
+      }
+    });
+
+    // Check view state on element edits
+    $target.on("blur", function() {
+      setQuestionRequiredFlag(question, $target, view.text.question_optional_flag);
+    });
+
+
+    // Set initial view state
+    setQuestionRequiredFlag(question, $target, view.text.question_optional_flag);
+  });
+}
+
+
+/* The design calls for a visual indicator that the question is optional.
+ * This function is to handle the adding the extra element.
+ **/
+function setQuestionRequiredFlag(question, $target, text) {
+  var regExpTextWithSpace = " " + text.replace(/(\(|\))/mig, "\\$1"); // Need to escape parenthesis for RegExp
+  var textWithSpace =  " " + text;
+  var re = new RegExp(regExpTextWithSpace + "$");
+
+  // Since we always remove first we can add knowing duplicates should not happen.
+  $target.text($target.text().replace(re, ""));
+  if(!question.data().validation.required) {
+    $target.text($target.text() + textWithSpace);
+    // TODO: something to update the target (editable element data)
+  }
 }
 
 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -199,7 +199,7 @@ function bindEditableContentHandlers() {
   var $editContentForm = $("#editContentForm");
   var $saveButton = $editContentForm.find(":submit");
   if($editContentForm.length) {
-    $saveButton.attr("disabled", true); // disable until needed.
+    $saveButton.prop("disabled", true); // disable until needed.
 
     $(".fb-editable").each(function(i, node) {
       var $node = $(node);
@@ -287,7 +287,7 @@ function bindEditableContentHandlers() {
         onSaveRequired: function() {
           // Code detected something changed to
           // make the submit button available.
-          $saveButton.attr("disabled", false);
+          $saveButton.prop("disabled", false);
         },
         type: $node.data("fb-content-type")
       }));
@@ -426,7 +426,7 @@ function setQuestionRequiredFlag(question, $target, text) {
 
   // If we've changed the $target content, or the eitor has, we
   // need to check whether required flag needs to show, or not.
-  $target.data("instance").update();
+  $target.data("instance").update(true); // passing true prevents onSaveRequired trigger to keep 'Save' button disabled.
 }
 
 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -422,8 +422,11 @@ function setQuestionRequiredFlag(question, $target, text) {
   $target.text($target.text().replace(re, ""));
   if(!question.data().validation.required) {
     $target.text($target.text() + textWithSpace);
-    // TODO: something to update the target (editable element data)
   }
+
+  // If we've changed the $target content, or the eitor has, we
+  // need to check whether required flag needs to show, or not.
+  $target.data("instance").update();
 }
 
 

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -14,7 +14,7 @@
  **/
 
 
-import { mergeObjects, createElement, safelyActivateFunction, updateHiddenInputOnForm } from './utilities';
+import { mergeObjects, createElement, safelyActivateFunction, updateHiddenInputOnForm, isBoolean } from './utilities';
 var showdown  = require('showdown');
 var converter = new showdown.Converter({
                   noHeaderId: true,
@@ -109,7 +109,16 @@ class EditableElement extends EditableBase {
   }
 
   set content(content) {
-    this._content = content.trim();
+    var trimmedContent = content.trim();
+    if(this._content != trimmedContent) {
+      this._content = trimmedContent;
+
+      // If something change, let's make sure it's not
+      if(this._content != "" && this._content != this._defaultContent && this._content != this._originalContent) {
+        safelyActivateFunction(this._config.onSaveRequired);
+      }
+    }
+
     this.populate(content);
   }
 
@@ -117,12 +126,9 @@ class EditableElement extends EditableBase {
     this.$node.addClass(this._config.editClassname);
   }
 
-  update(suppressSaveNotification) {
+  update() {
     this.content = this.$node.text().trim();
     this.$node.removeClass(this._config.editClassname);
-    if(!suppressSaveNotification) {
-      safelyActivateFunction(this._config.onSaveRequired);
-    }
   }
 
   // Expects content or blank string to show content or default text in view.

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -111,16 +111,18 @@ class EditableElement extends EditableBase {
   set content(content) {
     this._content = content.trim();
     this.populate(content);
-    safelyActivateFunction(this._config.onSaveRequired);
   }
 
   edit() {
     this.$node.addClass(this._config.editClassname);
   }
 
-  update() {
+  update(suppressSaveNotification) {
     this.content = this.$node.text().trim();
     this.$node.removeClass(this._config.editClassname);
+    if(!suppressSaveNotification) {
+      safelyActivateFunction(this._config.onSaveRequired);
+    }
   }
 
   // Expects content or blank string to show content or default text in view.

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -201,5 +201,12 @@ function property(context, props) {
 }
 
 
+/* Determine if passed item is of Boolean origin.
+ **/
+function isBoolean(thing) {
+  return thing.constructor === Boolean;
+}
+
+
 // Make available for importing.
-export { mergeObjects, createElement, safelyActivateFunction, isFunction, uniqueString, findFragmentIdentifier, meta, post, updateHiddenInputOnForm, property };
+export { mergeObjects, createElement, safelyActivateFunction, isFunction, uniqueString, findFragmentIdentifier, meta, post, updateHiddenInputOnForm, property, isBoolean };

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -383,7 +383,7 @@ html {
 
 
 /* Question Menu
- * ------------- *
+ * ------------- */
 .QuestionMenu {
   [data-action="required"].on {
     position: relative;
@@ -411,7 +411,7 @@ html {
     }
   }
 }
-*/
+
 
 /* govuk-navigation does not appear to exist
  * so adding something simple here.

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -208,6 +208,11 @@ html {
   .EditableCollectionFieldComponent,
   .EditableGroupFieldComponent,
   .EditableComponentCollectionItem {
+
+    legend {
+      display: contents;
+    }
+
     .ActivatedMenu_Activator {
       top: 45px;
     }

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -207,8 +207,6 @@ html {
 [data-fb-pagetype="page.multiplequestions"] {
   .EditableCollectionFieldComponent,
   .EditableGroupFieldComponent,
-  .EditableTextFieldComponent,
-  .EditableTextareaFieldComponent,
   .EditableComponentCollectionItem {
     .ActivatedMenu_Activator {
       top: 45px;


### PR DESCRIPTION
Adds the new Question Menu used for changing settings on a Question. In this case, and the only thing currently available for change, sets whether a Question is required/optional.

<img width="636" alt="Screenshot 2021-05-24 at 11 41 44" src="https://user-images.githubusercontent.com/76942244/119336096-168ddc00-bc85-11eb-91a9-feb3f2ca03b6.png">

<img width="409" alt="Screenshot 2021-05-24 at 11 41 55" src="https://user-images.githubusercontent.com/76942244/119336139-29a0ac00-bc85-11eb-9730-12c4289f799d.png">

<img width="416" alt="Screenshot 2021-05-24 at 11 42 24" src="https://user-images.githubusercontent.com/76942244/119336159-2f968d00-bc85-11eb-834f-1614de2662f7.png">
