### PR TITLE
Return Expression HTML elements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,11 +10,11 @@ gem 'delayed_job_active_record'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-# gem 'metadata_presenter',
-#    github: 'ministryofjustice/fb-metadata-presenter',
-#    branch: 'feature/move-upload-to-gem'
+gem 'metadata_presenter',
+   github: 'ministryofjustice/fb-metadata-presenter',
+   branch: 'page-with-component'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.1.0'
+# gem 'metadata_presenter', '2.1.0'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile
+++ b/Gemfile
@@ -10,11 +10,11 @@ gem 'delayed_job_active_record'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-   github: 'ministryofjustice/fb-metadata-presenter',
-   branch: 'page-with-component'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'page-with-component'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '2.1.0'
+gem 'metadata_presenter', '2.1.1'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 68119ae7282cf591dea945d75be75defa178f508
-  branch: page-with-component
-  specs:
-    metadata_presenter (2.1.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (>= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 6.0.3.4, < 6.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -177,6 +166,11 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
+    metadata_presenter (2.1.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (>= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 6.0.3.4, < 6.2.0)
     method_source (1.0.0)
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
@@ -395,7 +389,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   hashie
   listen (~> 3.6)
-  metadata_presenter!
+  metadata_presenter (= 2.1.1)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.0)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 68119ae7282cf591dea945d75be75defa178f508
+  branch: page-with-component
+  specs:
+    metadata_presenter (2.1.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (>= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 6.0.3.4, < 6.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -166,11 +177,6 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    metadata_presenter (2.1.0)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (>= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 6.0.3.4, < 6.2.0)
     method_source (1.0.0)
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
@@ -389,7 +395,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   hashie
   listen (~> 3.6)
-  metadata_presenter (= 2.1.0)
+  metadata_presenter!
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.0)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/api/expressions_controller.rb
+++ b/app/controllers/api/expressions_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class ExpressionsController < BranchesController
-    rescue_from(ArgumentError) do |exception|
+    rescue_from(ArgumentError) do |_exception|
       render json: { message: 'unprocessable entity' }, status: :unprocessable_entity
     end
     before_action :validate_params
@@ -27,9 +27,7 @@ module Api
       page_with_component.find_component_by_uuid(params[:component_id])
     end
 
-    def component_type
-      component.type
-    end
+    delegate :type, to: :component, prefix: true
     helper_method :component_type
 
     def expression_name(attribute)

--- a/app/controllers/api/expressions_controller.rb
+++ b/app/controllers/api/expressions_controller.rb
@@ -1,0 +1,52 @@
+module Api
+  class ExpressionsController < BranchesController
+    rescue_from(ArgumentError) do |exception|
+      render json: { message: 'unprocessable entity' }, status: :unprocessable_entity
+    end
+    before_action :validate_params
+
+    def show
+      @expression = Expression.new(
+        component: params[:component_id],
+        page: page_with_component
+      )
+
+      render partial: 'expression_answers',
+             locals: {
+               f: default_form_builder.new(:expression, @expression, view_context, {}),
+               conditional_index: params[:conditional_index],
+               expression_index: params[:expression_index]
+             }
+    end
+
+    def page_with_component
+      @page_with_component ||= service.page_with_component(params[:component_id])
+    end
+
+    def component
+      page_with_component.find_component_by_uuid(params[:component_id])
+    end
+
+    def component_type
+      component.type
+    end
+    helper_method :component_type
+
+    def expression_name(attribute)
+      "branch[conditionals_attributes][#{params[:conditional_index]}]" \
+      "[expressions_attributes][#{params[:expression_index]}][#{attribute}]"
+    end
+    helper_method :expression_name
+
+    def expression_id(attribute)
+      "branch_conditionals_attributes_#{params[:conditional_index]}_" \
+      "expressions_attributes_#{params[:expression_index]}_#{attribute}"
+    end
+    helper_method :expression_id
+
+    def validate_params
+      Integer(params[:conditional_index]) &&
+        Integer(params[:expression_index])
+    end
+  end
+end

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -40,7 +40,7 @@ class Branch
 
   def conditionals_attributes=(hash)
     hash.each do |_index, conditional_hash|
-      conditionals.push(Conditional.new(conditional_hash))
+      conditionals.push(Conditional.new(conditional_hash.merge(service: service)))
     end
   end
 

--- a/app/models/conditional.rb
+++ b/app/models/conditional.rb
@@ -34,7 +34,7 @@ class Conditional
       expressions.push(
         Expression.new(
           expression_hash.merge(
-            page: service.page_with_component(expression_hash["component"])
+            page: service.page_with_component(expression_hash['component'])
           )
         )
       )

--- a/app/models/conditional.rb
+++ b/app/models/conditional.rb
@@ -1,12 +1,17 @@
 class Conditional
   include ActiveModel::Model
-  attr_accessor :next
+  attr_accessor :next, :service
   attr_writer :expressions
 
   validates :next, presence: true
 
   IF = 'if'.freeze
   AND = 'and'.freeze
+
+  def initialize(attributes)
+    @service = attributes.delete(:service)
+    super
+  end
 
   def to_metadata
     {
@@ -26,7 +31,13 @@ class Conditional
 
   def expressions_attributes=(hash)
     hash.each do |_index, expression_hash|
-      expressions.push(Expression.new(expression_hash))
+      expressions.push(
+        Expression.new(
+          expression_hash.merge(
+            page: service.page_with_component(expression_hash["component"])
+          )
+        )
+      )
     end
   end
 

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -3,7 +3,7 @@ class Expression
   attr_accessor :component, :operator, :field, :page
 
   OPERATORS = [
-    %w[is is],
+    ['is', 'is'], # rubocop:disable Style/WordArray
     ['is not', 'is_not'],
     ['is answered', 'is_answered'],
     ['is not answered', 'is_not_answered']

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -2,10 +2,17 @@ class Expression
   include ActiveModel::Model
   attr_accessor :component, :operator, :field, :page
 
+  OPERATORS = [
+    ['is', 'is'],
+    ['is not', 'is_not'],
+    ['is answered', 'is_answered'],
+    ['is not answered', 'is_not_answered']
+  ].freeze
+
   def to_metadata
     {
       'operator' => operator,
-      'page' => page,
+      'page' => page.uuid,
       'component' => component,
       'field' => field
     }
@@ -13,5 +20,15 @@ class Expression
 
   def ==(other)
     component == other.component
+  end
+
+  def answers
+    component_obj = page.find_component_by_uuid(component)
+    items = component_obj.items
+    items.map { |item| [item.label, item.uuid] }
+  end
+
+  def operators
+    OPERATORS
   end
 end

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -3,7 +3,7 @@ class Expression
   attr_accessor :component, :operator, :field, :page
 
   OPERATORS = [
-    ['is', 'is'],
+    %w[is is],
     ['is not', 'is_not'],
     ['is answered', 'is_answered'],
     ['is not answered', 'is_not_answered']

--- a/app/views/branches/_expression_answers.html.erb
+++ b/app/views/branches/_expression_answers.html.erb
@@ -1,0 +1,16 @@
+<div class="" data-expression-index="<%= expression_index %>" data-component-type="<%= component_type %>">
+  <%= f.select :operators, @expression.operators,
+    { include_blank: false },
+    {
+      class: 'govuk-select',
+      name: expression_name('operator'),
+      id: expression_id('operator')
+    }  %>
+  <%= f.select :answers, @expression.answers,
+    { include_blank: false },
+    {
+      class: 'govuk-select',
+      name: expression_name('answer'),
+      id: expression_id('answer')
+    } %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,8 @@ Rails.application.routes.draw do
       resources :branches, param: :previous_flow_uuid do
         get '/conditionals/:conditional_index', to: 'branches#new_conditional'
       end
+
+      get '/components/:component_id/conditionals/:conditional_index/expressions/:expression_index', to: 'expressions#show'
     end
   end
 

--- a/spec/generators/new_flow_branch_generator_spec.rb
+++ b/spec/generators/new_flow_branch_generator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe NewFlowBranchGenerator do
     let(:expression) do
       {
         operator: 'is',
-        page: 'expression-page-uuid',
+        page: double(uuid: 'expression-page-uuid'),
         component: 'component-uuid',
         field: 'field-uuid'
       }

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -58,13 +58,17 @@ RSpec.describe Branch do
         }
       }
     end
-    let(:conditional) do
+    let(:expected_conditional) do
       object = Conditional.new(
-        'next' => '3bbf86fc-701f-4cb6-8083-12404b293da0'
+        'next' => '3bbf86fc-701f-4cb6-8083-12404b293da0',
+        'service' => service
       )
       object.tap do
         object.expressions.push(
-          Expression.new('component' => 'd1c04d9e-877f-4219-a96f-e21dde925f4b')
+          Expression.new(
+            'component' => 'd1c04d9e-877f-4219-a96f-e21dde925f4b',
+            'page' => double(uuid: 'some-page-uuid')
+          )
         )
       end
     end
@@ -72,7 +76,7 @@ RSpec.describe Branch do
     it 'assigns conditionals' do
       expect(branch.conditionals).to eq(
         [
-          conditional
+          expected_conditional
         ]
       )
     end

--- a/spec/models/conditional_spec.rb
+++ b/spec/models/conditional_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Conditional do
           {
             'operator' => 'is',
             'component' => '67890',
-            'page' => 'some=page-uuid',
+            'page' => double(uuid: 'some-page-uuid'),
             'field' => 'some-field-uuid'
           }
         )
       ]
-    }
+    }.merge(service: service)
   end
   let(:expected_conditional) do
     {
@@ -25,7 +25,7 @@ RSpec.describe Conditional do
         {
           'operator' => 'is',
           'component' => '67890',
-          'page' => 'some=page-uuid',
+          'page' => 'some-page-uuid',
           'field' => 'some-field-uuid'
         }
       ]
