### PR TITLE
Separate out new and edit branch errors acceptance tests

### DIFF
--- a/acceptance/features/edit_branch_error_summaries_spec.rb
+++ b/acceptance/features/edit_branch_error_summaries_spec.rb
@@ -9,66 +9,10 @@ feature 'Branching errors' do
     given_I_have_a_service
   end
 
-  scenario 'when all required fields are filled in' do
-    given_I_add_all_pages_for_a_form_with_branching
-    and_I_return_to_flow_page
-    and_I_want_to_add_branching
-
-    and_I_select_the_destination_page_dropdown
-    then_I_should_see_the_correct_number_of_options(
-      '#branch_conditionals_attributes_0_next',
-      8
-    )
-    and_I_choose_an_option(
-      'branch[conditionals_attributes][0][next]',
-      'Favourite hiking destination'
-    )
-
-    and_I_select_the_condition_dropdown
-    then_I_should_see_the_correct_number_of_options(
-      '#branch_conditionals_attributes_0_expressions_attributes_0_component',
-      5
-    )
-    and_I_choose_an_option(
-      'branch[conditionals_attributes][0][expressions_attributes][0][component]',
-      'What is your favourite hobby?'
-    )
-    then_I_should_see_statement_answers
-
-    and_I_select_the_operator_dropdown
-    and_I_choose_an_option(
-      'branch[conditionals_attributes][0][expressions_attributes][0][operator]',
-      'is'
-    )
-
-    and_I_select_the_field_dropdown
-    then_I_should_see_the_correct_number_of_options(
-      '#branch_conditionals_attributes_0_expressions_attributes_0_field',
-      2
-    )
-    and_I_choose_an_option(
-      'branch[conditionals_attributes][0][expressions_attributes][0][field]',
-      'Hiking'
-    )
-
-    and_I_select_the_otherwise_dropdown
-    then_I_should_see_the_correct_number_of_options(
-      '#branch_default_next',
-      8
-    )
-    and_I_choose_an_option(
-      'branch[default_next]',
-      'Which flavours of ice cream have you eaten?'
-    )
-
-    when_I_save_my_changes
-    then_I_should_see_no_errors
-  end
-
   scenario 'when no required fields are filled in' do
     given_I_add_all_pages_for_a_form_with_branching
     and_I_return_to_flow_page
-    and_I_want_to_add_branching
+    and_I_want_to_add_branching(1)
 
     when_I_save_my_changes
     then_I_should_see_an_error_summary
@@ -81,7 +25,7 @@ feature 'Branching errors' do
   scenario 'when the "Go to" field is not filled in' do
     given_I_add_all_pages_for_a_form_with_branching
     and_I_return_to_flow_page
