### PR TITLE
Save the field property on expression when we create branches

### DIFF
--- a/app/views/branches/_expression_answers.html.erb
+++ b/app/views/branches/_expression_answers.html.erb
@@ -23,12 +23,12 @@
       name: expression.name_attr(
         conditional_index: conditional_index,
         expression_index: expression_index,
-        attribute: 'answer'
+        attribute: 'field'
       ),
       id: expression.id_attr(
         conditional_index: conditional_index,
         expression_index: expression_index,
-        attribute: 'answer'
+        attribute: 'field'
       )
     }
   %>


### PR DESCRIPTION
## Context

The name of the property is called "field" in the expression model so we should save with the same name.

This fixes the saving of the branch page.