### PR TITLE
Prevent adding pages with reserved URLs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,7 +30,7 @@ module ApplicationHelper
   end
 
   def strip_url(url)
-    url.to_s.chomp('/').reverse.chomp('/').reverse
+    url.to_s.chomp('/').reverse.chomp('/').reverse.strip.downcase
   end
 
   # Remove once hotjar testing is complete

--- a/app/services/page_creation.rb
+++ b/app/services/page_creation.rb
@@ -1,5 +1,6 @@
 class PageCreation
   include ActiveModel::Model
+  include ApplicationHelper
   attr_accessor :page_url,
                 :page_type,
                 :component_type,
@@ -38,7 +39,7 @@ class PageCreation
   def metadata
     NewPageGenerator.new(
       page_type: page_type,
-      page_url: page_url.strip,
+      page_url: strip_url(page_url),
       component_type: component_type,
       latest_metadata: latest_metadata,
       add_page_after: add_page_after,

--- a/app/validators/metadata_url_validator.rb
+++ b/app/validators/metadata_url_validator.rb
@@ -1,12 +1,28 @@
 class MetadataUrlValidator < ActiveModel::EachValidator
   include ApplicationHelper
 
+  RESERVED = %w[
+    admin
+    dashboard
+    health
+    maintenance
+    metrics
+    ping
+    reserved
+  ].freeze
+
   def validate_each(record, attribute, value)
     return if value.blank?
 
+    clean_value = strip_url(value)
+
     urls = all_pages(record).map { |page| strip_url(page['url']) }
-    if urls.include?(strip_url(value))
+    if urls.include?(clean_value)
       record.errors.add(attribute, :taken)
+    end
+
+    if RESERVED.include?(clean_value)
+      record.errors.add(attribute, :reserved)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -203,7 +203,7 @@ en:
       models:
         page_creation:
           taken: "You already have a page with that name"
-          restricted: "That name is used for something else"
+          reserved: "That name is used for something else"
           has_space: "Your page name cannot include spaces"
           has_special_chars:  "Your page name cannot include special characters other than hyphens (-)"
         branch:

--- a/spec/services/page_creation_spec.rb
+++ b/spec/services/page_creation_spec.rb
@@ -97,9 +97,9 @@ RSpec.describe PageCreation, type: :model do
             standalone_urls = attributes[:latest_metadata]['standalone_pages'].map { |page| page['url'] }
             page_urls + standalone_urls
           end
-          let(:with_slash) { ['/name', '/email-address'] }
+          let(:invalid_urls) { ['/with-slash', 'space-at-end ', 'space in middle', '_'] }
           let(:reserved_urls) { MetadataUrlValidator::RESERVED }
-          let(:existing_urls) { all_page_urls + with_slash + reserved_urls }
+          let(:existing_urls) { all_page_urls + invalid_urls + reserved_urls }
 
           it 'has errors' do
             should_not allow_values(existing_urls).for(:page_url)

--- a/spec/services/page_creation_spec.rb
+++ b/spec/services/page_creation_spec.rb
@@ -98,7 +98,8 @@ RSpec.describe PageCreation, type: :model do
             page_urls + standalone_urls
           end
           let(:with_slash) { ['/name', '/email-address'] }
-          let(:existing_urls) { all_page_urls + with_slash }
+          let(:reserved_urls) { MetadataUrlValidator::RESERVED }
+          let(:existing_urls) { all_page_urls + with_slash + reserved_urls }
 
           it 'has errors' do
             should_not allow_values(existing_urls).for(:page_url)


### PR DESCRIPTION
## Prevent adding pages with reserved URLs

We have a couple of URLs currently which are used by the platform in
order to either check for application health or to scrape metrics.

We should prevent the user from creating a page with a URL which is in
our restricted list.

![Screenshot 2021-08-18 at 16 47 44](https://user-images.githubusercontent.com/3466862/129929832-dea3f6ae-f89c-40f6-a187-93a91f499a62.png)

## Downcase URLs when creating a new page

To lower the friction for users when creating a new page just
automatically downcase it in their behalf instead of presenting them with
another error.