### PR TITLE
Make sure that all items are generating UUIDs

### DIFF
--- a/app/services/page_updater.rb
+++ b/app/services/page_updater.rb
@@ -49,7 +49,7 @@ class PageUpdater
       end
     end
 
-    new_object = make_sure_uuids_are_unique(new_object)
+    new_object = check_item_uuids(new_object)
 
     @latest_metadata[page_collection][index] = new_object
     @latest_metadata
@@ -74,7 +74,7 @@ class PageUpdater
   # When the frontend sends new options it uses the component UUID to the
   # option uuid so we need to do this.
   #
-  def make_sure_uuids_are_unique(new_object)
+  def check_item_uuids(new_object)
     object =
       ActiveSupport::HashWithIndifferentAccess.new(new_object)
 
@@ -82,7 +82,7 @@ class PageUpdater
       component_id = component[:_uuid]
 
       Array(component[:items]).each do |item|
-        if item[:_uuid] == component_id
+        if item[:_uuid] == component_id || item[:_uuid].blank?
           item[:_uuid] = SecureRandom.uuid
         end
       end


### PR DESCRIPTION
## Context

New items added by the user are not generating the UUIDs, adding
the check makes the items generates the UUIDs.

Those are useful when we are selecting the expressions in the branching
If the user chooses the option "I love Star Wars" (the UUID 1234-...) then
the user will be redirected to the "Yes you shall pass!" page.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>

## Caveats

The script to add UUIDs to items that are blank will be done in the Metadata API repo.