### PR TITLE
Deploy testable editor app automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           only_for_branches: main
           failure_message: ":facepalm:  Failed job $CIRCLE_JOB  :homer-disappear:"
           include_job_number_field: false
-  build_and_deploy_to_test:
+  build_and_deploy_testable_branch:
     working_directory: ~/circle/git/fb-editor
     docker: &ecr_image
       - image: $AWS_BUILD_IMAGE_ECR_ACCOUNT_URL
@@ -56,6 +56,32 @@ jobs:
             ENVIRONMENT_NAME: test
           command: './deploy-scripts/bin/build'
       - run:
+          name: deploy testable branch
+          environment:
+            APPLICATION_NAME: fb-editor
+            PLATFORM_ENV: test
+            K8S_NAMESPACE: formbuilder-saas-test
+          command: './deploy-scripts/bin/deploy'
+      - slack/status:
+          fail_only: true
+          failure_message: ":facepalm:  Failed job ${CIRCLE_JOB} for ${CIRCLE_BRANCH}  :homer-disappear:"
+          include_job_number_field: false
+  build_and_deploy_to_test:
+    working_directory: ~/circle/git/fb-editor
+    docker: *ecr_image
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 19.03.13
+      - add_ssh_keys: *ssh_keys
+      - run: *base_environment_variables
+      - run: *deploy_scripts
+      - run:
+          name: build and push docker images
+          environment:
+            ENVIRONMENT_NAME: test
+          command: './deploy-scripts/bin/build'
+      - run:
           name: deploy to test
           environment:
             APPLICATION_NAME: fb-editor
@@ -77,6 +103,21 @@ jobs:
           name: Run acceptance tests
           command: 'make acceptance-ci -s'
       - slack/status: *slack_status
+  testable_branch_acceptance_tests:
+    docker: *ecr_image
+    resource_class: large
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Run acceptance tests
+          environment:
+            ACCEPTANCE_TESTS_EDITOR_APP: "https://${CIRCLE_BRANCH}.apps.live-1.cloud-platform.service.justice.gov.uk/"
+          command: 'make acceptance-ci-testable-branch -s'
+      - slack/status:
+          fail_only: true
+          failure_message: ":facepalm:  Failed job $CIRCLE_JOB  :homer-disappear:"
+          include_job_number_field: false
   build_and_deploy_to_live:
     working_directory: ~/circle/git/fb-editor
     docker: *ecr_image
@@ -109,7 +150,11 @@ workflows:
   version: 2
   test_and_build:
     jobs:
-      - test
+      - test:
+          filters:
+            branches:
+              ignore:
+                - /^testable-.*$/
       - build_and_deploy_to_test:
           requires:
             - test
@@ -132,3 +177,25 @@ workflows:
       - build_and_deploy_to_live:
           requires:
             - confirm_live_deploy
+  deploy_testable_branch:
+    jobs:
+      - test:
+          filters:
+            branches:
+              only:
+                - /^testable-.*$/
+      - build_and_deploy_testable_branch:
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - /^testable-.*$/
+      - testable_branch_acceptance_tests:
+          requires:
+            - build_and_deploy_testable_branch
+      - slack/approval-notification:
+          message: ":test_tube: :test_tube: :test_tube:\nSuccessfully deployed branch\nVisit: https://${CIRCLE_BRANCH}.apps.live-1.cloud-platform.service.justice.gov.uk\n:test_tube: :test_tube: :test_tube:"
+          include_job_number_field: false
+          requires:
+            - testable_branch_acceptance_tests

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ acceptance: setup
 copy-env-vars-ci:
 	cp .env.acceptance_tests.ci .env.acceptance_tests
 
+.PHONY: copy-testable-branch-env-vars-ci
+copy-testable-branch-env-vars-ci:
+	cp .env.acceptance_tests.testable_branch .env.acceptance_tests
+
 .PHONY: add-env-vars-ci
 add-env-vars-ci:
 	echo "ACCEPTANCE_TESTS_USER=${ACCEPTANCE_TESTS_USER}" >> .env.acceptance_tests
@@ -44,6 +48,14 @@ setup-ci:
 
 .PHONY: acceptance-ci
 acceptance-ci: copy-env-vars-ci add-env-vars-ci setup-ci
+	docker-compose -f docker-compose.ci.yml run --rm editor_ci bundle exec rspec -f doc acceptance
+
+.PHONY: add-testable-branch-env-vars-ci
+add-testable-branch-env-vars-ci:
+	echo "ACCEPTANCE_TESTS_EDITOR_APP=${ACCEPTANCE_TESTS_EDITOR_APP}" >> .env.acceptance_tests
+
+.PHONY: acceptance-ci-testable-branch
+acceptance-ci-testable-branch: copy-testable-branch-env-vars-ci add-testable-branch-env-vars-ci add-env-vars-ci setup-ci
 	docker-compose -f docker-compose.ci.yml run --rm editor_ci bundle exec rspec -f doc acceptance
 
 .PHONY: assets

--- a/deploy/fb-editor-chart/templates/deployment.yaml
+++ b/deploy/fb-editor-chart/templates/deployment.yaml
@@ -3,23 +3,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "fb-editor-web-{{ .Values.environmentName }}"
+  name: "{{ .Values.app_name }}-web-{{ .Values.environmentName }}"
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: "fb-editor-web-{{ .Values.environmentName }}"
+      app: "{{ .Values.app_name }}-web-{{ .Values.environmentName }}"
   template:
     metadata:
       labels:
