### PR TITLE
Exclude health endpoint from Sentry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,7 @@ workflows:
             branches:
               only:
                 - main
+                - feature/1568-frontend-create-editor-api-endpoints-for-default-text
       - acceptance_tests:
           requires:
             - build_and_deploy_to_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,6 @@ workflows:
             branches:
               only:
                 - main
-                - feature/1568-frontend-create-editor-api-endpoints-for-default-text
       - acceptance_tests:
           requires:
             - build_and_deploy_to_test

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -96,41 +96,11 @@ PagesController.edit = function() {
     var $node = $(this);
     new AddComponent($node, { $form: $form });
   });
-/*
+
   // Initialise questions
-  let questionMenuTemplate = $("[data-component-template=QuestionMenu]");
-  $("[data-fb-content-data]").each(function() {
+  setupQuestions.call(view);
 
-    // Initialise the question as an object.
-    var $node = $(this);
-    var question = new Question($node, {
-      data: $node.data("fb-content-data"),
-      view: view
-    });
-
-    // Create a menu for Question property editing.
-    var $ul = $(questionMenuTemplate.html());
-    var $target = $(SELECTOR_LABEL_HEADING, $node);
-    //var $optionalFlag = $("<span class=\"flag\">&nbsp;" + view.text.question_optional_flag + "</span>").css("font-size", $target.get(0).style.fontSize);
-
-    // Need to make sure $ul is added to body before we try to create a QuestionMenu out of it.
-    view.$body.append($ul);
-
-    new QuestionMenu($ul, {
-      activator_text: questionMenuTemplate.data("activator-text"),
-      $target: $target,
-      question: question,
-      view: view,
-      question_property_fields: $("[data-component-template=QuestionPropertyFields]").html(),
-      onSetRequired: function(questionMenu) {
-        setQuestionRequiredFlag(question, $target, view.text.question_optional_flag);
-      }
-    });
-
-    // Set initial view state
-    setQuestionRequiredFlag(question, $target, view.text.question_optional_flag);
-  });
-*/
+  // Setting focus for editing.
   focusOnEditableComponent.call(view);
 }
 
@@ -143,22 +113,6 @@ PagesController.create = function() {
   ServicesController.edit.call(this);
 }
 
-
-
-/* The design calls for a visual indicator that the question is optional.
- * This function is to handle the adding the extra element.
- **/
-function setQuestionRequiredFlag(question, $target, text) {
-  var regExpTextWithSpace = " " + text.replace(/(\(|\))/mig, "\\$1"); // Need to escape parenthesis for RegExp
-  var textWithSpace =  " " + text;
-  var re = new RegExp(regExpTextWithSpace + "$");
-
-  // Since we always remove first we can add knowing duplicates should not happen.
-  $target.text($target.text().replace(re, ""));
-  if(!question.data().validation.required) {
-    $target.text($target.text() + textWithSpace);
-  }
-}
 
 
 /* Gives add component buttons functionality to select a component type
@@ -245,7 +199,7 @@ function bindEditableContentHandlers() {
   var $editContentForm = $("#editContentForm");
   var $saveButton = $editContentForm.find(":submit");
   if($editContentForm.length) {
-    $saveButton.attr("disabled", true); // disable until needed.
+    $saveButton.prop("disabled", true); // disable until needed.
 
     $(".fb-editable").each(function(i, node) {
       var $node = $(node);
@@ -333,7 +287,7 @@ function bindEditableContentHandlers() {
         onSaveRequired: function() {
           // Code detected something changed to
           // make the submit button available.
-          $saveButton.attr("disabled", false);
+          $saveButton.prop("disabled", false);
         },
         type: $node.data("fb-content-type")
       }));
@@ -407,6 +361,73 @@ function createDialogConfiguration() {
       "ui-dialog": $template.data("classes")
     }
   });
+}
+
+
+/* Apply functionality for Question Menu that handles the settings
+ * for the question and page view.
+ **/
+function setupQuestions() {
+  var view = this;
+  var questionMenuTemplate = $("[data-component-template=QuestionMenu]");
+
+  $("[data-fb-content-data]").not("[data-fb-content-type='content']").each(function() {
+
+    // Initialise the question as an object.
+    var $node = $(this);
+    var question = new Question($node, {
+      data: $node.data("fb-content-data"),
+      view: view
+    });
+
+    // Create a menu for Question property editing.
+    var $ul = $(questionMenuTemplate.html());
+    var $target = $(SELECTOR_LABEL_HEADING, $node);
+    //var $optionalFlag = $("<span class=\"flag\">&nbsp;" + view.text.question_optional_flag + "</span>").css("font-size", $target.get(0).style.fontSize);
+
+    // Need to make sure $ul is added to body before we try to create a QuestionMenu out of it.
+    view.$body.append($ul);
+
+    new QuestionMenu($ul, {
+      activator_text: questionMenuTemplate.data("activator-text"),
+      $target: $target,
+      question: question,
+      view: view,
+      question_property_fields: $("[data-component-template=QuestionPropertyFields]").html(),
+      onSetRequired: function(questionMenu) {
+        setQuestionRequiredFlag(question, $target, view.text.question_optional_flag);
+      }
+    });
+
+    // Check view state on element edits
+    $target.on("blur", function() {
+      setQuestionRequiredFlag(question, $target, view.text.question_optional_flag);
+    });
+
+
+    // Set initial view state
+    setQuestionRequiredFlag(question, $target, view.text.question_optional_flag);
+  });
+}
+
+
+/* The design calls for a visual indicator that the question is optional.
+ * This function is to handle the adding the extra element.
+ **/
+function setQuestionRequiredFlag(question, $target, text) {
+  var regExpTextWithSpace = " " + text.replace(/(\(|\))/mig, "\\$1"); // Need to escape parenthesis for RegExp
+  var textWithSpace =  " " + text;
+  var re = new RegExp(regExpTextWithSpace + "$");
+
+  // Since we always remove first we can add knowing duplicates should not happen.
+  $target.text($target.text().replace(re, ""));
+  if(!question.data().validation.required) {
+    $target.text($target.text() + textWithSpace);
+  }
+
+  // If we've changed the $target content, or the eitor has, we
+  // need to check whether required flag needs to show, or not.
+  $target.data("instance").update();
 }
 
 

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -14,7 +14,7 @@
  **/
 
 
