### PR TITLE
Tear down testable editors automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   ruby: circleci/ruby@1.1.3
   node: circleci/node@4.5.1
   browser-tools: circleci/browser-tools@1.1.3
+  kubernetes: circleci/kubernetes@0.12.0
 
 jobs:
   build:
@@ -169,6 +170,21 @@ jobs:
             K8S_NAMESPACE: formbuilder-saas-test
           command: './deploy-scripts/bin/deploy'
       - slack/status: *testable_slack_status
+  remove_testable_editors:
+    docker:
+      - image: 'cimg/ruby:2.7-node'
+    steps:
+    - checkout
+    - ruby/install-deps
+    - kubernetes/install-kubectl
+    - run: *deploy_scripts
+    - run:
+        name: set kubernetes context for saas namespace
+        command: './deploy-scripts/bin/set_testable_editors_context'
+    - run:
+        name: remove testable editors
+        command: bundle exec rails remove:testable_editors
+    - slack/status: *testable_slack_status
   build_web_image:
     working_directory: ~/circle/git/fb-editor
     docker: *ecr_image
@@ -289,6 +305,13 @@ jobs:
 
 workflows:
   version: 2
+  tear_down_testable_editors:
+    jobs:
+      - remove_testable_editors:
+          filters:
+            branches:
+              only:
+                - main
   test_and_build:
     jobs:
       - build:

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -2,14 +2,14 @@ require 'net/http'
 require 'uri'
 
 class NotificationService
-  def self.notify(message)
+  def self.notify(message, webhook: ENV['SLACK_PUBLISH_WEBHOOK'])
     body = {
       text: message,
       username: 'MOJ Forms Editor',
       icon_emoji: ':rockon:'
     }
 
-    uri = URI.parse(ENV['SLACK_PUBLISH_WEBHOOK'])
+    uri = URI.parse(webhook)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
 

--- a/app/services/testable_editor_remover.rb
+++ b/app/services/testable_editor_remover.rb
@@ -17,7 +17,12 @@ class TestableEditorRemover
     testable_editors_to_remove.each do |testable_editor|
       k8s_config_removal_service(testable_editor).tap do |removal_service|
         removal_service.call
-        NotificationService.notify(removal_service.status.join("\n"))
+        if webhook
+          NotificationService.notify(
+            removal_service.status.join("\n"),
+            webhook: ENV['SLACK_WEBHOOK']
+          )
+        end
       end
     end
   end
@@ -69,5 +74,11 @@ class TestableEditorRemover
         name: "#{testable_editor}#{configuration[:append]}"
       }
     end
+  end
+
+  def webhook
+    # This is only run during deployment. SLACK_WEBHOOK exists in the CircleCI deployment job
+    # SLACK_PUBLISH_WEBHOOK is used by the Editor itself when running in Test or Live
+    @webhook ||= ENV['SLACK_WEBHOOK']
   end
 end

--- a/spec/services/testable_editor_remover_spec.rb
+++ b/spec/services/testable_editor_remover_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe TestableEditorRemover do
     let(:removal_service) { double(call: true, status: []) }
 
     before do
-      allow(ENV).to receive(:[]).with('SLACK_PUBLISH_WEBHOOK').and_return(webhook)
+      allow(ENV).to receive(:[])
+      allow(ENV).to receive(:[]).with('SLACK_WEBHOOK').and_return(webhook)
       allow(testable_editor_remover).to receive(
         :remote_branches
       ).and_return(remote_branches)


### PR DESCRIPTION
This adds a specific CircleCI job to tear down any testable editors
whose branches have been merged into main.

The rake task makes use of `SLACK_WEBHOOK` which is the current
environment variable set in the CircleCI project settings. It sends a
message to the deployment channel. This is instead of using the
`SLACK_PUBLISH_WEBHOOK` which the Editor itself makes use of when the
publishing of a service occurs for the first time.