### PR TITLE
Change destination

### DIFF
--- a/app/controllers/api/destinations_controller.rb
+++ b/app/controllers/api/destinations_controller.rb
@@ -1,0 +1,28 @@
+module Api
+  class DestinationsController < BranchesController
+    def new
+      @destination = build_destination
+
+      render :new, layout: false
+    end
+
+    def create
+      @destination = build_destination
+
+      if @destination.change
+        redirect_to edit_service_path(service.service_id)
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def build_destination
+      Destination.new(
+        flow_uuid: params[:flow_uuid],
+        destination_uuid: params[:destination_uuid]
+      )
+    end
+  end
+end

--- a/app/controllers/api/destinations_controller.rb
+++ b/app/controllers/api/destinations_controller.rb
@@ -17,6 +17,7 @@ module Api
 
     def build_destination
       Destination.new(
+        service: service,
         flow_uuid: params[:flow_uuid],
         destination_uuid: params[:destination_uuid]
       )

--- a/app/controllers/api/destinations_controller.rb
+++ b/app/controllers/api/destinations_controller.rb
@@ -7,13 +7,10 @@ module Api
     end
 
     def create
-      @destination = build_destination
+      destination = build_destination
 
-      if @destination.change
-        redirect_to edit_service_path(service.service_id)
-      else
-        render :new, status: :unprocessable_entity
-      end
+      destination.change
+      redirect_to edit_service_path(service.service_id)
     end
 
     private

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -11,4 +11,24 @@ class Destination
     service.flow[flow_uuid]['next']['default'] = destination_uuid
     service.metadata.to_h.deep_stringify_keys
   end
+
+  def destinations
+    (pages + branches).map { |item| [item.title, item.uuid] }
+  end
+
+  def current_destination
+    service.flow_object(flow_uuid).default_next
+  end
+
+  private
+
+  def pages
+    service.pages.reject do |page|
+      page.type.in?(INVALID_DESTINATIONS) || page.uuid == flow_uuid
+    end
+  end
+
+  def branches
+    service.branches.sort_by(&:title)
+  end
 end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,0 +1,14 @@
+class Destination
+  include ActiveModel::Model
+  include MetadataVersion
+  attr_accessor :service, :flow_uuid, :destination_uuid
+
+  INVALID_DESTINATIONS = %w[page.start page.confirmation].freeze
+
+  alias_method :change, :create_version
+
+  def metadata
+    service.flow[flow_uuid]['next']['default'] = destination_uuid
+    service.metadata.to_h.deep_stringify_keys
+  end
+end

--- a/app/models/metadata_version.rb
+++ b/app/models/metadata_version.rb
@@ -9,7 +9,7 @@ module MetadataVersion
       errors.add(:base, :invalid, message: version.errors)
       false
     else
-      @version = version
+      version.metadata
     end
   end
 end

--- a/app/views/api/destinations/new.html.erb
+++ b/app/views/api/destinations/new.html.erb
@@ -1,0 +1,5 @@
+<%= form_for @destination, url: api_service_flow_destinations_path(service.service_id, @destination.flow_uuid) do |f| %>
+  <%= f.select(:destination_uuid, []) %>
+
+  <%= f.submit t('actions.change_destination') %>
+<% end %>

--- a/app/views/api/destinations/new.html.erb
+++ b/app/views/api/destinations/new.html.erb
@@ -1,5 +1,29 @@
-<%= form_for @destination, url: api_service_flow_destinations_path(service.service_id, @destination.flow_uuid) do |f| %>
-  <%= f.select(:destination_uuid, []) %>
+<div class="component-dialog-form ui-dialog-content ui-widget-content" id="change-destination-dialog" data-activator-text="Change destination" data-cancel-text="Cancel" data-component="">
+  <h2 class="govuk-heading-m"><%= t('pages.destination.heading') %></h2>
 
