### PR TITLE
Create service flow objects from page objects for older services

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'feature/move-upload-to-gem'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '1.6.1'
+gem 'metadata_presenter', '1.8.1'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    metadata_presenter (1.6.1)
+    metadata_presenter (1.8.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -386,7 +386,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   hashie
   listen (~> 3.5)
-  metadata_presenter (= 1.6.1)
+  metadata_presenter (= 1.8.1)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.0)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -35,7 +35,7 @@ class ServicesController < PermissionsController
   end
 
   def create_flow
-    if service.flow.blank?
+    if service.flow.blank? || ENV['PLATFORM_ENV'] == 'test'
       ServiceUpdater.new(service.metadata).tap do |service_updater|
         service_updater.create_flow
         service_updater.update

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,6 +1,8 @@
 class ServicesController < PermissionsController
   layout 'form', only: :edit
 
+  before_action :create_flow, only: [:edit]
+
   def index
     @service_creation = ServiceCreation.new
   end
@@ -30,5 +32,14 @@ class ServicesController < PermissionsController
     params.require(
       :service_creation
     ).permit(:service_name).merge(current_user: current_user)
+  end
+
+  def create_flow
+    if service.flow.blank?
+      ServiceUpdater.new(service.metadata).tap do |service_updater|
+        service_updater.create_flow
+        service_updater.update
+      end
+    end
   end
 end

--- a/app/generators/new_flow_page_generator.rb
+++ b/app/generators/new_flow_page_generator.rb
@@ -24,7 +24,11 @@ class NewFlowPageGenerator
   end
 
   def next_page
-    @next_page ||= latest_metadata['pages'][page_index + 1]
+    @next_page ||= begin
+      return if page_index.nil?
+
+      latest_metadata['pages'][page_index + 1]
+    end
   end
 
   def default_metadata

--- a/app/generators/new_flow_page_generator.rb
+++ b/app/generators/new_flow_page_generator.rb
@@ -1,0 +1,33 @@
+class NewFlowPageGenerator
+  def initialize(page_uuid:, page_index:, latest_metadata:)
+    @page_uuid = page_uuid
+    @page_index = page_index
+    @latest_metadata = latest_metadata
+  end
+
+  def to_metadata
+    { page_uuid => flow_page_metadata }
+  end
+
+  private
+
+  attr_reader :page_uuid, :page_index, :latest_metadata
+
+  def flow_page_metadata
+    flow_page = default_metadata
+    flow_page['next']['default'] = default_next
+    flow_page
+  end
+
+  def default_next
+    next_page.present? ? next_page['_uuid'] : ''
+  end
+
+  def next_page
+    @next_page ||= latest_metadata['pages'][page_index + 1]
+  end
+
+  def default_metadata
+    DefaultMetadata['flow.page']
+  end
+end

--- a/app/generators/new_page_generator.rb
+++ b/app/generators/new_page_generator.rb
@@ -38,7 +38,6 @@ class NewPageGenerator
   def add_flow_page
     latest_metadata.tap do
       latest_metadata['pages'].insert(pages_index, page_metadata)
-      latest_metadata['pages'][0]['steps'].insert(steps_index, page_name)
     end
   end
 
@@ -71,12 +70,6 @@ class NewPageGenerator
 
       INSERT_LAST
     end
-  end
-
-  def steps_index
-    # steps array doesn't include start page so is always one count less than
-    # the pages array
-    pages_index.positive? ? pages_index - 1 : pages_index
   end
 
   def find_page_index_to_be_inserted_after

--- a/app/generators/new_service_generator.rb
+++ b/app/generators/new_service_generator.rb
@@ -18,11 +18,20 @@ class NewServiceGenerator
       metadata['created_by'] = current_user.id
     end
 
+    metadata['flow'] = start_page_flow_object(metadata)
     metadata['standalone_pages'] = footer_pages
     metadata
   end
 
   private
+
+  def start_page_flow_object(metadata)
+    NewFlowPageGenerator.new(
+      page_uuid: metadata['pages'][0]['_uuid'],
+      page_index: 0,
+      latest_metadata: metadata
+    ).to_metadata
+  end
 
   def footer_pages
     I18n.t('footer').map do |attributes|

