### PR TITLE
Render edit branch page

### DIFF
--- a/app/controllers/api/expressions_controller.rb
+++ b/app/controllers/api/expressions_controller.rb
@@ -14,33 +14,15 @@ module Api
       render partial: 'expression_answers',
              locals: {
                f: default_form_builder.new(:expression, @expression, view_context, {}),
+               expression: @expression,
                conditional_index: params[:conditional_index],
                expression_index: params[:expression_index]
              }
     end
 
     def page_with_component
-      @page_with_component ||= service.page_with_component(params[:component_id])
+      service.page_with_component(params[:component_id])
     end
-
-    def component
-      page_with_component.find_component_by_uuid(params[:component_id])
-    end
-
-    delegate :type, to: :component, prefix: true
-    helper_method :component_type
-
-    def expression_name(attribute)
-      "branch[conditionals_attributes][#{params[:conditional_index]}]" \
-      "[expressions_attributes][#{params[:expression_index]}][#{attribute}]"
-    end
-    helper_method :expression_name
-
-    def expression_id(attribute)
-      "branch_conditionals_attributes_#{params[:conditional_index]}_" \
-      "expressions_attributes_#{params[:expression_index]}_#{attribute}"
-    end
-    helper_method :expression_id
 
     def validate_params
       Integer(params[:conditional_index]) &&

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -80,7 +80,9 @@ class Branch
       service,
       {},
       previous_flow_object
-    ).all.push(previous_flow_object)
+    ).all
+     .uniq
+     .push(previous_flow_object)
   end
 
   private

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -25,12 +25,30 @@ class Expression
   end
 
   def answers
-    component_obj = page.find_component_by_uuid(component)
-    items = component_obj.items
-    items.map { |item| [item.label, item.uuid] }
+    component_object.items.map { |item| [item.label, item.uuid] }
   end
 
   def operators
     OPERATORS
+  end
+
+  def component_type
+    component_object.type
+  end
+
+  def name_attr(conditional_index:, expression_index:, attribute:)
+    "branch[conditionals_attributes][#{conditional_index}]" \
+    "[expressions_attributes][#{expression_index}][#{attribute}]"
+  end
+
+  def id_attr(conditional_index:, expression_index:, attribute:)
+    "branch_conditionals_attributes_#{conditional_index}_" \
+    "expressions_attributes_#{expression_index}_#{attribute}"
+  end
+
+  private
+
+  def component_object
+    @component_object ||= page.find_component_by_uuid(component)
   end
 end

--- a/app/views/branches/_expression_answers.html.erb
+++ b/app/views/branches/_expression_answers.html.erb
@@ -1,16 +1,35 @@
-<div class="" data-expression-index="<%= expression_index %>" data-component-type="<%= component_type %>">
-  <%= f.select :operators, @expression.operators,
+<div class="answer" data-expression-index="<%= expression_index %>" data-component-type="<%= expression.component_type %>">
+  <%= f.select :operators, expression.operators,
     { include_blank: false },
     {
       class: 'govuk-select',
-      name: expression_name('operator'),
-      id: expression_id('operator')
-    }  %>
-  <%= f.select :answers, @expression.answers,
+      name: expression.name_attr(
+        conditional_index: conditional_index,
+        expression_index: expression_index,
+        attribute: 'operator'
+      ),
+      id: expression.id_attr(
+        conditional_index: conditional_index,
+        expression_index: expression_index,
+        attribute: 'operator'
+      )
+    }
+  %>
+
+  <%= f.select :answers, expression.answers,
     { include_blank: false },
     {
       class: 'govuk-select',
-      name: expression_name('answer'),
-      id: expression_id('answer')
-    } %>
+      name: expression.name_attr(
+        conditional_index: conditional_index,
+        expression_index: expression_index,
+        attribute: 'answer'
+      ),
+      id: expression.id_attr(
+        conditional_index: conditional_index,
+        expression_index: expression_index,
+        attribute: 'answer'
+      )
+    }
+  %>
 </div>

--- a/app/views/branches/_form_expressions.html.erb
+++ b/app/views/branches/_form_expressions.html.erb
@@ -19,5 +19,17 @@
         }
       %>
     </div>
+
+    <%# When creating a new conditional object the component will not have been chosen yet %>
+    <% if expression.object.component.present? %>
+        <%= render partial: 'expression_answers',
+                  locals: {
+                    f: default_form_builder.new(:expression, expression.object, self, {}),
+                    expression: expression.object,
+                    conditional_index: conditional.index,
+                    expression_index: expression.index
+                  }
+        %>
+    <% end %>
   </div>
 <% end %>

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe Expression do
   subject(:expression) do
     described_class.new(expression_hash)
   end
+  let(:expression_hash) { {} }
 
   describe '#to_metadata' do
     let(:expression_hash) do
@@ -52,11 +53,59 @@ RSpec.describe Expression do
   end
 
   describe '#operators' do
-    let(:expression_hash) { {} }
     let(:expected_operators) { Expression::OPERATORS }
 
     it 'returns all the operators' do
       expect(expression.operators).to eq(expected_operators)
+    end
+  end
+
+  describe '#component_type' do
+    let(:page) { service.find_page_by_url('star-wars-knowledge') }
+    let(:component) { page.components.find { |component| component.type == 'radios' } }
+    let(:expression_hash) do
+      {
+        'operator': 'is',
+        'page': page,
+        'component': component.uuid,
+        'field': 'some-field-uuid'
+      }
+    end
+
+    it 'returns the the type of the component' do
+      expect(expression.component_type).to eq('radios')
+    end
+  end
+
+  describe '#name_attr' do
+    let(:expected_name) do
+      'branch[conditionals_attributes][1][expressions_attributes][0][answer]'
+    end
+
+    it 'constucts the correct name attribute' do
+      expect(
+        expression.name_attr(
+          conditional_index: 1,
+          expression_index: 0,
+          attribute: 'answer'
+        )
+      ).to eq(expected_name)
+    end
+  end
+
+  describe '#id_attr' do
+    let(:expected_id) do
+      'branch_conditionals_attributes_0_expressions_attributes_1_operator'
+    end
+
+    it 'constructs the correct id attribute' do
+      expect(
+        expression.id_attr(
+          conditional_index: 0,
+          expression_index: 1,
+          attribute: 'operator'
+        )
+      ).to eq(expected_id)
     end
   end
 end


### PR DESCRIPTION
## Render Edit Branch page

This changes the expression answers template to allow for the rendering
of the branch edit page after the branch has been saved or the user is
directly visiting the edit page.

When a user creates a new branch it is necessary to show part of the
expression, specifically the list of previous questions that can be
chosen. However the answers and operators list should not be chosen.

When hitting the edit page we can just iterate over the answers as
normal but on the new page we have no answers to iterate over as the
user has yet to pick one.

## Only return unique previous page objects

Currently the TraversedPages object in the presenter will just go and
find the next page object from the service flow regardless of how many
branch objects may or may not be pointing to it.

For the moment strip the duplicates out of the Branch object. We will
make changes to the TraversedPages object in the future to stop this
from happening.