### PR TITLE
Fix edit branch page URL in the acceptance tests

### DIFF
--- a/acceptance/features/edit_branch_error_summaries_spec.rb
+++ b/acceptance/features/edit_branch_error_summaries_spec.rb
@@ -352,7 +352,7 @@ feature 'Branching errors' do
     editor.preview_page_images[1].click # favourite-hobby page
 
     ## temporary branch link work around until we have the service flow page
-    url = page.current_url.gsub('pages', 'branches').gsub('edit', 'new')
+    url = page.current_url.gsub('/pages/', '/branches/').gsub('/edit', '/new')
     visit url
 
     then_I_should_see_the_branching_page


### PR DESCRIPTION
## Rename acceptance test methods for better description 

The UI refers to a conditional as a branch, but in terms of the metadata
structure we refer to it as a conditional.

Confusion abounds.

## Correctly create edit branch link in acceptance tests …

Previously the gsub for 'edit' was accidentally changing the URL of the
editor in test, fb-editor-test, to fb-newor-test.

Change the method to capture the '/' as well to make sure this doesn't
happen.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>