### PR TITLE
Edit branch acceptance tests

### DIFF
--- a/acceptance/features/edit_branch_page.rb
+++ b/acceptance/features/edit_branch_page.rb
@@ -1,0 +1,50 @@
+require_relative '../spec_helper'
+
+feature 'New branch page' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'when editing the branch page' do
+    given_I_add_all_pages_for_a_form_with_branching
+    and_I_return_to_flow_page
+    and_I_want_to_add_branching(1)
+
+    then_I_should_see_the_branch_title(index: 0, title: 'Branch 1')
+    then_I_should_see_the_operator(I18n.t('branches.expression.if'))
+    then_I_should_not_see_text(I18n.t('branches.condition_add'))
+    then_I_should_not_see_text(I18n.t('branches.condition_remove'))
+
+    and_I_select_the_destination_page_dropdown
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][next]',
+      'Favourite hiking destination'
+    )
+
+    and_I_select_the_condition_dropdown
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][component]',
+      'What is your favourite hobby?'
+    )
+    then_I_should_see_the_add_condition_link
+
+    and_I_select_the_otherwise_dropdown
+    and_I_choose_an_option(
+      'branch[default_next]',
+      'Which flavours of ice cream have you eaten?'
+    )
+
+    # uncomment once missing 'Add condition' on edit pages bug is fixed
+    # when_I_save_my_changes
+    # then_I_should_be_on_the_correct_branch_page('edit')
+
+    then_I_can_add_and_delete_conditionals_and_expressions
+
+    when_I_save_my_changes
+    then_I_should_see_no_errors
+  end
+end

--- a/acceptance/features/new_branch_page.rb
+++ b/acceptance/features/new_branch_page.rb
@@ -63,6 +63,8 @@ feature 'New branch page' do
       'Which flavours of ice cream have you eaten?'
     )
 