--- a/app/services/page_destroyer.rb
+++ b/app/services/page_destroyer.rb
@@ -26,6 +26,21 @@ class PageDestroyer
     return @latest_metadata if object['_type'] == 'page.start'
 
     @latest_metadata[page_collection].delete_at(index)
+    @latest_metadata['flow'] = update_service_flow if page_collection == 'pages'
     @latest_metadata
+  end
+
+  private
+
+  def update_service_flow
+    linked_to_uuid = @latest_metadata['flow'][uuid]['next']['default']
+    @latest_metadata['flow'].each do |_flow_uuid, properties|
+      if properties['next']['default'] == uuid
+        properties['next']['default'] = linked_to_uuid
+      end
+    end
+
+    @latest_metadata['flow'].delete(uuid)
+    @latest_metadata['flow']
   end
 end

--- a/app/services/page_destroyer.rb
+++ b/app/services/page_destroyer.rb
@@ -26,7 +26,6 @@ class PageDestroyer
     return @latest_metadata if object['_type'] == 'page.start'
 
     @latest_metadata[page_collection].delete_at(index)
-    @latest_metadata['pages'][0]['steps'].delete(object['_id']) if flow_page?(page_collection)
     @latest_metadata
   end
 end

--- a/app/services/service_updater.rb
+++ b/app/services/service_updater.rb
@@ -1,0 +1,41 @@
+class ServiceUpdater
+  attr_reader :latest_metadata
+
+  def initialize(latest_metadata)
+    @latest_metadata = latest_metadata.to_h.deep_dup.deep_stringify_keys
+  end
+
+  def update
+    version = MetadataApiClient::Version.create(
+      service_id: latest_metadata['service_id'],
+      payload: latest_metadata
+    )
+
+    return version.metadata unless version.errors?
+
+    false
+  end
+
+  def create_flow
+    latest_metadata['flow'] = service_flow_from_pages
+    remove_start_page_steps
+  end
+
+  private
+
+  def service_flow_from_pages
+    latest_metadata['pages'].each_with_index.inject({}) do |hash, (page, index)|
+      hash.merge(
+        NewFlowPageGenerator.new(
+          page_uuid: page['_uuid'],
+          page_index: index,
+          latest_metadata: latest_metadata
+        ).to_metadata
+      )
+    end
+  end
+
+  def remove_start_page_steps
+    latest_metadata['pages'][0] = latest_metadata['pages'][0].except('steps')
+  end
+end

--- a/spec/generators/new_flow_page_generator_spec.rb
+++ b/spec/generators/new_flow_page_generator_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe NewFlowPageGenerator do
 
     context 'when there is no next page' do
       it_behaves_like 'a flow page generator' do
