### PR TITLE
Revert "Build(deps): Bump faraday_middleware from 1.0.0 to 1.1.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    faraday_middleware (1.1.0)
+    faraday_middleware (1.0.0)
       faraday (~> 1.0)
     fb-jwt-auth (0.7.0)
       activesupport


### PR DESCRIPTION
Reverts ministryofjustice/fb-editor#612

seems to be breaking the acceptance tests for some reason. revert until we can investigate