### PR TITLE
Return html for a new conditional

### DIFF
--- a/app/controllers/api/branches_controller.rb
+++ b/app/controllers/api/branches_controller.rb
@@ -1,0 +1,11 @@
+class Api::BranchesController < BranchesController
+  before_action :assign_branch, only: %i[new_conditional]
+
+  def new_conditional
+    @child_index = params[:child_index]
+    render partial: 'form_conditionals',
+           locals: {
+             f: default_form_builder.new(:branch, @branch, view_context, {})
+           }
+  end
+end

--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -1,11 +1,8 @@
 class BranchesController < FormController
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+  before_action :assign_branch, only: %i[new]
 
-  def new
-    @branch = Branch.new(branch_attributes)
-
-    @branch.conditionals << Conditional.new(expressions: [OpenStruct.new])
-  end
+  def new; end
 
   def create
     @branch = Branch.new(branch_params)
@@ -22,14 +19,32 @@ class BranchesController < FormController
     @branch = Branch.new(branch_attributes)
   end
 
+  def conditional_index
+    params[:conditional_index] ? params[:conditional_index].to_i + 1 : nil
+  end
+  helper_method :conditional_index
+
+  private
+
+  def assign_branch
+    @branch = Branch.new(branch_attributes)
+    @branch.conditionals << Conditional.new(expressions: [OpenStruct.new])
+  end
+
   def branch_attributes
     {
       service: service,
-      previous_flow_uuid: params[:previous_flow_uuid] || params.require(:branch).permit(:previous_flow_uuid)[:previous_flow_uuid]
+      previous_flow_uuid: previous_flow_uuid
     }
   end
 
   def branch_params
     params.require(:branch).permit!.merge(branch_attributes)
+  end
+
+  def previous_flow_uuid
+    params[:previous_flow_uuid] ||
+      params[:branch_previous_flow_uuid] ||
+      params.require(:branch).permit(:previous_flow_uuid)[:previous_flow_uuid]
   end
 end

--- a/app/views/branches/_form_conditionals.html.erb
+++ b/app/views/branches/_form_conditionals.html.erb
@@ -1,5 +1,5 @@
-<%= f.fields_for :conditionals do |conditional| %>
-  <div class="govuk-form-group <%= conditional.object.errors[:next].empty? ? '' : 'govuk-form-group--error'  %>" data-index-conditional="<%= conditional.index %>">
+<%= f.fields_for :conditionals, child_index: conditional_index do |conditional| %>
+  <div class="govuk-form-group <%= conditional.object.errors[:next].empty? ? '' : 'govuk-form-group--error'  %>" data-conditional-index="<%= conditional.index %>">
     <% conditional.object.errors[:next].each do |message| %>
       <span class="govuk-error-message"><%= message %></span>
     <% end %>
@@ -10,4 +10,3 @@
     <%= render 'form_expressions', conditional: conditional %>
   </div>
 <% end %>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,10 @@ Rails.application.routes.draw do
   namespace :api do
     resources :services do
       resources :pages, only: [:show]
+
+      resources :branches, param: :previous_flow_uuid do
+        get '/conditionals/:conditional_index', to: 'branches#new_conditional'
+      end
     end
   end
 

--- a/spec/requests/api/branches_spec.rb
+++ b/spec/requests/api/branches_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe 'Branch' do
+  describe 'GET /api/services/:service_id/branches/:branch_previous_flow_uuid/conditionals/:conditional_index' do
+    let(:request) do
+      get "/api/services/#{service.service_id}/branches/#{previous_flow_uuid}/conditionals/#{conditional_index}"
+    end
+    let(:previous_flow_uuid) { '68fbb180-9a2a-48f6-9da6-545e28b8d35a' }
+
+    before do
+      allow_any_instance_of(
+        Api::BranchesController
+      ).to receive(:require_user!).and_return(true)
+      allow_any_instance_of(
+        Api::BranchesController
+      ).to receive(:service).and_return(service)
+      request
+    end
+
+    context 'when there is one conditional' do
+      let(:conditional_index) { 1 }
+
+      it 'returns the next conditional' do
+        expect(response.body).to include(
+          'select name="branch[conditionals_attributes][2][next]"'
+        )
+      end
+    end
+
+    context 'when there are more than one conditional' do
+      let(:conditional_index) { 2 }
+
+      it 'returns the next conditional' do
+        expect(response.body).to include(
+          'select name="branch[conditionals_attributes][3][next]"'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the client-side JS requests a new conditional we should
return sending the right name parameter.

So let's assume that on the adding branch page there are 3 conditionals
and the user clicks "Add another rule" / "Add another conditional" (I am
not sure what is the name of the button) then the JS will request
a new conditional sending the total amount of conditionals that exists
withing the page

```
/services/123/branches/456/conditionals/3 (3 conditionals)
```

and this will return an HTML that needs to be rendered within the page.