### PR TITLE
Display dynamic error summary

### DIFF
--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -53,7 +53,7 @@ class Branch
   end
 
   def conditionals_validations
-    errors.add(:conditionals, 'Conditionals are not valid') if conditionals.map(&:invalid?).any?
+    conditionals.map(&:invalid?)
   end
 
   def conditionals
@@ -86,6 +86,29 @@ class Branch
 
   def previous_flow_title
     previous_flow_object.title
+  end
+
+  def previous_pages
+    service.pages
+  end
+
+  def any_errors?
+    conditional_errors? ||
+      expression_errors? ||
+      errors.present?
+  end
+
+  def conditional_errors?
+    conditionals.any? do |conditional|
+      conditional.errors.messages.present?
+    end
+  end
+
+  def expression_errors?
+    expression_collection = conditionals.map(&:expressions)
+    expression_collection.flatten.any? do |expression|
+      expression.errors.messages.present?
+    end
   end
 
   private

--- a/app/models/conditional.rb
+++ b/app/models/conditional.rb
@@ -4,7 +4,7 @@ class Conditional
   attr_writer :expressions
 
   validates :next, presence: true
-  validate :conditional_expressions
+  validate :expressions_validations
 
   IF = 'if'.freeze
   AND = 'and'.freeze
@@ -42,8 +42,8 @@ class Conditional
     end
   end
 
-  def conditional_expressions
-    errors.add(:component, 'Expressions are not valid') if expressions.map(&:invalid?).any?
+  def expressions_validations
+    expressions.map(&:invalid?)
   end
 
   private

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -2,7 +2,7 @@ class Expression
   include ActiveModel::Model
   attr_accessor :component, :operator, :field, :page
 
-  validates :component, :operator, :field, presence: true
+  validates :component, :operator, :page, :field, presence: true
 
   OPERATORS = [
     ['is', 'is'], # rubocop:disable Style/WordArray
@@ -14,7 +14,7 @@ class Expression
   def to_metadata
     {
       'operator' => operator,
-      'page' => page.uuid,
+      'page' => page&.uuid,
       'component' => component,
       'field' => field
     }

--- a/app/services/flow_branch.rb
+++ b/app/services/flow_branch.rb
@@ -7,7 +7,7 @@ class FlowBranch
   attr_accessor :branch, :latest_metadata
 
   def save
-    return false if branch.invalid?
+    return false if branch.invalid? || branch.any_errors?
 
     create_version
   end

--- a/app/views/branches/_error_summary.html.erb
+++ b/app/views/branches/_error_summary.html.erb
@@ -1,0 +1,38 @@
+<% if @branch.any_errors? %>
+  <div class="govuk-grid-column-two-thirds govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+       <ul class="govuk-list govuk-error-summary__list">
+        <% @branch.conditionals.each_with_index do |conditional, conditional_index| %>
+          <% conditional.errors.each do |error| %>
+            <li class="govuk-error-message">
+              <a href="#branch_conditionals_attributes_<%= conditional_index %>_<%= error.attribute %>"><%= error.message + (conditional_index + 1).to_s %></a>
+            </li>
+          <% end %>
+          <% conditional.expressions.each_with_index do |expression, expression_index| %>
+            <% expression.errors.each do |error| %>
+              <% if error.attribute == :component %>
+                <li class="govuk-error-message">
+                  <a href="#<%= expression.id_attr(
+                      conditional_index: conditional_index,
+                      expression_index: expression_index,
+                      attribute: error.attribute
+                    ) %>">
+                    <%= error.message + (conditional_index + 1).to_s %>
+                  </a>
+                </li>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+        <% @branch.errors.each do |error| %>
+          <li class="govuk-error-message">
+            <a href="#branch_<%= error.attribute %>"><%= error.message %></a>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/views/branches/_form_conditionals.html.erb
+++ b/app/views/branches/_form_conditionals.html.erb
@@ -4,7 +4,7 @@
     <div class="destination">
       <div class="govuk-form-group <%= conditional.object.errors[:next].empty? ? '' : 'govuk-form-group--error' %>">
         <% conditional.object.errors[:next].each do |message| %>
-          <span class="govuk-error-message"><%= message %></span>
+          <span class="govuk-error-message"><%= message + (conditional.index + 1).to_s %></span>
         <% end %>
 
         <%= conditional.label :next, t('branches.goto'), { class: "govuk-label" } %>

--- a/app/views/branches/_form_expressions.html.erb
+++ b/app/views/branches/_form_expressions.html.erb
@@ -5,7 +5,7 @@
       <%= expression.label :component, (expression.index == 0 ? t('branches.expression.if') : t('branches.expression.and')), { class: "govuk-label" } %>
 
       <% expression.object.errors[:component].each do |message| %>
-        <span class="govuk-error-message"><%= message %></span>
+        <span class="govuk-error-message"><%= message + (conditional.index + 1).to_s %></span>
       <% end %>
 
       <%= expression.select :component,

--- a/app/views/branches/edit.html.erb
+++ b/app/views/branches/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: 'error_summary' %>
+
 <div class="branches edit">
   <h1 class="govuk-heading-xl">
   <h1 class="fb-editable govuk-heading-xl"

--- a/app/views/branches/new.html.erb
+++ b/app/views/branches/new.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: 'error_summary' %>
+
 <div class="branches new">
   <h1 class="fb-editable govuk-heading-xl"
       data-fb-content-id="page[heading]"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -199,10 +199,6 @@ en:
         password: 'Set password'
       branch:
         default_next: Otherwise
-      conditional:
-        next: Go to
-      expression:
-        component: Question
     errors:
       models:
         page_creation:
@@ -210,6 +206,12 @@ en:
           restricted: "That name is used for something else"
           has_space: "Your page name cannot include spaces"
           has_special_chars:  "Your page name cannot include special characters other than hyphens (-)"
+        branch:
+          blank: "Select a destination for '%{attribute}'"
+        conditional:
+          blank: "Select a destination for Branch "
+        expression:
+          blank: "Select a question for the condition for Branch "
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."
         too_short: "Your answer for ‘%{attribute}’ is too short (%{count} characters at least)"

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe Branch do
       end
 
       it 'does not accept blank conditionals' do
-        expect(branch.errors[:conditionals]).to be_present
+        expect(branch.conditionals_validations).to be_present
       end
 
       it 'adds error to conditionals object' do

--- a/spec/models/conditional_spec.rb
+++ b/spec/models/conditional_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Conditional do
       end
 
       it 'does not accept blank component expressions' do
-        expect(conditional.errors[:component]).to be_present
+        expect(conditional.expressions_validations).to be_present
       end
 
       it 'adds an error to the expression object' do


### PR DESCRIPTION
[Trello](https://trello.com/c/8kKFMwlr/1808-displaying-error-messages-and-or-summary-on-branch-edit-page)

### Adds validations to the new and edit branches templates.
We check errors at each layer (ie: branch, conditional, expression) and surface errors in the respective views if triggered.

<img width="865" alt="Screenshot 2021-08-13 at 18 24 20" src="https://user-images.githubusercontent.com/29227502/129551582-e54d8fe1-eb32-4f21-b955-40752bfaca80.png">

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>