-  <%= f.submit t('actions.change_destination') %>
-<% end %>
+  <p><%= t('pages.destination.lede') %></p>
+
+  <%= form_for @destination, url: api_service_flow_destinations_path(service.service_id, @destination.flow_uuid) do |f| %>
+
+    <%= f.select :destination_uuid, @destination.destinations,
+      {
+        include_blank: false,
+        selected: @destination.current_destination
+      },
+      {
+        class: 'govuk-select',
+        name: 'destination_uuid',
+        id: 'destination_uuid'
+      }
+    %>
+
+    <p class="govuk-hint"><%= t('pages.destination.hint') %></p>
+
+    <div class="ui-dialog-buttonpane ui-widget-content ui-helper-clearfix">
+      <div class="ui-dialog-buttonset">
+        <%= f.submit t('pages.destination.submit'), class: 'govuk-button fb-govuk-button', id: 'fb-editor-change-destination' %>
+        <button type="button" class="ui-button ui-corner-all ui-widget"><%= t('pages.destination.cancel') %></button>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -50,6 +50,10 @@
             <%= link_to t('services.branch'),
               new_branches_path(service.service_id, page.uuid) %>
           </li>
+          <li data-action="edit">
+            <%= link_to t('actions.change_destination'),
+              new_api_service_flow_destination_path(service.service_id, page.uuid) %>
+          </li>
           <% end %>
         </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,7 +73,7 @@ en:
     delete_page: 'Delete page...'
     option_add: 'Add option'
     option_remove: 'Delete...'
-    change_destination: 'Change destination'
+    change_destination: 'Change destination...'
   branches:
     branch_add: 'Add another branch'
     branch_remove: 'Delete'
@@ -96,6 +96,12 @@ en:
     cancel: 'Cancel'
     actions: 'Actions'
     footer: 'Form footer'
+    destination:
+      heading: 'Change destination'
+      lede: 'Update this connection to lead to the following page:'
+      hint: 'The page that was previously following (and attached to it) will be moved to the orphaned pages'
+      submit: 'Change destination'
+      cancel: 'Cancel'
   components:
     list:
       text: 'Text'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
     delete_page: 'Delete page...'
     option_add: 'Add option'
     option_remove: 'Delete...'
+    change_destination: 'Change destination'
   branches:
     branch_add: 'Add another branch'
     branch_remove: 'Delete'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,10 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :services do
+      resources :flow, param: :uuid, only: [] do
+        resources :destinations, only: [:new, :create]
+      end
+
       resources :pages, only: [:show]
 
       resources :branches, param: :previous_flow_uuid do

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe Destination do
+  subject(:destination) do
+    described_class.new(
+      service: service,
+      flow_uuid: flow_uuid,
+      destination_uuid: destination_uuid
+    )
+  end
+
+  describe '#change' do
+    context 'when changing the flow object destination' do
+      let(:flow_uuid) { '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' }
+      let(:destination_uuid) { 'e337070b-f636-49a3-a65c-f506675265f0' }
+      let(:version) { double(errors?: false, errors: [], metadata: updated_metadata) }
+      let(:updated_metadata) do
+        metadata = service_metadata.deep_dup
+        metadata['flow'][flow_uuid]['next']['default'] = destination_uuid
+        metadata
+      end
+
+      before do
+        expect(
+          MetadataApiClient::Version
+        ).to receive(:create).with(
+          service_id: service.service_id,
+          payload: updated_metadata
+        ).and_return(version)
+      end
+
+      it 'correctly updates the default next' do
+        updated_flow = destination.change['flow'][flow_uuid]
+        expect(updated_flow['next']['default']).to eq(destination_uuid)
+      end
+    end
+  end
+end

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -6,14 +6,16 @@ RSpec.describe Destination do
       destination_uuid: destination_uuid
     )
   end
+  let(:latest_metadata) { metadata_fixture('branching') }
+  let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+  let(:flow_uuid) { '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' } # Full name
+  let(:destination_uuid) { 'e337070b-f636-49a3-a65c-f506675265f0' }
 
   describe '#change' do
     context 'when changing the flow object destination' do
-      let(:flow_uuid) { '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' }
-      let(:destination_uuid) { 'e337070b-f636-49a3-a65c-f506675265f0' }
       let(:version) { double(errors?: false, errors: [], metadata: updated_metadata) }
       let(:updated_metadata) do
-        metadata = service_metadata.deep_dup
+        metadata = latest_metadata.deep_dup
         metadata['flow'][flow_uuid]['next']['default'] = destination_uuid
         metadata
       end
