### PR TITLE
Update browser tools orb and install all browser tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   slack: circleci/slack@3.4.2
   ruby: circleci/ruby@1.1.3
   node: circleci/node@4.5.1
-  browser-tools: circleci/browser-tools@1.1.3
+  browser-tools: circleci/browser-tools@1.2.1
   kubernetes: circleci/kubernetes@0.12.0
 
 jobs:
@@ -252,8 +252,12 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
+      - browser-tools/install-browser-tools
+      - run:
+          name: Check browser tools install
+          command: |
+            google-chrome --version
+            chromedriver --version
       - run: *wait_for_db
       - run: *db_setup
       - run:
@@ -286,8 +290,12 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
+      - browser-tools/install-browser-tools
+      - run:
+          name: Check browser tools install
+          command: |
+            google-chrome --version
+            chromedriver --version
       - run: *wait_for_db
       - run: *db_setup
       - run:


### PR DESCRIPTION
Swap to install all the browser tools as `install-chrome` by itself is
broken.

There is an open PR to resolve this issue. In the meantime just install
all the things.

https://github.com/CircleCI-Public/browser-tools-orb/issues/33