### PR TITLE
Create session datastore adapter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,33 +15,21 @@ class ApplicationController < ActionController::Base
   helper_method :back_link
 
   def save_user_data
-    return {} if params[:answers].blank? || params[:id].blank?
+    return {} if params[:id].blank?
 
-    service_id = params[:id]
-    session[service_id] ||= {}
-    session[service_id]['user_data'] ||= {}
-
-    params[:answers].each do |field, answer|
-      session[service_id]['user_data'][field] = if answer.respond_to?(:original_filename)
-                                                  {
-                                                    'original_filename' => answer.original_filename
-                                                  }
-                                                else
-                                                  answer
-                                                end
-    end
+    Preview::SessionDataAdapter.new(session, params[:id]).save(answer_params)
   end
 
   def load_user_data
-    user_data = session[params[:id]] || {}
-
-    user_data['user_data'] || {}
+    Preview::SessionDataAdapter.new(session, params[:id]).load_data
   end
 
   def remove_user_data(component_id)
-    user_data = session[params[:id]] || {}
-    user_data['user_data'].delete(component_id)
-    user_data['user_data']
+    Preview::SessionDataAdapter.new(session, params[:id]).delete(component_id)
+  end
+
+  def answer_params
+    Preview::AnswerParams.new(@page_answers).answers
   end
 
   def upload_adapter

--- a/app/models/preview/answer_params.rb
+++ b/app/models/preview/answer_params.rb
@@ -1,0 +1,39 @@
+module Preview
+  class AnswerParams
+    def initialize(page_answers)
+      @page_answers = page_answers
+      @answer_params = @page_answers.answers.to_h
+    end
+
+    def answers
+      set_uploaded_file_details
+      set_optional_checkboxes
+
+      @answer_params
+    end
+
+    private
+
+    def set_uploaded_file_details
+      if @page_answers.uploaded_files.present?
+        @page_answers.uploaded_files.map do |uploaded_file|
+          @answer_params[uploaded_file.component.id] =
+            @page_answers.send(uploaded_file.component.id).merge(uploaded_file.file)
+        end
+      end
+    end
+
+    def set_optional_checkboxes
+      checkbox_components.each do |component|
+        @answer_params[component.id] = [] if @page_answers.send(component.id).blank?
+      end
+    end
+
+    def checkbox_components
+      # not all pages have components
+      Array(@page_answers.page.components).select do |component|
+        component.type == 'checkboxes'
+      end
+    end
+  end
+end

--- a/app/models/preview/session_data_adapter.rb
+++ b/app/models/preview/session_data_adapter.rb
@@ -1,0 +1,32 @@
+module Preview
+  class SessionDataAdapter
+    attr_reader :session, :service_id
+
+    def initialize(session, service_id)
+      @session = session
+      @service_id = service_id
+    end
+
+    def save(answers)
+      return {} if answers.blank?
+
+      session[service_id] ||= {}
+      session[service_id]['user_data'] ||= {}
+
+      answers.each do |field, answer|
+        session[service_id]['user_data'][field] = answer
+      end
+    end
+
+    def load_data
+      user_data = session[service_id] || {}
+      user_data['user_data'] || {}
+    end
+
+    def delete(component_id)
+      user_data = session[service_id] || {}
+      user_data['user_data'].delete(component_id)
+      user_data['user_data']
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe ApplicationController do
   describe '#save_user_data' do
     before do
       allow(controller).to receive(:params).and_return(params)
+      allow(controller).to receive(:answer_params).and_return(answer_params)
       controller.save_user_data
     end
 
@@ -41,24 +42,28 @@ RSpec.describe ApplicationController do
           id: '123456'
         }
       end
+      let(:answer_params) do
+        {
+          'computer' => {
+            'original_filename' => 'computer_says_no.gif',
+            'content_type' => 'application/image',
+            'tempfile' => 'path/to/file/computer_says_no.gif'
+          }
+        }
+      end
 
       it 'saves it with the service id' do
         expect(controller.session.to_h).to eq(
-          {
-            '123456' => {
-              'user_data' => {
-                'computer' => { 'original_filename' => 'computer_says_no.gif' }
-              }
-            }
-          }
+          { '123456' => { 'user_data' => answer_params } }
         )
       end
     end
 
     context 'when saving user data to the session' do
+      let(:answer_params) { { 'frodo' => 'samwise' } }
       let(:params) do
         {
-          answers: { 'frodo' => 'samwise' },
+          answers: answer_params,
           id: '123456'
         }
       end
@@ -79,6 +84,15 @@ RSpec.describe ApplicationController do
         expect(controller.load_user_data.to_h).to eq(
           { 'frodo' => 'samwise' }
         )
+      end
+    end
+
+    context 'with no service id in the params' do
+      let(:answer_params) { {} }
+      let(:params) { {} }
+
+      it 'saves nothing' do
+        expect(controller.load_user_data.to_h).to eq({})
       end
     end
   end

