### PR TITLE
Fix incorrect syntax (which somehow wasn't breaking anything??)

### DIFF
--- a/app/javascript/src/component_activated_question_menu.js
+++ b/app/javascript/src/component_activated_question_menu.js
@@ -56,7 +56,7 @@ class QuestionMenu extends ActivatedMenu {
 
   /* Change required option state for view purpose
    **/
-  setRequiredViewState = function() {
+  setRequiredViewState() {
     if(this.question.data.validation.required) {
       $("[data-action=required]").addClass("on");
     }


### PR DESCRIPTION
Not sure why this wasn't causing some complaint in Webpack or just causing a JS syntax.
Test file against this shows all working fine with/without the change. Maybe just a fluke or bug in JS syntax.
Have now corrected, in any case.