### PR TITLE
Optional checkboxes acceptance tests

### DIFF
--- a/acceptance/features/mark_questions_as_optional_spec.rb
+++ b/acceptance/features/mark_questions_as_optional_spec.rb
@@ -27,21 +27,6 @@ feature 'Mark question as optional' do
     and_I_update_the_question_to_be_optional
   end
 
-  def when_I_want_to_select_question_properties
-    editor.question_heading.first.click
-    editor.question_three_dots_button.click
-    editor.should_not have_css('span', text: 'Delete...')
-  end
-
-  def and_I_want_to_set_a_question_optional
-    editor.required_question.click
-  end
-
-  def and_I_update_the_question_to_be_optional
-    editor.choose 'No', visible: false
-    editor.click_button 'Update'
-  end
-
   def page_url
     "Stormtrooper-#{SecureRandom.uuid}"
   end

--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -78,6 +78,14 @@ feature 'Preview form' do
     when_I_update_the_question_name('Date of birth')
     and_I_return_to_flow_page
 
+    given_I_add_a_single_question_page_with_checkboxes
+    and_I_add_a_page_url('favourite-fruit')
+    when_I_add_the_page
+    when_I_update_the_question_name('What is your favourite fruit?')
+    and_I_edit_the_option_items
+    and_I_make_the_question_optional
+    and_I_return_to_flow_page
+
     given_I_add_a_check_answers_page
     and_I_add_a_page_url('cya')
     when_I_add_the_page
@@ -113,12 +121,14 @@ feature 'Preview form' do
     within_window(preview_form) do
       expect(page.text).to include('Service name goes here')
       page.click_button 'Start now'
+
       expect(page.text).to include('Full name')
       then_I_should_not_see_optional_text(page.text)
       page.click_button 'Continue'
       then_I_should_see_an_error_message(page.text, ['Full name'])
       page.fill_in 'Full name', with: 'Charmy Pappitson'
       page.click_button 'Continue'
+
       expect(page.text).to include(content_component)
       then_I_should_not_see_optional_text(page.text)
       page.click_button 'Continue'
@@ -126,9 +136,11 @@ feature 'Preview form' do
       page.fill_in text_component_question, with: 'Car Car Binks'
       page.fill_in textarea_component_question, with: 'R2-Detour'
       page.click_button 'Continue'
+
       expect(page.text).to include(content_page_heading)
       then_I_should_not_see_optional_text(page.text)
       page.click_button 'Continue'
+
       expect(page.text).to include('Date of birth')
       then_I_should_not_see_optional_text(page.text)
       page.click_button 'Continue'
@@ -137,12 +149,29 @@ feature 'Preview form' do
       page.fill_in 'Month', with: '06'
       page.fill_in 'Year', with: '2002'
       page.click_button 'Continue'
+
+      expect(page.text).to include('What is your favourite fruit?')
+      and_I_select_an_option_item
+      page.click_button 'Continue'
+
       expect(page.text).to include('Check your answers')
       expect(page.text).to include('Charmy Pappitson')
+      expect(page.text).to include('Car Car Binks')
+      expect(page.text).to include('R2-Detour')
       expect(page.text).to include('03 June 2002')
+      expect(page.text).to include('Apples')
       then_I_should_not_see_optional_text(page.text)
       then_I_should_not_see_content_page_in_check_your_answers(page)
       then_I_should_not_see_content_components_in_check_your_answers(page)
+
+      and_I_want_to_change_the_checkbox_answer
+      expect(page.text).to include('What is your favourite fruit?')
+      and_I_unselect_an_option_item
+      page.click_button 'Continue'
+
+      expect(page.text).to include('Check your answers')
+      expect(page.text).not_to include('Apples')
+
       page.click_button 'Accept and send application'
       expect(page.text).to include('Application complete')
     end
@@ -154,5 +183,32 @@ feature 'Preview form' do
 
   def then_I_should_not_see_content_components_in_check_your_answers(page)
     expect(page.text).to_not include(content_page_heading)
