### PR TITLE
Use Presenter 2.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.5.0'
+gem 'metadata_presenter', '2.5.1'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    metadata_presenter (2.5.0)
+    metadata_presenter (2.5.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -391,7 +391,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.5.0)
+  metadata_presenter (= 2.5.1)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.0)
   pg (>= 0.18, < 2.0)

--- a/spec/models/pages_flow_spec.rb
+++ b/spec/models/pages_flow_spec.rb
@@ -1502,7 +1502,7 @@ RSpec.describe PagesFlow do
             [
               {
                 type: 'page.start',
-                title: 'Branching Fixture 4',
+                title: 'Branching Fixture 7',
                 uuid: 'cf6dc32f-502c-4215-8c27-1151a45735bb',
                 next: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
                 thumbnail: 'start'


### PR DESCRIPTION
Includes updates to the names of the Branching fixtures that were
incorrect.