-    and_I_want_to_add_branching
+    and_I_want_to_add_branching(1)
 
     and_I_select_the_condition_dropdown
     then_I_should_see_the_correct_number_of_options(
@@ -129,7 +73,7 @@ feature 'Branching errors' do
   scenario 'when the Otherwise/default next field is not filled in' do
     given_I_add_all_pages_for_a_form_with_branching
     and_I_return_to_flow_page
-    and_I_want_to_add_branching
+    and_I_want_to_add_branching(1)
 
     and_I_select_the_destination_page_dropdown
     then_I_should_see_the_correct_number_of_options(
@@ -177,7 +121,7 @@ feature 'Branching errors' do
   scenario 'when there are two conditional objects to a branching point' do
     given_I_add_all_pages_for_a_form_with_branching
     and_I_return_to_flow_page
-    and_I_want_to_add_branching
+    and_I_want_to_add_branching(1)
 
     and_I_want_to_add_another_conditional
     then_I_should_see_another_conditional
@@ -245,10 +189,6 @@ feature 'Branching errors' do
     expect(find('ul.govuk-error-summary__list')).to have_selector('li', count: count)
   end
 
-  def then_I_should_see_no_errors
-    expect(page).not_to have_selector('.govuk-error-summary')
-  end
-
   def then_I_should_see_branching_error_message(text)
     expect(page).to have_selector('.govuk-form-group--error', text: text)
   end
@@ -261,102 +201,5 @@ feature 'Branching errors' do
 
   def then_I_should_see_another_conditional
     expect(page).to have_selector('.Branch', count: 2)
-  end
-
-  def and_I_select_the_destination_page_dropdown
-    editor.destination_options.click
-  end
-
-  def and_I_select_the_condition_dropdown
-    editor.conditional_options.click
-  end
-
-  def then_I_should_see_statement_answers
-    expect(editor).to have_operator_options
-    expect(editor).to have_field_options
-  end
-
-  def and_I_select_the_field_dropdown
-    editor.field_options.click
-  end
-
-  def and_I_select_the_operator_dropdown
-    editor.operator_options.click
-  end
-
-  def and_I_select_the_otherwise_dropdown
-    editor.otherwise_options.click
-  end
-
-  def then_I_should_see_the_correct_number_of_options(id, amount)
-    options = find(id).all('option')
-    expect(options.length).to eq(amount)
-  end
-
-  def and_I_choose_an_option(name, option)
-    select(option, from: name)
-  end
-
-  # Branching page set up
-  def given_I_add_all_pages_for_a_form_with_branching
-    given_I_add_a_single_question_page_with_radio
-    and_I_add_a_page_url('favourite-hobby')
-    when_I_add_the_page
-    when_I_update_the_question_name('What is your favourite hobby?')
-    and_I_edit_the_option_items('Hiking', 'Sewing')
-    and_I_return_to_flow_page
-
-    given_I_add_a_single_question_page_with_checkboxes
-    and_I_add_a_page_url('ice-cream')
-    when_I_add_the_page
-    when_I_update_the_question_name('Which flavours of ice cream have you eaten?')
-    and_I_edit_the_option_items('Hokey Pokey', 'Chocolate')
-    and_I_return_to_flow_page
-
-    given_I_add_a_single_question_page_with_text
-    and_I_add_a_page_url('hiking')
-    when_I_add_the_page
-    when_I_update_the_question_name('Favourite hiking destination')
-    and_I_return_to_flow_page
-
-    given_I_add_a_single_question_page_with_text
-    and_I_add_a_page_url('sewing')
-    when_I_add_the_page
-    when_I_update_the_question_name('Favourite sewing project')
-    and_I_return_to_flow_page
-
-    given_I_add_a_check_answers_page
-    and_I_add_a_page_url('cya')
-    when_I_add_the_page
-    and_I_return_to_flow_page
-
-    given_I_add_a_confirmation_page
-    and_I_add_a_page_url('confirmation')
-    when_I_add_the_page
-  end
-
-  def when_I_update_the_question_name(question_name)
-    editor.question_heading.first.set(question_name)
-    when_I_save_my_changes
-  end
-
-  def and_I_edit_the_option_items(*item)
-    editor.editable_options.first.set(item[0])
-    editor.service_name.click
-    editor.editable_options.last.set(item[1])
-    editor.service_name.click
-    when_I_save_my_changes
-  end
-
-  def and_I_want_to_add_branching
-    editor.preview_page_images[1].hover # favourite-hobby page
-    editor.three_dots_button.click
-    editor.branching_link.click
-
-    then_I_should_see_the_branching_page
-  end
-
-  def then_I_should_see_the_branching_page
-    expect(editor.question_heading.first.text).to eq('Branching point 1')
   end
 end

--- a/acceptance/features/new_branch_page.rb
+++ b/acceptance/features/new_branch_page.rb
@@ -1,0 +1,90 @@
+require_relative '../spec_helper'
+
+feature 'New branch page' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'when all required fields are filled in' do
+    given_I_add_all_pages_for_a_form_with_branching
+    and_I_return_to_flow_page
+    and_I_want_to_add_branching(1)
+
+    then_I_should_be_on_the_correct_branch_page('new')
+
+    and_I_select_the_destination_page_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_next',
+      8
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][next]',
+      'Favourite hiking destination'
+    )
+
+    and_I_select_the_condition_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_expressions_attributes_0_component',
+      5
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][component]',
+      'What is your favourite hobby?'
+    )
+    then_I_should_see_statement_answers
+
+    and_I_select_the_operator_dropdown
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][operator]',
+      'is answered'
+    )
+
+    and_I_select_the_field_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_conditionals_attributes_0_expressions_attributes_0_field',
+      2
+    )
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][field]',
+      'Hiking'
+    )
+
+    and_I_select_the_otherwise_dropdown
+    then_I_should_see_the_correct_number_of_options(
+      '#branch_default_next',
+      8
+    )
+    and_I_choose_an_option(
+      'branch[default_next]',
+      'Which flavours of ice cream have you eaten?'
+    )
+
+    when_I_save_my_changes
+    then_I_should_be_on_the_correct_branch_page('edit')
+    then_I_should_see_previous_saved_choices(
+      'branch[conditionals_attributes][0][expressions_attributes][0][operator]',
+      'is answered'
+    )
+    then_I_should_see_previous_saved_choices(
+      'branch[conditionals_attributes][0][expressions_attributes][0][field]',
+      'Hiking'
+    )
+    then_I_should_see_no_errors
+  end
+
+  def then_I_should_be_on_the_correct_branch_page(path)
+    expect(URI(current_url).path.split('/').last).to eq(path)
+  end
+
+  def then_I_should_see_previous_saved_choices(attribute, selected)
+    expect(page).to have_select(attribute, selected: selected)
+  end
+
+  def then_I_should_see_no_errors
+    expect(page).not_to have_selector('.govuk-error-summary')
+  end
+end

