### PR TITLE
Remove testable editors from Cloud Platform

### DIFF
--- a/app/services/k8s_config_removal_service.rb
+++ b/app/services/k8s_config_removal_service.rb
@@ -1,0 +1,37 @@
+class K8sConfigRemovalService
+  attr_reader :status
+
+  def initialize(namespace:, targets:)
+    @namespace = namespace
+    @targets = targets
+    @status = []
+  end
+
+  def call
+    targets.each do |target|
+      result = delete(config: target[:config], name: target[:name])
+      message = if result.nil?
+                  "Failed to delete #{target[:config]} for #{target[:name]}"
+                else
+                  "Successfully deleted #{target[:config]} for #{target[:name]}"
+                end
+
+      Rails.logger.info(message)
+      status.push(message)
+    end
+  end
+
+  private
+
+  attr_writer :status
+  attr_reader :namespace, :targets
+
+  def delete(config:, name:)
+    Publisher::Utils::Shell.output_of(
+      '$(which kubectl)',
+      "delete #{config} #{name} -n #{namespace}"
+    )
+  rescue Publisher::Utils::Shell::CmdFailedError => e
+    Sentry.capture_exception(e)
+  end
+end

--- a/app/services/testable_editor_remover.rb
+++ b/app/services/testable_editor_remover.rb
@@ -1,0 +1,73 @@
+class TestableEditorRemover
+  WEB = '-web-test'.freeze
+  WORKERS = '-workers-test'.freeze
+  CONFIGURATIONS = [
+    { type: 'configmap', append: '-config-map' },
+    { type: 'deployment', append: WEB },
+    { type: 'deployment', append: WORKERS },
+    { type: 'ingress', append: '-ing-test' },
+    { type: 'service', append: '-svc-test' },
+    { type: 'servicemonitor', append: '-service-monitor-test' }
+  ].freeze
+  NAMESPACE = 'formbuilder-saas-test'.freeze
+  ORIGIN = 'origin/'.freeze
+  TESTABLE = 'testable-'.freeze
+
+  def call
+    testable_editors_to_remove.each do |testable_editor|
+      k8s_config_removal_service(testable_editor).tap do |removal_service|
+        removal_service.call
+        NotificationService.notify(removal_service.status.join("\n"))
+      end
+    end
+  end
+
+  private
+
+  def testable_editors_to_remove
+    unique_testable_deployments - testable_editor_branches
+  end
+
+  def testable_editor_branches
+    branches = remote_branches.split(' ').map do |branch|
+      branch.gsub(ORIGIN, '') if branch.include?(TESTABLE)
+    end
+    branches.compact
+  end
+
+  def remote_branches
+    run('$(which git) branch -r')
+  end
+
+  def unique_testable_deployments
+    deployments = kubernetes_deployments.split("\n").map do |deployment|
+      if deployment.include?(TESTABLE)
+        deployment.split(' ')[0].gsub(/#{WEB}|#{WORKERS}/, '')
+      end
+    end
+    deployments.compact.uniq
+  end
+
+  def kubernetes_deployments
+    run("$(which kubectl) get deployments -n #{NAMESPACE}")
+  end
+
+  def run(cmd)
+    Publisher::Utils::Shell.output_of(cmd)
+  rescue Publisher::Utils::Shell::CmdFailedError => e
+    Sentry.capture_exception(e)
+  end
+
+  def k8s_config_removal_service(testable_editor)
+    K8sConfigRemovalService.new(namespace: NAMESPACE, targets: targets(testable_editor))
+  end
+
+  def targets(testable_editor)
+    CONFIGURATIONS.map do |configuration|
+      {
+        config: configuration[:type],
+        name: "#{testable_editor}#{configuration[:append]}"
+      }
+    end
+  end
+end

--- a/lib/tasks/remove_testable_editors.rake
+++ b/lib/tasks/remove_testable_editors.rake
@@ -1,0 +1,8 @@
+namespace 'remove' do
+  desc 'Removes any testable editors whose branches have been merged and deleted from remote'
+  task testable_editors: [:environment] do
+    TestableEditorRemover.new.call
+  rescue StandardError => e
+    Sentry.capture_exception(e)
+  end
+end

--- a/spec/services/k8s_config_removal_service_spec.rb
+++ b/spec/services/k8s_config_removal_service_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe K8sConfigRemovalService do
+  subject(:removal_service) do
+    described_class.new(namespace: namespace, targets: targets)
+  end
+
+  context 'removing target kubernetes configurations' do
+    let(:namespace) { 'it is full of stars' }
+    let(:targets) do
+      [
+        { config: 'config1', name: 'something-to-remove' },
+        { config: 'config2', name: 'something-else-to-remove' },
+        { config: 'config3', name: 'this-too' }
+      ]
+    end
+
+    context 'successfully removing configurations' do
+      let(:status_messages) do
+        [
+          'Successfully deleted config1 for something-to-remove',
+          'Successfully deleted config2 for something-else-to-remove',
+          'Successfully deleted config3 for this-too'
+        ]
+      end
+
+      before do
+        allow(Publisher::Utils::Shell).to receive(:output_of).and_return(true)
+      end
+
+      it 'creates the correct success status messages' do
+        removal_service.call
+        expect(removal_service.status).to eq(status_messages)
+      end
+    end
+
+    context 'failed to remove configurations' do
+      let(:status_messages) do
+        [
+          'Failed to delete config1 for something-to-remove',
+          'Failed to delete config2 for something-else-to-remove',
+          'Failed to delete config3 for this-too'
+        ]
+      end
+
+      before do
+        allow(Publisher::Utils::Shell).to receive(
+          :output_of
+        ).and_raise(Publisher::Utils::Shell::CmdFailedError)
+      end
+
+      it 'creates the correct failure status messages' do
+        removal_service.call
+        expect(removal_service.status).to eq(status_messages)
+      end
+    end
+
+    context 'kubectl commands' do
+      let(:config) { 'some-config' }
+      let(:name) { 'some-name' }
+      let(:targets) { [{ config: config, name: name }] }
+
+      before do
+        allow(Publisher::Utils::Shell).to receive(:capture_with_stdin).and_return('success')
+      end
+
+      it 'runs the correct kubectil commands' do
+        expect(Publisher::Utils::Shell).to receive(
+          :output_of
+        ).with('$(which kubectl)', "delete #{config} #{name} -n #{namespace}").once
+        removal_service.call
+      end
+    end
+  end
+end

--- a/spec/services/testable_editor_remover_spec.rb
+++ b/spec/services/testable_editor_remover_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe TestableEditorRemover do
+  subject(:testable_editor_remover) { described_class.new }
+
+  context 'removing testable editors' do
+    let(:remote_branches) do
+      "origin/HEAD -> origin/main\n  origin/acceptance-test/delete-component-multi-question\n  origin/main\n  origin/test-create-form\n  origin/testable-editor-to-keep"
+    end
+    let(:kubernetes_deployments) do
+      "NAME                                                              READY   UP-TO-DATE   AVAILABLE   AGE\ntestable-editor-to-keep-web-test                                2/2     2            2           134d\ntestable-editor-to-keep-workers-test                           2/2     2            2           134d\nfb-metadata-api-test                                              2/2     2            2           245d\ntestable-editor-to-remove-web-test       2/2     2            2           2d3h\ntestable-editor-to-remove-workers-test   2/2     2            2           2d3h"
+    end
+    let(:expected_targets) do
+      [
+        { config: 'configmap', name: 'testable-editor-to-remove-config-map' },
+        { config: 'deployment', name: 'testable-editor-to-remove-web-test' },
+        { config: 'deployment', name: 'testable-editor-to-remove-workers-test' },
+        { config: 'ingress', name: 'testable-editor-to-remove-ing-test' },
+        { config: 'service', name: 'testable-editor-to-remove-svc-test' },
+        { config: 'servicemonitor', name: 'testable-editor-to-remove-service-monitor-test' }
+      ]
+    end
+    let(:expected_params) do
+      {
+        namespace: 'formbuilder-saas-test',
+        targets: expected_targets
+      }
+    end
+    let(:webhook) { 'https://www.example.com' }
+    let(:removal_service) { double(call: true, status: []) }
+
+    before do
+      allow(ENV).to receive(:[]).with('SLACK_PUBLISH_WEBHOOK').and_return(webhook)
+      allow(testable_editor_remover).to receive(
+        :remote_branches
+      ).and_return(remote_branches)
+      allow(testable_editor_remover).to receive(
+        :kubernetes_deployments
+      ).and_return(kubernetes_deployments)
+      stub_request(:post, webhook)
+        .with(
+          body: '{"text":"","username":"MOJ Forms Editor","icon_emoji":":rockon:"}',
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'User-Agent' => 'Ruby'
+          }
+        ).to_return(status: 200, body: '', headers: {})
+    end
+
+    it 'should call the removal service with the expected parameters' do
+      expect(K8sConfigRemovalService).to receive(
+        :new
+      ).with(expected_params).and_return(removal_service)
+      testable_editor_remover.call
+    end
+  end
+end


### PR DESCRIPTION
This adds the ability to remove any testable editors whose branches have
been merged into main and then deleted from Github.

Currently this is a rake task but we will add a CircleCI job to trigger
the automatic removal overnight.