### PR TITLE
Flow thumbnail link generator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.4.0'
+gem 'metadata_presenter', '2.4.1'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    metadata_presenter (2.4.0)
+    metadata_presenter (2.4.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -391,7 +391,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.4.0)
+  metadata_presenter (= 2.4.1)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.0)
   pg (>= 0.18, < 2.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,16 +8,18 @@ module ApplicationHelper
            else
              page.components.first.type
            end
-    thumbnail_link(uuid: page.uuid, type: type, heading: page.title)
+    thumbnail_link(uuid: page.uuid, thumbnail: type, title: page.title)
   end
   # Remove once new service flow page is finished
 
-  def thumbnail_link(uuid:, type:, heading:)
-    link_to edit_page_path(service.service_id, uuid), class: "form-step_thumbnail #{type}", 'aria-hidden': true do
+  def thumbnail_link(args)
+    link_to edit_page_path(
+      service.service_id, args[:uuid]
+    ), class: "form-step_thumbnail #{args[:thumbnail]}", 'aria-hidden': true do
       concat image_pack_tag('thumbnails/thumbs_header.png', class: 'header', alt: '')
       concat tag.span("#{t('actions.edit')}: ", class: 'govuk-visually-hidden')
-      concat tag.span(heading, class: 'text')
-      concat image_pack_tag("thumbnails/thumbs_#{type}.jpg", class: 'body', alt: '')
+      concat tag.span(args[:title], class: 'text')
+      concat image_pack_tag("thumbnails/thumbs_#{args[:thumbnail]}.jpg", class: 'body', alt: '')
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,31 +1,23 @@
 module ApplicationHelper
   include MetadataPresenter::ApplicationHelper
 
-  # Used to display a thumbnail on form page with dynamic heading.
-  # Due to complexity have created this helper to keep logic out
-  # of the template.
-  def flow_thumbnail(page, parent_id)
-    heading = flow_thumbnail_heading(page)
+  # Remove once new service flow page is finished
+  def flow_thumbnail(page)
     type = if page.components.blank?
-             page._type.gsub('page.', '')
+             page.type.gsub('page.', '')
            else
-             page.components[0]._type
+             page.components.first.type
            end
-    link_to edit_page_path(parent_id, page.uuid), class: "form-step_thumbnail #{type}", 'aria-hidden': true do
+    thumbnail_link(uuid: page.uuid, type: type, heading: page.title)
+  end
+  # Remove once new service flow page is finished
+
+  def thumbnail_link(uuid:, type:, heading:)
+    link_to edit_page_path(service.service_id, uuid), class: "form-step_thumbnail #{type}", 'aria-hidden': true do
       concat image_pack_tag('thumbnails/thumbs_header.png', class: 'header', alt: '')
       concat tag.span("#{t('actions.edit')}: ", class: 'govuk-visually-hidden')
       concat tag.span(heading, class: 'text')
       concat image_pack_tag("thumbnails/thumbs_#{type}.jpg", class: 'body', alt: '')
-    end
-  end
-
-  def flow_thumbnail_heading(page)
-    if page.components.blank?
-      page.heading
-    elsif page._type == 'page.multiplequestions'
-      page.heading
-    else
-      page.components[0].label || page.components[0].legend
     end
   end
 

--- a/app/models/pages_flow.rb
+++ b/app/models/pages_flow.rb
@@ -79,8 +79,23 @@ class PagesFlow
     {
       type: obj.type,
       title: obj.title,
-      uuid: obj.uuid
+      uuid: obj.uuid,
+      thumbnail: thumbnail_type(obj)
     }
+  end
+
+  def thumbnail_type(obj)
+    if use_flow_type?(obj)
+      obj.type.gsub(/(flow|page)./, '')
+    else
+      obj.components.first.type
+    end
+  end
+
+  def use_flow_type?(obj)
+    obj.components.blank? ||
+      obj.branch? ||
+      obj.type =~ /page.(start|checkanswers|confirmation)/
   end
 
   def branch_conditionals(conditionals)

--- a/app/views/partials/_standalone.html.erb
+++ b/app/views/partials/_standalone.html.erb
@@ -6,7 +6,7 @@
     <ul class="govuk-navigation govuk-!-margin-top-8">
       <% service.standalone_pages.each do |page| %>
         <li class="standalone-pages govuk-!-padding-right-9 govuk-!-margin-top-5">
-          <%= flow_thumbnail(page, service.service_id) %>
+          <%= flow_thumbnail(page) %>
           <%= link_to page.url, edit_page_path(service.service_id, page.uuid), class: 'govuk-link' %>
         </li>
       <% end %>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -20,13 +20,13 @@
     <% service.pages.each do |page| %>
       <section class="form-step" aria-label="<%= t('aria.' + page.type) %>">
 
-        <%= flow_thumbnail(page, service.service_id) %>
+        <%= flow_thumbnail(page) %>
 
         <ul class="govuk-navigation component-activated-menu"
             data-activator-text="<%= t('pages.actions') %>"
             data-activator-classname="form-step_button"
             data-component="PageActionMenu"
-            data-page-heading="<%= flow_thumbnail_heading(page) %>"
+            data-page-heading="<%= page.title %>"
             data-uuid="<%= page._uuid %>">
           <li data-action="edit">
             <%= link_to t('actions.edit_page'),

--- a/spec/models/pages_flow_spec.rb
+++ b/spec/models/pages_flow_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe PagesFlow do
               type: 'page.start',
               title: 'Service name goes here',
               uuid: 'cf6dc32f-502c-4215-8c27-1151a45735bb',
-              next: '9e1ba77f-f1e5-42f4-b090-437aa9af7f73'
+              next: '9e1ba77f-f1e5-42f4-b090-437aa9af7f73',
+              thumbnail: 'start'
             }
           ],
           [
@@ -28,7 +29,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Full name',
               uuid: '9e1ba77f-f1e5-42f4-b090-437aa9af7f73',
-              next: 'df1ba645-f748-46d0-ad75-f34112653e37'
+              next: 'df1ba645-f748-46d0-ad75-f34112653e37',
+              thumbnail: 'text'
             }
           ],
           [
@@ -36,7 +38,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Email address',
               uuid: 'df1ba645-f748-46d0-ad75-f34112653e37',
-              next: '4b8c6bf3-878a-4446-9198-48351b3e2185'
+              next: '4b8c6bf3-878a-4446-9198-48351b3e2185',
+              thumbnail: 'text'
             }
           ],
           [
@@ -44,7 +47,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Parent name',
               uuid: '4b8c6bf3-878a-4446-9198-48351b3e2185',
-              next: '54ccc6cd-60c0-4749-947b-a97af1bc0aa2'
+              next: '54ccc6cd-60c0-4749-947b-a97af1bc0aa2',
+              thumbnail: 'text'
             }
           ],
           [
@@ -52,7 +56,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Your age',
               uuid: '54ccc6cd-60c0-4749-947b-a97af1bc0aa2',
-              next: 'b8335af2-6642-4e2f-8192-0dd12279eec7'
+              next: 'b8335af2-6642-4e2f-8192-0dd12279eec7',
+              thumbnail: 'number'
             }
           ],
           [
@@ -60,7 +65,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Family Hobbies',
               uuid: 'b8335af2-6642-4e2f-8192-0dd12279eec7',
-              next: '68fbb180-9a2a-48f6-9da6-545e28b8d35a'
+              next: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
+              thumbnail: 'textarea'
             }
           ],
           [
@@ -68,7 +74,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Do you like Star Wars?',
               uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
-              next: '7806cd64-0c05-450e-ba6f-2325c8b22d46'
+              next: '7806cd64-0c05-450e-ba6f-2325c8b22d46',
+              thumbnail: 'radios'
             }
           ],
           [
@@ -76,7 +83,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'What is the day that you like to take holidays?',
               uuid: '7806cd64-0c05-450e-ba6f-2325c8b22d46',
-              next: '0c022e95-0748-4dda-8ba5-12fd1d2f596b'
+              next: '0c022e95-0748-4dda-8ba5-12fd1d2f596b',
+              thumbnail: 'date'
             }
           ],
           [
@@ -84,7 +92,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'What would you like on your burger?',
               uuid: '0c022e95-0748-4dda-8ba5-12fd1d2f596b',
-              next: 'e8708909-922e-4eaf-87a5-096f7a713fcb'
+              next: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
+              thumbnail: 'checkboxes'
             }
           ],
           [
@@ -92,7 +101,8 @@ RSpec.describe PagesFlow do
               type: 'page.multiplequestions',
               title: 'How well do you know Star Wars?',
               uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
-              next: '80420693-d6f2-4fce-a860-777ca774a6f5'
+              next: '80420693-d6f2-4fce-a860-777ca774a6f5',
+              thumbnail: 'text'
             }
           ],
           [
@@ -100,7 +110,8 @@ RSpec.describe PagesFlow do
               type: 'page.content',
               title: 'Tell me how many lights you see',
               uuid: '80420693-d6f2-4fce-a860-777ca774a6f5',
-              next: '2ef7d11e-0307-49e9-9fe2-345dc528dd66'
+              next: '2ef7d11e-0307-49e9-9fe2-345dc528dd66',
+              thumbnail: 'content'
             }
           ],
           [
@@ -108,7 +119,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Upload your best dog photo',
               uuid: '2ef7d11e-0307-49e9-9fe2-345dc528dd66',
-              next: 'e337070b-f636-49a3-a65c-f506675265f0'
+              next: 'e337070b-f636-49a3-a65c-f506675265f0',
+              thumbnail: 'upload'
             }
           ],
           [
@@ -116,7 +128,8 @@ RSpec.describe PagesFlow do
               type: 'page.checkanswers',
               title: 'Check your answers',
               uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
-              next: '778e364b-9a7f-4829-8eb2-510e08f156a3'
+              next: '778e364b-9a7f-4829-8eb2-510e08f156a3',
+              thumbnail: 'checkanswers'
             }
           ],
           [
@@ -124,7 +137,8 @@ RSpec.describe PagesFlow do
               type: 'page.confirmation',
               title: 'Complaint sent',
               uuid: '778e364b-9a7f-4829-8eb2-510e08f156a3',
-              next: ''
+              next: '',
+              thumbnail: 'confirmation'
             }
           ]
         ]