-        let(:page_uuid) { latest_metadata['pages'].last['_uuid']}
+        let(:page_uuid) { latest_metadata['pages'].last['_uuid'] }
         let(:page_index) { latest_metadata['pages'].size - 1 }
         let(:expected_metadata) do
           {

--- a/spec/generators/new_flow_page_generator_spec.rb
+++ b/spec/generators/new_flow_page_generator_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe NewFlowPageGenerator do
+  subject(:generator) do
+    described_class.new(
+      page_uuid: page_uuid,
+      page_index: page_index,
+      latest_metadata: latest_metadata
+    )
+  end
+  let(:latest_metadata) { metadata_fixture('branching') }
+  let(:valid) { true }
+
+  describe '#to_metadata' do
+    shared_examples 'a flow page generator' do
+      it 'creates valid base flow object metadata' do
+        expect(
+          MetadataPresenter::ValidateSchema.validate(
+            generator.to_metadata, 'flow.base'
+          )
+        ).to be(valid)
+      end
+
+      it 'creates valid flow page object metadata' do
+        expect(
+          MetadataPresenter::ValidateSchema.validate(
+            generator.to_metadata[page_uuid], 'flow.page'
+          )
+        ).to be(valid)
+      end
+
+      it 'creates the correct metadata with the next page uuid' do
+        expect(generator.to_metadata).to eq(expected_metadata)
+      end
+    end
+
+    context 'when there is a next page' do
+      it_behaves_like 'a flow page generator' do
+        let(:page_uuid) { latest_metadata['pages'][0]['_uuid'] }
+        let(:page_index) { 0 }
+        let(:expected_metadata) do
+          {
+            page_uuid => {
+              '_type' => 'flow.page',
+              'next' => {
+                'default' => latest_metadata['pages'][1]['_uuid']
+              }
+            }
+          }
+        end
+      end
+    end
+
+    context 'when there is no next page' do
+      it_behaves_like 'a flow page generator' do
+        let(:page_uuid) { latest_metadata['pages'].last['_uuid']}
+        let(:page_index) { latest_metadata['pages'].size - 1 }
+        let(:expected_metadata) do
+          {
+            page_uuid => {
+              '_type' => 'flow.page',
+              'next' => {
+                'default' => ''
+              }
+            }
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/generators/new_flow_page_generator_spec.rb
+++ b/spec/generators/new_flow_page_generator_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe NewFlowPageGenerator do
     context 'when there is no next page' do
       it_behaves_like 'a flow page generator' do
         let(:page_uuid) { latest_metadata['pages'].last['_uuid'] }
-        let(:page_index) { latest_metadata['pages'].size - 1 }
+        let(:page_index) { nil }
         let(:expected_metadata) do
           {
             page_uuid => {

--- a/spec/generators/new_page_generator_spec.rb
+++ b/spec/generators/new_page_generator_spec.rb
@@ -74,10 +74,6 @@ RSpec.describe NewPageGenerator do
           '_type' => component_type
         )
       end
-
-      it 'adds the new page to the steps' do
-        expect(generator.to_metadata['pages'][0]['steps']).to include("page.#{page_url}")
-      end
     end
 
     context 'when there is more than just a start page' do
@@ -95,13 +91,6 @@ RSpec.describe NewPageGenerator do
           expect(pages).to_not be_blank
           expect(pages[3]).to include(page_attributes)
         end
-
-        it 'adds the new page after given page steps' do
-          expect(
-            # the step index is 2 because 'steps' doesn't count the start page
-            generator.to_metadata['pages'][0]['steps'][2]
-          ).to include("page.#{page_url}")
-        end
       end
 
       context 'when inserting page after an invalid page' do
@@ -110,12 +99,6 @@ RSpec.describe NewPageGenerator do
         it 'adds new page in last position' do
           expect(generator.to_metadata['pages']).to_not be_blank
           expect(generator.to_metadata['pages'].last).to include(page_attributes)
-        end
-
-        it 'adds the new page to last step' do
-          expect(
-            generator.to_metadata['pages'][0]['steps'].last
-          ).to include("page.#{page_url}")
         end
       end
 

--- a/spec/generators/new_service_generator_spec.rb
+++ b/spec/generators/new_service_generator_spec.rb
@@ -10,6 +10,16 @@ RSpec.describe NewServiceGenerator do
           current_user: current_user
         ).to_metadata
       end
+      let(:expected_service_flow) do
+        {
+          service_metadata['pages'][0]['_uuid'] => {
+            '_type' => 'flow.page',
+            'next' => {
+              'default' => ''
+            }
+          }
+        }
+      end
 
       it 'creates a valid service metadata' do
         expect(
@@ -25,6 +35,11 @@ RSpec.describe NewServiceGenerator do
           '_type' => 'page.start',
           'url' => '/'
         )
+      end
+
+      it 'creates the start page flow object' do
+        expect(service_metadata['flow']).to be_present
+        expect(service_metadata['flow']).to eq(expected_service_flow)
       end
 
       it 'creates the default footer pages' do

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe 'Services' do
+  let(:current_user) do
+    double(id: SecureRandom.uuid)
+  end
+
+  describe 'GET /services/:id/edit' do
+    before do
+      expect_any_instance_of(ApplicationController).to receive(:service).at_least(:once).and_return(service)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
+      allow_any_instance_of(PermissionsController).to receive(:require_user!).and_return(true)
+    end
+
+    context 'when there is no flow object in the service metadata' do
+      let(:service) do
+        MetadataPresenter::Service.new(metadata_fixture('no_flow_service'))
+      end
+      let(:service_updater) do
+        double(create_flow: true, update: true)
+      end
+
+      it 'will call the service updater' do
+        expect(ServiceUpdater).to receive(:new).with(
+          service.metadata
+        ).and_return(service_updater)
+        expect(service_updater).to receive(:create_flow)
+
+        get "/services/#{service.service_id}/edit"
+      end
+    end
+
+    context 'when a flow object exists in the metadata' do
+      let(:service) do
+        MetadataPresenter::Service.new(metadata_fixture('branching'))
+      end
+
+      it 'does not call the service updater' do
+        expect(ServiceUpdater).not_to receive(:new)
+        get "/services/#{service.service_id}/edit"
+      end
+    end
+  end
+end

--- a/spec/services/page_creation_spec.rb
+++ b/spec/services/page_creation_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe PageCreation, type: :model do
   subject(:page_creation) do
     described_class.new(attributes)
   end
-  let(:attributes) { { latest_metadata: metadata_fixture(:version) } }
+  let(:attributes) { { latest_metadata: metadata_fixture(:version_with_flow) } }
 
   describe '#page_uuid' do
     it 'generates uuid' do
@@ -18,7 +18,7 @@ RSpec.describe PageCreation, type: :model do
         component_type: 'text',
         page_url: 'admiral-ackbar',
         service_id: 'it-is-a-trap',
-        latest_metadata: metadata_fixture(:version)
+        latest_metadata: metadata_fixture(:version_with_flow)
       }
     end
 
@@ -43,7 +43,7 @@ RSpec.describe PageCreation, type: :model do
     context 'when is invalid' do
       context 'when attributes invalid' do
         let(:attributes) do
-          { page_url: '/foo/bar/baz', latest_metadata: metadata_fixture(:version) }
+          { page_url: '/foo/bar/baz', latest_metadata: metadata_fixture(:version_with_flow) }
         end
 
         it 'returns false' do

--- a/spec/services/page_destroyer_spec.rb
+++ b/spec/services/page_destroyer_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe PageDestroyer do
   subject(:page) { described_class.new(attributes) }
-  let(:service_id) { service.service_id }
+  let(:service_id) { fixture['service_id'] }
+  let(:fixture) { metadata_fixture(:version_with_flow) }
   let(:version) do
     double(errors?: false, errors: [], metadata: updated_metadata)
   end
@@ -17,13 +18,13 @@ RSpec.describe PageDestroyer do
   describe '#destroy' do
     context 'when deleting start page' do
       let(:updated_metadata) do
-        service_metadata.deep_dup
+        fixture.deep_dup
       end
       let(:attributes) do
         {
-          uuid: service_metadata['pages'][0]['_uuid'],
-          service_id: service.service_id,
-          latest_metadata: service_metadata
+          uuid: fixture['pages'][0]['_uuid'],
+          service_id: service_id,
+          latest_metadata: fixture
         }
       end
       before do
@@ -32,47 +33,86 @@ RSpec.describe PageDestroyer do
         ).to_not receive(:create)
       end
 
