### PR TITLE
Display dynamic error summary

### DIFF
--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -86,13 +86,26 @@ class Branch
   end
 
   def previous_pages
-    MetadataPresenter::TraversedPages.new(
-      service,
-      {},
-      previous_flow_object
-    ).all
-     .uniq
-     .push(previous_flow_object)
+    service.pages
+  end
+
+  def any_errors?
+    errors.present? || conditional_errors? ||
+      expression_errors?
+  end
+
+  def conditional_errors?
+    conditionals.any? do |conditional|
+      conditional.errors.messages.present?
+    end
+  end
+
+  def expression_errors?
+    conditionals.map do |conditional|
+      conditional.expressions.any? do |expression|
+        expression.errors.messages.present?
+      end
+    end
   end
 
   private

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -50,7 +50,7 @@ class Branch
   end
 
   def conditionals_validations
-    errors.add(:conditionals, 'Conditionals are not valid') if conditionals.map(&:invalid?).any?
+    conditionals.map(&:invalid?)
   end
 
   def conditionals

--- a/app/models/conditional.rb
+++ b/app/models/conditional.rb
@@ -4,7 +4,7 @@ class Conditional
   attr_writer :expressions
 
   validates :next, presence: true
-  validate :conditional_expressions
+  validate :expressions_validations
 
   IF = 'if'.freeze
   AND = 'and'.freeze
@@ -42,8 +42,8 @@ class Conditional
     end
   end
 
-  def conditional_expressions
-    errors.add(:component, 'Expressions are not valid') if expressions.map(&:invalid?).any?
+  def expressions_validations
+    expressions.map(&:invalid?)
   end
 
   private

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -2,7 +2,7 @@ class Expression
   include ActiveModel::Model
   attr_accessor :component, :operator, :field, :page
 
-  validates :component, :operator, :field, presence: true
+  validates :component, :operator, :page, :field, presence: true
 
   OPERATORS = [
     ['is', 'is'], # rubocop:disable Style/WordArray
@@ -14,7 +14,7 @@ class Expression
   def to_metadata
     {
       'operator' => operator,
-      'page' => page.uuid,
+      'page' => page&.uuid,
       'component' => component,
       'field' => field
     }

--- a/app/views/branches/_error_summary.html.erb
+++ b/app/views/branches/_error_summary.html.erb
@@ -1,4 +1,4 @@
-<% if @branch.errors.present? %>
+<% if @branch.any_errors? %>
   <div class="govuk-grid-column-two-thirds govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
       There is a problem

--- a/app/views/branches/_error_summary.html.erb
+++ b/app/views/branches/_error_summary.html.erb
@@ -1,0 +1,38 @@
+<% if @branch.errors.present? %>
+  <div class="govuk-grid-column-two-thirds govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+       <ul class="govuk-list govuk-error-summary__list">
+        <% @branch.conditionals.each_with_index do |conditional, conditional_index| %>
+          <% conditional.errors.each do |error| %>
+            <li class="govuk-error-message">
+              <a href="#branch_conditionals_attributes_<%= conditional_index %>_<%= error.attribute %>"><%= error.message %></a>
+            </li>
+          <% end %>
+          <% conditional.expressions.each_with_index do |expression, expression_index| %>
+            <% expression.errors.each do |error| %>
+              <% if error.attribute == :component %>
+                <li class="govuk-error-message">
+                  <a href="#<%= expression.id_attr(
+                      conditional_index: conditional_index,
+                      expression_index: expression_index,
+                      attribute: error.attribute
+                    ) %>">
+                    <%= error.message %>
+                  </a>
+                </li>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+        <% @branch.errors.each do |error| %>
+          <li class="govuk-error-message">
+            <a href="#branch_<%= error.attribute %>"><%= error.message %></a>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/views/branches/edit.html.erb
+++ b/app/views/branches/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: 'error_summary' %>
+
 <div class="branches edit">
   <h1 class="govuk-heading-xl">
   <h1 class="fb-editable govuk-heading-xl"

--- a/app/views/branches/new.html.erb
+++ b/app/views/branches/new.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: 'error_summary' %>
+
 <div class="branches new">
   <h1 class="fb-editable govuk-heading-xl"
       data-fb-content-id="page[heading]"

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe Branch do
       end
 
       it 'does not accept blank conditionals' do
-        expect(branch.errors[:conditionals]).to be_present
+        expect(branch.conditionals_validations).to be_present
       end
 
       it 'adds error to conditionals object' do

--- a/spec/models/conditional_spec.rb
+++ b/spec/models/conditional_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Conditional do
       end
 
       it 'does not accept blank component expressions' do
-        expect(conditional.errors[:component]).to be_present
+        expect(conditional.expressions_validations).to be_present
       end
 
       it 'adds an error to the expression object' do


### PR DESCRIPTION
[Trello card](https://trello.com/c/bDWzozGP/1818-displaying-dynamic-error-summary-at-the-top-of-the-branch-edit-page)

Adds validations to the new and edit branches templates.

I've also renamed the method `conditional_expressions` to `expressions_validations` to make it more in line with the `conditionals_validations` naming as they both function in the same way just on different objects. 

### Preview
<img width="775" alt="Screenshot 2021-08-11 at 11 07 10" src="https://user-images.githubusercontent.com/29227502/129011297-57e53dad-16d8-4cb2-be7e-90475abbadac.png">

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>