-import { mergeObjects, createElement, safelyActivateFunction, updateHiddenInputOnForm } from './utilities';
+import { mergeObjects, createElement, safelyActivateFunction, updateHiddenInputOnForm, isBoolean } from './utilities';
 var showdown  = require('showdown');
 var converter = new showdown.Converter({
                   noHeaderId: true,
@@ -109,9 +109,17 @@ class EditableElement extends EditableBase {
   }
 
   set content(content) {
-    this._content = content.trim();
+    var trimmedContent = content.trim();
+    if(this._content != trimmedContent) {
+      this._content = trimmedContent;
+
+      // If something change, let's make sure it's not
+      if(this._content != "" && this._content != this._defaultContent && this._content != this._originalContent) {
+        safelyActivateFunction(this._config.onSaveRequired);
+      }
+    }
+
     this.populate(content);
-    safelyActivateFunction(this._config.onSaveRequired);
   }
 
   edit() {

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -201,5 +201,12 @@ function property(context, props) {
 }
 
 
+/* Determine if passed item is of Boolean origin.
+ **/
+function isBoolean(thing) {
+  return thing.constructor === Boolean;
+}
+
+
 // Make available for importing.
-export { mergeObjects, createElement, safelyActivateFunction, isFunction, uniqueString, findFragmentIdentifier, meta, post, updateHiddenInputOnForm, property };
+export { mergeObjects, createElement, safelyActivateFunction, isFunction, uniqueString, findFragmentIdentifier, meta, post, updateHiddenInputOnForm, property, isBoolean };

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -207,9 +207,12 @@ html {
 [data-fb-pagetype="page.multiplequestions"] {
   .EditableCollectionFieldComponent,
   .EditableGroupFieldComponent,
-  .EditableTextFieldComponent,
-  .EditableTextareaFieldComponent,
   .EditableComponentCollectionItem {
+
+    legend {
+      display: contents;
+    }
+
     .ActivatedMenu_Activator {
       top: 45px;
     }
@@ -383,7 +386,7 @@ html {
 
 
 /* Question Menu
- * ------------- *
+ * ------------- */
 .QuestionMenu {
   [data-action="required"].on {
     position: relative;
@@ -411,7 +414,7 @@ html {
     }
   }
 }
-*/
+
 
 /* govuk-navigation does not appear to exist
  * so adding something simple here.

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,8 +1,16 @@
+EXCLUDE_PATHS = %w[/health].freeze
+
 Sentry.init do |config|
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
   config.logger =  Logger.new(STDOUT)
 
-  config.traces_sample_rate = 1
+  config.traces_sampler = lambda do |sampling_context|
+    transaction_context = sampling_context[:transaction_context]
+    transaction_name = transaction_context[:name]
+
+    !transaction_name.in?(EXCLUDE_PATHS)
+  end
+
   config.before_send = lambda do |event, _hint|
     if event.request && event.request.data
       filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)


### PR DESCRIPTION
`/health` is used by Kubernetes to check whether the container is ok. We
do not need this to make it to Sentry.

Following the docs here:

https://docs.sentry.io/platforms/ruby/configuration/sampling/

Returning true would set the sample rate to 1 which means every request
is sent to Sentry. Returning false sets it to 0 so the the transaction
is not sent.

`sentry: [Tracing] Discarding <rails.request> transaction </health> because traces_sampler returned 0 or false`

In the future it may be necessary to adjust the sample rate so that it
is not 100% of all transactions, but for the purposes of the trial it
will do for now.