### PR TITLE
Fix CI acceptance tests

### DIFF
--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -63,7 +63,7 @@ class EditorApp < SitePrism::Page
   element :add_a_component_button, :link, 'Add component'
   element :question_component,
           :xpath,
-          "//span[@class='ui-menu-item-wrapper' and contains(.,'Question')]"
+          "//*[@role='menuitem' and contains(.,'Question')]"
   element :content_component,
           :xpath,
           "//a[@class='ui-menu-item-wrapper' and contains(.,'Content area')]"


### PR DESCRIPTION
The Add component -> Question -> * changes html classes
when is hovered or not hovered. So changing the question to use
a different attribute makes the test not brittle

Co-authored-by: Steven Burnell <steven.burnell@digital.justice.gov.uk>