### PR TITLE
Fix/delete content components

### DIFF
--- a/acceptance/features/edit_check_answers_page_spec.rb
+++ b/acceptance/features/edit_check_answers_page_spec.rb
@@ -52,6 +52,46 @@ feature 'Edit check your answers page' do
     then_I_should_see_the_first_extra_component(content_extra_component)
   end
 
+  scenario 'deleting components' do
+    given_I_have_a_check_your_answers_page
+    and_I_add_a_content_component(
+      content: content_component
+    )
+    and_I_add_a_content_extra_component(
+      content: content_extra_component
+    )
+    when_I_save_my_changes
+    then_I_should_see_my_content(content_component, content_extra_component)
+
+    when_I_want_to_select_component_properties('.output', content_component)
+    and_I_want_to_delete_a_component
+    when_I_save_my_changes
+    then_I_should_not_see_my_content(content_component)
+
+    when_I_want_to_select_component_properties('.output', content_extra_component)
+    and_I_want_to_delete_a_component
+    when_I_save_my_changes
+    then_I_should_not_see_my_content(content_extra_component)
+
+
+    and_I_add_a_content_component(
+      content: content_component
+    )
+    and_I_add_a_content_extra_component(
+      content: content_extra_component
+    )
+    when_I_save_my_changes
+    then_I_should_see_my_content(content_component, content_extra_component)
+
+    when_I_want_to_select_component_properties('.output', content_component)
+    and_I_want_to_delete_a_component
+
+    when_I_want_to_select_component_properties('.output', content_extra_component)
+    and_I_want_to_delete_a_component
+    when_I_save_my_changes
+    then_I_should_not_see_my_content(content_component, content_extra_component)
+  end
+
   def and_I_change_the_send_heading(send_heading)
     editor.page_send_heading.set(send_heading)
   end

--- a/acceptance/features/edit_multiple_questions_page_spec.rb
+++ b/acceptance/features/edit_multiple_questions_page_spec.rb
@@ -46,7 +46,7 @@ feature 'Edit multiple questions page' do
     and_I_add_a_textarea_component
     and_I_change_the_text_component(text_component_question)
     when_I_save_my_changes
-    when_I_want_to_select_component_properties
+    when_I_want_to_select_component_properties('h2', text_component_question)
     and_I_want_to_delete_a_component
     when_I_save_my_changes
     and_the_text_component_is_deleted

--- a/acceptance/features/edit_multiple_questions_page_spec.rb
+++ b/acceptance/features/edit_multiple_questions_page_spec.rb
@@ -35,10 +35,10 @@ feature 'Edit multiple questions page' do
 
   scenario 'adding and updating components' do
     given_I_have_a_multiple_questions_page
-    and_I_add_a_text_component
-    and_I_add_a_textarea_component
-    and_I_add_a_radio_component
-    and_I_add_a_checkbox_component
+    and_I_add_the_component(editor.add_text)
+    and_I_add_the_component(editor.add_text_area)
+    and_I_add_the_component(editor.add_radio)
+    and_I_add_the_component(editor.add_checkboxes)
     and_I_update_the_components
     when_I_save_my_changes
     and_I_return_to_flow_page
@@ -46,10 +46,10 @@ feature 'Edit multiple questions page' do
     then_I_can_answer_the_questions_in_the_page(preview_form)
   end
 
-  scenario 'deleting components' do
+  scenario 'deleting a text component' do
     given_I_have_a_multiple_questions_page
-    and_I_add_a_text_component
-    and_I_add_a_textarea_component
+    and_I_add_the_component(editor.add_text)
+    and_I_add_the_component(editor.add_text_area)
     and_I_change_the_text_component(text_component_question)
     when_I_save_my_changes
     when_I_want_to_select_component_properties('h2', text_component_question)

--- a/acceptance/features/edit_multiple_questions_page_spec.rb
+++ b/acceptance/features/edit_multiple_questions_page_spec.rb
@@ -21,6 +21,12 @@ feature 'Edit multiple questions page' do
   let(:checkboxes_component_options) do
     ['Prequels']
   end