@@ -42,13 +42,38 @@ RSpec.describe Conditional do
     context 'with multiple expressions' do
       before do
         conditional_hash['expressions'].push(
-          Expression.new('component' => '0987')
+          Expression.new('component' => '0987', 'page' => double(uuid: 'some-page-uuid'))
         )
       end
 
       it 'returns and as the condition type' do
         expect(conditional.to_metadata['_type']).to eq('and')
       end
+    end
+  end
+
+  describe '#expressions' do
+    let(:page) { service.find_page_by_url('do-you-like-star-wars') }
+    let(:component) { page.components.first }
+    let(:conditional_hash) do
+      {
+        'next' => '12345',
+        'expressions' => [expression]
+      }.merge(service: service)
+    end
+    let(:expression) do
+      Expression.new(
+        {
+          'operator' => 'is',
+          'component' => component.uuid,
+          'page' => page,
+          'field' => 'some-field-id'
+        }
+      )
+    end
+
+    it 'returns an array of expressions' do
+      expect(conditional.expressions).to eq([expression])
     end
   end
 end

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -2,26 +2,61 @@ RSpec.describe Expression do
   subject(:expression) do
     described_class.new(expression_hash)
   end
-  let(:expression_hash) do
-    {
-      'operator': 'is',
-      'page': 'some-page-uuid',
-      'component': 'some-component-uuid',
-      'field': 'some-field-uuid'
-    }
-  end
-  let(:expected_expression) do
-    {
-      'operator' => 'is',
-      'page' => 'some-page-uuid',
-      'component' => 'some-component-uuid',
-      'field' => 'some-field-uuid'
-    }
-  end
 
   describe '#to_metadata' do
