### PR TITLE
Do not send error to sentry if service name exists

### DIFF
--- a/app/services/metadata_api_client/resource.rb
+++ b/app/services/metadata_api_client/resource.rb
@@ -1,5 +1,7 @@
 module MetadataApiClient
   class Resource
+    SERVICE_NAME_EXISTS = 'Name has already been taken'.freeze
+
     attr_accessor :id, :name, :metadata
 
     def initialize(attributes = {})
@@ -16,6 +18,9 @@ module MetadataApiClient
       errors = JSON.parse(
         exception.response_body, symbolize_names: true
       )[:message]
+
+      sentry_errors = errors.reject { |err| err == SERVICE_NAME_EXISTS }
+      Sentry.capture_message(sentry_errors.join(' | ')) if sentry_errors.present?
 
       MetadataApiClient::ErrorMessages.new(errors)
     end

--- a/app/services/metadata_api_client/version.rb
+++ b/app/services/metadata_api_client/version.rb
@@ -7,7 +7,6 @@ module MetadataApiClient
         ).body
       )
     rescue Faraday::UnprocessableEntityError => e
-      Sentry.capture_exception(e)
       error_messages(e)
     end
   end


### PR DESCRIPTION
When a service name already exists the metadata api will return a 422
with the error message 'Name has already been taken'. This is expected
behaviour and we do not really want to be notified for it every time it
happens.

Move the sending of to sentry to the resource.rb as that is what is used
during both the creation of a service and also the updating of a
version.

Reject any errors from the errors array if it is to do with the service
name existing and then send any remaining to Sentry.

The parsed error messages are actually more helpful as the main
exception that is raised is just the Faraday exception with the general
422 message and no further details.

Might be better done with Sentry scopes like:

```
Sentry.with_scope do |scope|
  sentry_errors = errors.reject { |err| err == SERVICE_NAME_EXISTS }
  unless sentry_errors.blank?
    scope.set_context(
      'additional_errors',
      { errors: sentry_errors.join(' | ') }
    )
    Sentry.capture_exception(e)
  end
end
```

Doing it that way we'll also get the intial exception that was raised.

But perhaps next week