### PR TITLE
Acceptance tests for errors on branching page

### DIFF
--- a/acceptance/features/branching_error_summaries.spec.rb
+++ b/acceptance/features/branching_error_summaries.spec.rb
@@ -72,15 +72,56 @@ feature 'Branching errors' do
 
     when_I_save_my_changes
     then_I_should_see_an_error_summary
-    then_I_should_see_all_error_summary_errors(
-      'ul.govuk-error-summary__list',
-      3
-    )
+    then_I_should_see_error_summary_errors(3)
     then_I_should_see_all_branching_error_messages
   end
 
-  # scenario 'when the branch field is not filled in' do
-  # end
+  scenario 'when the "Go to" field is not filled in' do
+    given_I_add_all_pages_for_a_form_with_branching
+    and_I_return_to_flow_page
+    and_I_want_to_add_branching
+
+    and_I_select_the_condition_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_expressions_attributes_0_component',
+      5
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][component]',
+      'What is your favourite hobby?'
+    )
+    then_I_should_see_statement_answers
+
+    and_I_select_the_operator_dropdown
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][operator]',
+      'is'
+    )
+
+    and_I_select_the_field_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_expressions_attributes_0_field',
+      2
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][field]',
+      'Hiking'
+    )
+
+    and_I_select_the_otherwise_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_default_next',
+      8
+    )
+    and_I_choose_an_option(
+      'branch[default_next]',
+      'Which flavours of ice cream have you eaten?'
+    )
+
+    when_I_save_my_changes
+    then_I_should_see_error_summary_errors(1)
+    then_I_should_see_error_for_go_to_destination('Select a destination for Branch 1')
+  end
 
   # scenario 'when the conditional field is not filled in' do
   # end
@@ -100,12 +141,16 @@ feature 'Branching errors' do
     expect(page).to have_selector('.govuk-error-summary')
   end
 
-  def then_I_should_see_all_error_summary_errors(selector, count)
-    expect(find(selector)).to have_selector('li', count: count)
+  def then_I_should_see_error_summary_errors(count)
+    expect(find('ul.govuk-error-summary__list')).to have_selector('li', count: count)
   end
 
   def then_I_should_see_no_errors
     expect(page).not_to have_selector('.govuk-error-summary')
+  end
+
+  def then_I_should_see_error_for_go_to_destination(text)
+    expect(page).to have_selector('.govuk-form-group--error', text: text)
   end
 
   # Branching options / selections

--- a/acceptance/features/branching_error_summaries.spec.rb
+++ b/acceptance/features/branching_error_summaries.spec.rb
@@ -123,11 +123,53 @@ feature 'Branching errors' do
     then_I_should_see_branching_error_message('Select a destination for Branch 1')
   end
 
-  # scenario 'when the conditional field is not filled in' do
-  # end
+  scenario 'when the Otherwise/default next field is not filled in' do
+    given_I_add_all_pages_for_a_form_with_branching
+    and_I_return_to_flow_page
+    and_I_want_to_add_branching
 
-  # scenario 'when the expression field is not filled in' do
-  # end
+    and_I_select_the_destination_page_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_next',
+      8
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][next]',
+      'Favourite hiking destination'
+    )
+
+    and_I_select_the_condition_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_expressions_attributes_0_component',
+      5
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][component]',
+      'What is your favourite hobby?'
+    )
+    then_I_should_see_statement_answers
+
+    and_I_select_the_operator_dropdown
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][operator]',
+      'is'
+    )
+
+    and_I_select_the_field_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_expressions_attributes_0_field',
+      2
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][field]',
+      'Hiking'
+    )
+
+    when_I_save_my_changes
+    then_I_should_see_an_error_summary
+    then_I_should_see_error_summary_errors(1)
+    then_I_should_see_branching_error_message("Select a destination for 'Otherwise'")
+  end
 
   scenario 'when there are two branch objects' do
     given_I_add_all_pages_for_a_form_with_branching

--- a/acceptance/features/branching_error_summaries.spec.rb
+++ b/acceptance/features/branching_error_summaries.spec.rb
@@ -73,7 +73,9 @@ feature 'Branching errors' do
     when_I_save_my_changes
     then_I_should_see_an_error_summary
     then_I_should_see_error_summary_errors(3)
