### PR TITLE
Small refactor of acceptance tests common method

### DIFF
--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -130,28 +130,28 @@ feature 'Preview form' do
       page.click_button 'Start now'
 
       expect(page.text).to include('Full name')
-      then_I_should_not_see_optional_text(page.text)
+      then_I_should_not_see_optional_text
       page.click_button 'Continue'
-      then_I_should_see_an_error_message(page.text, ['Full name'])
+      then_I_should_see_an_error_message('Full name')
       page.fill_in 'Full name', with: 'Charmy Pappitson'
       page.click_button 'Continue'
 
       expect(page.text).to include(content_component)
-      then_I_should_not_see_optional_text(page.text)
+      then_I_should_not_see_optional_text
       page.click_button 'Continue'
-      then_I_should_see_an_error_message(page.text)
+      then_I_should_see_an_error_message
       page.fill_in text_component_question, with: 'Car Car Binks'
       page.fill_in textarea_component_question, with: 'R2-Detour'
       page.click_button 'Continue'
 
       expect(page.text).to include(content_page_heading)
-      then_I_should_not_see_optional_text(page.text)
+      then_I_should_not_see_optional_text
       page.click_button 'Continue'
 
       expect(page.text).to include('Date of birth')
-      then_I_should_not_see_optional_text(page.text)
+      then_I_should_not_see_optional_text
       page.click_button 'Continue'
-      then_I_should_see_an_error_message(page.text, ['Date of birth'])
+      then_I_should_see_an_error_message('Date of birth')
       page.fill_in 'Day', with: '03'
       page.fill_in 'Month', with: '06'
       page.fill_in 'Year', with: '2002'
@@ -171,7 +171,7 @@ feature 'Preview form' do
       expect(page.text).to include('03 June 2002')
       expect(page.text).to include('Apples')
       expect(page.text).to include('Upload your file')
-      then_I_should_not_see_optional_text(page.text)
+      then_I_should_not_see_optional_text
       then_I_should_not_see_content_page_in_check_your_answers(page)
       then_I_should_not_see_content_components_in_check_your_answers(page)
 

--- a/acceptance/features/preview_page_spec.rb
+++ b/acceptance/features/preview_page_spec.rb
@@ -41,7 +41,7 @@ feature 'Preview page' do
     within_window(preview_page) do
       expect(page.find('button')).to_not be_disabled
       expect(page.text).to include('Before you start')
-      then_I_should_not_see_optional_text(page.text)
+      then_I_should_not_see_optional_text
     end
   end
 
@@ -75,7 +75,7 @@ feature 'Preview page' do
   end
 
   def then_I_should_be_on_the_check_your_answers_page
-    then_I_should_not_see_optional_text(page.text)
+    then_I_should_not_see_optional_text
     expect(page.current_url).to include('cya')
   end
 

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -168,7 +168,7 @@ module CommonSteps
     within_window(preview_page) do
       expect(page.find('[type="submit"]')).to_not be_disabled
       expect(page.text).to include('Question')
-      then_I_should_not_see_optional_text(page.text)
+      then_I_should_not_see_optional_text
       yield if block_given?
     end
   end
@@ -255,11 +255,11 @@ module CommonSteps
     element.find('.output', visible: false)
   end
 
-  def then_I_should_not_see_optional_text(text)
-    OPTIONAL_TEXT.each { |optional| expect(text).not_to include(optional) }
+  def then_I_should_not_see_optional_text
+    OPTIONAL_TEXT.each { |optional| expect(page.text).not_to include(optional) }
   end
 
-  def then_I_should_see_an_error_message(text, fields = [])
+  def then_I_should_see_an_error_message(*fields)
     expect(page.text).to include(ERROR_MESSAGE)
     if fields.empty?
       expect(page.text).to include('Enter an answer for')


### PR DESCRIPTION
`page` is always available when the methods are called so no need to
pass it in.

Also change method signature to use a splat