+    then_I_can_add_and_delete_conditionals_and_expressions
+
     when_I_save_my_changes
     then_I_should_be_on_the_correct_branch_page('edit')
     then_I_should_see_previous_saved_choices(
@@ -76,15 +78,7 @@ feature 'New branch page' do
     then_I_should_see_no_errors
   end
 
-  def then_I_should_be_on_the_correct_branch_page(path)
-    expect(URI(current_url).path.split('/').last).to eq(path)
-  end
-
   def then_I_should_see_previous_saved_choices(attribute, selected)
     expect(page).to have_select(attribute, selected: selected)
-  end
-
-  def then_I_should_see_no_errors
-    expect(page).not_to have_selector('.govuk-error-summary')
   end
 end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -111,10 +111,14 @@ class EditorApp < SitePrism::Page
   element :three_dots_button, '.form-step_button'
   element :preview_page_link, :link, 'Preview page'
   element :add_page_here_link, :link, 'Add page here'
-  element :delete_page_link, :link, 'Delete page...'
-  element :delete_page_modal_button, :button, 'Delete page'
-  element :branching_link, :link, 'Add branching'
-  element :add_another_branch, :link, 'Add another branch'
+  element :delete_page_link, :link, I18n.t('actions.delete_page')
+  element :delete_page_modal_button, :button, I18n.t('dialogs.button_delete_page')
+  element :branching_link, :link, I18n.t('services.branch')
+
+  element :add_condition, :button, I18n.t('branches.condition_add')
+  element :remove_condition, :button, I18n.t('branches.condition_remove') # bin icon
+  element :add_another_branch, :link, I18n.t('branches.branch_add')
+  element :conditional_three_dot, :button, '.ActivatedMenu_Activator'
 
   element :destination_options, '#branch_conditionals_attributes_0_next'
   element :conditional_options, '#branch_conditionals_attributes_0_expressions_attributes_0_component'
@@ -128,5 +132,9 @@ class EditorApp < SitePrism::Page
 
   def modal_create_service_button
     all('.ui-dialog-buttonpane button').first
+  end
+
+  def branch_title(index)
+    find("div[data-conditional-index='#{index}'] p")
   end
 end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -60,7 +60,7 @@ class EditorApp < SitePrism::Page
           :xpath,
           "//a[@class='ui-menu-item-wrapper' and contains(.,'Content page')]"
 
-  element :add_a_component_button, :link, 'Add component'
+  element :add_a_component_button, :link, I18n.t('components.actions.add_component')
   element :question_component,
           :xpath,
           "//*[@role='menuitem' and contains(.,'Question')]"
@@ -73,16 +73,16 @@ class EditorApp < SitePrism::Page
           :xpath,
           "//span[@class='ui-menu-item-wrapper' and contains(.,'Required...')]"
 
-  element :add_text, :link, 'Text', visible: false
-  element :add_text_area, :link, 'Textarea', visible: false
-  element :add_number, :link, 'Number', visible: false
-  element :add_file_upload, :link, 'File upload', visible: false
-  element :add_date, :link, 'Date', visible: false
-  element :add_radio, :link, 'Radio buttons', visible: false
-  element :add_checkboxes, :link, 'Checkboxes', visible: false
-  element :add_content, :link, 'Content area', visible: false
+  element :add_text, :link, I18n.t('components.list.text'), visible: false
+  element :add_text_area, :link, I18n.t('components.list.textarea'), visible: false
+  element :add_number, :link, I18n.t('components.list.number'), visible: false
+  element :add_file_upload, :link, I18n.t('components.list.upload'), visible: false
+  element :add_date, :link, I18n.t('components.list.date'), visible: false
+  element :add_radio, :link, I18n.t('components.list.radios'), visible: false
+  element :add_checkboxes, :link, I18n.t('components.list.checkboxes'), visible: false
+  element :add_content, :link, I18n.t('components.menu.content_area'), visible: false
 
-  elements :add_page_submit_button, :button, 'Add page'
+  elements :add_page_submit_button, :button, I18n.t('pages.create')
   element :save_page_button, :xpath, '//input[@value="Save"]'
 
   elements :radio_options, :xpath, '//input[@type="radio"]', visible: false
@@ -109,8 +109,8 @@ class EditorApp < SitePrism::Page
   elements :form_urls, '.form-step a.govuk-link'
   elements :preview_page_images, '.form-step img.body'
   element :three_dots_button, '.form-step_button'
-  element :preview_page_link, :link, 'Preview page'
-  element :add_page_here_link, :link, 'Add page here'
+  element :preview_page_link, :link, I18n.t('actions.preview_page')
+  element :add_page_here_link, :link, I18n.t('actions.add_page')
   element :delete_page_link, :link, I18n.t('actions.delete_page')
   element :delete_page_modal_button, :button, I18n.t('dialogs.button_delete_page')
   element :branching_link, :link, I18n.t('services.branch')

--- a/acceptance/support/branching_steps.rb
+++ b/acceptance/support/branching_steps.rb
@@ -37,6 +37,23 @@ module BranchingSteps
     when_I_add_the_page
   end
 
+  def then_I_can_add_and_delete_conditionals_and_expressions
+    and_I_add_another_condition
+    then_I_should_see_the_operator(I18n.t('branches.expression.and'))
+    then_I_should_see_another_question_list
+    then_I_should_see_the_delete_condition_button
+
+    and_I_delete_the_condition
+    then_I_should_not_see_the_operator(I18n.t('branches.expression.and'))
+    then_I_should_not_see_text(I18n.t('branches.condition_remove'))
+
+    and_I_add_another_branch
+    then_I_should_see_the_branch_title(index: 1, title: 'Branch 2')
+
+    and_I_delete_the_conditional(1)
+    then_I_should_not_see_text('Branch 2')
+  end
+
   def when_I_update_the_question_name(question_name)
     editor.question_heading.first.set(question_name)
     when_I_save_my_changes
@@ -94,5 +111,77 @@ module BranchingSteps
 
   def and_I_select_the_otherwise_dropdown
     editor.otherwise_options.click
+  end
+
+  def then_I_should_see_no_errors
+    expect(page).not_to have_selector('.govuk-error-summary')
+  end
+
+  def then_I_should_be_on_the_correct_branch_page(path)
+    expect(URI(current_url).path.split('/').last).to eq(path)
+  end
+
+  def and_I_add_another_condition
+    editor.add_condition.click
+  end
+
+  def and_I_delete_the_condition
+    editor.remove_condition.click
+  end
+
+  def and_I_add_another_branch
+    editor.add_another_branch.click
+  end
+
+  def and_I_delete_the_conditional(index)
+    editor.find("div[data-conditional-index='#{index}'] button").click
+    editor.find('a.branch-remover').click
+  end
+
+  def then_I_should_see_the_operator(text)
+    page_with_css('div.question label.govuk-label', text)
+  end
+
+  def page_with_css(element, text)
+    expect(page).to have_css(element, text: text)
+  end
+
+  def page_without_css(element, text)
+    expect(page).not_to have_css(element, text: text)
+  end
+
+  def then_I_should_see_another_question_list
+    then_I_should_see_text(I18n.t('branches.expression.and'))
+    then_I_should_see_text(I18n.t('branches.select_question'))
+  end
+
+  def then_I_should_not_see_text(text)
+    expect(page).not_to have_text(text)
+  end
+
+  def then_I_should_see_text(text)
+    expect(page).to have_text(text)
+  end
+
+  def then_I_should_see_the_add_condition_link
+    # wait for the api call to get the operators and answers
+    sleep(2)
+    expect(page).to have_text(I18n.t('branches.condition_add'))
+  end
+
+  def then_I_should_not_see_the_delete_condition_button
+    page_without_css('button.condition-remove', I18n.t('branches.condition_remove'))
+  end
+
+  def then_I_should_see_the_delete_condition_button
+    page_with_css('button.condition-remover', I18n.t('branches.condition_remove'))
+  end
+
+  def then_I_should_not_see_the_operator(text)
+    page_without_css('div.question label.govuk-label', text)
+  end
+
+  def then_I_should_see_the_branch_title(index:, title:)
+    expect(editor.branch_title(index).text).to eq(title)
   end
 end

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -1,9 +1,9 @@
 module CommonSteps
   OPTIONAL_TEXT = [
-    '[Optional section heading]',
-    '[Optional lede paragraph]',
-    '[Optional content]',
-    '[Optional hint text]'
+    I18n.t('default_text.section_heading'),
+    I18n.t('default_text.lede'),
+    I18n.t('default_text.content'),
+    I18n.t('default_text.option_hint')
   ].freeze
   ERROR_MESSAGE = 'There is a problem'.freeze
 
@@ -183,7 +183,7 @@ module CommonSteps
   def when_I_want_to_select_question_properties
     editor.question_heading.first.click
     editor.question_three_dots_button.click
-    editor.should_not have_css('span', text: 'Delete...')
+    expect(editor).not_to have_css('span', text: I18n.t('question.menu.remove'))
   end
 
   def and_I_want_to_set_a_question_optional

--- a/acceptance/support/multiple_questions_page_helper.rb
+++ b/acceptance/support/multiple_questions_page_helper.rb
@@ -73,7 +73,7 @@ module MultipleQuestionsPageHelper
   end
 
   def and_I_want_to_delete_a_component
-    editor.find('span', text: 'Delete...').click
-    editor.find('button', text: 'Delete option').click
+    editor.find('span', text: I18n.t('question.menu.remove')).click
+    editor.find('button', text: I18n.t('dialogs.button_delete_option')).click
   end
 end

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -37,7 +37,7 @@
             File.join(preview_service_path(service.service_id), page.url),
             target: '_blank' %>
           </li>
-          <li data-action="add"><a href="#add-page-here">Add page here</a></li>
+          <li data-action="add"><a href="#add-page-here"><%= t('actions.add_page') %></a></li>
           <li data-action="delete">
             <% unless page.type == 'page.start' %>
               <%= link_to t('actions.delete_page'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,7 @@ en:
   actions:
     edit: 'Edit'
     save: 'Save'
+    add_page: 'Add page here'
     publish_to_test: 'Publish to Test'
     publish_to_live: 'Publish to Live'
     edit_page: 'Edit Page'


### PR DESCRIPTION
## Add acceptance tests for the Edit Branch page

This adds some acceptance tests around user interaction with the new and
edit branch pages.

Users should be able to add and delete expressions and conditionals.

Use I18n translations in editor app for acceptance tests