@@ -30,6 +32,57 @@ RSpec.describe Destination do
       it 'correctly updates the default next' do
         updated_flow = destination.change['flow'][flow_uuid]
         expect(updated_flow['next']['default']).to eq(destination_uuid)
+      end
+    end
+  end
+
+  describe '#destinations' do
+    context 'when listing all the destinations' do
+      let(:expected_destinations) do
+        [
+          'Do you like Star Wars?',
+          'How well do you know Star Wars?',
+          'What is your favourite fruit?',
+          'Do you like apple juice?',
+          'Do you like orange juice?',
+          'What is your favourite band?',
+          'Which app do you use to listen music?',
+          'What is the best form builder?',
+          'Which Formbuilder is the best?',
+          'What would you like on your burger?',
+          'Global warming',
+          'We love chickens',
+          'What is the best marvel series?',
+          'Loki',
+          'Other quotes',
+          'Select all Arnold Schwarzenegger quotes',
+          'You are right',
+          'You are wrong',
+          'You are wrong',
+          'Check your answers',
+          'Branching point 1',
+          'Branching point 2',
+          'Branching point 3',
+          'Branching point 4',
+          'Branching point 5',
+          'Branching point 6',
+          'Branching point 7'
+        ]
+      end
+
+      it 'returns branches and pages without start, confirmation and the page that is being changed' do
+        destinations = destination.destinations.map { |d| d[0] }
+        expect(destinations).to eq(expected_destinations)
+      end
+    end
+  end
+
+  describe '#current_destination' do
+    let(:expected_current_destination) { '68fbb180-9a2a-48f6-9da6-545e28b8d35a' } # Do you like star wars?
+
+    context 'when getting the list of destinations' do
+      it 'returns the current destination for the page' do
+        expect(destination.current_destination).to eq(expected_current_destination)
       end
     end
   end

--- a/spec/requests/api/destination_spec.rb
+++ b/spec/requests/api/destination_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe 'Destinations spec', type: :request do
+  describe 'GET /api/services/:service_id/flow/:flow_uuid/destinations/new' do
+    let(:request) do
+      get "/api/services/#{service.service_id}/flow/#{flow_uuid}/destinations/new"
+    end
+    let(:flow_uuid) { '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' }
+
+    context 'when changing the destination of a page' do
+      let(:invalid_destinations) do
+        [
+          'Service name goes here',
+          'Full name',
+          'Confirmation'
+        ]
+      end
+      let(:expected_destinations) do
+        [
+          'Email address',
+          'Parent name',
+          'Your age',
+          'Family Hobbies',
+          'Do you like Star Wars?',
+          'What is the day that you like to take holidays?',
+          'What would you like on your burger?',
+          'How well do you know Star Wars?',
+          'Tell me how many lights you see',
+          'Upload your best dog photo',
+          'Check your answers'
+        ]
+      end
+
+      before do
+        allow_any_instance_of(
+          Api::DestinationsController
+        ).to receive(:require_user!).and_return(true)
+
+        allow_any_instance_of(
+          Api::DestinationsController
+        ).to receive(:service).and_return(service)
+
+        request
+      end
+
+      it 'returns the list of possible destinations' do
+        expected_destinations.each do |title|
+          expect(response.body).to include(title)
+        end
+      end
+
+      it 'does not include the start page, confirmation page or the page being changed' do
+        invalid_destinations.each do |title|
+          expect(response.body).not_to include(title)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/expressions_spec.rb
+++ b/spec/requests/api/expressions_spec.rb
@@ -1,7 +1,5 @@
-require 'rails_helper'
-
 RSpec.describe 'Expressions spec', type: :request do
-  describe 'GET /components/:component_id/conditionals/:conditionals_index/expressions/:expressions_index' do
+  describe 'GET /api/services/:service_id/components/:component_id/conditionals/:conditionals_index/expressions/:expressions_index' do
     let(:request) do
       get "/api/services/#{service.service_id}/components/#{component_id}/conditionals/#{conditionals_index}/expressions/#{expressions_index}"
     end


### PR DESCRIPTION
## Change page destination

Update the destination UUID for a given flow object.

## Return the list of destinations

API endpoint to return the modal for changing a pages destination.

The destination list should not include the start page, confirmation
page nor the page who's destination is being changed.


## Add change destination link to page three dot menu

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>