### PR TITLE
Use page UUIDs instead of IDs when updating and destroying

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -31,7 +31,7 @@ class PagesController < FormController
   end
 
   def destroy
-    @metadata_updater = PageDestroyer.new(common_params.merge(id: @page.id))
+    @metadata_updater = PageDestroyer.new(common_params.merge(uuid: @page.uuid))
 
     @metadata_updater.destroy
     redirect_to edit_service_path(service.service_id)
@@ -47,7 +47,7 @@ class PagesController < FormController
 
   def page_update_params
     update_params = ActiveSupport::HashWithIndifferentAccess.new({
-      id: @page.id
+      uuid: @page.uuid
     }.merge(common_params).merge(page_attributes))
 
     if params[:page] && additional_component

--- a/app/services/metadata_finder.rb
+++ b/app/services/metadata_finder.rb
@@ -1,15 +1,15 @@
 # The included object needs to respond to #id, #latest_metadata
 #
 module MetadataFinder
-  def find_node_attribute_by_id
+  def find_node_attribute_by_uuid
     latest_metadata.extend Hashie::Extensions::DeepLocate
 
-    latest_metadata.deep_locate(find_id).first
+    latest_metadata.deep_locate(find_uuid).first
   end
 
-  def find_id
+  def find_uuid
     lambda do |key, value, _object|
-      key == '_id' && value == id
+      key == '_uuid' && value == uuid
     end
   end
 

--- a/app/services/page_destroyer.rb
+++ b/app/services/page_destroyer.rb
@@ -1,10 +1,10 @@
 class PageDestroyer
   include MetadataFinder
-  attr_reader :latest_metadata, :id, :service_id, :attributes
+  attr_reader :latest_metadata, :uuid, :service_id, :attributes
 
   def initialize(attributes)
     @latest_metadata = attributes.delete(:latest_metadata).to_h.deep_dup
-    @id = attributes.delete(:id)
+    @uuid = attributes.delete(:uuid)
     @service_id = attributes.delete(:service_id)
     @attributes = attributes
   end
@@ -19,14 +19,14 @@ class PageDestroyer
   end
 
   def metadata
-    object = find_node_attribute_by_id
+    object = find_node_attribute_by_uuid
     page_collection, index = find_page_collection_and_index(object)
 
     # Don't delete start pages
     return @latest_metadata if object['_type'] == 'page.start'
 
     @latest_metadata[page_collection].delete_at(index)
-    @latest_metadata['pages'][0]['steps'].delete(@id) if flow_page?(page_collection)
+    @latest_metadata['pages'][0]['steps'].delete(object['_id']) if flow_page?(page_collection)
     @latest_metadata
   end
 end

--- a/app/services/page_updater.rb
+++ b/app/services/page_updater.rb
@@ -1,10 +1,10 @@
 class PageUpdater
   include MetadataFinder
-  attr_reader :latest_metadata, :id, :service_id, :actions, :attributes
+  attr_reader :latest_metadata, :uuid, :service_id, :actions, :attributes
 
   def initialize(attributes)
     @latest_metadata = attributes.delete(:latest_metadata).to_h.deep_dup
-    @id = attributes.delete(:id)
+    @uuid = attributes.delete(:uuid)
     @service_id = attributes.delete(:service_id)
     @actions = attributes.delete(:actions)
     @attributes = attributes
@@ -26,7 +26,7 @@ class PageUpdater
   end
 
   def metadata
