### PR TITLE
Use I18n in acceptance tests

### DIFF
--- a/acceptance/features/create_service_spec.rb
+++ b/acceptance/features/create_service_spec.rb
@@ -58,25 +58,25 @@ feature 'Create a service' do
 
   def then_I_should_see_a_validation_message_for_required
     expect(editor.text).to include(
-      'Your answer for ‘Give your form a name’ cannot be blank.'
+      I18n.t('activemodel.errors.messages.blank', attribute: 'Give your form a name')
     )
   end
 
   def then_I_should_see_a_validation_message_for_min_length
     expect(editor.text).to include(
-      'Your answer for ‘Give your form a name’ is too short (3 characters at least)'
+      I18n.t('activemodel.errors.messages.too_short', attribute: 'Give your form a name', count: '3')
     )
   end
 
   def then_I_should_see_a_validation_message_for_max_length
     expect(editor.text).to include(
-      'Your answer for ‘Give your form a name’ is too long (128 characters at most)'
+      I18n.t('activemodel.errors.messages.too_long', attribute: 'Give your form a name', count: '128')
     )
   end
 
   def then_I_should_see_the_unique_validation_message
     expect(editor.text).to include(
-      "Your answer for ‘Give your form a name' is already used by another form. Please modify it."
+      I18n.t('activemodel.errors.messages.taken', attribute: 'Give your form a name')
     )
   end
 end

--- a/acceptance/features/default_text_spec.rb
+++ b/acceptance/features/default_text_spec.rb
@@ -60,15 +60,15 @@ feature 'Default text' do
   end
 
   def then_I_should_see_default_text
-    expect(editor.question_hint.text).to eq('[Optional hint text]')
+    expect(editor.question_hint.text).to eq(I18n.t('default_text.hint'))
   end
 
   def and_I_should_not_see_the_default_text
-    expect(page.text).to_not include('[Optional hint text]')
+    expect(page.text).to_not include(I18n.t('default_text.hint'))
   end
 
   def and_I_should_not_see_the_optional_section_heading_text
-    expect(page.text).to_not include('[Optional section heading]')
+    expect(page.text).to_not include(I18n.t('default_text.section_heading'))
   end
 
   def when_I_customise_hint
@@ -80,7 +80,13 @@ feature 'Default text' do
   end
 
   def then_I_should_see_default_text_in_label_and_options
-    expect(editor.all_hints.map(&:text)).to eq(['[Optional hint text]', '[Optional hint text]', '[Optional hint text]'])
+    expect(editor.all_hints.map(&:text)).to eq(
+      [
+        I18n.t('default_text.hint'),
+        I18n.t('default_text.hint'),
+        I18n.t('default_text.hint')
+      ]
+    )
   end
 
   def when_I_customise_all_hints

--- a/acceptance/features/edit_branch_error_summaries_spec.rb
+++ b/acceptance/features/edit_branch_error_summaries_spec.rb
@@ -3,9 +3,7 @@ require_relative '../spec_helper'
 feature 'Branching errors' do
   let(:editor) { EditorApp.new }
   let(:service_name) { generate_service_name }
-  let(:unsupported_type_error) do
-    'This type of question is not currently supported to create a branching condition. Please select a radio button or checkbox question.'
-  end
+  let(:unsupported_type_error) { I18n.t('activemodel.errors.messages.unsupported') }
 
   background do
     given_I_am_logged_in
@@ -20,9 +18,9 @@ feature 'Branching errors' do
     when_I_save_my_changes
     then_I_should_see_an_error_summary
     then_I_should_see_error_summary_errors(3)
-    then_I_should_see_branching_error_message('Select a destination for Branch 1')
-    then_I_should_see_branching_error_message('Select a question for the condition for Branch 1')
-    then_I_should_see_branching_error_message("Select a destination for 'Otherwise'")
+    then_I_should_see_branching_error_message("#{I18n.t('activemodel.errors.models.conditional.blank')}1")
+    then_I_should_see_branching_error_message("#{I18n.t('activemodel.errors.models.expression.blank')}1")
+    then_I_should_see_branching_error_message(I18n.t('activemodel.errors.models.branch.blank', attribute: 'Otherwise'))
   end
 
   scenario 'when the "Go to" field is not filled in' do
