### PR TITLE
Add https to service link on the publish page

### DIFF
--- a/app/presenters/publish_service_presenter.rb
+++ b/app/presenters/publish_service_presenter.rb
@@ -11,8 +11,8 @@ class PublishServicePresenter
     )
 
     if publish_service.present?
-      host = new(publish_service, view: view).hostname
-      view.link_to host, "https://#{host}", target: '_blank', class: 'govuk-link', rel: 'noopener'
+      host = "https://#{new(publish_service, view: view).hostname}"
+      view.link_to host, host, target: '_blank', class: 'govuk-link', rel: 'noopener'
     end
   end
 

--- a/spec/presenters/publish_service_presenter_spec.rb
+++ b/spec/presenters/publish_service_presenter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PublishServicePresenter do
 
     let(:params) { { id: service.service_id } }
     let(:expected_hostname) do
-      %(<a target=\"_blank\" class=\"govuk-link\" rel=\"noopener\" href=\"https://version-fixture.dev.test.form.service.justice.gov.uk\">version-fixture.dev.test.form.service.justice.gov.uk</a>)
+      %(<a target=\"_blank\" class=\"govuk-link\" rel=\"noopener\" href=\"https://version-fixture.dev.test.form.service.justice.gov.uk\">https://version-fixture.dev.test.form.service.justice.gov.uk</a>)
     end
 
     before do


### PR DESCRIPTION
[Trello card](https://trello.com/c/a9lVZd66/1838-bug-add-https-when-displaying-published-form-link-bug-backlog-priority-order-20)

## Context

The published link doesn't include 'https://' which can cause issues for users who manually copy paste the link into a browser (as that won't work without the https)