-    then_I_should_see_all_branching_error_messages
+    then_I_should_see_branching_error_message('Select a destination for Branch 1')
+    then_I_should_see_branching_error_message('Select a question for the condition for Branch 1')
+    then_I_should_see_branching_error_message("Select a destination for 'Otherwise'")
   end
 
   scenario 'when the "Go to" field is not filled in' do
@@ -119,6 +121,7 @@ feature 'Branching errors' do
     )
 
     when_I_save_my_changes
+    then_I_should_see_an_error_summary
     then_I_should_see_error_summary_errors(1)
     then_I_should_see_branching_error_message('Select a destination for Branch 1')
   end
@@ -227,16 +230,13 @@ feature 'Branching errors' do
     )
 
     when_I_save_my_changes
+    then_I_should_see_an_error_summary
     then_I_should_see_error_summary_errors(2)
     then_I_should_see_branching_error_message('Select a destination for Branch 2')
     then_I_should_see_branching_error_message('Select a question for the condition for Branch 2')
   end
 
   # Errors
-  def then_I_should_see_all_branching_error_messages
-    expect(page).to have_selector('.govuk-form-group--error', count: 3)
-  end
-
   def then_I_should_see_an_error_summary
     expect(page).to have_selector('.govuk-error-summary')
   end

--- a/acceptance/features/branching_error_summaries.spec.rb
+++ b/acceptance/features/branching_error_summaries.spec.rb
@@ -91,6 +91,7 @@ feature 'Branching errors' do
   # scenario 'when there are two branch objects' do
   # end
 
+  # Errors
   def then_I_should_see_all_branching_error_messages
     expect(page).to have_selector('.govuk-form-group--error', count: 3)
   end
@@ -107,8 +108,18 @@ feature 'Branching errors' do
     expect(page).not_to have_selector('.govuk-error-summary')
   end
 
-  def and_I_select_the_otherwise_dropdown
-    editor.otherwise_options.click
+  # Branching options / selections
+  def and_I_select_the_destination_page_dropdown
+    editor.destination_options.click
+  end
+
+  def and_I_select_the_condition_dropdown
+    editor.conditional_options.click
+  end
+
+  def then_I_should_see_statement_answers
+    expect(editor).to have_operator_options
+    expect(editor).to have_field_options
   end
 
   def and_I_select_the_field_dropdown
@@ -119,25 +130,8 @@ feature 'Branching errors' do
     editor.operator_options.click
   end
 
-  def then_I_should_see_statement_answers
-    expect(page).to have_selector(
-      '#branch_conditionals_attributes_0_expressions_attributes_0_operator'
-    )
-    expect(page).to have_selector(
-      '#branch_conditionals_attributes_0_expressions_attributes_0_field'
-    )
-  end
-
-  def and_I_select_the_condition_dropdown
-    editor.conditional_options.click
-  end
-
-  def and_I_choose_an_option(name, option)
-    select(option, from: name)
-  end
-
-  def and_I_select_the_destination_page_dropdown
-    editor.destination_options.click
+  def and_I_select_the_otherwise_dropdown
+    editor.otherwise_options.click
   end
 
   def then_I_should_see_the_correct_number_of_options(id, amount)
@@ -145,13 +139,11 @@ feature 'Branching errors' do
     expect(options.length).to eq(amount)
   end
 
-  def and_I_want_to_add_branching
-    editor.preview_page_images[1].hover # favourite-hobby page
-    editor.three_dots_button.click
-    editor.branching_link.click
-    then_I_should_see_the_branching_page
+  def and_I_choose_an_option(name, option)
+    select(option, from: name)
   end
 
+  # Branching page set up
   def given_I_add_all_pages_for_a_form_with_branching
     given_I_add_a_single_question_page_with_radio
     and_I_add_a_page_url('favourite-hobby')
@@ -189,10 +181,6 @@ feature 'Branching errors' do
     when_I_add_the_page
   end
 
-  def then_I_should_see_the_branching_page
-    expect(editor.question_heading.first.text).to eq('Branching point 1')
-  end
-
   def when_I_update_the_question_name(question_name)
     editor.question_heading.first.set(question_name)
     when_I_save_my_changes