--- a/acceptance/spec_helper.rb
+++ b/acceptance/spec_helper.rb
@@ -31,6 +31,7 @@ RSpec.configure do |config|
 
   config.include TestHelpers
   config.include CommonSteps
+  config.include BranchingSteps
   config.include DataContentId
   config.include MultipleQuestionsPageHelper
 end

--- a/acceptance/support/branching_steps.rb
+++ b/acceptance/support/branching_steps.rb
@@ -1,0 +1,98 @@
+module BranchingSteps
+  # Branching page set up
+  def given_I_add_all_pages_for_a_form_with_branching
+    given_I_add_a_single_question_page_with_radio
+    and_I_add_a_page_url('favourite-hobby')
+    when_I_add_the_page
+    when_I_update_the_question_name('What is your favourite hobby?')
+    and_I_edit_the_option_items('Hiking', 'Sewing')
+    and_I_return_to_flow_page
+
+    given_I_add_a_single_question_page_with_checkboxes
+    and_I_add_a_page_url('ice-cream')
+    when_I_add_the_page
+    when_I_update_the_question_name('Which flavours of ice cream have you eaten?')
+    and_I_edit_the_option_items('Hokey Pokey', 'Chocolate')
+    and_I_return_to_flow_page
+
+    given_I_add_a_single_question_page_with_text
+    and_I_add_a_page_url('hiking')
+    when_I_add_the_page
+    when_I_update_the_question_name('Favourite hiking destination')
+    and_I_return_to_flow_page
+
+    given_I_add_a_single_question_page_with_text
+    and_I_add_a_page_url('sewing')
+    when_I_add_the_page
+    when_I_update_the_question_name('Favourite sewing project')
+    and_I_return_to_flow_page
+
+    given_I_add_a_check_answers_page
+    and_I_add_a_page_url('cya')
+    when_I_add_the_page
+    and_I_return_to_flow_page
+
+    given_I_add_a_confirmation_page
+    and_I_add_a_page_url('confirmation')
+    when_I_add_the_page
+  end
+
+  def when_I_update_the_question_name(question_name)
+    editor.question_heading.first.set(question_name)
+    when_I_save_my_changes
+  end
+
+  def and_I_edit_the_option_items(*item)
+    editor.editable_options.first.set(item[0])
+    editor.service_name.click
+    editor.editable_options.last.set(item[1])
+    editor.service_name.click
+    when_I_save_my_changes
+  end
+
+  def and_I_want_to_add_branching(index)
+    editor.preview_page_images[index].hover
+    editor.three_dots_button.click
+    editor.branching_link.click
+
+    then_I_should_see_the_branching_page
+  end
+
+  def then_I_should_see_the_branching_page
+    expect(editor.question_heading.first.text).to eq('Branching point 1')
+  end
+
+  def and_I_select_the_destination_page_dropdown
+    editor.destination_options.click
+  end
+
+  def then_I_should_see_the_correct_number_of_options(id, amount)
+    options = find(id).all('option')
+    expect(options.length).to eq(amount)
+  end
+
+  def and_I_choose_an_option(name, option)
+    select(option, from: name)
+  end
+
+  def and_I_select_the_condition_dropdown
+    editor.conditional_options.click
+  end
+
+  def then_I_should_see_statement_answers
+    expect(editor).to have_operator_options
+    expect(editor).to have_field_options
+  end
+
+  def and_I_select_the_field_dropdown
+    editor.field_options.click
+  end
+
+  def and_I_select_the_operator_dropdown
+    editor.operator_options.click
+  end
+
+  def and_I_select_the_otherwise_dropdown
+    editor.otherwise_options.click
+  end
+end


### PR DESCRIPTION
- Move the creation of a new branch page to its' own test file.
- Check for correct paths for '/new' and '/edit' before and after saving
- Check correctly selected operator and answer are chosen by default
- Move shared steps to BranchingSteps module