+    let(:expression_hash) do
+      {
+        'operator': 'is',
+        'page': double(uuid: 'some-page-uuid'),
+        'component': 'some-component-uuid',
+        'field': 'some-field-uuid'
+      }
+    end
+    let(:expected_expression) do
+      {
+        'operator' => 'is',
+        'page' => 'some-page-uuid',
+        'component' => 'some-component-uuid',
+        'field' => 'some-field-uuid'
+      }
+    end
+
     it 'returns the correct structure' do
       expect(expression.to_metadata).to eq(expected_expression)
+    end
+  end
+
+  describe '#answers' do
+    let(:metadata) { metadata_fixture(:branching) }
+    let(:service) { MetadataPresenter::Service.new(metadata) }
+    let(:page) { service.find_page_by_url('do-you-like-star-wars') }
+
+    let(:expression_hash) do
+      {
+        'operator': 'is',
+        'page': page,
+        'component': page.components.first.uuid,
+        'field': ''
+      }
+    end
+    let(:answers) do
+      [
+        ['Only on weekends', 'c5571937-9388-4411-b5fa-34ddf9bc4ca0'],
+        ['Hell no!', '67160ff1-6f7c-43a8-8bf6-49b3d5f450f6']
+      ]
+    end
+
+    it 'returns a list of answers' do
+      expect(expression.answers).to eq(answers)
+    end
+  end
+
+  describe '#operators' do
+    let(:expression_hash) { {} }
+    let(:expected_operators) { Expression::OPERATORS }
+
+    it 'returns all the operators' do
+      expect(expression.operators).to eq(expected_operators)
     end
   end
 end

