### PR TITLE
Making the Support site open in a new tab/window

### DIFF
--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -16,7 +16,7 @@
           <%= link_to t('.forms'), services_path %>
         </li>
         <li>
-         <%= link_to t('.support'), t('.supportURL') %>
+         <%= link_to t('.support'), t('.supportURL'), target: :_blank %>
         </li>
         <li>
           <%= link_to t('.sign_out', user_name: user_name), user_session_path, method: :delete %>


### PR DESCRIPTION
Hopefully making the journey to / back from the support page on the "product" site less confusing.