-      it 'creates new version with start page' do
+      it 'does not delete the start page from the pages array or the service flow' do
         expect(page.destroy).to eq(updated_metadata)
       end
     end
 
     context 'when deleting other flow pages' do
-      let(:updated_metadata) do
-        metadata = service_metadata.deep_dup
-        metadata['pages'].delete_at(1)
-        metadata
-      end
-      let(:attributes) do
-        {
-          uuid: '9e1ba77f-f1e5-42f4-b090-437aa9af7f73',
-          service_id: service.service_id,
-          latest_metadata: service_metadata
-        }
+      context 'page is in the middle of a flow' do
+        let(:start_page_uuid) { fixture['pages'][0]['_uuid'] }
+        let(:page_to_delete_uuid) { fixture['pages'][1]['_uuid'] }
+        let(:third_page_uuid) { fixture['pages'][2]['_uuid'] }
+        let(:updated_metadata) do
+          metadata = fixture.deep_dup
+          metadata['pages'].delete_at(1)
+          metadata['flow'].delete(page_to_delete_uuid)
+          metadata['flow'][start_page_uuid]['next']['default'] = third_page_uuid
+          metadata
+        end
+        let(:attributes) do
+          {
+            uuid: page_to_delete_uuid,
+            service_id: service_id,
+            latest_metadata: fixture
+          }
+        end
+
+        it 'creates new version with page deleted and the page flow object deleted' do
+          expect(page.destroy).to eq(updated_metadata)
+        end
+
+        it 'updates the reference to the deleted page to point at the next page in the flow' do
+          start_page_flow = page.destroy['flow'][start_page_uuid]
+          expect(start_page_flow['next']['default']).to eq(third_page_uuid)
+        end
       end
 
