### PR TITLE
Use Node 14.17.1-r0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 New editor from the MoJ online.
 
 ## Setup
-Ensure you are running on Node version 14.17.0:
-`nvm use 14.17.0`
+Ensure you are running on Node version 14.17.1:
+`nvm use 14.17.1`
 
 Compile the necessary assets and run webpack:
 `make assets`

--- a/acceptance/Dockerfile
+++ b/acceptance/Dockerfile
@@ -5,7 +5,7 @@ ARG UID=1001
 RUN apk add git yarn build-base postgresql-contrib postgresql-dev bash libcurl
 RUN apk add build-base bash tzdata chromium-chromedriver chromium zlib-dev xorg-server
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=14.17.0-r0 npm
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=14.17.1-r0 npm
 
 WORKDIR /usr/src/app
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -5,7 +5,7 @@ ARG UID=1001
 RUN apk add git yarn build-base postgresql-contrib postgresql-dev \
       bash libcurl curl
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=14.17.0-r0 npm
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=14.17.1-r0 npm
 
 RUN addgroup -g ${UID} -S appgroup && \
   adduser -u ${UID} -S appuser -G appgroup

--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -4,7 +4,7 @@ ARG UID=1001
 
 RUN apk add git yarn build-base postgresql-contrib postgresql-dev bash libcurl curl
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=14.17.0-r0 npm
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=14.17.1-r0 npm
 
 ARG KUBE_VERSION="1.17.3"
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fb_editor",
   "private": true,
   "engines": {
-    "node": "14.17.0"
+    "node": "14.17.1"
   },
   "dependencies": {
     "@rails/actioncable": "^6.1.3",


### PR DESCRIPTION
Currently, the build fails as 14.17.0 is no longer available on APK.
This updates the Node version.