@@ -204,5 +192,16 @@ feature 'Branching errors' do
     editor.editable_options.last.set(item[1])
     editor.service_name.click
     when_I_save_my_changes
+  end
+
+  def and_I_want_to_add_branching
+    editor.preview_page_images[1].hover # favourite-hobby page
+    editor.three_dots_button.click
+    editor.branching_link.click
+    then_I_should_see_the_branching_page
+  end
+
+  def then_I_should_see_the_branching_page
+    expect(editor.question_heading.first.text).to eq('Branching point 1')
   end
 end

--- a/acceptance/features/branching_error_summaries.spec.rb
+++ b/acceptance/features/branching_error_summaries.spec.rb
@@ -62,11 +62,22 @@ feature 'Branching errors' do
     )
 
     when_I_save_my_changes
-    there_should_be_no_errors
+    then_I_should_see_no_errors
   end
 
-  # scenario 'when no required fields are filled in' do
-  # end
+  scenario 'when no required fields are filled in' do
+    given_I_add_all_pages_for_a_form_with_branching
+    and_I_return_to_flow_page
+    and_I_want_to_add_branching
+
+    when_I_save_my_changes
+    then_I_should_see_an_error_summary
+    then_I_should_see_all_error_summary_errors(
+      'ul.govuk-error-summary__list',
+      3
+    )
+    then_I_should_see_all_branching_error_messages
+  end
 
   # scenario 'when the branch field is not filled in' do
   # end
@@ -80,7 +91,19 @@ feature 'Branching errors' do
   # scenario 'when there are two branch objects' do
   # end
 
-  def there_should_be_no_errors
+  def then_I_should_see_all_branching_error_messages
+    expect(page).to have_selector('.govuk-form-group--error', count: 3)
+  end
+
+  def then_I_should_see_an_error_summary
+    expect(page).to have_selector('.govuk-error-summary')
+  end
+
+  def then_I_should_see_all_error_summary_errors(selector, count)
+    expect(find(selector)).to have_selector('li', count: count)
+  end
+
+  def then_I_should_see_no_errors
     expect(page).not_to have_selector('.govuk-error-summary')
   end
 

