### PR TITLE
Feature/1568 frontend create editor api endpoints for default text

### DIFF
--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -107,15 +107,19 @@ feature 'Preview form' do
       expect(page.text).to include('Service name goes here')
       page.click_button 'Start now'
       expect(page.text).to include('Full name')
+      then_I_should_not_see_optional_text(page)
       page.fill_in 'Full name', with: 'Charmy Pappitson'
       page.click_button 'Continue'
       expect(page.text).to include(content_component)
+      then_I_should_not_see_optional_text(page)
       page.fill_in text_component_question, with: 'Car Car Binks'
       page.fill_in textarea_component_question, with: 'R2-Detour'
       page.click_button 'Continue'
       expect(page.text).to include(content_page_heading)
+      then_I_should_not_see_optional_text(page)
       page.click_button 'Continue'
       expect(page.text).to include('Date of birth')
+      then_I_should_not_see_optional_text(page)
       page.fill_in 'Day', with: '03'
       page.fill_in 'Month', with: '06'
       page.fill_in 'Year', with: '2002'
@@ -123,6 +127,7 @@ feature 'Preview form' do
       expect(page.text).to include('Check your answers')
       expect(page.text).to include('Charmy Pappitson')
       expect(page.text).to include('03 June 2002')
+      then_I_should_not_see_optional_text(page)
       then_I_should_not_see_content_page_in_check_your_answers(page)
       then_I_should_not_see_content_components_in_check_your_answers(page)
       page.click_button 'Accept and send application'
@@ -136,5 +141,16 @@ feature 'Preview form' do
 
   def then_I_should_not_see_content_components_in_check_your_answers(page)
     expect(page.text).to_not include(content_page_heading)
+  end
+
+  def then_I_should_not_see_optional_text(page)
+    [
+      "[Optional section heading]",
+      "[Optional lede paragraph]",
+      "[Optional content]",
+      "[Optional hint text]"
+    ].each do |optional_text|
+      expect(page.text).to_not include(optional_content)
+    end
   end
 end

