### PR TITLE
Add acceptance test for optional file upload

### DIFF
--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -86,6 +86,13 @@ feature 'Preview form' do
     and_I_make_the_question_optional
     and_I_return_to_flow_page
 
+    given_I_add_a_single_question_page_with_upload
+    and_I_add_a_page_url('file-upload')
+    when_I_add_the_page
+    when_I_update_the_question_name('Upload your file')
+    and_I_make_the_question_optional
+    and_I_return_to_flow_page
+
     given_I_add_a_check_answers_page
     and_I_add_a_page_url('cya')
     when_I_add_the_page
@@ -154,12 +161,16 @@ feature 'Preview form' do
       and_I_select_an_option_item
       page.click_button 'Continue'
 
+      expect(page.text).to include('Upload your file')
+      page.click_button 'Continue'
+
       expect(page.text).to include('Check your answers')
       expect(page.text).to include('Charmy Pappitson')
       expect(page.text).to include('Car Car Binks')
       expect(page.text).to include('R2-Detour')
       expect(page.text).to include('03 June 2002')
       expect(page.text).to include('Apples')
+      expect(page.text).to include('Upload your file')
       then_I_should_not_see_optional_text(page.text)
       then_I_should_not_see_content_page_in_check_your_answers(page)
       then_I_should_not_see_content_components_in_check_your_answers(page)


### PR DESCRIPTION
Small addition to the test that makes sure that it is possible for
a user to continue in preview past the optional file upload
question and that that it is then shown on the Check Your Answers page.