### PR TITLE
Adding the missing hint on the What will be the URL modal

### DIFF
--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -92,7 +92,8 @@
         <%= f.hidden_field :page_type, value: f.object.page_type.nil? ? 'singlequestion' : f.object.page_type  %>
         <%= f.hidden_field :component_type, value: f.object.component_type.nil? ? 'text' : f.object.component_type %>
         <div class="govuk-form-group <%= !f.object.errors.empty? ? 'govuk-form-group--error' :'' %>">
-          <%= f.label :page_url, class: "govuk-label govuk-label--m" %>
+          <%= f.label :page_url, class: "govuk-label govuk-label--m" %> 
+          <span class="govuk-hint"><%= t('activemodel.attributes.page_creation.page_url_hint') %></span>
           <% f.object.errors.each do |error|  %>
             <span class="govuk-error-message"><%= error.message %></span>
           <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -167,6 +167,7 @@ en:
         pdf_hint: All answers will be written in a pdf attached to the email
       page_creation:
         page_url: "What will be the URL for this page?"
+        page_url_hint: "This can not contain any space."
       publish_service_creation:
         allow_anonymous: 'Allow anyone with the link to view'
         require_authentication: 'Set a username and password'


### PR DESCRIPTION
As a short term improvement to reduce frustration with that step.