--- a/spec/requests/api/expressions_spec.rb
+++ b/spec/requests/api/expressions_spec.rb
@@ -7,31 +7,30 @@ RSpec.describe 'Expressions spec', type: :request do
     end
 
     context 'when authenticated' do
-      let(:page){ service.find_page_by_url('do-you-like-star-wars') }
+      let(:page) { service.find_page_by_url('do-you-like-star-wars') }
       let(:component_id) { page.components.first.uuid }
       let(:conditionals_index) { 0 }
       let(:expressions_index) { 1 }
       let(:expected_operators) do
         [
-          "<option value=\"is\">is</option>",
-          "<option value=\"is_not\">is not</option>",
-          "<option value=\"is_answered\">is answered</option>",
-          "<option value=\"is_not_answered\">is not answered</option>"
+          '<option value="is">is</option>',
+          '<option value="is_not">is not</option>',
+          '<option value="is_answered">is answered</option>',
+          '<option value="is_not_answered">is not answered</option>'
         ]
       end
       let(:expected_answers) do
         [
-          "<option value=\"c5571937-9388-4411-b5fa-34ddf9bc4ca0\">Only on weekends</option>",
-          "<option value=\"67160ff1-6f7c-43a8-8bf6-49b3d5f450f6\">Hell no!</option></select>"
+          '<option value="c5571937-9388-4411-b5fa-34ddf9bc4ca0">Only on weekends</option>',
+          '<option value="67160ff1-6f7c-43a8-8bf6-49b3d5f450f6">Hell no!</option></select>'
         ]
       end
       let(:expected_expression_index) do
-        "data-expression-index=\"1\""
+        'data-expression-index="1"'
       end
       let(:expected_conditional_index) do
-        "branch[conditionals_attributes][0]"
+        'branch[conditionals_attributes][0]'
       end
-
 
       before do
         allow_any_instance_of(
@@ -74,4 +73,3 @@ RSpec.describe 'Expressions spec', type: :request do
     end
   end
 end
-

--- a/spec/requests/api/expressions_spec.rb
+++ b/spec/requests/api/expressions_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe 'Expressions spec', type: :request do
+  describe 'GET /components/:component_id/conditionals/:conditionals_index/expressions/:expressions_index' do
+    let(:request) do
+      get "/api/services/#{service.service_id}/components/#{component_id}/conditionals/#{conditionals_index}/expressions/#{expressions_index}"
+    end
+
+    context 'when authenticated' do
+      let(:page){ service.find_page_by_url('do-you-like-star-wars') }
+      let(:component_id) { page.components.first.uuid }
+      let(:conditionals_index) { 0 }
+      let(:expressions_index) { 1 }
+      let(:expected_operators) do
+        [
+          "<option value=\"is\">is</option>",
+          "<option value=\"is_not\">is not</option>",
+          "<option value=\"is_answered\">is answered</option>",
+          "<option value=\"is_not_answered\">is not answered</option>"
+        ]
+      end
+      let(:expected_answers) do
+        [
+          "<option value=\"c5571937-9388-4411-b5fa-34ddf9bc4ca0\">Only on weekends</option>",
+          "<option value=\"67160ff1-6f7c-43a8-8bf6-49b3d5f450f6\">Hell no!</option></select>"
+        ]
+      end
+      let(:expected_expression_index) do
+        "data-expression-index=\"1\""
+      end
+      let(:expected_conditional_index) do
+        "branch[conditionals_attributes][0]"
+      end
+
+
+      before do
+        allow_any_instance_of(
+          Api::ExpressionsController
+        ).to receive(:require_user!).and_return(true)
+
+        allow_any_instance_of(
+          Api::ExpressionsController
+        ).to receive(:service).and_return(service)
+
+        request
+      end
+
+      it 'returns all the operators' do
+        expected_operators.each do |operator|
+          expect(response.body).to include(operator)
+        end
+      end
+
+      it 'returns all the answers' do
+        expected_answers.each do |answer|
+          expect(response.body).to include(answer)
+        end
+      end
+
+      it 'returns the correct expressions index' do
+        expect(response.body).to include(expected_expression_index)
+      end
+
+      it 'returns the correct conditional index' do
+        expect(response.body).to include(expected_conditional_index)
+      end
+
+      context 'when the api request is incorrect' do
+        let(:conditionals_index) { 'hello' }
+        it 'returns a 422 unprocessable entity error' do
+          expect(response.status).to be(422)
+        end
+      end
+    end
+  end
+end
+

--- a/spec/services/branch_creation_spec.rb
+++ b/spec/services/branch_creation_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe BranchCreation, type: :model do
       }
     end
     let(:component_uuid) { 'some-component-uuid' }
