### PR TITLE
Use app specific secrets

### DIFF
--- a/deploy/fb-editor-chart/templates/secrets.yaml
+++ b/deploy/fb-editor-chart/templates/secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: fb-editor-secrets-{{ .Values.environmentName }}
+  name: "{{ .Values.app_name }}-secrets-{{ .Values.environmentName }}"
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 type: Opaque
 data:


### PR DESCRIPTION
Further to the testable editor work, we also need to create a specific
secrets file for the testable branches as the editor_host is used for
the Auth0 implementation.

Without this app specific secrets the editor_host is overwritten each
time on deployment so the fb-editor-test ends authenticating into one of
the branch apps instead.