+  end
+
+  def and_I_edit_the_option_items
+    editor.editable_options.first.set('Apples')
+    editor.service_name.click
+    editor.editable_options.last.set('Oranges')
+    editor.service_name.click
+    when_I_save_my_changes
+  end
+
+  def and_I_make_the_question_optional
+    when_I_want_to_select_question_properties
+    and_I_want_to_set_a_question_optional
+    and_I_update_the_question_to_be_optional
+    when_I_save_my_changes
+  end
+
+  def and_I_want_to_change_the_checkbox_answer
+    page.find(:link, text: 'Your answer for What is your favourite fruit?', visible: false).click
+  end
+
+  def and_I_select_an_option_item
+    page.find(:css, '#answers-favourite-fruit-checkboxes-1-apples-field', visible: false).check
+  end
+
+  def and_I_unselect_an_option_item
+    page.find(:css, '#answers-favourite-fruit-checkboxes-1-apples-field', visible: false).uncheck
   end
 end

--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -114,19 +114,19 @@ feature 'Preview form' do
       expect(page.text).to include('Service name goes here')
       page.click_button 'Start now'
       expect(page.text).to include('Full name')
-      then_I_should_not_see_optional_text(page)
+      then_I_should_not_see_optional_text(page.text)
       page.fill_in 'Full name', with: 'Charmy Pappitson'
       page.click_button 'Continue'
       expect(page.text).to include(content_component)
-      then_I_should_not_see_optional_text(page)
+      then_I_should_not_see_optional_text(page.text)
       page.fill_in text_component_question, with: 'Car Car Binks'
       page.fill_in textarea_component_question, with: 'R2-Detour'
       page.click_button 'Continue'
       expect(page.text).to include(content_page_heading)
-      then_I_should_not_see_optional_text(page)
+      then_I_should_not_see_optional_text(page.text)
       page.click_button 'Continue'
       expect(page.text).to include('Date of birth')
-      then_I_should_not_see_optional_text(page)
+      then_I_should_not_see_optional_text(page.text)
       page.fill_in 'Day', with: '03'
       page.fill_in 'Month', with: '06'
       page.fill_in 'Year', with: '2002'
@@ -134,7 +134,7 @@ feature 'Preview form' do
       expect(page.text).to include('Check your answers')
       expect(page.text).to include('Charmy Pappitson')
       expect(page.text).to include('03 June 2002')
-      then_I_should_not_see_optional_text(page)
+      then_I_should_not_see_optional_text(page.text)
       then_I_should_not_see_content_page_in_check_your_answers(page)
       then_I_should_not_see_content_components_in_check_your_answers(page)
       page.click_button 'Accept and send application'
@@ -148,16 +148,5 @@ feature 'Preview form' do
 
   def then_I_should_not_see_content_components_in_check_your_answers(page)
     expect(page.text).to_not include(content_page_heading)
-  end
-
-  def then_I_should_not_see_optional_text(page)
-    [
-      "[Optional section heading]",
-      "[Optional lede paragraph]",
-      "[Optional content]",
-      "[Optional hint text]"
-    ].each do |optional_text|
-      expect(page.text).to_not include(optional_content)
-    end
   end
 end

--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -115,10 +115,14 @@ feature 'Preview form' do
       page.click_button 'Start now'
       expect(page.text).to include('Full name')
       then_I_should_not_see_optional_text(page.text)
+      page.click_button 'Continue'
+      then_I_should_see_an_error_message(page.text, ['Full name'])
       page.fill_in 'Full name', with: 'Charmy Pappitson'
       page.click_button 'Continue'
       expect(page.text).to include(content_component)
       then_I_should_not_see_optional_text(page.text)
+      page.click_button 'Continue'
+      then_I_should_see_an_error_message(page.text)
       page.fill_in text_component_question, with: 'Car Car Binks'
       page.fill_in textarea_component_question, with: 'R2-Detour'
       page.click_button 'Continue'
