### PR TITLE
Update Branch terminology in UI

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,7 +27,7 @@ en:
     service_email_body: 'Please find attached a submission sent from %{service_name}'
     service_email_pdf_heading: 'Submission for %{service_name}'
     service_email_pdf_subheading: ''
-    branching_title: 'Branching node %{branching_number}'
+    branching_title: 'Branching point %{branching_number}'
   dialogs:
     button_cancel: 'Cancel'
     button_delete: 'Delete'

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -41,35 +41,35 @@ RSpec.describe Branch do
       let(:branches) { [] }
 
       it 'returns title' do
-        expect(branch.title).to eq('Branching node 1')
+        expect(branch.title).to eq('Branching point 1')
       end
     end
 
     context 'when branches size met' do
       let(:branches) do
         [
-          double(title: 'Branching node 1'),
-          double(title: 'Branching node 2'),
-          double(title: 'Branching node 3')
+          double(title: 'Branching point 1'),
+          double(title: 'Branching point 2'),
+          double(title: 'Branching point 3')
         ]
       end
 
       it 'returns next branching title' do
-        expect(branch.title).to eq('Branching node 4')
+        expect(branch.title).to eq('Branching point 4')
       end
     end
 
     context 'when branches were deleted before' do
       let(:branches) do
         [
-          double(title: 'Branching node 1'),
-          double(title: 'Branching node 3'),
-          double(title: 'Branching node 4')
+          double(title: 'Branching point 1'),
+          double(title: 'Branching point 3'),
+          double(title: 'Branching point 4')
         ]
       end
 
       it 'returns next branching title' do
-        expect(branch.title).to eq('Branching node 5')
+        expect(branch.title).to eq('Branching point 5')
       end
     end
   end

--- a/spec/services/branch_creation_spec.rb
+++ b/spec/services/branch_creation_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe BranchCreation, type: :model do
       end
 
       it 'updates the service flow with the title' do
-        expect(flow_object['title']).to eq('Branching node 8')
+        expect(flow_object['title']).to eq('Branching point 8')
       end
 
       it 'updates previous page adding the branch as default next' do


### PR DESCRIPTION
After the recent work around the branching terminology `Branching node`
is now called `Branching point`