### PR TITLE
Set app specific config maps

### DIFF
--- a/deploy/fb-editor-chart/templates/config_map.yaml
+++ b/deploy/fb-editor-chart/templates/config_map.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: fb-editor-config-map
+  name: "{{ .Values.app_name }}-config-map"
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 data:
   RAILS_ENV: production

--- a/deploy/fb-editor-chart/templates/secrets.yaml
+++ b/deploy/fb-editor-chart/templates/secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ .Values.app_name }}-secrets-{{ .Values.environmentName }}"
+  name: fb-editor-secrets-{{ .Values.environmentName }}
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 type: Opaque
 data:


### PR DESCRIPTION
The PR https://github.com/ministryofjustice/fb-editor/pull/481 was in
fact making the wrong thing app specific.

editor_host is indeed injected using the 'secrets' but it is actually
set in the `configmaps` not in the `secrets`. The secrets can be shared
across any instance of the editor as they are always the same.

The `configmaps` on the other hand _do_ need to be app specific :(