### PR TITLE
Testable 1855 enable save functionality

### DIFF
--- a/app/javascript/src/component_branch.js
+++ b/app/javascript/src/component_branch.js
@@ -126,6 +126,7 @@ class BranchCondition {
     this.branch = conf.branch;
     this.question = new BranchQuestion($node.find(conf.selector_question), conf);
     this.remover = new BranchConditionRemover($remover, conf);
+    this.answer = new BranchAnswer($node.find(conf.selector_answer), conf);
   }
 
   update(component, callback) {

--- a/app/javascript/src/controller_branches.js
+++ b/app/javascript/src/controller_branches.js
@@ -21,6 +21,7 @@ const DefaultController = require('./controller_default');
 const ActivatedMenu = require('./component_activated_menu');
 const Branch = require('./component_branch');
 const BRANCH_SELECTOR = ".branch";
+const BRANCH_ANSWER_SELECTOR = ".answer";
 const BRANCH_CONDITION_SELECTOR = ".condition";
 const BRANCH_REMOVE_SELECTOR = ".branch-remover";
 const BRANCH_CONDITION_ADD_SELECTOR = ".condition-injector";
@@ -118,6 +119,7 @@ BranchesController.addBranchMenu = function(args) {
 BranchesController.createBranch = function($node) {
   var branch = new Branch($node, {
     branch_index: this._branchCount,
+    selector_answer: BRANCH_ANSWER_SELECTOR,
     selector_branch_remove: BRANCH_REMOVE_SELECTOR,
     selector_condition: BRANCH_CONDITION_SELECTOR,
     selector_condition_add: BRANCH_CONDITION_ADD_SELECTOR,

--- a/app/views/branches/_expression_answers.html.erb
+++ b/app/views/branches/_expression_answers.html.erb
@@ -1,4 +1,4 @@
-<div class="answer" data-expression-index="<%= expression_index %>" data-component-type="<%= expression.component_type %>">
+<div class="answer govuk-form-group" data-expression-index="<%= expression_index %>" data-component-type="<%= expression.component_type %>">
   <%= f.select :operators, expression.operators,
     {
       include_blank: false,

--- a/test/component_branch_test.js
+++ b/test/component_branch_test.js
@@ -216,7 +216,16 @@ describe("Branch", function () {
     it("should make the remover public", function() {
       var instance = $condition.data("instance");
       expect(instance.remover).to.exist;
+      expect(instance.remover.$node.length).to.equal(1);
     });
+
+    it("should make the question public", function() {
+      var instance = $condition.data("instance");
+      expect(instance.question).to.exist;
+      expect(instance.question.$node.length).to.equal(1);
+    });
+
+    it("should make the answer public");
 
     it("should make (public but indicated as) private reference to config", function() {
       var instance = $condition.data("instance");

--- a/test/component_branch_test.js
+++ b/test/component_branch_test.js
@@ -48,6 +48,10 @@ describe("Branch", function () {
               <option value="b34f593a" data-supports-branching="false">Unsupported Question</option>
             </select>
           </div>
+          <div class="answer">
+            <select><option>is</option></select>
+            <select><option>This answer value</option></select>
+          </div>
           <button class="condition-remover">` + TEXT_REMOVE_BRANCH + `</button>
         </div>
         <button class="condition-injector">` + TEXT_ADD_CONDITION + `</button>
@@ -56,6 +60,7 @@ describe("Branch", function () {
     var $node = $(html);
     var branch = new Branch($node, {
       branch_index: INDEX_BRANCH,
+      selector_answer: BRANCH_ANSWER_SELECTOR,
       selector_branch_remove: BRANCH_REMOVE_SELECTOR,
       selector_condition: BRANCH_CONDITION_SELECTOR,
       selector_condition_add: BRANCH_CONDITION_ADD_SELECTOR,
@@ -225,7 +230,11 @@ describe("Branch", function () {
       expect(instance.question.$node.length).to.equal(1);
     });
 
-    it("should make the answer public");
+    it("should make the answer public", function() {
+      var instance = $condition.data("instance");
+      expect(instance.answer).to.exist;
+      expect(instance.answer.$node.length).to.equal(1);
+    });
 
     it("should make (public but indicated as) private reference to config", function() {
       var instance = $condition.data("instance");
@@ -260,6 +269,7 @@ describe("Branch", function () {
       it("should add html for answer on selected question", function() {
         var condition = $condition.data("instance");
 
+        $condition.find(BRANCH_ANSWER_SELECTOR).remove(); // First remove the hardcoded .answer element.
         expect($condition).to.exist;
         expect($condition.length).to.equal(1);
         expect($condition.find(BRANCH_ANSWER_SELECTOR).length).to.equal(0);


### PR DESCRIPTION
Fix JS to create BranchAnswer components on page load.

The lack of created components also had a visual impact, which means this...
<img width="890" alt="Screenshot 2021-08-31 at 16 25 34" src="https://user-images.githubusercontent.com/76942244/131531195-f41e9cb0-3565-4ee8-a9f1-ab80fc8de1ce.png">

...is now corrected to look like this:
<img width="882" alt="Screenshot 2021-08-31 at 16 25 46" src="https://user-images.githubusercontent.com/76942244/131531251-d1ea842b-3840-493e-87b2-f77ae2296fa9.png">