-    let(:page_uuid) { 'another-page-uuid'}
+    let(:page_uuid) { 'another-page-uuid' }
 
     before do
       allow_any_instance_of(MetadataPresenter::Service)

--- a/spec/services/branch_creation_spec.rb
+++ b/spec/services/branch_creation_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe BranchCreation, type: :model do
           'expressions_attributes' => {
             '0' => {
               'operator' => 'is',
-              'page' => 'another-page-uuid',
-              'component' => 'some-component-uuid',
+              'page' => page_uuid,
+              'component' => component_uuid,
               'field' => 'some-field-uuid'
             }
           }
@@ -59,6 +59,15 @@ RSpec.describe BranchCreation, type: :model do
         default_next: default_next
       }
     end
+    let(:component_uuid) { 'some-component-uuid' }
+    let(:page_uuid) { 'another-page-uuid'}
+
+    before do
+      allow_any_instance_of(MetadataPresenter::Service)
+        .to receive(:page_with_component)
+        .with(component_uuid)
+        .and_return(double(uuid: page_uuid))
+    end
 
     context 'when metadata is valid' do
       let(:valid) { true }
@@ -71,8 +80,8 @@ RSpec.describe BranchCreation, type: :model do
             'expressions' => [
               {
                 'operator' => 'is',
-                'page' => 'another-page-uuid',
-                'component' => 'some-component-uuid',
+                'page' => page_uuid,
+                'component' => component_uuid,
                 'field' => 'some-field-uuid'
               }
             ]

--- a/spec/services/branch_updater_spec.rb
+++ b/spec/services/branch_updater_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe BranchUpdater, type: :model do
       }
     end
 
+    let(:component_uuid) { 'some-component-uuid' }
+    let(:page_uuid) { 'another-page-uuid' }
+
+    before do
+      allow_any_instance_of(MetadataPresenter::Service)
+        .to receive(:page_with_component)
+        .with(component_uuid)
+        .and_return(double(uuid: page_uuid))
+    end
+
     context 'when metadata is valid' do
       let(:valid) { true }
       let(:flow_object) { branch_updater.metadata['flow'][previous_flow_uuid] }
@@ -55,8 +65,8 @@ RSpec.describe BranchUpdater, type: :model do
             'expressions' => [
               {
                 'operator' => 'is',
-                'page' => 'another-page-uuid',
-                'component' => 'some-component-uuid',
+                'page' => page_uuid,
+                'component' => component_uuid,
                 'field' => 'some-field-uuid'
               }
             ]


### PR DESCRIPTION
[Trello card](https://trello.com/c/HBC7iR7g/1729-backend-api-to-return-expression-html-elements)

### Return API Expression HTML elements 
Returns the HTML snippets for the operator and the answers for a particular expression.
We pass the Page object through so the Expression class has access to it.
Error handling has been included, a 422 is produced when the endpoint is hit incorrectly.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>

### Use MetadataPresenter gem 2.1.1