### PR TITLE
Testable 1643 modals not getting focus

### DIFF
--- a/app/javascript/src/component_activated_dialog.js
+++ b/app/javascript/src/component_activated_dialog.js
@@ -57,6 +57,9 @@ class ActivatedDialog {
     });
 
     $dialog.parents(".ui-dialog").addClass("ActivatedDialog");
+    $dialog.on( "dialogclose", function( event, ui ) {
+      $(document).trigger("ActivatedDialogClose");
+    });
 
     this._config = conf;
     this.$node = $dialog;

--- a/app/javascript/src/component_activated_menu.js
+++ b/app/javascript/src/component_activated_menu.js
@@ -235,6 +235,7 @@ class ActivatedMenuActivator {
 
     menu.$node.before($node);
     $node.addClass("ActivatedMenu_Activator");
+    $node.attr("aria-haspopup", "menu");
 
     this.$node = $node;
     this.menu = menu;

--- a/app/javascript/src/component_dialog.js
+++ b/app/javascript/src/component_dialog.js
@@ -51,6 +51,9 @@ class Dialog {
 
       $node.parents(".ui-dialog").addClass("Dialog");
       $node.data("instance", this);
+      $node.on( "dialogclose", function( event, ui ) {
+        $(document).trigger("DialogClose");
+      });
 
       Dialog.setElements.call(this, $node);
       Dialog.setDefaultText.call(this, $node);

--- a/app/javascript/src/component_dialog.js
+++ b/app/javascript/src/component_dialog.js
@@ -71,8 +71,18 @@ class Dialog {
   }
 
   open(text) {
+    var $node = this.$node;
     this.content = text || {};
     this.$node.dialog("open");
+    window.setTimeout(function() {
+      // Not great but works.
+      // We want the focus put inside dialog as all functionality to trap tabbing is there already.
+      // Because we sometimes open dialogs from other components, those other components may (like
+      // menus) shift focus from the opening dialog. We need this delay to allow those other events
+      // to play out before we try to set focus in the dialog. Delay time is arbitrary but we
+      // obviously want it as low as possible to avoid user annoyance. Increase only if have to.
+      $node.parent().find("input, button").not(".ui-dialog-titlebar-close").eq(0).focus();
+    }, 100);
   }
 }
 

--- a/app/javascript/src/component_dialog_configuration.js
+++ b/app/javascript/src/component_dialog_configuration.js
@@ -74,9 +74,8 @@ class DialogConfiguration extends Dialog {
   }
 
   open(text, action) {
-    this.content = text;
-    this._saveAction = action;
-    this.$node.dialog("open");
+    this._saveAction = action || function() {};
+    super.open(text);
   }
 
   save() {

--- a/app/javascript/src/component_dialog_configuration.js
+++ b/app/javascript/src/component_dialog_configuration.js
@@ -56,6 +56,9 @@ class DialogConfiguration extends Dialog {
       $node.parents(".ui-dialog").removeClass("Dialog");
       $node.parents(".ui-dialog").addClass("DialogConfiguration");
       $node.data("instance", this);
+      $node.on( "dialogclose", function( event, ui ) {
+        $(document).trigger("DialogConfigurationClose");
+      });
 
       DialogConfiguration.setElements.call(this, $node);
       DialogConfiguration.setDefaultText.call(this, $node);

--- a/app/javascript/src/component_dialog_confirmation.js
+++ b/app/javascript/src/component_dialog_confirmation.js
@@ -55,6 +55,9 @@ class DialogConfirmation extends Dialog {
       $node.parents(".ui-dialog").removeClass("Dialog");
       $node.parents(".ui-dialog").addClass("DialogConfirmation");
       $node.data("instance", this);
+      $node.on( "dialogclose", function( event, ui ) {
+        $(document).trigger("DialogConfirmationClose");
+      });
 
       DialogConfirmation.setElements.call(this, $node);
       DialogConfirmation.setDefaultText.call(this, $node);

--- a/app/javascript/src/controller_default.js
+++ b/app/javascript/src/controller_default.js
@@ -23,16 +23,43 @@ const post = require('./utilities').post;
 
 class DefaultController {
   constructor(app) {
+    var view = this;
+    var $document = $(document);
     this.type = $(".fb-main-grid-wrapper").data("fb-pagetype");
     this.page = app.page;
     this.text = app.text;
     this.dialog = createDialog.call(this);
     this.dialogConfirmation = createDialogConfirmation.call(this);
     this.dialogConfirmationDelete = createDialogConfirmationDelete.call(this);
-    this.$document = $(document);
+    this.$document = $document;
     this.$body = $(document.body);
+    this.$lastPoint = $(); // Use it to set a focal point in switching between components.
 
     isolatedMethodDeleteLinks();
+
+    // To support keyboard navigation, try to set focus
+    // for tabbing back to last important point.
+    $document.on("DialogClose ActivatedDialogClose", function() {
+      view.$lastPoint.focus();
+      view.$lastPoint = $(); // Reset in case it was never used after any setting.
+    });
+  }
+
+  /* We have difficulty supporting keyboard tabbing because some components
+   * need to interact with others thus, jumping the tab focus around the
+   * actual DOM. Some components also have their own keyboard tabbing handling,
+   * such as the jQueryUI Dialogs, which makes it even harder to keep track.
+   * To compensate, we use a variable on the view called $lastPoint. This is
+   * expected to be a jQuery node, set by the last point (node) we want to
+   * come back to after a Dialog has closed, for instance (shifting focus back).
+   *
+   * Register the activator node  as a possible last point for tab focus support.
+   **/
+  addLastPointHandler($node) {
+    var view = this;
+    $node.on("keydown", function() {
+      view.$lastPoint = $node;
+    });
   }
 }
 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -336,35 +336,38 @@ function enhanceContent(view) {
  **/
 function enhanceQuestions(view) {
   view.$editable.filter("[data-fb-content-type=text], [data-fb-content-type=number], [data-fb-content-type=upload]").each(function(i, node) {
-    new TextQuestion($(this), {
+    var question = new TextQuestion($(this), {
       form: view.dataController.$form,
       text: {
         default_content: view.text.defaults.content,
         optionalFlag: view.text.question_optional_flag
       }
     });
+    view.addLastPointHandler(question.menu.activator.$node);
   });
 
   view.$editable.filter("[data-fb-content-type=date]").each(function(i, node) {
-    new DateQuestion($(this), {
+    var question = new DateQuestion($(this), {
       form: view.dataController.$form,
       text: {
         optionalFlag: view.text.question_optional_flag
       }
     });
+    view.addLastPointHandler(question.menu.activator.$node);
   });
 
   view.$editable.filter("[data-fb-content-type=textarea]").each(function(i, node) {
-    new TextareaQuestion($(this), {
+    var question = new TextareaQuestion($(this), {
       form: view.dataController.$form,
       text: {
         optionalFlag: view.text.question_optional_flag
       }
     });
+    view.addLastPointHandler(question.menu.activator.$node);
   });
 
   view.$editable.filter("[data-fb-content-type=checkboxes]").each(function(i, node) {
-    new CheckboxesQuestion($(this), {
+    var question = new CheckboxesQuestion($(this), {
       form: view.dataController.$form,
       text: {
         edit: view.text.actions.edit,
@@ -388,10 +391,11 @@ function enhanceQuestions(view) {
         });
       }
     });
+    view.addLastPointHandler(question.menu.activator.$node);
   });
 
   view.$editable.filter("[data-fb-content-type=radios]").each(function(i, node) {
-    new RadiosQuestion($(this), {
+    var question = new RadiosQuestion($(this), {
       form: view.dataController.$form,
       text: {
         edit: view.text.actions.edit,
@@ -415,6 +419,7 @@ function enhanceQuestions(view) {
         });
       }
     });
+    view.addLastPointHandler(question.menu.activator.$node);
   });
 }
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -42,7 +42,8 @@ class ServicesController extends DefaultController {
 /* Setup for the Edit action
  **/
 ServicesController.edit = function() {
-  let $document = $(document);
+  var view = this;
+  var $document = $(document);
   // Bind document event listeners to control functionality not specific to a single component or where
   // a component can be activated by more than one element (prevents complicated multiple element binding/handling).
   $document.on("PageActionMenuSelection", pageActionMenuSelection.bind(this) );
@@ -53,13 +54,15 @@ ServicesController.edit = function() {
 
   // Create the context menus for each page thumbnail.
   $("[data-component='PageActionMenu']").each((i, el) => {
-    new PageActionMenu($(el), pageCreateDialog, {
+    var menu = new PageActionMenu($(el), pageCreateDialog, {
       selection_event: "PageActionMenuSelection",
       preventDefault: true, // Stops the default action of triggering element.
       menu: {
         position: { at: "right+2 top-2" }
       }
     });
+
+    view.addLastPointHandler(menu.activator.$node);
   });
 
   // Create the menu for Add Page functionality.
@@ -72,6 +75,7 @@ ServicesController.edit = function() {
       }
     });
 
+    view.addLastPointHandler(menu.activator.$node);
     $document.on(selection_event, PageAdditionMenu.selection.bind(menu) );
   });
 
@@ -264,7 +268,6 @@ function applyCustomOverviewWorkaround() {
   $container.scrollLeft(containerWidth); // Align to right so Add page button is visible
   $overview.height($container.outerHeight(true));
 }
-
 
 
 module.exports = ServicesController;

--- a/app/javascript/styles/_component_activated_menu.scss
+++ b/app/javascript/styles/_component_activated_menu.scss
@@ -37,6 +37,12 @@
     text-indent: 0;
     top: -27px;
   }
+
+  &:focus {
+    @include focus;
+    border: none;
+    outline: none;
+  }
 }
 
 .ActivatedMenu_Menu {

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -3,12 +3,12 @@
   class: 'govuk-button editor-button fb-govuk-button fb-preview-button',
   target: '_blank' %>
 
-<h1 class="govuk-heading-xl"><%= t('pages.form') %></h1>
+<h1 class="govuk-heading-xl"><%= t('pages.flow.heading') %></h1>
 
 <div id="form-overview">
   <div class="container">
     <% service.pages.each do |page| %>
-      <div class="form-step">
+      <div class="form-step" aria-label="<%= t('pages.flow.step') %>">
 
         <%= flow_thumbnail(page, service.service_id) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,7 +59,9 @@ en:
     option_add: 'Add option'
     option_remove: 'Delete...'
   pages:
-    form: 'Pages flow'
+    flow:
+      heading: 'Pages flow'
+      step: 'Form page'
     name: 'Pages'
     create: 'Add page'
     cancel: 'Cancel'

--- a/test/component_dialog_configuration_test.js
+++ b/test/component_dialog_configuration_test.js
@@ -221,11 +221,11 @@ describe("DialogConfiguration", function() {
   describe("Save", function() {
     it("should run safely without passing action to open", function() {
 
-      // Open without passing a function should set action to undefined
+      // Open without passing a function should set action to blank function
       dialog.open({})
-      expect(dialog._saveAction).to.not.exist;
+      expect(typeof dialog._saveAction).to.equal("function");
 
-      // Now we know it does not exist, test the save() method.
+      // Since it is the default blank function we can test the save() method.
       // If all is fine the expectation should run without a fail.
       dialog.save();
       expect(1).to.equal(1);


### PR DESCRIPTION
Accessibility changes intended to keep focus within the opened dialog so user can navigate with tab key.
Most of that is already handled by the jQueryUI Dialog component but this PR adds handling to try and figure out what component initially activated the process and, therefore, which element we want to return the keyboard focus to on Dialog close.