@@ -148,7 +162,8 @@ RSpec.describe PagesFlow do
               type: 'page.start',
               title: 'Service name goes here',
               uuid: 'cf6dc32f-502c-4215-8c27-1151a45735bb',
-              next: '9e1ba77f-f1e5-42f4-b090-437aa9af7f73'
+              next: '9e1ba77f-f1e5-42f4-b090-437aa9af7f73',
+              thumbnail: 'start'
             }
           ],
           [
@@ -156,7 +171,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Full name',
               uuid: '9e1ba77f-f1e5-42f4-b090-437aa9af7f73',
-              next: '68fbb180-9a2a-48f6-9da6-545e28b8d35a'
+              next: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
+              thumbnail: 'text'
             }
           ],
           [
@@ -164,7 +180,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Do you like Star Wars?',
               uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
-              next: '09e91fd9-7a46-4840-adbc-244d545cfef7'
+              next: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+              thumbnail: 'radios'
             }
           ],
           [
@@ -172,6 +189,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 1',
               uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+              thumbnail: 'branch',
               conditionals: [
                 {
                   next: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
@@ -199,7 +217,8 @@ RSpec.describe PagesFlow do
               type: 'page.multiplequestions',
               title: 'How well do you know Star Wars?',
               uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
-              next: '0b297048-aa4d-49b6-ac74-18e069118185'
+              next: '0b297048-aa4d-49b6-ac74-18e069118185',
+              thumbnail: 'text'
             }
           ],
           [
@@ -207,7 +226,8 @@ RSpec.describe PagesFlow do
               title: 'What is your favourite fruit?',
               type: 'page.singlequestion',
               uuid: '0b297048-aa4d-49b6-ac74-18e069118185',
-              next: 'ffadeb22-063b-4e4f-9502-bd753c706b1d'
+              next: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+              thumbnail: 'radios'
             }
           ],
           [
@@ -215,6 +235,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 2',
               uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+              thumbnail: 'branch',
               conditionals: [
                 {
                   next: 'd4342dfd-0d09-4a91-a0ea-d7fd67e706cc',
@@ -251,13 +272,15 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Do you like apple juice?',
               uuid: 'd4342dfd-0d09-4a91-a0ea-d7fd67e706cc',
-              next: '05c3306c-0a39-42d2-9e0f-93fd49248f4e'
+              next: '05c3306c-0a39-42d2-9e0f-93fd49248f4e',
+              thumbnail: 'radios'
             },
             {
               type: 'page.singlequestion',
               title: 'Do you like orange juice?',
               uuid: '91e9f7c6-2f75-4b7d-9eb5-0cf352f7be66',
-              next: '05c3306c-0a39-42d2-9e0f-93fd49248f4e'
+              next: '05c3306c-0a39-42d2-9e0f-93fd49248f4e',
+              thumbnail: 'radios'
             }
           ],
           [
@@ -265,7 +288,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'What is your favourite band?',
               uuid: '05c3306c-0a39-42d2-9e0f-93fd49248f4e',
-              next: '1d02e508-5953-4eca-af2f-9d67511c8648'
+              next: '1d02e508-5953-4eca-af2f-9d67511c8648',
+              thumbnail: 'radios'
             }
           ],
           [
@@ -273,6 +297,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 3',
               uuid: '1d02e508-5953-4eca-af2f-9d67511c8648',
+              thumbnail: 'branch',
               conditionals: [
                 {
                   next: '8002df6e-29ab-4cdf-b520-1d7bb931a28f',
@@ -300,7 +325,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Which app do you use to listen music?',
               uuid: '8002df6e-29ab-4cdf-b520-1d7bb931a28f',
-              next: 'ef2cafe3-37e2-4533-9b0c-09a970cd38d4'
+              next: 'ef2cafe3-37e2-4533-9b0c-09a970cd38d4',
+              thumbnail: 'radios'
             }
           ],
           [
@@ -308,7 +334,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'What is the best form builder?',
               uuid: 'ef2cafe3-37e2-4533-9b0c-09a970cd38d4',
-              next: 'cf8b3e18-dacf-4e91-92e1-018035961003'
+              next: 'cf8b3e18-dacf-4e91-92e1-018035961003',
+              thumbnail: 'radios'
             }
           ],
           [
@@ -316,6 +343,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 4',
               uuid: 'cf8b3e18-dacf-4e91-92e1-018035961003',
+              thumbnail: 'branch',
               conditionals: [
                 {
                   next: 'b5efc09c-ece7-45ae-b0b3-8a7905e25040',
@@ -343,7 +371,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Which Formbuilder is the best?',
               uuid: 'b5efc09c-ece7-45ae-b0b3-8a7905e25040',
-              next: '0c022e95-0748-4dda-8ba5-12fd1d2f596b'
+              next: '0c022e95-0748-4dda-8ba5-12fd1d2f596b',
+              thumbnail: 'text'
             }
           ],
           [
@@ -351,7 +380,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'What would you like on your burger?',
               uuid: '0c022e95-0748-4dda-8ba5-12fd1d2f596b',
-              next: '618b7537-b42b-4551-ae7d-053afa4d9ca9'
+              next: '618b7537-b42b-4551-ae7d-053afa4d9ca9',
+              thumbnail: 'checkboxes'
             }
           ],
           [
@@ -359,6 +389,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 5',
               uuid: '618b7537-b42b-4551-ae7d-053afa4d9ca9',
+              thumbnail: 'branch',
               conditionals: [
                 {
                   next: 'bc666714-c0a2-4674-afe5-faff2e20d847',
@@ -395,13 +426,15 @@ RSpec.describe PagesFlow do
               type: 'page.content',
               title: 'Global warming',
               uuid: 'bc666714-c0a2-4674-afe5-faff2e20d847',
-              next: 'dc7454f9-4186-48d7-b055-684d57bbcdc7'
+              next: 'dc7454f9-4186-48d7-b055-684d57bbcdc7',
+              thumbnail: 'content'
             },
             {
               type: 'page.content',
               title: 'We love chickens',
               uuid: 'e2887f44-5e8d-4dc0-b1de-496ab6039430',
-              next: 'dc7454f9-4186-48d7-b055-684d57bbcdc7'
+              next: 'dc7454f9-4186-48d7-b055-684d57bbcdc7',
+              thumbnail: 'content'
             }
           ],
           [
@@ -409,7 +442,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'What is the best marvel series?',
               uuid: 'dc7454f9-4186-48d7-b055-684d57bbcdc7',
-              next: '84a347fc-8d4b-486a-9996-6a86fa9544c5'
+              next: '84a347fc-8d4b-486a-9996-6a86fa9544c5',
+              thumbnail: 'radios'
             }
           ],
           [
@@ -417,6 +451,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 6',
               uuid: '84a347fc-8d4b-486a-9996-6a86fa9544c5',
+              thumbnail: 'branch',
               conditionals: [
                 {
                   next: '2cc66e51-2c14-4023-86bf-ded49887cdb2',
@@ -466,13 +501,15 @@ RSpec.describe PagesFlow do
               type: 'page.content',
               title: 'Loki',
               uuid: '2cc66e51-2c14-4023-86bf-ded49887cdb2',
-              next: '48357db5-7c06-4e85-94b1-5e1c9d8f39eb'
+              next: '48357db5-7c06-4e85-94b1-5e1c9d8f39eb',
+              thumbnail: 'content'
             },
             {
               type: 'page.content',
               title: 'Other quotes',
               uuid: 'f6c51f88-7be8-4cb7-bbfc-6c905727a051',
-              next: '48357db5-7c06-4e85-94b1-5e1c9d8f39eb'
+              next: '48357db5-7c06-4e85-94b1-5e1c9d8f39eb',
+              thumbnail: 'content'
             }
           ],
           [
@@ -480,7 +517,8 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Select all Arnold Schwarzenegger quotes',
               uuid: '48357db5-7c06-4e85-94b1-5e1c9d8f39eb',
-              next: '1079b5b8-abd0-4bf6-aaac-1f01e69e3b39'
+              next: '1079b5b8-abd0-4bf6-aaac-1f01e69e3b39',
+              thumbnail: 'checkboxes'
             }
           ],
           [
@@ -488,6 +526,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 7',
               uuid: '1079b5b8-abd0-4bf6-aaac-1f01e69e3b39',
+              thumbnail: 'branch',
               conditionals: [
                 {
                   next: '56e80942-d0a4-405a-85cd-bd1b100013d6',
@@ -541,19 +580,22 @@ RSpec.describe PagesFlow do
               type: 'page.content',
               title: 'You are right',
               uuid: '56e80942-d0a4-405a-85cd-bd1b100013d6',
-              next: 'e337070b-f636-49a3-a65c-f506675265f0'
+              next: 'e337070b-f636-49a3-a65c-f506675265f0',
+              thumbnail: 'content'
             },
             {
               type: 'page.content',
               title: 'You are wrong', # wrong answers, GOTG quotes
               uuid: '6324cca4-7770-4765-89b9-1cdc41f49c8b',
-              next: 'e337070b-f636-49a3-a65c-f506675265f0'
+              next: 'e337070b-f636-49a3-a65c-f506675265f0',
+              thumbnail: 'content'
             },
             {
               type: 'page.content',
               title: 'You are wrong', # incomplete answers, Otherwise
               uuid: '941137d7-a1da-43fd-994a-98a4f9ea6d46',
-              next: 'e337070b-f636-49a3-a65c-f506675265f0'
+              next: 'e337070b-f636-49a3-a65c-f506675265f0',
+              thumbnail: 'content'
             }
           ],
           [
@@ -561,7 +603,8 @@ RSpec.describe PagesFlow do
               type: 'page.checkanswers',
               title: 'Check your answers',
               uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
-              next: '778e364b-9a7f-4829-8eb2-510e08f156a3'
+              next: '778e364b-9a7f-4829-8eb2-510e08f156a3',
+              thumbnail: 'checkanswers'
             }
           ],
           [
@@ -569,7 +612,8 @@ RSpec.describe PagesFlow do
               type: 'page.confirmation',
               title: 'Complaint sent',
               uuid: '778e364b-9a7f-4829-8eb2-510e08f156a3',
-              next: ''
+              next: '',
+              thumbnail: 'confirmation'
             }
           ]
         ]