@@ -70,7 +68,7 @@ feature 'Branching errors' do
     when_I_save_my_changes
     then_I_should_see_an_error_summary
     then_I_should_see_error_summary_errors(1)
-    then_I_should_see_branching_error_message('Select a destination for Branch 1')
+    then_I_should_see_branching_error_message("#{I18n.t('activemodel.errors.models.conditional.blank')}1")
   end
 
   scenario 'when the Otherwise/default next field is not filled in' do
@@ -118,7 +116,7 @@ feature 'Branching errors' do
     when_I_save_my_changes
     then_I_should_see_an_error_summary
     then_I_should_see_error_summary_errors(1)
-    then_I_should_see_branching_error_message("Select a destination for 'Otherwise'")
+    then_I_should_see_branching_error_message(I18n.t('activemodel.errors.models.branch.blank', attribute: 'Otherwise'))
   end
 
   scenario 'when there are two conditional objects to a branching point' do
@@ -186,8 +184,8 @@ feature 'Branching errors' do
     when_I_save_my_changes
     then_I_should_see_an_error_summary
     then_I_should_see_error_summary_errors(2)
-    then_I_should_see_branching_error_message('Select a destination for Branch 2')
-    then_I_should_see_branching_error_message('Select a question for the condition for Branch 2')
+    then_I_should_see_branching_error_message("#{I18n.t('activemodel.errors.models.conditional.blank')}2")
+    then_I_should_see_branching_error_message("#{I18n.t('activemodel.errors.models.expression.blank')}2")
   end
 
   # Errors

--- a/acceptance/features/edit_check_answers_page_spec.rb
+++ b/acceptance/features/edit_check_answers_page_spec.rb
@@ -16,7 +16,7 @@ feature 'Edit check your answers page' do
     'If you only knew the power of the dark side'
   end
   let(:optional_content) do
-    '[Optional content]'
+    I18n.t('default_text.content')
   end
 
   background do

--- a/acceptance/features/edit_multiple_questions_page_spec.rb
+++ b/acceptance/features/edit_multiple_questions_page_spec.rb
@@ -25,7 +25,7 @@ feature 'Edit multiple questions page' do
     'You underestimate the power of the Dark Side.'
   end
   let(:optional_content) do
-    '[Optional content]'
+    I18n.t('default_text.content')
   end
 
   background do

--- a/acceptance/features/edit_single_question_page_spec.rb
+++ b/acceptance/features/edit_single_question_page_spec.rb
@@ -149,6 +149,6 @@ feature 'Edit single question page' do
   end
 
   def and_I_have_optional_section_heading_text
-    expect(page.text).to include('[Optional section heading]')
+    expect(page.text).to include(I18n.t('default_text.section_heading'))
   end
 end

--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -7,7 +7,7 @@ feature 'Preview form' do
     'Multiple Page'
   end
   let(:optional_content) do
-    '[Optional content]'
+    I18n.t('default_text.content')
   end
   let(:content_component) do
     "I am a doctor not a doorstop"

--- a/acceptance/features/update_settings_form_information_spec.rb
+++ b/acceptance/features/update_settings_form_information_spec.rb
@@ -90,25 +90,25 @@ feature 'Update settings form information' do
 
   def then_I_should_see_a_validation_message_for_required
     expect(editor.text).to include(
-      'Your answer for ‘Form name’ cannot be blank.'
+      I18n.t('activemodel.errors.messages.blank', attribute: 'Form name')
     )
   end
 
   def then_I_should_see_a_validation_message_for_min_length
     expect(editor.text).to include(
-      'Your answer for ‘Form name’ is too short (3 characters at least)'
+      I18n.t('activemodel.errors.messages.too_short', attribute: 'Form name', count: '3')
     )
   end
 
   def then_I_should_see_a_validation_message_for_max_length
     expect(editor.text).to include(
-      'Your answer for ‘Form name’ is too long (128 characters at most)'
+      I18n.t('activemodel.errors.messages.too_long', attribute: 'Form name', count: '128')
     )
   end
 
   def then_I_should_see_the_unique_validation_message
     expect(editor.text).to include(
-      "Your answer for ‘Form name' is already used by another form. Please modify it."
+      I18n.t('activemodel.errors.messages.taken', attribute: 'Form name')
     )
   end
 end


### PR DESCRIPTION
Reduces some of the effort in updating tests if the content is ever
changed