-    object = find_node_attribute_by_id
+    object = find_node_attribute_by_uuid
     page_collection, index = find_page_collection_and_index(object)
 
     new_object = object.merge(attributes)

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe PagesController do
 
       it 'parses components as json' do
         expect(controller.page_update_params).to eq({
-          'id' => page.id,
+          'uuid' => page.uuid,
           'latest_metadata' => service_metadata,
           'components' => [component_params_one, component_params_two],
           'service_id' => service.service_id
@@ -52,7 +52,7 @@ RSpec.describe PagesController do
 
       it 'parses params' do
         expect(controller.page_update_params).to eq({
-          'id' => page.id,
+          'uuid' => page.uuid,
           'latest_metadata' => service_metadata,
           'service_id' => service.service_id,
           'heading' => 'They are taking the Hobbits to Isengard'

--- a/spec/services/page_destroyer_spec.rb
+++ b/spec/services/page_destroyer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe PageDestroyer do
       end
       let(:attributes) do
         {
-          id: 'page.start',
+          uuid: service_metadata['pages'][0]['_uuid'],
           service_id: service.service_id,
           latest_metadata: service_metadata
         }
@@ -46,7 +46,7 @@ RSpec.describe PageDestroyer do
       end
       let(:attributes) do
         {
-          id: 'page.name',
+          uuid: '9e1ba77f-f1e5-42f4-b090-437aa9af7f73',
           service_id: service.service_id,
           latest_metadata: service_metadata
         }
@@ -66,7 +66,7 @@ RSpec.describe PageDestroyer do
       end
       let(:attributes) do
         {
-          id: 'page.privacy',
+          uuid: '4b86fe8c-7723-4cce-9378-7b2510279e04',
           service_id: service.service_id,
           latest_metadata: service_metadata
         }

--- a/spec/services/page_updater_spec.rb
+++ b/spec/services/page_updater_spec.rb
@@ -1,4 +1,9 @@
 RSpec.describe PageUpdater do
+  def find_page_uuid(url, meta)
+    all_pages = meta['pages'] + meta['standalone_pages']
+    all_pages.find { |page| page['url'] == url }['_uuid']
+  end
+
   subject(:page) { described_class.new(attributes) }
   let(:service_id) { service.service_id }
   let(:updated_metadata) do
@@ -27,7 +32,7 @@ RSpec.describe PageUpdater do
     let(:valid) { true }
     let(:attributes) do
       {
-        id: 'page.start',
+        uuid: service_metadata['pages'][0]['_uuid'],
         service_id: service.service_id,
         latest_metadata: service_metadata
       }.merge(attributes_to_update)
@@ -101,7 +106,7 @@ RSpec.describe PageUpdater do
           end
           let(:attributes) do
             ActiveSupport::HashWithIndifferentAccess.new({
-              id: 'page._confirmation',
+              uuid: find_page_uuid('confirmation', fixture),
               service_id: service.service_id,
               latest_metadata: fixture,
               actions: { add_component: 'content', component_collection: 'components' },
@@ -146,7 +151,7 @@ RSpec.describe PageUpdater do
             ActiveSupport::HashWithIndifferentAccess.new({
               service_id: service.service_id,
               latest_metadata: service_metadata,
-              id: 'page.star-wars-knowledge',
+              uuid: find_page_uuid('star-wars-knowledge', updated_metadata),
               actions: { add_component: 'number', component_collection: 'components' }
             })
           end
@@ -185,7 +190,7 @@ RSpec.describe PageUpdater do
             ActiveSupport::HashWithIndifferentAccess.new({
               service_id: service.service_id,
               latest_metadata: service_metadata,
-              id: 'page.star-wars-knowledge',
+              uuid: find_page_uuid('star-wars-knowledge', updated_metadata),
               actions: { add_component: 'text', component_collection: 'components' }
             })
           end
@@ -242,7 +247,7 @@ RSpec.describe PageUpdater do
             ActiveSupport::HashWithIndifferentAccess.new({
               service_id: service.service_id,
               latest_metadata: service_metadata,
-              id: 'page.star-wars-knowledge',
+              uuid: find_page_uuid('star-wars-knowledge', updated_metadata),
               actions: { add_component: 'radios', component_collection: 'components' }
             })
           end
@@ -279,7 +284,7 @@ RSpec.describe PageUpdater do
           end
           let(:attributes) do
             ActiveSupport::HashWithIndifferentAccess.new({
-              id: 'page.check-answers',
+              uuid: find_page_uuid('check-answers', updated_metadata),
               service_id: service.service_id,
               latest_metadata: fixture,
               actions: { add_component: 'content', component_collection: 'extra_components' }
@@ -300,7 +305,7 @@ RSpec.describe PageUpdater do
       let(:page_url) { 'do-you-like-star-wars' }
       let(:attributes) do
         {
-          id: 'page.do-you-like-star-wars',
+          uuid: find_page_uuid('do-you-like-star-wars', service_metadata),
           service_id: service.service_id,
           latest_metadata: service_metadata
         }.merge(attributes_to_update)
@@ -386,7 +391,7 @@ RSpec.describe PageUpdater do
 
       let(:attributes) do
         ActiveSupport::HashWithIndifferentAccess.new({
-          id: 'page.privacy',
+          uuid: find_page_uuid('privacy', updated_metadata),
           service_id: service.service_id,
           latest_metadata: fixture
         }.merge(attributes_to_update))
@@ -408,7 +413,10 @@ RSpec.describe PageUpdater do
 
     context 'when removing the cannoli (aka a content component)' do
       let(:attributes_to_update) do
-        { id: 'page.check-answers', actions: { delete_components: [uuid] } }
+        {
+          uuid: find_page_uuid('check-answers', updated_metadata),
+          actions: { delete_components: [uuid] }
+        }
       end
 
       context 'removing from regular components' do


### PR DESCRIPTION
UUIDs are the identifier that we are predominantly using when
finding and interacting with pages and components. Using the ID is a
hold over from before UUIDs existed in the metadata.

With the soon to exist flow objects we use the UUID exclusively as the
object key as well as the reference to the previous and next objects.

When we come to update and destroy these flow objects we can no longer
use the page ID change the page updater and page destroyer to only
use UUIDs.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>