@@ -593,7 +637,8 @@ RSpec.describe PagesFlow do
         type: 'page.singlequestion',
         title: 'What is the best form builder?',
         uuid: 'ef2cafe3-37e2-4533-9b0c-09a970cd38d4',
-        next: 'cf8b3e18-dacf-4e91-92e1-018035961003'
+        next: 'cf8b3e18-dacf-4e91-92e1-018035961003',
+        thumbnail: 'radios'
       }
     end
 
@@ -610,6 +655,7 @@ RSpec.describe PagesFlow do
           type: 'flow.branch',
           title: 'Branching point 1',
           uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+          thumbnail: 'branch',
           conditionals: [
             {
               next: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
@@ -645,6 +691,7 @@ RSpec.describe PagesFlow do
           type: 'flow.branch',
           title: 'Branching point 5',
           uuid: '618b7537-b42b-4551-ae7d-053afa4d9ca9',
+          thumbnail: 'branch',
           conditionals: [
             {
               next: 'bc666714-c0a2-4674-afe5-faff2e20d847',
@@ -731,6 +778,7 @@ RSpec.describe PagesFlow do
           type: 'flow.branch',
           title: 'Branching point 7',
           uuid: '1079b5b8-abd0-4bf6-aaac-1f01e69e3b39',
+          thumbnail: 'branch',
           conditionals: [
             {
               next: '56e80942-d0a4-405a-85cd-bd1b100013d6',
@@ -780,6 +828,7 @@ RSpec.describe PagesFlow do
           type: 'flow.branch',
           title: 'Branching point 7',
           uuid: '1079b5b8-abd0-4bf6-aaac-1f01e69e3b39',
+          thumbnail: 'branch',
           conditionals: [
             {
               next: '56e80942-d0a4-405a-85cd-bd1b100013d6',


### PR DESCRIPTION
## Create thumbnail_link application helper

Move the generation of the thumbnail link into its own method so it can
be called independently with the correct arguments.

Remove the `flow_thumbnail_heading` method as there is already the `title`
method on the MetadataPresenter::Page object which does the same thing.

## Add thumbnail type to pages flow objects

This adds the thumbnail type to each pages flow object. This can be used
together with the object uuid and title to call the `thumbnail_link`
helper to generate the correct link to edit page or branch.

Each page flow object, pages and branches, now have a `thumbnail` property, e.g:

```
{
  type: 'page.singlequestion',
  title: 'Your age',
  uuid: '54ccc6cd-60c0-4749-947b-a97af1bc0aa2',
  next: 'b8335af2-6642-4e2f-8192-0dd12279eec7',
  thumbnail: 'number'
}
```

Therefore given a `flow_object` variable with the above example contents it 
is now possible to just pass it to call `thumbnail_link(flow_object)` which will
return the generated link to the object page with the correct attributes.