### PR TITLE
Fix ordering of steps array

### DIFF
--- a/app/generators/new_page_generator.rb
+++ b/app/generators/new_page_generator.rb
@@ -37,8 +37,8 @@ class NewPageGenerator
 
   def add_flow_page
     latest_metadata.tap do
-      latest_metadata['pages'].insert(insert_page_at, page_metadata)
-      latest_metadata['pages'][0]['steps'].insert(insert_page_at, page_name)
+      latest_metadata['pages'].insert(pages_index, page_metadata)
+      latest_metadata['pages'][0]['steps'].insert(steps_index, page_name)
     end
   end
 
@@ -61,14 +61,22 @@ class NewPageGenerator
 
   INSERT_LAST = -1
 
-  def insert_page_at
-    if add_page_after.present?
-      index = find_page_index_to_be_inserted_after
+  def pages_index
+    @pages_index ||= begin
+      if add_page_after.present?
+        index = find_page_index_to_be_inserted_after
 
-      return index + 1 if index
+        return index + 1 if index
+      end
+
+      INSERT_LAST
     end
+  end
 
-    INSERT_LAST
+  def steps_index
+    # steps array doesn't include start page so is always one count less than
+    # the pages array
+    pages_index.positive? ? pages_index - 1 : pages_index
   end
 
   def find_page_index_to_be_inserted_after

--- a/spec/generators/new_page_generator_spec.rb
+++ b/spec/generators/new_page_generator_spec.rb
@@ -90,14 +90,15 @@ RSpec.describe NewPageGenerator do
         end
 
         it 'adds new page after the given page' do
-          expect(generator.to_metadata['pages']).to_not be_blank
-          expect(generator.to_metadata['pages'][4]).to include(page_attributes)
+          pages = generator.to_metadata['pages']
+          expect(pages).to_not be_blank
+          expect(pages[3]).to include(page_attributes)
         end
 
         it 'adds the new page after given page steps' do
           expect(
-            # the step index is 3 because 'steps' doesn't count the start page
-            generator.to_metadata['pages'][0]['steps'][3]
+            # the step index is 2 because 'steps' doesn't count the start page
+            generator.to_metadata['pages'][0]['steps'][2]
           ).to include("page.#{page_url}")
         end
       end


### PR DESCRIPTION
When a user attempts to add a page somewhere in the middle of the flow
the page name was being incorrectly added in the wrong place.

This is because the steps array does not contain the start page and
therefore it needs to be inserted on step back from the index where it
would be added in the pages array.