### PR TITLE
Fix testable editor deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,8 +159,9 @@ jobs:
       - run: &base_environment_variables
           name: Setup base environment variable
           command: |
-            echo "export BUILD_SHA=$CIRCLE_SHA1" >> $BASH_ENV
-            echo "export SSH_FILE_FOR_SECRETS=~/.ssh/id_rsa_0fd3b5c2a17e0aa3d32a8441efcc94f5" >> $BASH_ENV
+            echo 'export BUILD_SHA=$CIRCLE_SHA1' >> $BASH_ENV
+            echo 'export SSH_FILE_FOR_SECRETS=~/.ssh/id_rsa_0fd3b5c2a17e0aa3d32a8441efcc94f5' >> $BASH_ENV
+            source $BASH_ENV
       - run: *deploy_scripts
       - run:
           name: deploy to test
@@ -249,10 +250,14 @@ jobs:
       - run: *db_setup
       - run:
           name: Run acceptance tests
-          environment:
-            ACCEPTANCE_TESTS_EDITOR_APP: 'https://fb-editor-test.apps.live-1.cloud-platform.service.justice.gov.uk/'
-            CI_MODE: 'true'
           command: |
+            EDITOR_APP=https://fb-editor-test.apps.live-1.cloud-platform.service.justice.gov.uk
+            echo 'export ACCEPTANCE_TESTS_EDITOR_APP=$EDITOR_APP' >> $BASH_ENV
+            echo 'export ACCEPTANCE_TESTS_USER=$ACCEPTANCE_TESTS_USER' >> $BASH_ENV
+            echo 'export ACCEPTANCE_TESTS_PASSWORD=$ACCEPTANCE_TESTS_PASSWORD' >> $BASH_ENV
+            echo 'export CI_MODE=true' >> $BASH_ENV
+            source $BASH_ENV
+
             TESTFILES=$(circleci tests glob "project/acceptance/**/*_spec.rb" | circleci tests split --split-by=name)
             bundle exec rspec acceptance $TESTFILES --profile 10 -f doc
       - slack/status: *slack_status
@@ -270,10 +275,14 @@ jobs:
       - run: *db_setup
       - run:
           name: Run acceptance tests
-          environment:
-            ACCEPTANCE_TESTS_EDITOR_APP: "https://${CIRCLE_BRANCH}.apps.live-1.cloud-platform.service.justice.gov.uk/"
-            CI_MODE: 'true'
           command: |
+            EDITOR_APP=https://${CIRCLE_BRANCH}.apps.live-1.cloud-platform.service.justice.gov.uk
+            echo 'export ACCEPTANCE_TESTS_EDITOR_APP=$EDITOR_APP' >> $BASH_ENV
+            echo 'export ACCEPTANCE_TESTS_USER=$ACCEPTANCE_TESTS_USER' >> $BASH_ENV
+            echo 'export ACCEPTANCE_TESTS_PASSWORD=$ACCEPTANCE_TESTS_PASSWORD' >> $BASH_ENV
+            echo 'export CI_MODE=true' >> $BASH_ENV
+            source $BASH_ENV
+
             TESTFILES=$(circleci tests glob "project/acceptance/**/*_spec.rb" | circleci tests split --split-by=name)
             bundle exec rspec acceptance $TESTFILES --profile 10 -f doc
       - slack/status:
@@ -318,7 +327,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - /^testable-.*$/
+                - /testable-.*/
       - lint:
           requires:
             - build
@@ -376,7 +385,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^testable-.*$/
+                - /testable-.*/
       - lint:
           requires:
             - build
@@ -398,7 +407,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^testable-.*$/
+                - /testable-.*/
       - build_workers_testable_branch:
           requires:
             - lint
@@ -408,7 +417,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^testable-.*$/
+                - /testable-.*/
       - deploy_testable_branch:
           requires:
             - build_web_testable_branch

--- a/deploy/fb-editor-chart/templates/deployment.yaml
+++ b/deploy/fb-editor-chart/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         # defined in config_map.yaml
         envFrom:
           - configMapRef:
-              name: fb-editor-config-map
+              name: "{{ .Values.app_name }}-config-map"
         env:
           - name: SECRET_KEY_BASE
             valueFrom:
@@ -148,7 +148,7 @@ spec:
         # defined in config_map.yaml
         envFrom:
           - configMapRef:
-              name: fb-editor-config-map
+              name: "{{ .Values.app_name }}-config-map"
         env:
           - name: SECRET_KEY_BASE
             valueFrom:


### PR DESCRIPTION
A few things to fix here:

- the regex to trigger or ignore the testable branches was incorrect
  according to CircleCI docs

- when using parallelism setting variables using the `environment`
  property in the steps does not work. They need to be exported to
`$BASH_ENV` and then sourced before running any commands that rely on
them.

- the deployment.yaml `configMapRef` was incorrectly always looking at
  the `fb-editor-config-map` when in fact it should have been looking at
the specific config map created for the testable editor. This is mainly
because of the `EDITOR_FULL_ROOT_URL` which has to be dynamic and is
used by Omniauth when authenticating a user.