### PR TITLE
Bump metadata presenter v2.3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.3.4'
+gem 'metadata_presenter', '2.3.5'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    metadata_presenter (2.3.4)
+    metadata_presenter (2.3.5)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -391,7 +391,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.3.4)
+  metadata_presenter (= 2.3.5)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.0)
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
Bump to metadata presenter gem v2.3.5
- Fixes spacing on 'check your answers' page

Relates to [PR](https://github.com/ministryofjustice/fb-metadata-presenter/pull/173)