-      it 'creates new version with page deleted' do
-        expect(page.destroy).to eq(updated_metadata)
+      context 'page is the last page in the service flow' do
+        let(:last_page_uuid) { fixture['pages'].last['_uuid'] }
+        let(:check_answers_uuid) { fixture['pages'][-2]['_uuid'] }
+        let(:updated_metadata) do
+          metadata = fixture.deep_dup
+          metadata['pages'].pop
+          metadata['flow'].delete(last_page_uuid)
+          metadata['flow'][check_answers_uuid]['next']['default'] = ''
+          metadata
+        end
+        let(:attributes) do
+          {
+            uuid: last_page_uuid,
+            service_id: service_id,
+            latest_metadata: fixture
+          }
+        end
+
+        it 'updates the previous pages default next to empty string' do
+          expect(page.destroy).to eq(updated_metadata)
+        end
       end
     end
 
     # In future, we may not want to allow users to delete Privacy, Accessibility or Cookies standalone pages
     context 'when deleting standalone pages' do
       let(:updated_metadata) do
-        metadata = service_metadata.deep_dup
+        metadata = fixture.deep_dup
         metadata['standalone_pages'].delete_at(1)
         metadata
       end
       let(:attributes) do
         {
-          uuid: '4b86fe8c-7723-4cce-9378-7b2510279e04',
-          service_id: service.service_id,
-          latest_metadata: service_metadata
+          uuid: fixture['standalone_pages'][1]['_uuid'],
+          service_id: service_id,
+          latest_metadata: fixture
         }
       end
 
       it 'creates new version with page deleted' do
         expect(page.destroy).to eq(updated_metadata)
+      end
+
+      it 'does not remove anything from the service flow' do
+        expect(page.destroy['flow'].size).to eq(fixture['flow'].size)
       end
     end
   end

--- a/spec/services/page_destroyer_spec.rb
+++ b/spec/services/page_destroyer_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe PageDestroyer do
       let(:updated_metadata) do
         metadata = service_metadata.deep_dup
         metadata['pages'].delete_at(1)
-        metadata['pages'][0]['steps'].delete('page.name')
         metadata
       end
       let(:attributes) do

