### PR TITLE
Testable 1687 labelling for thumbs on flow view

### DIFF
--- a/acceptance/features/add_page_in_the_middle_flow_spec.rb
+++ b/acceptance/features/add_page_in_the_middle_flow_spec.rb
@@ -4,6 +4,15 @@ feature 'Add page in the middle flow' do
   let(:editor) { EditorApp.new }
   let(:service_name) { generate_service_name }
   let(:page_url) { 'palpatine' }
+  let(:form_urls) do
+    # page url links have the word "Edit" as a visually hidden span element
+    # associated with them for added accessibility
+    [
+      "Edit\n/",
+      "Edit\nnew-page-url",
+      "Edit\npalpatine"
+    ]
+  end
 
   background do
     given_I_am_logged_in
@@ -15,7 +24,7 @@ feature 'Add page in the middle flow' do
     and_I_return_to_flow_page
     when_I_add_a_single_question_page_with_radio_after_start(url: 'new-page-url')
     and_I_return_to_flow_page
-    then_I_should_see_the_page_flow_in_order(order: ['/', 'new-page-url', 'palpatine'])
+    then_I_should_see_the_page_flow_in_order(order: form_urls)
   end
 
   def when_I_add_a_single_question_page_with_radio_after_start(url:)

--- a/acceptance/features/deleting_page_spec.rb
+++ b/acceptance/features/deleting_page_spec.rb
@@ -30,6 +30,6 @@ feature 'Deleting page' do
   end
 
   def then_I_should_not_see_the_deleted_page_anymore
-    expect(editor.form_urls.map(&:text)).to eq(['/'])
+    expect(editor.form_urls.count).to eq(1)
   end
 end

--- a/acceptance/features/edit_confirmation_page_spec.rb
+++ b/acceptance/features/edit_confirmation_page_spec.rb
@@ -20,7 +20,7 @@ feature 'Edit confirmation pages' do
     and_I_change_the_page_body(confirmation_body)
     when_I_save_my_changes
     and_I_return_to_flow_page
-    and_I_edit_the_page(url: confirmation_url)
+    and_I_edit_the_confirmation_page
     then_I_should_see_the_confirmation_heading(confirmation_heading)
     then_I_should_see_the_confirmation_lede(confirmation_lede)
     then_I_should_see_the_confirmation_body(confirmation_body)
@@ -42,6 +42,10 @@ feature 'Edit confirmation pages' do
 
   def then_I_should_see_the_confirmation_lede(lede)
     expect(editor.page_lede.text).to eq(lede)
+  end
+
+  def and_I_edit_the_confirmation_page
+    editor.find('.form-step a.govuk-link', text: confirmation_url).click
   end
 
   def then_I_should_see_the_confirmation_body(body)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
            end
     link_to edit_page_path(parent_id, page.uuid), class: "form-step_thumbnail #{type}", 'aria-hidden': true do
       concat image_pack_tag('thumbnails/thumbs_header.png', class: 'header')
-      concat tag.span(t('actions.edit') + ': ', class: 'govuk-visually-hidden')
+      concat tag.span("#{t('actions.edit')}: ", class: 'govuk-visually-hidden')
       concat tag.span(heading, class: 'text')
       concat image_pack_tag("thumbnails/thumbs_#{type}.jpg", class: 'body')
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,6 +13,7 @@ module ApplicationHelper
            end
     link_to edit_page_path(parent_id, page.uuid), class: "form-step_thumbnail #{type}", 'aria-hidden': true do
       concat image_pack_tag('thumbnails/thumbs_header.png', class: 'header')
+      concat tag.span(t('actions.edit') + ': ', class: 'govuk-visually-hidden')
       concat tag.span(heading, class: 'text')
       concat image_pack_tag("thumbnails/thumbs_#{type}.jpg", class: 'body')
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,10 +12,10 @@ module ApplicationHelper
              page.components[0]._type
            end
     link_to edit_page_path(parent_id, page.uuid), class: "form-step_thumbnail #{type}", 'aria-hidden': true do
-      concat image_pack_tag('thumbnails/thumbs_header.png', class: 'header')
+      concat image_pack_tag('thumbnails/thumbs_header.png', class: 'header', alt: '')
       concat tag.span("#{t('actions.edit')}: ", class: 'govuk-visually-hidden')
       concat tag.span(heading, class: 'text')
-      concat image_pack_tag("thumbnails/thumbs_#{type}.jpg", class: 'body')
+      concat image_pack_tag("thumbnails/thumbs_#{type}.jpg", class: 'body', alt: '')
     end
   end
 

