### PR TITLE
Add 'BRANCHING' feature flag

### DIFF
--- a/acceptance/features/edit_branch_error_summaries_spec.rb
+++ b/acceptance/features/edit_branch_error_summaries_spec.rb
@@ -349,11 +349,9 @@ feature 'Branching errors' do
   end
 
   def and_I_want_to_add_branching
-    editor.preview_page_images[1].click # favourite-hobby page
-
-    ## temporary branch link work around until we have the service flow page
-    url = page.current_url.gsub('/pages/', '/branches/').gsub('/edit', '/new')
-    visit url
+    editor.preview_page_images[1].hover # favourite-hobby page
+    editor.three_dots_button.click
+    editor.branching_link.click
 
     then_I_should_see_the_branching_page
   end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -113,7 +113,7 @@ class EditorApp < SitePrism::Page
   element :add_page_here_link, :link, 'Add page here'
   element :delete_page_link, :link, 'Delete page...'
   element :delete_page_modal_button, :button, 'Delete page'
-  element :branching_link, :link, 'Branching'
+  element :branching_link, :link, 'Add branching'
   element :add_another_branch, :link, 'Add another branch'
 
   element :destination_options, '#branch_conditionals_attributes_0_next'

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -16,8 +16,7 @@ class ServicesController < PermissionsController
   end
 
   def edit
-    # uncomment line below when building the service flow frontend
-    # @pages_flow = PagesFlow.new(service).build
+    @pages_flow = PagesFlow.new(service).build
     @page_creation = PageCreation.new
   end
 

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -5,6 +5,16 @@
 
 <h1 class="govuk-heading-xl"><%= t('pages.flow.heading') %></h1>
 
+  <% if ENV['BRANCHING'] == 'enabled' %>
+  <div class='govuk-!-margin-bottom-10'>
+    <% service.flow.each do |uuid, flow| %>
+      <% if flow['_type'] == 'flow.branch' %>
+        | <%= link_to flow['title'] || 'Untitled Branch', edit_branch_path(service.service_id, uuid) %> |
+      <% end %>
+    <% end %>
+  </div>
+  <% end %>
+
 <div id="form-overview">
   <div class="container">
     <% service.pages.each do |page| %>
@@ -35,6 +45,12 @@
               method: :delete, class: 'destructive delete' %>
             <% end %>
           </li>
+          <% if ENV['BRANCHING'] == 'enabled' %>
+          <li data-action="edit">
+            <%= link_to t('services.branch'),
+              new_branches_path(service.service_id, page.uuid) %>
+          </li>
+          <% end %>
         </ul>
 
         <%= link_to edit_page_path(service.service_id, page.uuid), class: 'govuk-link' do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,6 +171,7 @@ en:
     preview: 'Preview'
     create: 'Create a new form'
     cancel: 'Cancel'
+    branch: 'Add branching'
   activemodel:
     models:
       service_creation: 'Form'

--- a/deploy/fb-editor-chart/templates/config_map.yaml
+++ b/deploy/fb-editor-chart/templates/config_map.yaml
@@ -12,3 +12,4 @@ data:
   AUTH0_DOMAIN: moj-forms.eu.auth0.com
   ENCODED_PUBLIC_KEY: {{ .Values.encoded_public_key }}
   METADATA_API_URL: http://fb-metadata-api-svc-{{ .Values.environmentName }}
+  BRANCHING: {{ .Values.branching }}


### PR DESCRIPTION
Add a feature flag called 'BRANCHING'. This will be used in the Test
environment, injected via the fb-editor-deploy repo.

This surfaces the link to 'Add branching' and also uncomments the
building of the new pages flow object.

We also changed the edit branch error summary acceptance tests to make
use of the link now available.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>