@@ -127,6 +131,8 @@ feature 'Preview form' do
       page.click_button 'Continue'
       expect(page.text).to include('Date of birth')
       then_I_should_not_see_optional_text(page.text)
+      page.click_button 'Continue'
+      then_I_should_see_an_error_message(page.text, ['Date of birth'])
       page.fill_in 'Day', with: '03'
       page.fill_in 'Month', with: '06'
       page.fill_in 'Year', with: '2002'

--- a/acceptance/features/preview_page_spec.rb
+++ b/acceptance/features/preview_page_spec.rb
@@ -41,6 +41,7 @@ feature 'Preview page' do
     within_window(preview_page) do
       expect(page.find('button')).to_not be_disabled
       expect(page.text).to include('Before you start')
+      then_I_should_not_see_optional_text(page.text)
     end
   end
 
@@ -74,6 +75,7 @@ feature 'Preview page' do
   end
 
   def then_I_should_be_on_the_check_your_answers_page
+    then_I_should_not_see_optional_text(page.text)
     expect(page.current_url).to include('cya')
   end
 

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -180,6 +180,21 @@ module CommonSteps
     editor.save_page_button.click
   end
 
+  def when_I_want_to_select_question_properties
+    editor.question_heading.first.click
+    editor.question_three_dots_button.click
+    editor.should_not have_css('span', text: 'Delete...')
+  end
+
+  def and_I_want_to_set_a_question_optional
+    editor.required_question.click
+  end
+
+  def and_I_update_the_question_to_be_optional
+    editor.choose 'No', visible: false
+    editor.click_button 'Update'
+  end
+
   def given_I_have_a_single_question_page_with_radio
     given_I_add_a_single_question_page_with_radio
     and_I_add_a_page_url

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -1,4 +1,11 @@
 module CommonSteps
+  OPTIONAL_TEXT = [
+    '[Optional section heading]',
+    '[Optional lede paragraph]',
+    '[Optional content]',
+    '[Optional hint text]'
+  ]
+
   def given_I_am_logged_in
     editor.load
     editor.sign_in_button.click
@@ -160,6 +167,7 @@ module CommonSteps
     within_window(preview_page) do
       expect(page.find('input[type="submit"]')).to_not be_disabled
       expect(page.text).to include('Question')
+      then_I_should_not_see_optional_text(page.text)
       yield if block_given?
     end
   end
@@ -229,5 +237,9 @@ module CommonSteps
   rescue Capybara::ElementNotFound
     # body elements
     element.find('.output', visible: false)
+  end
+
+  def then_I_should_not_see_optional_text(text)
+    OPTIONAL_TEXT.each { |optional| expect(text).not_to include(optional) }
   end
 end

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -4,7 +4,8 @@ module CommonSteps
     '[Optional lede paragraph]',
     '[Optional content]',
     '[Optional hint text]'
-  ]
+  ].freeze
+  ERROR_MESSAGE = 'There is a problem'.freeze
 
   def given_I_am_logged_in
     editor.load
@@ -241,5 +242,14 @@ module CommonSteps
 
   def then_I_should_not_see_optional_text(text)
     OPTIONAL_TEXT.each { |optional| expect(text).not_to include(optional) }
+  end
+
+  def then_I_should_see_an_error_message(text, fields = [])
+    expect(page.text).to include(ERROR_MESSAGE)
+    if fields.empty?
+      expect(page.text).to include('Enter an answer for')
+    else
+      fields.each { |field| expect(text).to include("Enter an answer for #{field}")}
+    end
   end
 end


### PR DESCRIPTION
This adds further acceptance tests around the preview mode in the editor.

- Optional checkboxes should be able to be changed and the answers correctly saved
- Make sure optional text does not exist on any pages
- Check that error messages are shown to the user if they continue without entering an answer for a required question