--- a/spec/models/preview/answer_params_spec.rb
+++ b/spec/models/preview/answer_params_spec.rb
@@ -1,0 +1,79 @@
+RSpec.describe Preview::AnswerParams do
+  subject(:answer_params) do
+    described_class.new(page_answers)
+  end
+  let(:page_answers) do
+    MetadataPresenter::PageAnswers.new(page, answers)
+  end
+
+  describe '#answers' do
+    context 'when page has uploaded files' do
+      let(:page) { service.find_page_by_url('dog-picture') }
+      let(:file_details) do
+        Rack::Test::UploadedFile.new(
+          './spec/fixtures/computer_says_no.gif',
+          'application/image'
+        )
+      end
+      let(:answers) do
+        {
+          'dog-picture_upload_1' => file_details
+        }
+      end
+      let(:file) do
+        {
+          'fingerprint' => '28d-6dbfe5a3fff4a67260e7057e49b13ae0794598a949907a',
+          'size' => 1_392_565,
+          'type' => 'application/image',
+          'date' => 1_624_540_833
+        }
+      end
+      let(:uploaded_files) do
+        [
+          MetadataPresenter::UploadedFile.new(
+            file: file,
+            component: page.components.first
+          )
+        ]
+      end
+
+      before do
+        allow(page_answers).to receive(:uploaded_files).and_return(uploaded_files)
+      end
+
+      it 'returns the file information' do
+        expect(answer_params.answers).to eq(
+          {
+            'dog-picture_upload_1' => {
+              'original_filename' => 'computer_says_no.gif',
+              'content_type' => 'application/image',
+              'tempfile' => file_details.tempfile.path.to_s
+            }.merge(file)
+          }
+        )
+      end
+    end
+
+    context 'page with checkbox components' do
+      let(:page) { service.find_page_by_url('burgers') }
+
+      context 'when optional' do
+        let(:answers) { {} }
+        let(:expected_answers) { { 'burgers_checkboxes_1' => [] } }
+
+        it 'should set an empty array for unanswered optional checkboxes' do
+          expect(answer_params.answers).to eq(expected_answers)
+        end
+      end
+    end
+
+    context 'when other answers' do
+      let(:page) { service.find_page_by_url('name') }
+      let(:answers) { { 'name_text_1' => 'John Wick' } }
+
+      it 'returns the answers' do
+        expect(answer_params.answers).to eq(answers)
+      end
+    end
+  end
+end

--- a/spec/models/preview/session_data_adapter_spec.rb
+++ b/spec/models/preview/session_data_adapter_spec.rb
@@ -1,0 +1,133 @@
+RSpec.describe Preview::SessionDataAdapter do
+  subject(:session_adapter) do
+    described_class.new(session, service_id)
+  end
+  let(:service_id) { SecureRandom.uuid }
+
+  describe '#save(answers)' do
+    let(:session) { {} }
+
+    before do
+      session_adapter.save(answers)
+    end
+
+    context 'new answers' do
+      let(:answers) do
+        {
+          'leonard' => 'these tracks are just a few days old',
+          'teddy' => 'what are you, pocahontas?'
+        }
+      end
+
+      it 'saves new answers to the session under the correct service id' do
+        expect(session).to eq(
+          {
+            service_id => {
+              'user_data' => {
+                'leonard' => 'these tracks are just a few days old',
+                'teddy' => 'what are you, pocahontas?'
+              }
+            }
+          }
+        )
+      end
+    end
+
+    context 'existing answer' do
+      let(:session) do
+        {
+          service_id => {
+            'user_data' => {
+              'teddy' => 'lenny',
+              'leonard' => "it's leonard"
+            }
+          }
+        }
+      end
+      let(:answers) { { 'teddy' => 'leonard' } }
+
+      it 'updates the answer correctly' do
+        expect(session).to eq(
+          {
+            service_id => {
+              'user_data' => {
+                'teddy' => 'leonard',
+                'leonard' => "it's leonard"
+              }
+            }
+          }
+        )
+      end
+    end
+
+    context 'without answers' do
+      let(:answers) { {} }
+
+      it 'returns and empty hash' do
+        expect(session_adapter.save(answers)).to eq({})
+      end
+    end
+  end
+
+  describe '#load_data' do
+    context 'with existing session data' do
+      let(:session) do
+        {
+          service_id => {
+            'user_data' => {
+              'leonard' => "i can't remember to forget you"
+            }
+          },
+          '1234' => {
+            'user_data' => {
+              'some' => 'other data'
+            }
+          }
+        }
+      end
+
+      it 'loads the correct service user data' do
+        expect(session_adapter.load_data).to eq(
+          { 'leonard' => "i can't remember to forget you" }
+        )
+      end
+    end
+
+    context 'without existing session data' do
+      let(:session) { {} }
+
+      it 'returns and empty hash' do
+        expect(session).to eq({})
+      end
+    end
+  end
+
+  describe '#delete' do
+    let(:session) do
+      {
+        service_id => {
+          'user_data' => {
+            'to_delete' => 'John G',
+            'to_keep' => 'consider the source'
+          }
+        }
+      }
+    end
+
+    before do
+      session_adapter.delete('to_delete')
+    end
+
+    it 'deletes the data by component id' do
+      expect(session).to eq(
+        {
+          service_id => {
+            'user_data' => {
+              'to_keep' => 'consider the source'
+            }
+          }
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
This is mainly in response to the bug around optional checkbox answers.
When a user answers an optional checkbox and then returns to untick all
the answers this was not being reflected. This was fixed in the runner
however the editor's preview function uses a different method of saving
data.

This PR takes the editor closer to the runners approach of handling
data. the `AnswerParams` and `UserDataParams` are in fact exactly the
same in both apps. These could be moved to a single model in the
MetadataPresenter to be shared across both the editor and the runner.

Previewing an optional checkbox page should now save, and update user
data, as expected