### PR TITLE
Page creation detached objects

### DIFF
--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -131,7 +131,7 @@
   </div>
 </div>
 
-  <% if ENV['BRANCHING'] == 'enabled' %>
+  <% if ENV['BRANCHING'] == 'enabled' && @detached_objects.present? %>
   <div class="govuk-!-margin-top-10">
     <h2 class="govuk-heading-m"><%= t('pages.flow.detached') %></h2>
     <% @detached_objects.each do |flow| %>


### PR DESCRIPTION
When a new page is created the pages controller is used which renders
the services edit template containing the pages flow.

Cater for the possibility of there being no detached objects.