### PR TITLE
Check standalone pages for URL uniqueness

### DIFF
--- a/acceptance/features/create_page_spec.rb
+++ b/acceptance/features/create_page_spec.rb
@@ -73,13 +73,23 @@ feature 'Create page' do
     then_I_should_see_the_edit_confirmation_page
   end
 
-  scenario 'attempt to add a page with an existing url' do
+  scenario 'attempt to add a page with an existing url in the service flow' do
     given_I_have_a_single_question_page_with_text
     and_I_edit_the_service
     given_I_add_a_single_question_page_with_text
     and_I_add_an_existing_page_url
     when_I_add_the_page
     then_I_should_see_a_validation_error_message_that_page_url_exists
+  end
+
+  scenario 'attempt to add a page with an existing url in the standalone pages' do
+    service_standalone_pages.each do |url|
+      and_I_edit_the_service
+      given_I_add_a_single_question_page_with_text
+      and_I_add_a_page_url(url)
+      when_I_add_the_page
+      then_I_should_see_a_validation_error_message_that_page_url_exists
+    end
   end
 
   def and_I_add_an_existing_page_url
@@ -176,5 +186,9 @@ feature 'Create page' do
 
   def and_I_should_see_the_save_button_disabled
     expect(editor.save_page_button).to be_disabled
+  end
+
+  def service_standalone_pages
+    service.metadata['standalone_pages'].map { |page| page['url'] }
   end
 end

--- a/app/validators/metadata_url_validator.rb
+++ b/app/validators/metadata_url_validator.rb
@@ -4,14 +4,16 @@ class MetadataUrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
 
-    metadata = record.send(options[:metadata_method])
-
-    urls = metadata['pages'].map do |page|
-      strip_url(page['url'])
-    end
-
+    urls = all_pages(record).map { |page| strip_url(page['url']) }
     if urls.include?(strip_url(value))
       record.errors.add(attribute, :taken)
     end
+  end
+
+  private
+
+  def all_pages(record)
+    metadata = record.send(options[:metadata_method])
+    metadata['pages'] + metadata['standalone_pages']
   end
 end

--- a/spec/services/page_creation_spec.rb
+++ b/spec/services/page_creation_spec.rb
@@ -91,18 +91,17 @@ RSpec.describe PageCreation, type: :model do
           end
         end
 
-        context 'when url already exists on the same metadata' do
-          it 'have errors' do
-            should_not allow_values(
-              '/',
-              'name',
-              '/name',
-              'email-address',
-              '/email-address',
-              'parent-name',
-              'confirmation',
-              'check-answers'
-            ).for(:page_url)
+        context 'when url already exists in the same metadata' do
+          let(:all_page_urls) do
+            page_urls = attributes[:latest_metadata]['pages'].map { |page| page['url'] }
+            standalone_urls = attributes[:latest_metadata]['standalone_pages'].map { |page| page['url'] }
+            page_urls + standalone_urls
+          end
+          let(:with_slash) { ['/name', '/email-address'] }
+          let(:existing_urls) { all_page_urls + with_slash }
+
+          it 'has errors' do
+            should_not allow_values(existing_urls).for(:page_url)
           end
         end
       end


### PR DESCRIPTION
We had forgotten to also check the standalone pages for URL uniqueness
when creating a new page.

In the future we also need to check any restricted URLs as well.