--- a/spec/services/service_updater_spec.rb
+++ b/spec/services/service_updater_spec.rb
@@ -1,0 +1,107 @@
+RSpec.describe ServiceUpdater do
+  subject(:service_updater) { described_class.new(latest_metadata) }
+
+  describe '#create_flow' do
+    let(:latest_metadata) { metadata_fixture('no_flow_service') }
+
+    before do
+      service_updater.create_flow
+    end
+
+    context 'creating flow objects from existing pages' do
+      let(:valid) { true }
+      let(:service_flow) do
+        {
+          'cf6dc32f-502c-4215-8c27-1151a45735bb' => {
+            '_type' => 'flow.page',
+            'next' => {
+              'default' => '9e1ba77f-f1e5-42f4-b090-437aa9af7f73'
+            }
+          },
+          '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' => {
+            '_type' => 'flow.page',
+            'next' => {
+              'default' => 'df1ba645-f748-46d0-ad75-f34112653e37'
+            }
+          },
+          'df1ba645-f748-46d0-ad75-f34112653e37' => {
+            '_type' => 'flow.page',
+            'next' => {
+              'default' => '4b8c6bf3-878a-4446-9198-48351b3e2185'
+            }
+          },
+          '4b8c6bf3-878a-4446-9198-48351b3e2185' => {
+            '_type' => 'flow.page',
+            'next' => {
+              'default' => 'e337070b-f636-49a3-a65c-f506675265f0'
+            }
+          },
+          'e337070b-f636-49a3-a65c-f506675265f0' => {
+            '_type' => 'flow.page',
+            'next' => {
+              'default' => '778e364b-9a7f-4829-8eb2-510e08f156a3'
+            }
+          },
+          '778e364b-9a7f-4829-8eb2-510e08f156a3' => {
+            '_type' => 'flow.page',
+            'next' => {
+              'default' => ''
+            }
+          }
+        }
+      end
+
+      it 'creates the flow objects in the same order as the pages' do
+        page_uuids = latest_metadata['pages'].map { |page| page['_uuid'] }
+        flow_uuids = service_updater.latest_metadata['flow'].keys
+        expect(page_uuids).to eq(flow_uuids)
+      end
+
+      it 'creates the correct flow object structure' do
+        expect(service_updater.latest_metadata['flow']).to eq(service_flow)
+      end
+
+      it 'remove the steps from the start page' do
+        expect(service_updater.latest_metadata['pages'][0].keys).not_to include('steps')
+      end
+
+      it 'creates valid service metadata' do
+        expect(
+          MetadataPresenter::ValidateSchema.validate(
+            service_updater.latest_metadata, 'service.base'
+          )
+        ).to be(valid)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:service_id) { latest_metadata['service_id'] }
+    let(:latest_metadata) { metadata_fixture('no_flow_service') }
+
+    before do
+      expect(
+        MetadataApiClient::Version
+      ).to receive(:create).with(
+        service_id: service_id,
+        payload: latest_metadata
+      ).and_return(version)
+    end
+
+    context 'when there are no errors' do
+      let(:version) { double(errors?: false, errors: [], metadata: latest_metadata) }
+
+      it 'sends the metadata to the metadata api' do
+        service_updater.update
+      end
+    end
+
+    context 'when there are errors' do
+      let(:version) { double(errors?: true, errors: ['some error'], metadata: latest_metadata) }
+
+      it 'return false' do
+        expect(service_updater.update).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/services/service_updater_spec.rb
+++ b/spec/services/service_updater_spec.rb
@@ -61,10 +61,6 @@ RSpec.describe ServiceUpdater do
         expect(service_updater.latest_metadata['flow']).to eq(service_flow)
       end
 
-      it 'remove the steps from the start page' do
-        expect(service_updater.latest_metadata['pages'][0].keys).not_to include('steps')
-      end
-
       it 'creates valid service metadata' do
         expect(
           MetadataPresenter::ValidateSchema.validate(


### PR DESCRIPTION
## Create flow objects for older services

Older services made use of the pages array their flow as since there was
no conditional logic the editor and runner would just traverse the array
in order.

The runner is backwards compatible and will make use of either flow
objects or an array of page objects.

This adds the functionality that creates the flow objects from the pages
array for services that do not already use the flow objects. This occurs
when the user clicks on the editor link for any of their given services.

## Stop interacting with steps array in start page

The steps array actually ended up not being used by the presenter to
determine the order a simple form flow.

Since the steps array should not longer exist in the start page metadata
remove any code that interacts with it.

## Create start page flow object with service generation

When a new service is generated a flow object for its start page also
needs to be generated and added to the flow hash.

## Add flow object when adding new page to service

When a new page is added to a Service it currently either adds a page to
the end of the flow or inserts a page in the middle of the flow.

Add the required flow page objects to the service flow at the same time.
Since we are not doing branching at this stage when a page is added in
the middle of the flow it's default next should be the next page in the
flow. If added at the end then there should be no default next.

This requirement to always find an index for positionally adding a page
will go away once we have completed migration to using flow objects.