### PR TITLE
Render edit page passing attributes to the branch form object

### DIFF
--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -43,7 +43,7 @@ class BranchesController < FormController
   private
 
   def branch_metadata
-    branch_object = service.flow_object(params[:branch_id])
+    branch_object = service.flow_object(params[:branch_uuid])
     Branch.from_metadata(branch_object)
   end
 

--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -6,9 +6,12 @@ class BranchesController < FormController
 
   def create
     @branch = Branch.new(branch_params)
-    branch_creation = BranchCreation.new(branch: @branch, latest_metadata: service_metadata)
+    branch_creation = BranchCreation.new(
+      branch: @branch,
+      latest_metadata: service_metadata
+    )
 
-    if branch_creation.create
+    if branch_creation.save
       redirect_to edit_branch_path(service.service_id, branch_creation.branch_uuid)
     else
       render :new
@@ -16,7 +19,20 @@ class BranchesController < FormController
   end
 
   def edit
-    @branch = Branch.new(branch_attributes)
+    @branch = Branch.new(
+      branch_metadata.merge(service: service, previous_flow_uuid: params[:branch_id])
+    )
+  end
+
+  def update
+    @branch = Branch.new(branch_params)
+    branch_updater = BranchUpdater.new(
+      branch: @branch,
+      latest_metadata: service_metadata
+    )
+
+    branch_updater.save
+    render :edit
   end
 
   def conditional_index
@@ -25,6 +41,11 @@ class BranchesController < FormController
   helper_method :conditional_index
 
   private
+
+  def branch_metadata
+    branch_object = service.flow_object(params[:branch_id])
+    Branch.from_metadata(branch_object)
+  end
 
   def assign_branch
     @branch = Branch.new(branch_attributes)

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -4,6 +4,32 @@ class Branch
 
   validate :conditionals_validations
 
+  def self.from_metadata(flow_object)
+    conditionals_hash = { 'conditionals_attributes' => {} }
+
+    flow_object.conditionals.each_with_index do |conditional, index|
+      conditionals_hash['conditionals_attributes'][index.to_s] = {
+        'next' => conditional.next
+      }.merge(expressions_attributes(conditional))
+    end
+
+    conditionals_hash
+  end
+
+  def self.expressions_attributes(conditional)
+    expressions_hash = { 'expressions_attributes' => {} }
+
+    conditional.expressions.each_with_index do |expression, expression_index|
+      expressions_hash['expressions_attributes'][expression_index.to_s] = {
+        'page' => expression.page,
+        'component' => expression.component,
+        'field' => expression.field
+      }
+    end
+
+    expressions_hash
+  end
+
   def conditionals_validations
     errors.add(:conditionals, 'Conditionals are not valid') if conditionals.map(&:invalid?).any?
   end

--- a/app/models/metadata_version.rb
+++ b/app/models/metadata_version.rb
@@ -1,0 +1,15 @@
+module MetadataVersion
+  def create_version
+    version = MetadataApiClient::Version.create(
+      service_id: service.service_id,
+      payload: metadata
+    )
+
+    if version.errors?
+      errors.add(:base, :invalid, message: version.errors)
+      false
+    else
+      @version = version
+    end
+  end
+end

--- a/app/services/branch_creation.rb
+++ b/app/services/branch_creation.rb
@@ -1,40 +1,10 @@
-class BranchCreation
-  include ActiveModel::Model
-  delegate :previous_flow_uuid, :version, :service, :conditionals,
-           :default_next, to: :branch
-
-  attr_accessor :branch, :latest_metadata
-
-  def create
-    return false if branch.invalid?
-
-    version = MetadataApiClient::Version.create(
-      service_id: service.service_id,
-      payload: metadata
-    )
-
-    if version.errors?
-      errors.add(:base, :invalid, message: version.errors)
-      false
-    else
-      @version = version
-    end
-  end
-
-  def branch_uuid
-    new_branch.uuid
-  end
-
-  def metadata
-    latest_metadata['flow'].merge!(new_branch.to_metadata)
+class BranchCreation < FlowBranch
+  def update_previous_page
     latest_metadata['flow'][previous_flow_uuid]['next']['default'] = branch_uuid
-    latest_metadata
   end
 
