### PR TITLE
Temporary/1736 styling edit branch page

### DIFF
--- a/app/javascript/src/controller_branches.js
+++ b/app/javascript/src/controller_branches.js
@@ -1,0 +1,41 @@
+/**
+ * Branches Controller
+ * ----------------------------------------------------
+ * Description:
+ * Adds functionality for common FB Editor pages.
+ *
+ * Documentation:
+ *
+ *     - Requires jQuery & jQueryUI
+ *       https://api.jquery.com/
+ *       https://api.jqueryui.com/
+ *
+ *     - TODO:
+ *       (steven.burnell@digital.justice.gov.uk to add).
+ *
+ **/
+
+
+
+const DefaultController = require('./controller_default');
+
+
+class BranchesController extends DefaultController {
+  constructor(app) {
+    super(app);
+
+    switch(app.page.action) {
+      case "new":
+        BranchesController.create.call(this);
+    }
+  }
+}
+
+
+/* Setup for the create (new) action
+ **/
+BranchesController.create = function() {
+  console.log("BranchesController.create is alive");
+}
+
+module.exports = BranchesController;

--- a/app/javascript/src/controller_branches.js
+++ b/app/javascript/src/controller_branches.js
@@ -28,6 +28,8 @@ class BranchesController extends DefaultController {
       case "new":
         BranchesController.create.call(this);
     }
+
+    addMattsButton(); // Dev only while branches is WIP
   }
 }
 
@@ -37,5 +39,47 @@ class BranchesController extends DefaultController {
 BranchesController.create = function() {
   console.log("BranchesController.create is alive");
 }
+
+
+/* TO BE REMOVED
+ * Only here during early stages of development
+ * for developer aid and humour value :-)
+ **/
+function addMattsButton() {
+  var $mattsButton = $("<button>Matt's button</button>");
+  $mattsButton.css({
+    "animation": "blinker 0.5s linear infinite",
+    "background-color": "red",
+    "color": "white",
+    "display": "none",
+    "font-size": "30px",
+    "font-weight": "bold",
+    "padding": "10px",
+    "position": "absolute",
+    "right": "50px",
+    "top": "200px"
+  });
+
+  $(document.body).append($mattsButton);
+  $("#form-navigation-heading").on("click", function(event) {
+    $mattsButton.toggle();
+  });
+
+  if(document.cookie.search("colours=on") == 0) {
+    $(document.body).addClass("dev-colours-on");
+  }
+
+  $mattsButton.on("click", function() {
+    if(document.cookie.search("colours=on") == 0) {
+      document.cookie = "colours=off";
+      $(document.body).removeClass("dev-colours-on");
+    }
+    else {
+      document.cookie = "colours=on";
+      $(document.body).addClass("dev-colours-on");
+    }
+  });
+}
+
 
 module.exports = BranchesController;

--- a/app/javascript/src/controller_default.js
+++ b/app/javascript/src/controller_default.js
@@ -1,7 +1,8 @@
 /**
- * Default Page
+ * Default Controller
  * ----------------------------------------------------
  * Description:
+ * Default page controller to be inherited by all specific controllers.
  * Adds standard functionality required for common FB Editor pages.
  *
  * Documentation:

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -3,6 +3,7 @@ const PagesController = require('./controller_pages');
 const ServicesController = require('./controller_services');
 const FormListPage = require('./page_form_list');
 const PublishController = require('./controller_publish');
+const BranchesController = require('./controller_branches');
 
 
 // Determine the controller we need to use
@@ -31,6 +32,10 @@ function loadPageData(app) {
 var Controller;
 
 switch(controllerAndAction()) {
+  case "BranchesController#new":
+       Controller = BranchesController;
+  break;
+
   case "ServicesController#index":
   case "ServicesController#create":
        Controller = FormListPage;

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -137,6 +137,48 @@ html {
 }
 
 
+/* Branching
+ * ------------------- */
+.bob {
+  border: 5px solid pink;
+  margin-bottom: 10px;
+  padding: 10px;
+}
+
+.branch {
+  background-color: govuk-colour("light-grey");
+  border: 5px solid lightgreen;
+  border-radius: 15px;
+  margin-bottom: 10px;
+  padding: 10px;
+}
+
+.branches {
+  @include responsive_width("two-thirds");
+
+  margin-bottom: 10px;
+  padding: 10px;
+}
+
+.destination {
+  border: 5px solid orange;
+  margin-bottom: 10px;
+  padding: 10px;
+}
+
+.expression {
+  border: 5px solid purple;
+  margin-bottom: 10px;
+  padding: 10px;
+}
+
+.statement {
+  border: 5px solid lightblue;
+  margin-bottom: 10px;
+  padding: 10px;
+}
+
+
 /* Editable components
  * ------------------- */
 .AddComponent,

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -31,16 +31,6 @@ html {
   width: 1px;
 }
 
-#editContentForm {
-  position: absolute;
-  right: 0;
-  top: 3px;
-
-  @include govuk-media-query($until: tablet) {
-    position: static;
-  }
-}
-
 #header-logo-link {
   display: inline-block;
   margin-right: govuk-spacing(2);
