### PR TITLE
Make sure API and common routes can access the service metadata

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ class ApplicationController < ActionController::Base
   end
 
   def service_metadata
-    @service_metadata ||= MetadataApiClient::Service.latest_version(params[:id])
+    @service_metadata ||= MetadataApiClient::Service.latest_version(service_id_param)
   end
 
   def user_name
@@ -48,4 +48,8 @@ class ApplicationController < ActionController::Base
     end
   end
   helper_method :user_name
+
+  def service_id_param
+    params[:service_id] || params[:id]
+  end
 end

--- a/spec/requests/api/branches_spec.rb
+++ b/spec/requests/api/branches_spec.rb
@@ -9,9 +9,12 @@ RSpec.describe 'Branch' do
       allow_any_instance_of(
         Api::BranchesController
       ).to receive(:require_user!).and_return(true)
-      allow_any_instance_of(
-        Api::BranchesController
-      ).to receive(:service).and_return(service)
+      allow(MetadataApiClient::Service).to receive(:latest_version).with(
+        service.service_id
+      )
+        .and_return(
+          metadata_fixture(:version)
+        )
       request
     end
 


### PR DESCRIPTION
The param name for the API is params[:service_id] while on the
other routes are just params[:id] so adding the conditionality
makes everything works smoothly.

I tried to change the routes to use param: :service_id, but this
breaks the whole app so I tried secondly to change the API
to be param: :id but it doesn't work for nested routes so I had
to add the or statement.