### PR TITLE
Fix branch title when on the edit page

### DIFF
--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -23,7 +23,8 @@ class Branch
   def self.from_metadata(flow_object)
     attributes_hash = {
       'default_next' => flow_object['next']['default'],
-      'conditionals_attributes' => {}
+      'conditionals_attributes' => {},
+      'title' => flow_object['title']
     }
 
     flow_object.conditionals.each_with_index do |conditional, index|

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe Branch do
     let(:branch_metadata) { service.flow_object(branch_uuid) }
     let(:expected_metadata) do
       {
+        'title' => branch_metadata['title'],
         'default_next' => '0b297048-aa4d-49b6-ac74-18e069118185',
         'conditionals_attributes' => {
           '0' => {


### PR DESCRIPTION
## Context

When on the edit page we are using the `from_metadata` method to load the branch object so we need to pass the title as well otherwise the title would be wrong.