### PR TITLE
Show previous questions on Edit Branch page

### DIFF
--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -3,6 +3,7 @@ class Branch
   include BranchTitleGenerator
   attr_accessor :previous_flow_uuid, :service, :default_next
   attr_writer :title
+  attr_reader :traversable
 
   delegate :branches, to: :service
 
@@ -11,6 +12,7 @@ class Branch
 
   def initialize(attributes)
     @service = attributes.delete(:service)
+    @traversable = Traversable.new(service: service, flow_uuid: previous_flow_uuid)
     super
   end
 
@@ -68,7 +70,7 @@ class Branch
   end
 
   def previous_questions
-    results = question_pages.map do |page|
+    results = traversable.question_pages.map do |page|
       page.input_components.map do |component|
         [
           component.humanised_title,
@@ -85,21 +87,7 @@ class Branch
     previous_flow_object.title
   end
 
-  def previous_pages
-    MetadataPresenter::TraversedPages.new(
-      service,
-      {},
-      previous_flow_object
-    ).all
-     .uniq
-     .push(previous_flow_object)
-  end
-
   private
-
-  def question_pages
-    previous_pages.select(&:question_page?)
-  end
 
   def previous_flow_object
     service.find_page_by_uuid(previous_flow_uuid) ||

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -1,0 +1,35 @@
+class Route
+  attr_reader :service, :traverse_from
+  attr_accessor :page_uuids, :routes
+
+  def initialize(service:, traverse_from:)
+    @service = service
+    @traverse_from = traverse_from
+    @routes = []
+    @page_uuids = []
+  end
+
+  def traverse
+    @flow_uuid = traverse_from
+
+    until @flow_uuid.blank?
+      flow_object = service.flow_object(@flow_uuid)
+
+      if flow_object.branch?
+        destination_uuids(flow_object).each do |uuid|
+          @routes.push(Route.new(service: service, traverse_from: uuid))
+        end
+        break
+      else
+        @page_uuids.push(@flow_uuid) unless @page_uuids.include?(@flow_uuid)
+        @flow_uuid = flow_object.default_next
+      end
+    end
+  end
+
+  private
+
+  def destination_uuids(flow_object)
+    flow_object.conditionals.map(&:next).push(flow_object.default_next)
+  end
+end

--- a/app/models/traversable.rb
+++ b/app/models/traversable.rb
@@ -1,0 +1,38 @@
+class Traversable
+  attr_reader :service, :flow_uuid
+
+  def initialize(service:, flow_uuid:)
+    @service = service
+    @flow_uuid = flow_uuid
+    @page_uuids = []
+    @routes = []
+  end
+
+  def question_pages
+    previous_pages.select(&:question_page?)
+  end
+
+  private
+
+  def previous_pages
+    service.pages.reject do |page|
+      next if page.uuid == flow_uuid
+
+      following_pages_uuids.include?(page.uuid)
+    end
+  end
+
+  def following_pages_uuids
+    @following_pages_uuids ||= begin
+      @routes.push(Route.new(service: service, traverse_from: flow_uuid))
+      until @routes.empty?
+        route = @routes.shift
+        route.traverse
+        @page_uuids |= route.page_uuids
+        @routes |= route.routes
+      end
+
+      @page_uuids
+    end
+  end
+end

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -212,13 +212,6 @@ RSpec.describe Branch do
     end
   end
 
-  describe '#previous_pages' do
-    it 'returns all previously visited pages including the previous flow object' do
-      expected_pages = service.pages[0..service.pages.index(previous_flow_object)]
-      expect(branch.previous_pages).to eq(expected_pages)
-    end
-  end
-
   describe '#validations' do
     before do
       branch.valid?

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe Route do
+  subject(:route) do
+    described_class.new(service: service, traverse_from: traverse_from)
+  end
+
+  before do
+    route.traverse
+  end
+
+  describe '#traverse' do
+    let(:metadata) { metadata_fixture(:branching) }
+    let(:service) { MetadataPresenter::Service.new(metadata) }
+
+    context 'when traversing from the start' do
+      let(:traverse_from) { service.start_page.uuid }
+      let(:potential_routes) do
+        # total number of all conditional next's and the default_next
+        # for the first branch that is found
+        2
+      end
+      let(:expected_uuids) do
+        [
+          'cf6dc32f-502c-4215-8c27-1151a45735bb', # includes the start page
+          '9e1ba77f-f1e5-42f4-b090-437aa9af7f73',
+          '68fbb180-9a2a-48f6-9da6-545e28b8d35a'
+        ]
+      end
+
+      it 'should return the page uuids for all traversed pages' do
+        expect(route.page_uuids).to eq(expected_uuids)
+      end
+
+      it 'should return a route object for each possible conditional next' do
+        expect(route.routes.size).to eq(potential_routes)
+      end
+    end
+
+    context 'when traversing from the middle' do
+      let(:traverse_from) { service.find_page_by_url('favourite-fruit').uuid }
+      let(:potential_routes) { 3 }
+      let(:expected_uuids) { %w[0b297048-aa4d-49b6-ac74-18e069118185] }
+
+      it 'should return the page uuids for all traversed pages' do
+        expect(route.page_uuids).to eq(expected_uuids)
+      end
+
+      it 'should return a route object for each possible conditional next' do
+        expect(route.routes.size).to eq(potential_routes)
+      end
+    end
+  end
+end

--- a/spec/models/traversable_spec.rb
+++ b/spec/models/traversable_spec.rb
@@ -1,0 +1,101 @@
+RSpec.describe Traversable do
+  subject(:traversable) do
+    described_class.new(service: service, flow_uuid: flow_uuid)
+  end
+
+  def traversable_urls
+    traversable.question_pages.map(&:url)
+  end
+
+  describe '#question_pages' do
+    context 'simple flow with no branching' do
+      let(:metadata) { metadata_fixture(:version) }
+      let(:service) { MetadataPresenter::Service.new(metadata) }
+
+      context 'adding a branch at the end of the flow' do
+        let(:flow_uuid) { service.pages[-3].uuid } # page before check answers
+        let(:expected_urls) do
+          %w[
+            name
+            email-address
+            parent-name
+            your-age
+            family-hobbies
+            do-you-like-star-wars
+            holiday
+            burgers
+            star-wars-knowledge
+            dog-picture
+          ]
+        end
+
+        it 'returns only traversable question pages' do
+          expect(traversable_urls).to eq(expected_urls)
+        end
+      end
+
+      context 'adding a branch in the middle of the flow' do
+        let(:flow_uuid) { service.pages[3].uuid }
+        let(:expected_urls) { %w[name email-address parent-name] }
+
+        it 'returns only traversable question pages' do
+          expect(traversable_urls).to eq(expected_urls)
+        end
+      end
+
+      context 'adding a branch when there are no previous question pages' do
+        let(:flow_uuid) { service.start_page.uuid }
+
+        it 'does not return any question pages' do
+          expect(traversable_urls).to be_empty
+        end
+      end
+    end
+
+    context 'simple branching flow' do
+      let(:metadata) { metadata_fixture(:branching) }
+      let(:service) { MetadataPresenter::Service.new(metadata) }
+
+      context 'adding a branch at the end of the flow' do
+        let(:flow_uuid) { service.pages[-3].uuid } # page before check answers
+        let(:expected_urls) do
+          %w[name
+             do-you-like-star-wars
+             star-wars-knowledge
+             favourite-fruit
+             apple-juice
+             orange-juice
+             favourite-band
+             music-app
+             best-formbuilder
+             which-formbuilder
+             burgers
+             marvel-series
+             best-arnold-quote]
+        end
+
+        it 'returns only traversable question pages' do
+          expect(traversable_urls).to eq(expected_urls)
+        end
+      end
+
+      context 'adding a branch in the middle of the flow' do
+        let(:flow_uuid) { service.pages[8].uuid } # music-app (currently)
+        let(:expected_urls) do
+          %w[name
+             do-you-like-star-wars
+             star-wars-knowledge
+             favourite-fruit
+             apple-juice
+             orange-juice
+             favourite-band
+             music-app]
+        end
+
+        it 'returns only traversable question pages' do
+          expect(traversable_urls).to eq(expected_urls)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/branch_creation_spec.rb
+++ b/spec/services/branch_creation_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe BranchCreation, type: :model do
     before do
       allow(NewFlowBranchGenerator).to receive(:new).and_return(new_flow_branch_generator)
     end
-    let(:attributes) { {} }
+    let(:attributes) { { service: service } }
 
     it 'should return the uuid of the new flow branch object' do
       expect(branch_creation.branch_uuid).to eq(uuid)


### PR DESCRIPTION
This is the basis for returning the question pages that are previous to
the point where a user is trying to add a branch.

Functionally the app will traverse all possible routes in a flow _after_
the point where the branch is being added, collate all the service pages
and then filter those pages out before returning the remainder.

It will just return only pages that are of the single or multiple questions
type.

Currently this approach will return any question page which is
conceptually before the point in the flow the branch is being added.
This does include pages which would not technically be reachable should
a user of the form answer in such a way that they bypass the branch.

## Example

<img width="791" alt="Screenshot 2021-08-13 at 14 09 15" src="https://user-images.githubusercontent.com/3466862/129361776-1a7faa5c-2c17-44dc-8124-861bb427d39f.png">

In the example above this particular service flow, contrived as it may be, has a minimum of 3 potential routes that an end user might take. The route the yellow path takes will make the user visit the two orange pages which theoretically they would not be able to reach should the branch be added where the red diamond is. However, conceptually those pages are still _previous_ in the flow so we will still return them and present them as choosable questions on the Edit Branch page.

This is an ongoing discussion, but for now this is the approach that we have agreed.

Co-authored-by Tomas Destefi <tomas.destefi@digital.justice.gov.uk>