--- a/app/javascript/src/component_activated_menu.js
+++ b/app/javascript/src/component_activated_menu.js
@@ -19,12 +19,17 @@ const property = utilities.property;
 const mergeObjects = utilities.mergeObjects;
 const createElement = utilities.createElement;
 const safelyActivateFunction = utilities.safelyActivateFunction;
+const uniqueString = utilities.uniqueString;
 
 
 class ActivatedMenu {
   constructor($menu, config) {
-    this._config = mergeObjects({ menu: {} }, config);
+    if(!config.container_id) {
+      config.container_id = uniqueString("menu");
+    }
+
     this.$node = $menu;
+    this._config = mergeObjects({ menu: {} }, config);
     this.activator = new ActivatedMenuActivator(this, config);
     this.container = new ActivatedMenuContainer(this, config);
 
@@ -61,6 +66,7 @@ class ActivatedMenu {
   open(position) {
     ActivatedMenu.setMenuOpenPosition.call(this, position);
     this.activator.$node.addClass("active");
+    this.activator.$node.attr("aria-expanded", true);
     this.container.$node.show();
     this.$node.find(".ui-menu-item:first > :first-child").focus();
     this._state.open = true;
@@ -71,6 +77,7 @@ class ActivatedMenu {
     this._state.open = false;
     this.container.$node.hide();
     this.activator.$node.removeClass("active");
+    this.activator.$node.attr("aria-expanded", false);
 
     // Reset any externally/temporary setting of
     // component._state.position back to default.
@@ -172,10 +179,7 @@ class ActivatedMenuContainer {
   constructor(menu, config) {
     var $node = $(createElement("div", "", "ActivatedMenu_Container"));
 
-    if(config.container_id) {
-      $node.attr("id", config.container_id);
-    }
-
+    $node.attr("id", config.container_id);
     if(config.container_classname) {
       $node.addClass(config.container_classname);
     }
@@ -241,6 +245,7 @@ class ActivatedMenuActivator {
     menu.$node.before($node);
     $node.addClass("ActivatedMenu_Activator");
     $node.attr("aria-haspopup", "menu");
+    $node.attr("aria-controls", config.container_id);
 
     this.$node = $node;
     this.$node.data("instance", this);

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -8,7 +8,7 @@
 <div id="form-overview">
   <div class="container">
     <% service.pages.each do |page| %>
-      <div class="form-step" aria-label="<%= t('pages.flow.step') %>">
+      <div class="form-step" aria-label="<%= t('aria.' + page.type) %>">
 
         <%= flow_thumbnail(page, service.service_id) %>
 

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -8,7 +8,7 @@
 <div id="form-overview">
   <div class="container">
     <% service.pages.each do |page| %>
-      <div class="form-step" aria-label="<%= t('aria.' + page.type) %>">
+      <section class="form-step" aria-label="<%= t('aria.' + page.type) %>">
 
         <%= flow_thumbnail(page, service.service_id) %>
 
@@ -38,7 +38,7 @@
         </ul>
 
         <%= link_to page.url, edit_page_path(service.service_id, page.uuid), class: 'govuk-link' %>
-      </div>
+      </section>
     <% end %>
 
     <ul class="component-activated-menu govuk-navigation"

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -37,7 +37,10 @@
           </li>
         </ul>
 
-        <%= link_to page.url, edit_page_path(service.service_id, page.uuid), class: 'govuk-link' %>
+        <%= link_to edit_page_path(service.service_id, page.uuid), class: 'govuk-link' do %>
+           <span class="govuk-visually-hidden"><%= t('actions.edit') %></span>
+           <%= page.url %>
+        <% end %>
       </section>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,13 @@
 en:
+  aria:
+    flow_thumbnail: 'Form page'
+    page:
+      start: Start page
+      singlequestion: Single question page
+      multiplequestions: Multiple question page
+      checkanswers: Check your answers page
+      confirmation: Confirmation page
+      content: Content page
   default_text:
     section_heading: '[Optional section heading]'
     lede: '[Optional lede paragraph]'
@@ -61,7 +70,6 @@ en:
   pages:
     flow:
       heading: 'Pages flow'
-      step: 'Form page'
     name: 'Pages'
     create: 'Add page'
     cancel: 'Cancel'


### PR DESCRIPTION
Accessibility tweaks to text and element identifiers.

Edited note:
Changes to the text content of some elements caused Automated acceptance tests to fail. Those tests were looking for specific (link) text but no longer matched due to the inclusion of the work 'Edit'. This inclusion is dubious in terms of actually increasing accessibility but was suggested as an enhancement, without a real need to argue against. It should also be noted that the 'Edit' text itself is editable so may be improved, changed, or possibly even removed by (development/content) editor choice. 