--- a/app/javascript/src/controller_default.js
+++ b/app/javascript/src/controller_default.js
@@ -24,6 +24,7 @@ import { post } from './utilities';
 class DefaultController {
   constructor(app) {
     this.type = $(".fb-main-grid-wrapper").data("fb-pagetype");
+    this.page = app.page;
     this.text = app.text;
     this.dialog = createDialog.call(this);
     this.dialogConfirmation = createDialogConfirmation.call(this);

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -59,7 +59,8 @@ PagesController.edit = function() {
   this.editableContent = [];
   this.dialogConfiguration = createDialogConfiguration.call(this);
 
-  bindEditableContentHandlers.call(view);
+  workaroundForDefaultText(view);
+  bindEditableContentHandlers(view);
 
   // Handle page-specific view customisations here.
   switch(view.type) {
@@ -194,8 +195,7 @@ function focusOnEditableComponent() {
 /* Controls all the Editable Component setup for each page.
  * TODO: Add more description on how this works.
  **/
-function bindEditableContentHandlers() {
-  var view = this;
+function bindEditableContentHandlers(view) {
   var $editContentForm = $("#editContentForm");
   var $saveButton = $editContentForm.find(":submit");
   if($editContentForm.length) {
@@ -430,6 +430,22 @@ function setQuestionRequiredFlag(question, $target, text) {
   $target.data("instance").update();
 }
 
+
+/* Due to limitations in using the GDS templates, we cannot
+ * add appropriate HTML attributes to relevant elements in
+ * both radio and checkbox hints. This is a workaround to
+ * add them, so fixes missing default text without affecting
+ * the current method of finding them view fb-default-text
+ * attribute.
+ **/
+function workaroundForDefaultText(view) {
+  $(".govuk-radios__item, .govuk-checkboxes__item").each(function() {
+    var $this = $(this);
+    var $span = $this.find("span");
+    $span.attr("fb-default-text", view.text.defaults.option_hint);
+    $span.data("fb-default-text", view.text.defaults.option_hint);
+  });
+}
 
 
 /**************************************************************/

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -25,6 +25,7 @@ import { editableComponent } from './editable_components';
 import { DefaultController } from './controller_default';
 import { ServicesController } from './controller_services';
 
+const ATTRIBUTE_DEFAULT_TEXT = "fb-default-text";
 const SELECTOR_COLLECTION_FIELD_LABEL = "legend > :first-child";
 const SELECTOR_COLLECTION_FIELD_HINT = "fieldset > .govuk-hint";
 const SELECTOR_COLLECTION_ITEM = ".govuk-radios__item, .govuk-checkboxes__item";
@@ -206,7 +207,7 @@ function bindEditableContentHandlers(view) {
       view.editableContent.push(editableComponent($node, {
         editClassname: "active",
         data: $node.data("fb-content-data"),
-        attributeDefaultText: "fb-default-text",
+        attributeDefaultText: ATTRIBUTE_DEFAULT_TEXT,
         filters: {
           _id: function(index) {
             return this.replace(/^(.*)?[\d]+$/, "$1" + index);
@@ -442,8 +443,7 @@ function workaroundForDefaultText(view) {
   $(".govuk-radios__item, .govuk-checkboxes__item").each(function() {
     var $this = $(this);
     var $span = $this.find("span");
-    $span.attr("fb-default-text", view.text.defaults.option_hint);
-    $span.data("fb-default-text", view.text.defaults.option_hint);
+    $span.attr("data-" + ATTRIBUTE_DEFAULT_TEXT, view.text.defaults.option_hint);
   });
 }
 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -237,17 +237,15 @@ function bindEditableContentHandlers(view) {
         text: {
           addItem: view.text.actions.option_add,
           removeItem: view.text.actions.option_remove,
-
-          default_element: view.text.default_element,
-          default_content: view.text.default_content
+          default_content: view.text.defaults.content
         },
 
         onCollectionItemClone: function($node) {
            // @node is the collection item (e.g. <div> wrapping <input type=radio> and <label> elements)
            // Runs after the collection item has been cloned, so further custom manipulation can be
            // carried out on the element.
-           $node.find("label").text(view.text.default_option);
-           $node.find("span").text(view.text.default_option_hint);
+           $node.find("label").text(view.text.defaults.option);
+           $node.find("span").text(view.text.defaults.option_hint);
         },
         onItemAdd: function($node) {
           // @$node (jQuery node) Node (instance.$node) that has been added.

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -585,7 +585,7 @@ EditableCollectionFieldComponent.createCollectionItemTemplate = function(config)
   var $clone = this.$node.find(config.selectorCollectionItem).eq(0).clone();
   var data = mergeObjects({}, config.data, ["items", "_uuid"]); // pt.1 Copy without items and component uuid.
   var itemConfig = mergeObjects({}, config, ["data"]); // pt.2 Copy without data.
-  itemConfig.data = mergeObjects(data, config.data.items[0]); // Bug fix response to JS reference handling.
+  itemConfig.data = mergeObjects(data, config.data.items[0], "_uuid"); // Bug fix response to JS reference handling.
 
   // Filters could be changing the blah_1 values to blah_0, depending on filters in play.
   itemConfig.data = EditableCollectionFieldComponent.applyFilters(config.filters, 0, itemConfig.data);
@@ -634,7 +634,6 @@ EditableCollectionFieldComponent.addItem = function($node, config) {
   this.items.push(new EditableComponentCollectionItem(this, $node, config));
 
   // TODO: need to update the data on each item so _id and value are different.
-  
 }
 
 /* Private function

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -12,15 +12,16 @@ function controllerAndAction() {
 }
 
 // Fetch JSON data from server
-function loadData(app, url) {
-  if(url) {
-    $.getJSON(url, (data) => {
+function loadPageData(app) {
+  $.ajax({
+    url: app.page.data_url,
+    async: false,
+    dataType: "json",
+    success: function(data) {
       app.default_text = data.meta.default_text;
-      console.log("finished: ", app.default_text);
-    });
-  }
+    }
+  });
 }
-
 
 
 // Set the controller we want to use.
@@ -42,7 +43,7 @@ switch(controllerAndAction()) {
   case "PagesController#edit":
   case "PagesController#create":
        Controller = PagesController;
-       loadData(app, "/api/services/" + app.service.id  + "/pages/" + app.page.id);
+       loadPageData(app);
   break;
 
   case "PublishController#index":

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -18,7 +18,7 @@ function loadPageData(app) {
     async: false,
     dataType: "json",
     success: function(data) {
-      app.default_text = data.meta.default_text;
+      app.text.defaults = data.meta.default_text;
     }
   });
 }

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -5,38 +5,55 @@ import { FormListPage } from './page_form_list';
 import { PublishController } from './controller_publish'
 
 
-// Always runs when document ready.
-// app is global set inside app/view/partials/properties
-//
-$(document).ready(function() {
-  switch(controllerAndAction()) {
-    case "ServicesController#index":
-    case "ServicesController#create":
-         new FormListPage(app);
-    break;
-
-    case "ServicesController#edit":
-         new ServicesController(app);
-    break;
-
-    case "PagesController#edit":
-    case "PagesController#create":
-         new PagesController(app);
-    break;
-
-    case "PublishController#index":
-    case "PublishController#create":
-         new PublishController(app);
-    break;
-
-    default:
-         console.log(controllerAndAction());
-         new DefaultController(app);
-  }
-});
-
-
+// Determine the controller we need to use
 function controllerAndAction() {
   var controller = app.page.controller.charAt(0).toUpperCase() + app.page.controller.slice(1);
   return controller + "Controller#" + app.page.action;
 }
+
+// Fetch JSON data from server
+function loadData(app, url) {
+  if(url) {
+    $.getJSON(url, (data) => {
+      app.default_text = data.meta.default_text;
+      console.log("finished: ", app.default_text);
+    });
+  }
+}
+
+
+
+// Set the controller we want to use.
+// Initialise using doc.ready so everything is in place.
+// app is global set inside app/view/partials/properties
+//
+var Controller;
+
+switch(controllerAndAction()) {
+  case "ServicesController#index":
+  case "ServicesController#create":
+       Controller = FormListPage;
+  break;
+
+  case "ServicesController#edit":
+       Controller = ServicesController;
+  break;
+
+  case "PagesController#edit":
+  case "PagesController#create":
+       Controller = PagesController;
+       loadData(app, "/api/services/" + app.service.id  + "/pages/" + app.page.id);
+  break;
+
+  case "PublishController#index":
+  case "PublishController#create":
+       Controller = PublishController;
+  break;
+
+  default:
+       console.log(controllerAndAction());
+       Controller = DefaultController;
+}
+
+$(document).ready( () => new Controller(app) );
+ 

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -32,4 +32,4 @@
 <% # JS object should exist at this point so we're not checking for existence. %>
 <% # If app.page does not exist at this point, something is seriously wrong. %>
 <% # Let it fail so that we can see some error output in console. %>
-<% content_for :page_data_url do %><%= "/api/services/#{:id}/pages/#{:page_uuid}" %><% end %>
+<% content_for :page_data_url do %><%= api_service_page_path(':id', ':page_uuid') %><% end %>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -32,4 +32,4 @@
 <% # JS object should exist at this point so we're not checking for existence. %>
 <% # If app.page does not exist at this point, something is seriously wrong. %>
 <% # Let it fail so that we can see some error output in console. %>
-<% content_for :properties do %><%= @page.to_json.html_safe %><% end %>
+<% content_for :page_data_url do %><%= "/api/services/#{:id}/pages/#{:page_uuid}" %><% end %>

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -10,9 +10,6 @@
       id: "<%= params[:id] %>"
     },
     text: {
-      default_content: "<%= MetadataPresenter::DefaultText[:content] %>",
-      default_option: "<%= MetadataPresenter::DefaultText[:option] %>",
-      default_option_hint: "<%= MetadataPresenter::DefaultText[:option_hint] %>",
       question_optional_flag: "<%= t('question.optional_flag') %>",
       dialogs: {
         button_cancel: "<%= t('dialogs.button_cancel') %>",

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -1,8 +1,12 @@
 <script>
   var app = {
     page: {
+      id: "<%= params[:page_uuid] %>",
       action: "<%= action_name %>",
-      controller:  "<%= controller_name %>"
+      controller:  "<%= controller_name %>",
+    },
+    service: {
+      id: "<%= params[:id] %>"
     },
     text: {
       default_content: "<%= MetadataPresenter::DefaultText[:content] %>",

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -4,6 +4,7 @@
       id: "<%= params[:page_uuid] %>",
       action: "<%= action_name %>",
       controller:  "<%= controller_name %>",
+      data_url: "<%= yield :page_data_url %>"
     },
     service: {
       id: "<%= params[:id] %>"


### PR DESCRIPTION
Basically fixes the issue seen in https://trello.com/c/5k31Womn/1517-optional-hint-text-for-a-radio-checkbox-button-on-multiple-or-single-question-page-is-displayed-in-preview-mode-when-its-suppose

Optional hint text was visible on Preview simply because the fb-default-text attribute wasn't available to Radio and Checkbox items, using the GDS templates. We are now pulling them in from an API location and applying by different methods. It is likely this new method will eventually replace other existing attribute based versions but, during the course of implementing this fix, it became clear that will be a much larger piece of work than previously expected.

So, for now, the two methods co-exist with an expectation of phasing out the attribute-based approach over time as the FE moves to become more reliant on an API over what's in the rendered templates.

<img width="1024" alt="Screenshot 2021-05-25 at 13 01 21" src="https://user-images.githubusercontent.com/76942244/119501961-4f02e800-bd61-11eb-9c12-a8553a1c5eff.png">

<img width="964" alt="Screenshot 2021-05-25 at 13 01 31" src="https://user-images.githubusercontent.com/76942244/119501971-50ccab80-bd61-11eb-9e69-dfbcb39c9458.png">