+  let(:content_component) do
+    'You underestimate the power of the Dark Side.'
+  end
+  let(:optional_content) do
+    '[Optional content]'
+  end
 
   background do
     given_I_am_logged_in
@@ -50,6 +56,27 @@ feature 'Edit multiple questions page' do
     and_I_want_to_delete_a_component
     when_I_save_my_changes
     and_the_text_component_is_deleted
+  end
+
+  scenario 'deleting content components' do
+    given_I_have_a_multiple_questions_page
+    then_I_add_a_content_component(
+      content: content_component
+    )
+    when_I_save_my_changes
+    then_I_should_see_my_content(content_component)
+
+    when_I_want_to_select_component_properties('.output', content_component)
+    and_I_want_to_delete_a_component
+    when_I_save_my_changes
+    then_I_should_not_see_my_content(content_component)
+  end
+
+  def then_I_add_a_content_component(content:)
+    and_I_add_a_component
+    editor.add_content.click
+    expect(editor.first_component.text).to eq(optional_content)
+    when_I_change_editable_content(editor.first_component, content: content)
   end
 
   def then_I_can_answer_the_questions_in_the_page(preview_form)

--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -56,11 +56,11 @@ feature 'Preview form' do
     and_I_add_a_page_url('multi')
     when_I_add_the_page
     and_I_change_the_page_heading(multiple_page_heading)
-    and_I_add_a_text_component
+    and_I_add_the_component(editor.add_text)
     and_I_change_the_text_component(text_component_question)
     when_I_update_the_question_name('Multiple Question page')
     and_I_add_a_multiple_page_content_component(content: content_component)
-    and_I_add_a_textarea_component
+    and_I_add_the_component(editor.add_text_area)
     and_I_change_the_textarea_component(textarea_component_question, component: 2)
     when_I_save_my_changes
     and_I_return_to_flow_page

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -80,6 +80,7 @@ class EditorApp < SitePrism::Page
   element :add_date, :link, 'Date', visible: false
   element :add_radio, :link, 'Radio buttons', visible: false
   element :add_checkboxes, :link, 'Checkboxes', visible: false
+  element :add_content, :link, 'Content area', visible: false
 
   elements :add_page_submit_button, :button, 'Add page'
   element :save_page_button, :xpath, '//input[@value="Save"]'

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -267,4 +267,17 @@ module CommonSteps
       fields.each { |field| expect(text).to include("Enter an answer for #{field}")}
     end
   end
+
+  def then_I_should_see_my_content(*expected_text)
+    expected_text.each { |text| expect(page.text).to include(text)}
+  end
+
+  def then_I_should_not_see_my_content(*expected_text)
+    expected_text.each { |text| expect(page.text).to_not include(text)}
+  end
+
+  def when_I_want_to_select_component_properties(attribute, text)
+    page.find(attribute, text: text).click
+    page.first('.ActivatedMenu_Activator').click
+  end
 end

--- a/acceptance/support/multiple_questions_page_helper.rb
+++ b/acceptance/support/multiple_questions_page_helper.rb
@@ -90,11 +90,6 @@ module MultipleQuestionsPageHelper
     end
   end
 
-  def when_I_want_to_select_component_properties
-    page.find('h2', text: text_component_question).click
-    editor.first('.ActivatedMenu_Activator').click
-  end
-
   def and_I_want_to_delete_a_component
     editor.find('span', text: 'Delete...').click
     editor.find('button', text: 'Delete option').click

--- a/acceptance/support/multiple_questions_page_helper.rb
+++ b/acceptance/support/multiple_questions_page_helper.rb
@@ -5,10 +5,10 @@ module MultipleQuestionsPageHelper
     when_I_add_the_page
   end
 
-  def and_I_add_a_text_component
+  def and_I_add_the_component(component)
     and_I_add_a_component
     and_I_add_a_question
-    editor.add_text.click
+    component.click
   end
 
   def and_I_add_a_multiple_page_content_component
@@ -26,24 +26,6 @@ module MultipleQuestionsPageHelper
 
   def and_I_add_a_content_area
     editor.content_component.click