-  private
-
-  def new_branch
-    @new_branch ||= NewFlowBranchGenerator.new(
+  def flow_branch
+    @flow_branch ||= NewFlowBranchGenerator.new(
       default_next: default_next,
       conditionals: conditionals
     )

--- a/app/services/branch_updater.rb
+++ b/app/services/branch_updater.rb
@@ -1,0 +1,12 @@
+class BranchUpdater < FlowBranch
+  def flow_branch
+    existing_metadata = service.flow[previous_flow_uuid]
+    existing_metadata['next']['default'] = default_next
+    existing_metadata['next']['conditionals'] = conditionals.map(&:to_metadata)
+
+    OpenStruct.new(
+      to_metadata: { previous_flow_uuid => existing_metadata },
+      uuid: previous_flow_uuid
+    )
+  end
+end

--- a/app/services/flow_branch.rb
+++ b/app/services/flow_branch.rb
@@ -1,0 +1,29 @@
+class FlowBranch
+  include MetadataVersion
+  include ActiveModel::Model
+  delegate :previous_flow_uuid, :version, :service, :conditionals,
+           :default_next, to: :branch
+
+  attr_accessor :branch, :latest_metadata
+
+  def save
+    return false if branch.invalid?
+
+    create_version
+  end
+
+  def branch_uuid
+    flow_branch.uuid
+  end
+
+  def metadata
+    flow_branch_metadata = flow_branch.to_metadata
+    latest_metadata['flow'].merge!(flow_branch_metadata)
+    update_previous_page
+    latest_metadata
+  end
+
+  # Method signature to be implemented on the subclass if needed.
+  #
+  def update_previous_page; end
+end

--- a/app/views/branches/edit.html.erb
+++ b/app/views/branches/edit.html.erb
@@ -6,9 +6,9 @@
     Branching node 1
   </h1>
 
-
-  <%= form_for @branch, url: branches_path(service.service_id), method: :post do |f| %>
+  <%= form_for @branch,
+    url: branch_path(service.service_id, @branch.previous_flow_uuid),
+    method: :put do |f| %>
     <%= render 'form', f: f %>
   <% end %>
 </div>
-

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -95,7 +95,7 @@
         <%= f.hidden_field :page_type, value: f.object.page_type.nil? ? 'singlequestion' : f.object.page_type  %>
         <%= f.hidden_field :component_type, value: f.object.component_type.nil? ? 'text' : f.object.component_type %>
         <div class="govuk-form-group <%= !f.object.errors.empty? ? 'govuk-form-group--error' :'' %>">
-          <%= f.label :page_url, class: "govuk-label govuk-label--m" %> 
+          <%= f.label :page_url, class: "govuk-label govuk-label--m" %>
           <span class="govuk-hint"><%= t('activemodel.attributes.page_creation.page_url_hint') %></span>
           <% f.object.errors.each do |error|  %>
             <span class="govuk-error-message"><%= error.message %></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     member do
       resources :publish, only: [:index, :create]
       resources :pages, param: :page_uuid, only: [:create, :edit, :update, :destroy]
-      resources :branches, param: :branch_id, only: [:create, :edit, :update] do
+      resources :branches, param: :branch_uuid, only: [:create, :edit, :update] do
         collection do
           get '/:previous_flow_uuid/new', to: 'branches#new', as: 'new'
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,9 +18,9 @@ Rails.application.routes.draw do
     member do
       resources :publish, only: [:index, :create]
       resources :pages, param: :page_uuid, only: [:create, :edit, :update, :destroy]
-      resources :branches, param: :previous_flow_uuid, only: [:create, :edit] do
-        member do
-          get '/new', to: 'branches#new'
+      resources :branches, param: :branch_id, only: [:create, :edit, :update] do
+        collection do
+          get '/:previous_flow_uuid/new', to: 'branches#new', as: 'new'
         end
       end
 

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -16,6 +16,35 @@ RSpec.describe Branch do
     previous_flow_object.uuid
   end
 
+  describe '.from_metadata' do
+    let(:latest_metadata) { metadata_fixture(:branching) }
+    let(:service) do
+      MetadataPresenter::Service.new(latest_metadata)
+    end
+    let(:branch_id) { '09e91fd9-7a46-4840-adbc-244d545cfef7' }
+    let(:branch_metadata) { service.flow_object(branch_id) }
+    let(:expected_metadata) do
+      {
+        'conditionals_attributes' => {
+          '0' => {
+            'next' => 'e8708909-922e-4eaf-87a5-096f7a713fcb',
+            'expressions_attributes' => {
+              '0' => {
+                'page' => '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
+                'component' => 'ac41be35-914e-4b22-8683-f5477716b7d4',
+                'field' => 'c5571937-9388-4411-b5fa-34ddf9bc4ca0'
+              }
+            }
+          }
+        }
+      }
+    end
+
+    it 'serialises the branch objects metadata' do
+      expect(Branch.from_metadata(branch_metadata)).to eq(expected_metadata)
+    end
+  end
+
   describe '#conditionals_attributes=' do
     let(:attributes) do
       {

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Branch do
     let(:service) do
       MetadataPresenter::Service.new(latest_metadata)
     end
-    let(:branch_id) { '09e91fd9-7a46-4840-adbc-244d545cfef7' }
-    let(:branch_metadata) { service.flow_object(branch_id) }
+    let(:branch_uuid) { '09e91fd9-7a46-4840-adbc-244d545cfef7' }
+    let(:branch_metadata) { service.flow_object(branch_uuid) }
     let(:expected_metadata) do
       {
         'conditionals_attributes' => {


### PR DESCRIPTION
[Trello card](https://trello.com/c/vRkJTidU/1740-saving-edit-branch-page-after-editing-updating)

## Context

This PR adds the branch edit/update page.

The edit will render the form loading from the metadata and then saving by replacing the flow object with the new parameters.

