### PR TITLE
List destination in flow order

### DIFF
--- a/acceptance/features/edit_branch_error_summaries_spec.rb
+++ b/acceptance/features/edit_branch_error_summaries_spec.rb
@@ -57,7 +57,7 @@ feature 'Branching errors' do
     and_I_select_the_otherwise_dropdown
     then_I_should_see_the_correct_number_of_options(
       '#branch_default_next',
-      7
+      5
     )
     and_I_choose_an_option(
       'branch[default_next]',
@@ -81,7 +81,7 @@ feature 'Branching errors' do
     and_I_select_the_destination_page_dropdown
     then_I_should_see_the_correct_number_of_options(
       '#branch_conditionals_attributes_0_next',
-      8
+      6
     )
     and_I_choose_an_option(
       'branch[conditionals_attributes][0][next]',
@@ -125,7 +125,7 @@ feature 'Branching errors' do
     and_I_select_the_otherwise_dropdown
     then_I_should_see_the_correct_number_of_options(
       '#branch_default_next',
-      7
+      5
     )
     and_I_choose_an_option(
       'branch[default_next]',

--- a/acceptance/features/new_branch_page_spec.rb
+++ b/acceptance/features/new_branch_page_spec.rb
@@ -21,7 +21,7 @@ feature 'New branch page' do
     and_I_select_the_destination_page_dropdown
     then_I_should_see_the_correct_number_of_options(
       '#branch_conditionals_attributes_0_next',
-      8
+      6
     )
     and_I_choose_an_option(
       'branch[conditionals_attributes][0][next]',
@@ -58,7 +58,7 @@ feature 'New branch page' do
     and_I_select_the_otherwise_dropdown
     then_I_should_see_the_correct_number_of_options(
       '#branch_default_next',
-      7
+      5
     )
     and_I_choose_an_option(
       'branch[default_next]',

--- a/acceptance/support/branching_steps.rb
+++ b/acceptance/support/branching_steps.rb
@@ -50,7 +50,7 @@ module BranchingSteps
     and_I_add_another_branch
     then_I_should_see_the_branch_title(index: 1, title: 'Branch 2')
 
-    and_I_delete_the_conditional(1)
+    and_I_delete_the_branch(1)
     then_I_should_not_see_text('Branch 2')
   end
 
@@ -76,7 +76,9 @@ module BranchingSteps
   end
 
   def then_I_should_see_the_branching_page
-    expect(editor.question_heading.first.text).to eq('Branching point 1')
+    expect(editor.question_heading.first.text).to eq(
+      I18n.t('default_values.branching_title', branching_number: 1)
+    )
   end
 
   def and_I_select_the_destination_page_dropdown
@@ -133,7 +135,7 @@ module BranchingSteps
     editor.add_another_branch.click
   end
 
-  def and_I_delete_the_conditional(index)
+  def and_I_delete_the_branch(index)
     editor.find("div[data-conditional-index='#{index}'] button").click
     editor.find('a.branch-remover').click
   end

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -1,5 +1,6 @@
 class Branch
   include ActiveModel::Model
+  include DestinationsList
   include BranchTitleGenerator
   attr_accessor :previous_flow_uuid, :service, :default_next
   attr_writer :title
@@ -67,8 +68,8 @@ class Branch
     end
   end
 
-  def pages
-    service.pages.map { |page| [page.title, page.uuid] }
+  def destinations
+    destinations_list(flow_objects: ordered_flow)
   end
 
   def previous_questions
@@ -117,6 +118,10 @@ class Branch
   end
 
   private
+
+  def ordered_flow
+    OrderedFlow.new(service: service, exclude_branches: true).build
+  end
 
   def previous_flow_object
     service.find_page_by_uuid(previous_flow_uuid) ||

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,9 +1,8 @@
 class Destination
   include ActiveModel::Model
+  include DestinationsList
   include MetadataVersion
   attr_accessor :service, :flow_uuid, :destination_uuid
-
-  INVALID_DESTINATIONS = %w[page.start page.confirmation].freeze
 
   alias_method :change, :create_version
 
@@ -13,7 +12,7 @@ class Destination
   end
 
   def destinations
-    (pages + branches).map { |item| [item.title, item.uuid] }
+    destinations_list(flow_objects: ordered_flow, current_uuid: flow_uuid)
   end
 
   def current_destination
@@ -22,13 +21,7 @@ class Destination
 
   private
 
-  def pages
-    service.pages.reject do |page|
-      page.type.in?(INVALID_DESTINATIONS) || page.uuid == flow_uuid
-    end
-  end
-
-  def branches
-    service.branches.sort_by(&:title)
+  def ordered_flow
+    OrderedFlow.new(service: service).build
   end
 end

--- a/app/models/destinations_list.rb
+++ b/app/models/destinations_list.rb
@@ -4,7 +4,7 @@ module DestinationsList
       next if invalid_destination?(flow.uuid, current_uuid)
 
       [flow_title(flow), flow.uuid]
-    }.compact
+    }.compact.uniq
   end
 
   def flow_title(flow_object)

--- a/app/models/destinations_list.rb
+++ b/app/models/destinations_list.rb
@@ -1,0 +1,31 @@
+module DestinationsList
+  def destinations_list(flow_objects:, current_uuid: nil)
+    flow_objects.map { |flow|
+      next if invalid_destination?(flow.uuid, current_uuid)
+
+      [flow_title(flow), flow.uuid]
+    }.compact
+  end
+
+  def flow_title(flow_object)
+    return flow_object.title if flow_object.branch?
+
+    page = service.find_page_by_uuid(flow_object.uuid)
+    page.title
+  end
+
+  def invalid_destination?(flow_uuid, current_uuid)
+    flow_uuid == start_uuid ||
+      flow_uuid == confirmation_uuid ||
+      flow_uuid == current_uuid
+  end
+
+  def start_uuid
+    @start_uuid ||= service.start_page.uuid
+  end
+
+  def confirmation_uuid
+    @confirmation_uuid ||=
+      service.pages.find { |page| page.type == 'page.confirmation' }&.uuid
+  end
+end

--- a/app/models/ordered_flow.rb
+++ b/app/models/ordered_flow.rb
@@ -36,6 +36,8 @@ class OrderedFlow
   attr_accessor :service, :exclude_branches, :pages_flow, :ordered
 
   def add_flow_object(previous, current)
+    return if current.branch? && exclude_branches
+
     if pages_flow
       @ordered.append(
         FlowStack.new(

--- a/app/models/ordered_flow.rb
+++ b/app/models/ordered_flow.rb
@@ -1,0 +1,51 @@
+class OrderedFlow
+  def initialize(**args)
+    @service = args.fetch(:service)
+    @exclude_branches = args.fetch(:exclude_branches, false)
+    @pages_flow = args.fetch(:pages_flow, false)
+    @ordered = []
+  end
+
+  def build
+    previous_uuid = ''
+    next_uuid = service.start_page.uuid
+
+    service.flow.size.times do
+      # confirmation page, and in the future exit pages
+      next if next_uuid.empty?
+
+      flow_object = service.flow_object(next_uuid)
+      add_flow_object(service.flow_object(previous_uuid), flow_object)
+
+      if flow_object.branch?
+        flow_object.conditionals.each do |conditional|
+          next_object = service.flow_object(conditional.next)
+          add_flow_object(flow_object, next_object)
+        end
+      end
+
+      previous_uuid = flow_object.uuid
+      next_uuid = flow_object.default_next
+    end
+
+    @ordered
+  end
+
+  private
+
+  attr_accessor :service, :exclude_branches, :pages_flow, :ordered
+
+  def add_flow_object(previous, current)
+    if pages_flow
+      @ordered.append(
+        FlowStack.new(
+          service: service,
+          previous: previous,
+          current: current
+        )
+      )
+    else
+      @ordered.append(current)
+    end
+  end
+end

--- a/app/models/pages_flow.rb
+++ b/app/models/pages_flow.rb
@@ -1,7 +1,6 @@
 class PagesFlow
   def initialize(service)
     @service = service
-    @ordered = []
     @traversed = []
   end
 
@@ -29,41 +28,10 @@ class PagesFlow
   private
 
   attr_reader :service
-  attr_accessor :ordered, :traversed
+  attr_accessor :traversed
 
   def ordered_flow
-    previous_uuid = ''
-    next_uuid = service.start_page.uuid
-
-    service.flow.size.times do
-      # confirmation page, and in the future exit pages
-      next if next_uuid.empty?
-
-      flow_object = service.flow_object(next_uuid)
-      add_flow_stack(service.flow_object(previous_uuid), flow_object)
-
-      if flow_object.branch?
-        flow_object.conditionals.each do |conditional|
-          next_object = service.flow_object(conditional.next)
-          add_flow_stack(flow_object, next_object)
-        end
-      end
-
-      previous_uuid = flow_object.uuid
-      next_uuid = flow_object.default_next
-    end
-
-    @ordered
-  end
-
-  def add_flow_stack(previous, current)
-    @ordered.append(
-      FlowStack.new(
-        service: service,
-        previous: previous,
-        current: current
-      )
-    )
+    OrderedFlow.new(service: service, pages_flow: true).build
   end
 
   def convert_flow_objects(group)

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -16,9 +16,9 @@
 
       <%= f.label :default_next, t('branches.goto'), { class: "govuk-label" } %>
       <%= f.select :default_next,
-      @branch.pages,
-      { selected: @branch.previous_flow_default_next},
-      { class: 'govuk-select' } %>
+          @branch.destinations,
+          { selected: @branch.previous_flow_default_next },
+          { class: 'govuk-select' } %>
     </div>
     <p class="govuk-!-font-weight-bold"><%= t('branches.hint_otherwise') %></p>
   </div>

--- a/app/views/branches/_form_conditionals.html.erb
+++ b/app/views/branches/_form_conditionals.html.erb
@@ -14,7 +14,7 @@
 
         <%= conditional.label :next, t('branches.goto'), { class: "govuk-label" } %>
         <%= conditional.select :next,
-          @branch.pages,
+          @branch.destinations,
           { include_blank: t('branches.select_destination') },
           { class: 'govuk-select' } %>
       </div>

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -143,26 +143,40 @@ RSpec.describe Branch do
     end
   end
 
-  describe '#pages' do
-    it 'returns all pages' do
-      expect(branch.pages.map { |page| page[0] }).to eq(
-        [
-          'Service name goes here',
-          'Full name',
-          'Email address',
-          'Parent name',
-          'Your age',
-          'Family Hobbies',
-          'Do you like Star Wars?',
-          'What is the day that you like to take holidays?',
-          'What would you like on your burger?',
-          'How well do you know Star Wars?',
-          'Tell me how many lights you see',
-          'Upload your best dog photo',
-          'Check your answers',
-          'Complaint sent'
-        ]
-      )
+  describe '#destinations' do
+    let(:latest_metadata) { metadata_fixture(:branching) }
+    let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+    let(:previous_page) do
+      service.find_page_by_url('name')
+    end
+    let(:expected_destination_pages) do
+      [
+        'Full name',
+        'Do you like Star Wars?',
+        'How well do you know Star Wars?',
+        'What is your favourite fruit?',
+        'Do you like apple juice?',
+        'Do you like orange juice?',
+        'What is your favourite band?',
+        'Which app do you use to listen music?',
+        'What is the best form builder?',
+        'Which Formbuilder is the best?',
+        'What would you like on your burger?',
+        'Global warming',
+        'We love chickens',
+        'What is the best marvel series?',
+        'Loki',
+        'Other quotes',
+        'Select all Arnold Schwarzenegger quotes',
+        'You are right',
+        'You are wrong',
+        'You are wrong',
+        'Check your answers'
+      ]
+    end
+
+    it 'returns valid destinations without branches' do
+      expect(branch.destinations.map(&:first)).to eq(expected_destination_pages)
     end
   end
 

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -41,36 +41,36 @@ RSpec.describe Destination do
       let(:expected_destinations) do
         [
           'Do you like Star Wars?',
+          'Branching point 1',
           'How well do you know Star Wars?',
           'What is your favourite fruit?',
+          'Branching point 2',
           'Do you like apple juice?',
           'Do you like orange juice?',
           'What is your favourite band?',
+          'Branching point 3',
           'Which app do you use to listen music?',
           'What is the best form builder?',
+          'Branching point 4',
           'Which Formbuilder is the best?',
           'What would you like on your burger?',
+          'Branching point 5',
           'Global warming',
           'We love chickens',
           'What is the best marvel series?',
+          'Branching point 6',
           'Loki',
           'Other quotes',
           'Select all Arnold Schwarzenegger quotes',
+          'Branching point 7',
           'You are right',
           'You are wrong',
           'You are wrong',
-          'Check your answers',
-          'Branching point 1',
-          'Branching point 2',
-          'Branching point 3',
-          'Branching point 4',
-          'Branching point 5',
-          'Branching point 6',
-          'Branching point 7'
+          'Check your answers'
         ]
       end
 
-      it 'returns branches and pages without start, confirmation and the page that is being changed' do
+      it 'returns branches and pages in flow order without start, confirmation and the page that is being changed' do
         destinations = destination.destinations.map { |d| d[0] }
         expect(destinations).to eq(expected_destinations)
       end

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -86,4 +86,46 @@ RSpec.describe Destination do
       end
     end
   end
+
+  context 'when there are different branches point to the same page' do
+    let(:page_flow) do
+      service.flow_object(service.find_page_by_url('name').uuid)
+    end
+    let(:flow_objects) { [page_flow, page_flow] }
+    let(:expected_destination_list) do
+      [['Full name', '9e1ba77f-f1e5-42f4-b090-437aa9af7f73']]
+    end
+
+    before do
+      allow_any_instance_of(Destination).to receive(:service).and_return(service)
+    end
+
+    it 'does not allow duplicate list items' do
+      expect(
+        destination.destinations_list(flow_objects: flow_objects)
+      ).to eq(expected_destination_list)
+    end
+  end
+
+  context 'when pages have the same titles' do
+    let(:wrong_answers_page) do
+      service.flow_object('6324cca4-7770-4765-89b9-1cdc41f49c8b')
+    end
+    let(:incomplete_answers_page) do
+      service.flow_object('941137d7-a1da-43fd-994a-98a4f9ea6d46')
+    end
+    let(:flow_objects) { [wrong_answers_page, incomplete_answers_page] }
+    let(:expected_destination_list) do
+      [
+        ['You are wrong', '6324cca4-7770-4765-89b9-1cdc41f49c8b'],
+        ['You are wrong', '941137d7-a1da-43fd-994a-98a4f9ea6d46']
+      ]
+    end
+
+    it 'will list both pages' do
+      expect(
+        destination.destinations_list(flow_objects: flow_objects)
+      ).to eq(expected_destination_list)
+    end
+  end
 end

--- a/spec/models/ordered_flow_spec.rb
+++ b/spec/models/ordered_flow_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe OrderedFlow do
+  subject(:ordered_flow) do
+    described_class.new(arguments.merge(service: service))
+  end
+  let(:latest_metadata) { metadata_fixture(:branching) }
+  let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+
+  describe '#build' do
+    context 'when building the pages flow' do
+      let(:arguments) { { pages_flow: true } }
+
+      it 'adds FlowStack objects' do
+        ordered_flow.build.each do |obj|
+          expect(obj).to be_a_kind_of(FlowStack)
+        end
+      end
+    end
+
+    context 'when excluding branches' do
+      let(:arguments) { { exclude_branches: true } }
+
+      it 'should not include any branch flow objects' do
+        expect(ordered_flow.build.any? { |flow| flow.type == 'flow.branch' }).to be_falsey
+      end
+    end
+
+    context 'when not building the pages flow or excluding branches' do
+      let(:arguments) { {} }
+
+      it 'should include flow branch objects' do
+        expect(ordered_flow.build.any? { |flow| flow.type == 'flow.branch' }).to be_truthy
+      end
+
+      it 'should use the MetadataPresenter::Flow objects' do
+        ordered_flow.build.each do |obj|
+          expect(obj).to be_a_kind_of(MetadataPresenter::Flow)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Order destinations list by flow

Previously we were ordering the pages and branches by when they were
added to the service. In fact these need to be ordered by the flow, much
in the same way as the PagesFlow object does when building the rich
object passed to the frontend.

Create an OrderedFlow object to be responsible for the correct ordering.
Use a DestinationsList module for creating the select list with the
correct attributes.


## Update branching point destination list

We do not want the start page or confirmation page to appear in the
destination list.

Update the branch_spec to use the branching fixture as that has
branching point flow objects.

Update the destination_spec to have the correct ordering of flow
objects. The branches are no longer listed last.

There should be no duplicated list items.

## Use OrderedFlow to build the service flow objects

## Update acceptance tests for new destination lists

The destination lists no longer contain the start page or the
confirmation page so update the acceptance tests accordingly.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>