@@ -99,6 +89,16 @@ html {
   .name {
     display: table-cell;
     width: 75%;
+  }
+}
+
+#fb-editor-save {
+  position: absolute;
+  right: 0;
+  top: 3px;
+
+  @include govuk-media-query($until: tablet) {
+    position: static;
   }
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -149,7 +149,7 @@ html {
   background-color: govuk-colour("light-grey");
   border: 5px solid lightgreen;
   border-radius: 15px;
-  margin-bottom: 10px;
+  margin-bottom: 20px;
   padding: 10px;
 }
 
@@ -169,7 +169,7 @@ html {
 .expression {
   border: 5px solid purple;
   margin-bottom: 10px;
-  padding: 10px;
+  padding: 20px;
 }
 
 .statement {

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -157,6 +157,7 @@ html {
 .branches {
   @include responsive_width("two-thirds");
 
+  border: 5px solid red;
   margin-bottom: 10px;
   padding: 10px;
 }

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -139,6 +139,7 @@ html {
 
 /* Branching
  * ------------------- */
+.dev-colours-on {
 .bob {
   border: 5px solid pink;
   margin-bottom: 10px;
@@ -178,6 +179,12 @@ html {
   padding: 10px;
 }
 
+@keyframes blinker {
+  25% {
+    opacity: 0;
+  }
+}
+}
 
 /* Editable components
  * ------------------- */

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -7,4 +7,4 @@
   @branch.pages,
   include_blank: '--- Select a destination page ---' %>
 
-<%= f.submit t('actions.save'), class: 'editor-button govuk-button fb-govuk-button' %>
+<%= f.submit t('actions.save'), class: 'govuk-button fb-govuk-button', id: 'fb-editor-save' %>

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -1,10 +1,16 @@
 
-<%= f.hidden_field :previous_flow_uuid, value: @branch.previous_flow_uuid %>
+  <div class="branch">
+    <%= f.hidden_field :previous_flow_uuid, value: @branch.previous_flow_uuid %>
+    <%= render 'form_conditionals', f: f %>
+  </div>
 
-<%= render 'form_conditionals', f: f %>
+  <div class="destination">
+    <div class="govuk-form-group">
+      <%= f.select :default_next,
+        @branch.pages,
+        { include_blank: '--- Select a destination page ---' },
+        { class: 'govuk-select' } %>
+    </div>
+  </div>
 
-<%= f.select :default_next,
-  @branch.pages,
-  include_blank: '--- Select a destination page ---' %>
-
-<%= f.submit t('actions.save'), class: 'govuk-button fb-govuk-button', id: 'fb-editor-save' %>
+  <%= f.submit t('actions.save'), class: 'govuk-button fb-govuk-button', id: 'fb-editor-save' %>

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -1,11 +1,14 @@
 
   <div class="branch">
+    <p>Branch ...</p>
     <%= f.hidden_field :previous_flow_uuid, value: @branch.previous_flow_uuid %>
     <%= render 'form_conditionals', f: f %>
   </div>
 
   <div class="destination">
     <div class="govuk-form-group">
+      <p>Otherwise</p>
+      <%= f.label :default_next, "Go to", { class: "govuk-label" } %>
       <%= f.select :default_next,
         @branch.pages,
         { include_blank: '--- Select a destination page ---' },

--- a/app/views/branches/_form_conditionals.html.erb
+++ b/app/views/branches/_form_conditionals.html.erb
@@ -1,12 +1,17 @@
 <%= f.fields_for :conditionals, child_index: conditional_index do |conditional| %>
-  <div class="govuk-form-group <%= conditional.object.errors[:next].empty? ? '' : 'govuk-form-group--error'  %>" data-conditional-index="<%= conditional.index %>">
-    <% conditional.object.errors[:next].each do |message| %>
-      <span class="govuk-error-message"><%= message %></span>
-    <% end %>
-    <%= conditional.select :next,
-      @branch.pages,
-      include_blank: '--- Select a destination page ---' %>
+  <div class="destination">
+    <div class="govuk-form-group <%= conditional.object.errors[:next].empty? ? '' : 'govuk-form-group--error'  %>" data-conditional-index="<%= conditional.index %>">
+      <% conditional.object.errors[:next].each do |message| %>
+        <span class="govuk-error-message"><%= message %></span>
+      <% end %>
 
-    <%= render 'form_expressions', conditional: conditional %>
+      <%= conditional.label :next, "Go to", { class: "govuk-label" } %>
+      <%= conditional.select :next,
+        @branch.pages,
+        { include_blank: '--- Select a destination page ---' },
+        { class: 'govuk-select' } %>
+    </div>
   </div>
+
+  <%= render 'form_expressions', conditional: conditional %>
 <% end %>

--- a/app/views/branches/_form_expressions.html.erb
+++ b/app/views/branches/_form_expressions.html.erb
@@ -1,7 +1,13 @@
 <%= conditional.fields_for :expressions do |expression| %>
-  <div data-index-expression="<%= expression.index %>">
-    <%= expression.select :component,
-      @branch.previous_questions,
-      include_blank: '--Select a question--' %>
+  <div class="expression">
+    <div class="statement govuk-form-group" data-index-expression="<%= expression.index %>">
+      <%= expression.select :component,
+        @branch.previous_questions,
+        { include_blank: '--Select a question--' },
+        { class: 'govuk-select' } %>
+    </div>
+    <div class="bob">
+      [bob ?? goes here]
+    </div>
   </div>
 <% end %>

--- a/app/views/branches/edit.html.erb
+++ b/app/views/branches/edit.html.erb
@@ -1,5 +1,8 @@
-<h1>Branching page</h1>
+<div class="branches edit" style="border: 5px solid red">
+  <h1>Branching node 1 (what text here)</h1>
 
-<%= form_for @branch, url: branches_path(service.service_id), method: :post do |f| %>
-  <%= render 'form', f: f %>
-<% end %>
+  <%= form_for @branch, url: branches_path(service.service_id), method: :post do |f| %>
+    <%= render 'form', f: f %>
+  <% end %>
+</div>
+

--- a/app/views/branches/edit.html.erb
+++ b/app/views/branches/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="branches edit" style="border: 5px solid red">
+<div class="branches edit">
   <h1>Branching node 1 (what text here)</h1>
 
   <%= form_for @branch, url: branches_path(service.service_id), method: :post do |f| %>

--- a/app/views/branches/new.html.erb
+++ b/app/views/branches/new.html.erb
@@ -1,4 +1,4 @@
-<div class="branches new" style="border: 5px solid red">
+<div class="branches new">
   <h1>Branching node 1 (what text here)</h1>
   <p>After "<%= @branch.previous_flow_title %>"</p>
 

--- a/app/views/branches/new.html.erb
+++ b/app/views/branches/new.html.erb
@@ -1,5 +1,8 @@
-<h1>After "<%= @branch.previous_flow_title %>"</h1>
+<div class="branches new" style="border: 5px solid red">
+  <h1>Branching node 1 (what text here)</h1>
+  <p>After "<%= @branch.previous_flow_title %>"</p>
 
-<%= form_for @branch, url: branches_path(service.service_id), method: :post do |f| %>
-  <%= render 'form', f: f %>
-<% end %>
+  <%= form_for @branch, url: branches_path(service.service_id), method: :post do |f| %>
+    <%= render 'form', f: f %>
+  <% end %>
+</div>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -18,7 +18,7 @@
         <p><%= t('.callout') %></p>
       </div>
 
-      <%= button_to @sign_in_url, method: :post, class: 'editor-button govuk-button fb-govuk-button  govuk-button--start govuk-!-margin-top-2' do %>
+      <%= button_to @sign_in_url, method: :post, class: 'govuk-button fb-govuk-button  govuk-button--start govuk-!-margin-top-2' do %>
         <%= t('.sign_in') %>
         <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
           <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -17,7 +17,7 @@
     <% end %>
   <% end %>
 
-  <%= f.submit t('actions.save'), class: 'editor-button govuk-button fb-govuk-button' %>
+  <%= f.submit t('actions.save'), class: 'govuk-button fb-govuk-button', id: 'fb-editor-save' %>
 <% end %>
 
 <%= render template: @page.template %>

--- a/app/views/publish/index.html.erb
+++ b/app/views/publish/index.html.erb
@@ -29,7 +29,7 @@
         url: publish_index_path(service.service_id),
         html: { id: 'publish-form-dev', class: 'publish-form', data: { first_publish: false } }) do |f| %>
       <%= render 'form', f: f, deployment_environment: 'dev' %>
-      <%= f.submit t('actions.publish_to_test'), class: 'govuk-button editor-button fb-govuk-button' %>
+      <%= f.submit t('actions.publish_to_test'), class: 'govuk-button fb-govuk-button' %>
     <% end %>
   </dd>
 
@@ -51,7 +51,7 @@
         url: publish_index_path(service.service_id),
         html: { id: 'publish-form-live', class: 'publish-form', data: { first_publish: false } }) do |f| %>
       <%= render 'form', f: f, deployment_environment: 'production' %>
-      <%= f.submit t('actions.publish_to_live'), class: 'govuk-button editor-button fb-govuk-button' %>
+      <%= f.submit t('actions.publish_to_live'), class: 'govuk-button fb-govuk-button' %>
     <% end %>
   </dd>
 </dl>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -1,6 +1,6 @@
 <%= link_to t('actions.preview_form'),
   preview_service_path(service.service_id),
-  class: 'govuk-button editor-button fb-govuk-button fb-preview-button',
+  class: 'govuk-button fb-govuk-button fb-preview-button',
   target: '_blank' %>
 
 <h1 class="govuk-heading-xl"><%= t('pages.flow.heading') %></h1>
@@ -102,7 +102,7 @@
           <% end %>
           <%= f.text_field :page_url, class: "govuk-input"  %>
         </div>
-        <%= f.submit 'Add page', class: "editor-button govuk-button fb-govuk-button" %>
+        <%= f.submit 'Add page', class: "govuk-button fb-govuk-button" %>
       <% end %>
     </div>
 

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -33,7 +33,7 @@
             <% end %>
             <%= f.text_field :service_name, class: "govuk-input" %>
           <div>
-          <%= f.submit t('services.create'), class: "editor-button govuk-button fb-govuk-button" %>
+          <%= f.submit t('services.create'), class: "govuk-button fb-govuk-button" %>
         <% end %>
       </div>
     </div>

--- a/app/views/settings/email/index.html.erb
+++ b/app/views/settings/email/index.html.erb
@@ -26,7 +26,7 @@
 
       <%= render 'form', f: f, deployment_environment: 'dev' %>
 
-      <button type="submit" class="editor-button govuk-button fb-govuk-button" data-module="govuk-button">
+      <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
         Save
       </button>
     <% end %>
@@ -54,7 +54,7 @@
 
       <%= render 'form', f: f, deployment_environment: 'production' %>
 
-      <button type="submit" class="editor-button govuk-button fb-govuk-button" data-module="govuk-button">
+      <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
         Save
       </button>
     <% end %>

--- a/app/views/settings/form_information/index.html.erb
+++ b/app/views/settings/form_information/index.html.erb
@@ -11,6 +11,6 @@
     <% end %>
     <%= f.text_field :service_name, class: "govuk-input width-responsive-two-thirds" %>
   </div>
-  <%= f.submit t('actions.save'), class: "editor-button govuk-button fb-govuk-button" %>
+  <%= f.submit t('actions.save'), class: "govuk-button fb-govuk-button" %>
 <% end %>
 

--- a/spec/requests/api/branches_spec.rb
+++ b/spec/requests/api/branches_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Branch' do
 
       it 'returns the next conditional' do
         expect(response.body).to include(
-          'select name="branch[conditionals_attributes][2][next]"'
+          'name="branch[conditionals_attributes][2][next]"'
         )
       end
     end
@@ -30,7 +30,7 @@ RSpec.describe 'Branch' do
 
       it 'returns the next conditional' do
         expect(response.body).to include(
-          'select name="branch[conditionals_attributes][3][next]"'
+          'name="branch[conditionals_attributes][3][next]"'
         )
       end
     end


### PR DESCRIPTION
Some temporary WIP styles and basic markup to help with development.
Should leave page looking like this:
<img width="1650" alt="Screenshot 2021-07-26 at 22 37 02" src="https://user-images.githubusercontent.com/76942244/127062627-cfa9de5f-e216-4eed-8034-910ec553114a.png">


Now updated to add toggle for keeping it Secret Squirrel
![secret-squirrel](https://user-images.githubusercontent.com/76942244/127155750-c7dc537b-c462-4402-a8c4-9be02b711e79.png)


Click the heading (see below screenshot) to reveal the toggle button, which will add a cookie (and required CSS class) to control appearance of colours. Button toggle on/off setting and clicking the heading toggles button on/off - although it does not persist on page reload, unlike any set dev-only colours.

<img width="445" alt="Screenshot 2021-07-27 at 13 45 54" src="https://user-images.githubusercontent.com/76942244/127156063-2b0e92ed-fe33-4239-8177-69b9c36ba5c3.png">
