### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     tty: true
     stdin_open: true
     ports:
-      - 9090:3000
+      - 3000:3000
     environment:
       RAILS_ENV: development
       DATABASE_URL: "postgres://postgres:password@editor-db/editor_local"


### PR DESCRIPTION
The docker file `/docker/web/Dockerfile` currently exposes port 3000 rather than 9090 so making this match means you can run `docker-compose build` and `docker-compose up` from a fresh clone without needing other changes.