--- a/acceptance/features/branching_error_summaries.spec.rb
+++ b/acceptance/features/branching_error_summaries.spec.rb
@@ -1,0 +1,185 @@
+require_relative '../spec_helper'
+
+feature 'Branching errors' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'when all required fields are filled in' do
+    given_I_add_all_pages_for_a_form_with_branching
+    and_I_return_to_flow_page
+    and_I_want_to_add_branching
+
+    and_I_select_the_destination_page_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_next',
+      8
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][next]',
+      'Favourite hiking destination'
+    )
+
+    and_I_select_the_condition_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_expressions_attributes_0_component',
+      5
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][component]',
+      'What is your favourite hobby?'
+    )
+    then_I_should_see_statement_answers
+
+    and_I_select_the_operator_dropdown
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][operator]',
+      'is'
+    )
+
+    and_I_select_the_field_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_expressions_attributes_0_field',
+      2
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][field]',
+      'Hiking'
+    )
+
+    and_I_select_the_otherwise_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_default_next',
+      8
+    )
+    and_I_choose_an_option(
+      'branch[default_next]',
+      'Which flavours of ice cream have you eaten?'
+    )
+
+    when_I_save_my_changes
+    there_should_be_no_errors
+  end
+
+  # scenario 'when no required fields are filled in' do
+  # end
+
+  # scenario 'when the branch field is not filled in' do
+  # end
+
+  # scenario 'when the conditional field is not filled in' do
+  # end
+
+  # scenario 'when the expression field is not filled in' do
+  # end
+
+  # scenario 'when there are two branch objects' do
+  # end
+
+  def there_should_be_no_errors
+    expect(page).not_to have_selector('.govuk-error-summary')
+  end
+
+  def and_I_select_the_otherwise_dropdown
+    editor.otherwise_options.click
+  end
+
+  def and_I_select_the_field_dropdown
+    editor.field_options.click
+  end
+
+  def and_I_select_the_operator_dropdown
+    editor.operator_options.click
+  end
+
+  def then_I_should_see_statement_answers
+    expect(page).to have_selector(
+      '#branch_conditionals_attributes_0_expressions_attributes_0_operator'
+    )
+    expect(page).to have_selector(
+      '#branch_conditionals_attributes_0_expressions_attributes_0_field'
+    )
+  end
+
+  def and_I_select_the_condition_dropdown
+    editor.conditional_options.click
+  end
+
+  def and_I_choose_an_option(name, option)
+    select(option, from: name)
+  end
+
+  def and_I_select_the_destination_page_dropdown
+    editor.destination_options.click
+  end
+
+  def then_I_should_see_the_correct_number_of_options(id, amount)
+    options = find(id).all('option')
+    expect(options.length).to eq(amount)
+  end
+
+  def and_I_want_to_add_branching
+    editor.preview_page_images[1].hover # favourite-hobby page
+    editor.three_dots_button.click
+    editor.branching_link.click
+    then_I_should_see_the_branching_page
+  end
+
+  def given_I_add_all_pages_for_a_form_with_branching
+    given_I_add_a_single_question_page_with_radio
+    and_I_add_a_page_url('favourite-hobby')
+    when_I_add_the_page
+    when_I_update_the_question_name('What is your favourite hobby?')
+    and_I_edit_the_option_items('Hiking', 'Sewing')
+    and_I_return_to_flow_page
+
+    given_I_add_a_single_question_page_with_checkboxes
+    and_I_add_a_page_url('ice-cream')
+    when_I_add_the_page
+    when_I_update_the_question_name('Which flavours of ice cream have you eaten?')
+    and_I_edit_the_option_items('Hokey Pokey', 'Chocolate')
+    and_I_return_to_flow_page
+
+    given_I_add_a_single_question_page_with_text
+    and_I_add_a_page_url('hiking')
+    when_I_add_the_page
+    when_I_update_the_question_name('Favourite hiking destination')
+    and_I_return_to_flow_page
+
+    given_I_add_a_single_question_page_with_text
+    and_I_add_a_page_url('sewing')
+    when_I_add_the_page
+    when_I_update_the_question_name('Favourite sewing project')
+    and_I_return_to_flow_page
+
+    given_I_add_a_check_answers_page
+    and_I_add_a_page_url('cya')
+    when_I_add_the_page
+    and_I_return_to_flow_page
+
+    given_I_add_a_confirmation_page
+    and_I_add_a_page_url('confirmation')
+    when_I_add_the_page
+  end
+
+  def then_I_should_see_the_branching_page
+    expect(editor.question_heading.first.text).to eq('Branching point 1')
+  end
+
+  def when_I_update_the_question_name(question_name)
+    editor.question_heading.first.set(question_name)
+    when_I_save_my_changes
+  end
+
+  def and_I_edit_the_option_items(*item)
+    editor.editable_options.first.set(item[0])
+    editor.service_name.click
+    editor.editable_options.last.set(item[1])
+    editor.service_name.click
+    when_I_save_my_changes
+  end
+end

--- a/acceptance/features/branching_error_summaries.spec.rb
+++ b/acceptance/features/branching_error_summaries.spec.rb
@@ -120,7 +120,7 @@ feature 'Branching errors' do
 
     when_I_save_my_changes
     then_I_should_see_error_summary_errors(1)
-    then_I_should_see_error_for_go_to_destination('Select a destination for Branch 1')
+    then_I_should_see_branching_error_message('Select a destination for Branch 1')
   end
 
   # scenario 'when the conditional field is not filled in' do
@@ -129,8 +129,66 @@ feature 'Branching errors' do
   # scenario 'when the expression field is not filled in' do
   # end
 
