### PR TITLE
Run acceptance tests without docker compose in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ orbs:
   slack: circleci/slack@3.4.2
   ruby: circleci/ruby@1.1.3
   node: circleci/node@4.5.1
+  browser-tools: circleci/browser-tools@1.1.3
 
 jobs:
   build:
@@ -50,14 +51,14 @@ jobs:
       - run: bundle exec brakeman -q --no-pager -i brakeman.ignore
       - slack/status: *slack_status
   test:
-    docker:
+    docker: &test_image
       - image: 'cimg/ruby:2.7-node'
       - environment:
           POSTGRES_DB: editor_local
           POSTGRES_PASSWORD: password
           POSTGRES_USER: postgres
         image: 'circleci/postgres:12.4'
-    environment:
+    environment: &test_environment
       BUNDLE_JOBS: '3'
       BUNDLE_RETRY: '3'
       PGHOST: 127.0.0.1
@@ -71,10 +72,10 @@ jobs:
       - run: *node_version
       - node/install-packages:
           pkg-manager: yarn
-      - run:
+      - run: &wait_for_db
           name: Wait for DB
           command: 'dockerize -wait tcp://localhost:5432 -timeout 1m'
-      - run:
+      - run: &db_setup
           name: Database setup
           command: |
             bundle exec rails db:setup
@@ -82,7 +83,7 @@ jobs:
       - run:
           name: Running the tests
           command: |
-            TESTFILES=$(circleci tests glob "project/spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob "project/spec/**/*_spec.rb" | circleci tests split --split-by=name)
             bundle exec rspec $TESTFILES --profile 10
       - slack/status: *slack_status
   build_and_deploy_testable_branch:
@@ -151,26 +152,46 @@ jobs:
           failure_message: ":alert:  Failed to deploy to Test  :try_not_to_cry:"
           include_job_number_field: false
   acceptance_tests:
-    docker: *ecr_image
+    docker: *test_image
     resource_class: large
+    environment: *test_environment
+    parallelism: 3
     steps:
       - checkout
-      - setup_remote_docker
+      - ruby/install-deps
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
+      - run: *wait_for_db
+      - run: *db_setup
       - run:
           name: Run acceptance tests
-          command: 'make acceptance-ci -s'
+          environment:
+            ACCEPTANCE_TESTS_EDITOR_APP: 'https://fb-editor-test.apps.live-1.cloud-platform.service.justice.gov.uk/'
+            CI_MODE: 'true'
+          command: |
+            TESTFILES=$(circleci tests glob "project/acceptance/**/*_spec.rb" | circleci tests split --split-by=name)
+            bundle exec rspec acceptance $TESTFILES --profile 10 -f doc
       - slack/status: *slack_status
   testable_branch_acceptance_tests:
-    docker: *ecr_image
+    docker: *test_image
     resource_class: large
+    environment: *test_environment
+    parallelism: 3
     steps:
       - checkout
-      - setup_remote_docker
+      - ruby/install-deps
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
+      - run: *wait_for_db
+      - run: *db_setup
       - run:
           name: Run acceptance tests
           environment:
             ACCEPTANCE_TESTS_EDITOR_APP: "https://${CIRCLE_BRANCH}.apps.live-1.cloud-platform.service.justice.gov.uk/"
-          command: 'make acceptance-ci-testable-branch -s'
+            CI_MODE: 'true'
+          command: |
+            TESTFILES=$(circleci tests glob "project/acceptance/**/*_spec.rb" | circleci tests split --split-by=name)
+            bundle exec rspec acceptance $TESTFILES --profile 10 -f doc
       - slack/status:
           fail_only: true
           failure_message: ":facepalm:  Failed job $CIRCLE_JOB  :homer-disappear:"

--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,6 @@ setup-ci:
 acceptance-ci: copy-env-vars-ci add-env-vars-ci setup-ci
 	docker-compose -f docker-compose.ci.yml run --rm editor_ci bundle exec rspec -f doc acceptance
 
-.PHONY: add-testable-branch-env-vars-ci
-add-testable-branch-env-vars-ci:
-	echo "ACCEPTANCE_TESTS_EDITOR_APP=${ACCEPTANCE_TESTS_EDITOR_APP}" >> .env.acceptance_tests
-
-.PHONY: acceptance-ci-testable-branch
-acceptance-ci-testable-branch: copy-testable-branch-env-vars-ci add-testable-branch-env-vars-ci add-env-vars-ci setup-ci
-	docker-compose -f docker-compose.ci.yml run --rm editor_ci bundle exec rspec -f doc acceptance
-
 .PHONY: assets
 assets:
 	yarn install


### PR DESCRIPTION
Similar approach to the unit tests in the CircleCI config we use the
built in parallelism as well as the orbs and prebuilt circle images and
browser tools to run the acceptance tests instead of using docker
compose.

This knocks about 3 minutes off the run time.

It also means that we no longer need to have a specific make task for
the testable editor branches. We are keeping the make command for the
standard acceptance tests should anyone wish to run them locally in that
way.