-  end
-
-  def and_I_add_a_textarea_component
-    and_I_add_a_component
-    and_I_add_a_question
-    editor.add_text_area.click
-  end
-
-  def and_I_add_a_radio_component
-    and_I_add_a_component
-    and_I_add_a_question
-    editor.add_radio.click
-  end
-
-  def and_I_add_a_checkbox_component
-    and_I_add_a_component
-    and_I_add_a_question
-    editor.add_checkboxes.click
   end
 
   def and_I_update_the_components

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -114,15 +114,6 @@ class PagesController < FormController
   end
   helper_method :pages_presenters
 
-  def delete_components(update_params)
-    update_params[:components].each do |k, v|
-      if params['delete_components'].include?(JSON.parse(v)['_uuid'])
-        update_params[:components].delete(k)
-      end
-    end
-    update_params[:components] = [] if update_params[:components].blank?
-  end
-
   private
 
   # The metadata presenter gem requires this objects to render a page

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -58,7 +58,9 @@ class PagesController < FormController
     end
 
     if params['delete_components'].present?
-      delete_components(update_params)
+      update_params[:actions] = (update_params[:actions] || {}).merge(
+        delete_components: params['delete_components']
+      )
     end
 
     parse_components(update_params)

--- a/app/services/page_updater.rb
+++ b/app/services/page_updater.rb
@@ -39,6 +39,16 @@ class PageUpdater
       @component_added = component
     end
 
+    if @actions && @actions[:delete_components].present?
+      %w[components extra_components].each do |component_type|
+        next if new_object[component_type].blank?
+
+        new_object[component_type].delete_if do |hash|
+          hash['_uuid'].in?(@actions[:delete_components])
+        end
+      end
+    end
+
     new_object = make_sure_uuids_are_unique(new_object)
 
     @latest_metadata[page_collection][index] = new_object

--- a/spec/services/page_updater_spec.rb
+++ b/spec/services/page_updater_spec.rb
@@ -405,5 +405,49 @@ RSpec.describe PageUpdater do
         ).to eq(expected_updated_page)
       end
     end
+
+    context 'when removing the cannoli (aka a content component)' do
+      let(:attributes_to_update) do
+        { id: 'page.check-answers', actions: { delete_components: [uuid] } }
+      end
+
+      context 'removing from regular components' do
+        let(:uuid) { 'b065ff4f-90c5-4ba2-b4ac-c984a9dd2470' }
+        let(:updated_metadata) do
+          metadata = service_metadata.deep_dup
+          metadata['pages'][-2]['components'] = []
+          metadata
+        end
+
+        it 'removes the correct component' do
+          update = page.update
+          page = update['pages'].find { |p| p['url'] == 'check-answers' }
+          component_uuids = page['components'].map do |component|
+            component['_uuid']
+          end
+
+          expect(component_uuids).to_not include(uuid)
+        end
+      end
+
+      context 'removing from extra_components' do
+        let(:uuid) { '3e6ef27e-91a6-402f-8291-b7ce669e824e' }
+        let(:updated_metadata) do
+          metadata = service_metadata.deep_dup
+          metadata['pages'][-2]['extra_components'] = []
+          metadata
+        end
+
+        it 'removes the correct component' do
+          update = page.update
+          page = update['pages'].find { |p| p['url'] == 'check-answers' }
+          component_uuids = page['components'].map do |component|
+            component['_uuid']
+          end
+
+          expect(component_uuids).to_not include(uuid)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Story: https://trello.com/c/OmxYLkoG/1673-bug-editor-unable-to-delete-content-components-on-check-your-answer-pages

### Fix delete components bug
This commit fixes an issue whereby the content components in the check answers pages were not deleting.

### Add acceptance tests for deleting a content component for check your answers and multiple question pages

### Acceptance test for deleting content component for multiple question page
Note: The mechanism for adding a content component on a multiple question page is different to adding a content component on the check your answers page.
Hence why there are two methods that are very similar, `then_I_add_a_content_component` and `and_I_add_a_content_component`.

### Refactor the method to add a component in the acceptance tests
This refactor makes the method more generic, meaning we can remove the other more specific methods.