-  # scenario 'when there are two branch objects' do
-  # end
+  scenario 'when there are two branch objects' do
+    given_I_add_all_pages_for_a_form_with_branching
+    and_I_return_to_flow_page
+    and_I_want_to_add_branching
+
+    and_I_want_to_add_another_branch
+    then_I_should_see_another_branch
+
+    and_I_select_the_destination_page_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_next',
+      8
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][next]',
+      'Favourite hiking destination'
+    )
+
+    and_I_select_the_condition_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_expressions_attributes_0_component',
+      5
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][component]',
+      'What is your favourite hobby?'
+    )
+    then_I_should_see_statement_answers
+
+    and_I_select_the_operator_dropdown
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][operator]',
+      'is'
+    )
+
+    and_I_select_the_field_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_expressions_attributes_0_field',
+      2
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][field]',
+      'Hiking'
+    )
+
+    and_I_select_the_otherwise_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_default_next',
+      8
+    )
+    and_I_choose_an_option(
+      'branch[default_next]',
+      'Which flavours of ice cream have you eaten?'
+    )
+
+    when_I_save_my_changes
+    then_I_should_see_error_summary_errors(2)
+    then_I_should_see_branching_error_message('Select a destination for Branch 2')
+    then_I_should_see_branching_error_message('Select a question for the condition for Branch 2')
+  end
 
   # Errors
   def then_I_should_see_all_branching_error_messages
@@ -149,11 +207,19 @@ feature 'Branching errors' do
     expect(page).not_to have_selector('.govuk-error-summary')
   end
 
-  def then_I_should_see_error_for_go_to_destination(text)
+  def then_I_should_see_branching_error_message(text)
     expect(page).to have_selector('.govuk-form-group--error', text: text)
   end
 
   # Branching options / selections
+  def and_I_want_to_add_another_branch
+    editor.add_another_branch.click
+  end
+
+  def then_I_should_see_another_branch
+    expect(page).to have_selector('.Branch', count: 2)
+  end
+
   def and_I_select_the_destination_page_dropdown
     editor.destination_options.click
   end

--- a/acceptance/features/branching_error_summaries.spec.rb
+++ b/acceptance/features/branching_error_summaries.spec.rb
@@ -348,9 +348,12 @@ feature 'Branching errors' do
   end
 
   def and_I_want_to_add_branching
-    editor.preview_page_images[1].hover # favourite-hobby page
-    editor.three_dots_button.click
-    editor.branching_link.click
+    editor.preview_page_images[1].click # favourite-hobby page
+
+    ## temporary branch link work around until we have the service flow page
+    url = page.current_url.gsub('pages', 'branches').gsub('edit', 'new')
+    visit url
+
     then_I_should_see_the_branching_page
   end
 

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -113,6 +113,13 @@ class EditorApp < SitePrism::Page
   element :add_page_here_link, :link, 'Add page here'
   element :delete_page_link, :link, 'Delete page...'
   element :delete_page_modal_button, :button, 'Delete page'
+  element :branching_link, :link, 'Branching'
+
+  element :destination_options, '#branch_conditionals_attributes_0_next'
+  element :conditional_options, '#branch_conditionals_attributes_0_expressions_attributes_0_component'
+  element :operator_options, '#branch_conditionals_attributes_0_expressions_attributes_0_operator'
+  element :field_options, '#branch_conditionals_attributes_0_expressions_attributes_0_field'
+  element :otherwise_options, '#branch_default_next'
 
   def edit_service_link(service_name)
     find("#service-#{service_name.parameterize} .edit")

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -114,6 +114,7 @@ class EditorApp < SitePrism::Page
   element :delete_page_link, :link, 'Delete page...'
   element :delete_page_modal_button, :button, 'Delete page'
   element :branching_link, :link, 'Branching'
+  element :add_another_branch, :link, 'Add another branch'
 
   element :destination_options, '#branch_conditionals_attributes_0_next'
   element :conditional_options, '#branch_conditionals_attributes_0_expressions_attributes_0_component'


### PR DESCRIPTION
[Trello](https://trello.com/c/mOvjeeC8/1839-acceptance-tests-error-summary-on-branches-edit-and-new-pages)

### Scenarios tested:
- Happy path (all fields are filled in, no errors are triggered and a save is successful)
- All fields are missing (ensure all errors are triggered)
- Only the 'Go to' destination is missing (should trigger the correct error)
- Only the 'Otherwise' destination is missing (should trigger the correct error)
- When there are 2 branches, all fields in Branch 1 are filled in but no fields in Branch 2 are filled in (should trigger errors regarding Branch 2 only)

### Branching link work around
In order for these tests to work, we need to be able to access the branching page.
We currently do not have the add branching link in the live environment so are not able to access the page this way.
There is a work around to access the branching page until the link becomes available.