-        app: "fb-editor-web-{{ .Values.environmentName }}"
+        app: "{{ .Values.app_name }}-web-{{ .Values.environmentName }}"
         appGroup: "fb-editor"
         fb-service-token-cache-access: "true"
         tier: "frontend"
     spec:
       containers:
-      - name: "fb-editor-web-{{ .Values.environmentName }}"
+      - name: "{{ .Values.app_name }}-web-{{ .Values.environmentName }}"
         image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-editor-web:{{ .Values.circleSha1 }}"
         volumeMounts:
         - mountPath: /tmp
@@ -115,17 +115,17 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "fb-editor-workers-{{ .Values.environmentName }}"
+  name: "{{ .Values.app_name }}-workers-{{ .Values.environmentName }}"
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: "fb-editor-workers-{{ .Values.environmentName }}"
+      app: "{{ .Values.app_name }}-workers-{{ .Values.environmentName }}"
   template:
     metadata:
       labels:
-        app: "fb-editor-workers-{{ .Values.environmentName }}"
+        app: "{{ .Values.app_name }}-workers-{{ .Values.environmentName }}"
         appGroup: "fb-editor"
         fb-service-token-cache-access: "true"
         tier: "frontend"
@@ -134,7 +134,7 @@ spec:
         runAsUser: 1001
       serviceAccountName: "formbuilder-editor-workers-{{ .Values.environmentName }}"
       containers:
-      - name: "fb-editor-workers-{{ .Values.environmentName }}"
+      - name: "{{ .Values.app_name }}-workers-{{ .Values.environmentName }}"
         image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-editor-workers:{{ .Values.circleSha1 }}"
         volumeMounts:
         - mountPath: /tmp

--- a/deploy/fb-editor-chart/templates/ingress.yaml
+++ b/deploy/fb-editor-chart/templates/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: "fb-editor-ing-{{ .Values.environmentName }}"
+  name: "{{ .Values.app_name }}-ing-{{ .Values.environmentName }}"
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -21,5 +21,5 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: fb-editor-svc-{{ .Values.environmentName }}
+          serviceName: "{{ .Values.app_name }}-svc-{{ .Values.environmentName }}"
           servicePort: 80

--- a/deploy/fb-editor-chart/templates/service.yaml
+++ b/deploy/fb-editor-chart/templates/service.yaml
@@ -1,10 +1,10 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: "fb-editor-svc-{{ .Values.environmentName }}"
+  name: "{{ .Values.app_name }}-svc-{{ .Values.environmentName }}"
   namespace: formbuilder-saas-{{ .Values.environmentName }}
   labels:
-    app: "fb-editor-web-{{ .Values.environmentName }}"
+    app: "{{ .Values.app_name }}-web-{{ .Values.environmentName }}"
     appGroup: "fb-editor"
 spec:
   ports:
@@ -12,4 +12,4 @@ spec:
     name: http
     targetPort: 3000
   selector:
-    app: "fb-editor-web-{{ .Values.environmentName }}"
+    app: "{{ .Values.app_name }}-web-{{ .Values.environmentName }}"

--- a/deploy/fb-editor-chart/templates/service_monitor.yaml
+++ b/deploy/fb-editor-chart/templates/service_monitor.yaml
@@ -1,12 +1,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: "fb-editor-service-monitor-{{ .Values.environmentName }}"
+  name: "{{ .Values.app_name }}-service-monitor-{{ .Values.environmentName }}"
   namespace: "formbuilder-saas-{{ .Values.environmentName }}"
 spec:
   selector:
     matchLabels:
-      app: "fb-editor-web-{{ .Values.environmentName }}"
+      app: "{{ .Values.app_name }}-web-{{ .Values.environmentName }}"
   endpoints:
   - port: http
     interval: 15s
@@ -19,7 +19,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: "fb-editor-web-{{ .Values.environmentName }}"
+      app: "{{ .Values.app_name }}-web-{{ .Values.environmentName }}"
   policyTypes:
   - Ingress
   ingress:


### PR DESCRIPTION
This adds the capability for the editor app to be deployed into the test
environment as a separate app based upon the name of the branch. The
branch needs to be prepended with 'testable-' as this is what triggers
CircleCI to begin building a separate application.

This process relies very heavily on two environment variables being set:

- editor_host
- app_name

The editor_host is set as a secret in the fb-editor-deploy repo, with
different values for Test and Live. This needs to be overridden in any
deployable branch to include the branch name. It is the thing that makes
the authentication mechanism work correctly. The editor app is the only
app that makes use of this environment variable presently. All other
apps will ignore the value set when a standard deployment is triggered.

The app_name is used to set the hostname for the app which Kubernetes
will use to create the necessary ingress rules as well as deployment
configuration.

We also trigger the acceptance tests to run once the app has been
deployed out. This requires the environment variable
`ACCEPTANCE_TESTS_EDITOR_APP` to be dynamically set. Previously this is
injected into the environment in CircleCI as it is set in
`.env.acceptance_tests.ci` which the Make script copies to a file called
`.enc.acceptance_tests` which the acceptance tests make use of during
their run.

`ACCEPTANCE_TESTS_EDITOR_APP` is set in the CircleCI config to take in
the branch name interpolated into the URL that the tests should visit
once they have spun up.

This PR does not cover tearing down the testable app once the branch has
been merged in. That will be done in a future PR.

Slack will notify you in the deployments channel once the acceptance tests have finished running:

![Screenshot 2021-06-14 at 19 47 18](https://user-images.githubusercontent.com/3466862/122091221-7dc02b80-ce00-11eb-86e9-87c3b1a27ccc.png)
