### PR TITLE
Create service flow once

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -35,7 +35,7 @@ class ServicesController < PermissionsController
   end
 
   def create_flow
-    if service.flow.blank? || ENV['PLATFORM_ENV'] == 'test'
+    if service.flow.blank?
       ServiceUpdater.new(service.metadata).tap do |service_updater|
         service_updater.create_flow
         service_updater.update

--- a/spec/requests/services_spec.rb
+++ b/spec/requests/services_spec.rb
@@ -33,23 +33,9 @@ RSpec.describe 'Services' do
         MetadataPresenter::Service.new(metadata_fixture('branching'))
       end
 
-      context 'in Test environment' do
-        it 'does not call the service updater' do
-          expect(ServiceUpdater).to receive(:new).and_return(service_updater)
-          get "/services/#{service.service_id}/edit"
-        end
-      end
-
-      context 'in Live environment' do
-        before do
-          allow(ENV).to receive(:[])
-          allow(ENV).to receive(:[]).with('PLATFORM_ENV').and_return('live')
-        end
-
-        it 'does not call the service updater' do
-          expect(ServiceUpdater).not_to receive(:new)
-          get "/services/#{service.service_id}/edit"
-        end
+      it 'does not call the service updater' do
+        expect(ServiceUpdater).not_to receive(:new)
+        get "/services/#{service.service_id}/edit"
       end
     end
   end


### PR DESCRIPTION
Now that the [previous PR](https://github.com/ministryofjustice/fb-editor/pull/553)
has been merged to main we can remove the creation of service flow every
time a user visits the flow page in test.

The reason it existed was documented in [this commit](https://github.com/ministryofjustice/fb-editor/commit/76683bcd1faa963e74559edb65bbe1a11b238596)