### PR TITLE
Previous page title

### DIFF
--- a/acceptance/features/edit_branch_page_spec.rb
+++ b/acceptance/features/edit_branch_page_spec.rb
@@ -45,6 +45,7 @@ feature 'New branch page' do
     then_I_can_add_and_delete_conditionals_and_expressions
 
     when_I_save_my_changes
+    then_I_should_see_the_previous_page_title('What is your favourite hobby?')
     then_I_should_see_no_errors
   end
 end

--- a/acceptance/features/new_branch_page_spec.rb
+++ b/acceptance/features/new_branch_page_spec.rb
@@ -15,6 +15,7 @@ feature 'New branch page' do
     and_I_want_to_add_branching(1)
 
     then_I_should_be_on_the_correct_branch_page('new')
+    then_I_should_see_the_previous_page_title('What is your favourite hobby?')
     then_I_should_see_text(I18n.t('branches.title_otherwise'))
     then_I_should_see_text(I18n.t('branches.hint_otherwise'))
 

--- a/acceptance/support/branching_steps.rb
+++ b/acceptance/support/branching_steps.rb
@@ -188,4 +188,8 @@ module BranchingSteps
   def then_I_should_see_the_branch_title(index:, title:)
     expect(editor.branch_title(index).text).to eq(title)
   end
+
+  def then_I_should_see_the_previous_page_title(page_title)
+    expect(editor).to have_text(page_title)
+  end
 end

--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -20,7 +20,7 @@ class BranchesController < FormController
 
   def edit
     @branch = Branch.new(
-      branch_metadata.merge(service: service, previous_flow_uuid: params[:branch_uuid])
+      branch_metadata.merge(service: service, branch_uuid: params[:branch_uuid])
     )
   end
 

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -124,16 +124,17 @@ class Branch
     end
   end
 
-  def foo
-    # returns a single uuid
-    # find the flow objects (array) that have the branch_uuid as their next. Pull out the first uuid
-    byebug
-
-  end
-
   def previous_page_title
-    page = service.find_page_by_uuid(foo)
-    page.title
+    @previous_page_title ||= begin
+      return previous_flow_object.title if previous_flow_uuid.present?
+
+      titles = service.flow_objects.map do |flow|
+        if flow.all_destination_uuids.include?(branch_uuid)
+          flow.title || service.find_page_by_uuid(flow.uuid).title
+        end
+      end
+      titles.compact.first
+    end
   end
 
   private

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -2,7 +2,7 @@ class Branch
   include ActiveModel::Model
   include DestinationsList
   include BranchTitleGenerator
-  attr_accessor :previous_flow_uuid, :service, :default_next
+  attr_accessor :previous_flow_uuid, :service, :default_next, :branch_uuid
   attr_writer :title
   attr_reader :traversable
 
@@ -14,6 +14,8 @@ class Branch
   def initialize(attributes)
     @service = attributes.delete(:service)
     @traversable = Traversable.new(service: service, flow_uuid: previous_flow_uuid)
+    @branch_uuid = attributes.delete(:branch_uuid)
+    @previous_flow_uuid = attributes.delete(:previous_flow_uuid)
     super
   end
 
@@ -91,8 +93,12 @@ class Branch
     previous_flow_object.title
   end
 
+  def flow_uuid
+    previous_flow_uuid || branch_uuid
+  end
+
   def previous_flow_default_next
-    service.flow_object(previous_flow_uuid).default_next
+    service.flow_object(flow_uuid).default_next
   end
 
   def previous_pages
@@ -116,6 +122,18 @@ class Branch
     expression_collection.flatten.any? do |expression|
       expression.errors.messages.present?
     end
+  end
+
+  def foo
+    # returns a single uuid
+    # find the flow objects (array) that have the branch_uuid as their next. Pull out the first uuid
+    byebug
+
+  end
+
+  def previous_page_title
+    page = service.find_page_by_uuid(foo)
+    page.title
   end
 
   private

--- a/app/views/branches/edit.html.erb
+++ b/app/views/branches/edit.html.erb
@@ -7,9 +7,14 @@
       data-fb-content-type="element">
     <%= @branch.title %>
   </h1>
+  <%
+=begin%>
+ <p class="govuk-heading-m"><%= t('branches.after', page_title: @branch.foo) %></p>
+<%
+=end%>
 
   <%= form_for @branch,
-    url: branch_path(service.service_id, @branch.previous_flow_uuid),
+    url: branch_path(service.service_id, @branch.branch_uuid),
     method: :put do |f| %>
     <%= render 'form', f: f %>
   <% end %>

--- a/app/views/branches/edit.html.erb
+++ b/app/views/branches/edit.html.erb
@@ -7,11 +7,10 @@
       data-fb-content-type="element">
     <%= @branch.title %>
   </h1>
-  <%
-=begin%>
- <p class="govuk-heading-m"><%= t('branches.after', page_title: @branch.foo) %></p>
-<%
-=end%>
+
+  <% if @branch.previous_page_title.present? %>
+    <p class="govuk-heading-m"><%= t('branches.after', page_title: @branch.previous_page_title) %></p>
+  <% end %>
 
   <%= form_for @branch,
     url: branch_path(service.service_id, @branch.branch_uuid),

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -324,4 +324,49 @@ RSpec.describe Branch do
       expect(branch.previous_flow_default_next).to eq(previous_flow_object.default_next)
     end
   end
+
+  describe '#branch_attached?' do
+    subject(:branch) { described_class.new(service: service) }
+    let(:latest_metadata) { metadata_fixture(:branching) }
+    let(:service) do
+      MetadataPresenter::Service.new(latest_metadata)
+    end
+    let(:branch_uuid) { '09e91fd9-7a46-4840-adbc-244d545cfef7' }
+    let(:branch_metadata) { service.flow_object(branch_uuid) }
+
+    context 'when branching point has been detached' do
+      it 'should return false' do
+        expect(branch.branch_attached?).to eq(false)
+      end
+    end
+
+    # context 'when branching point is attached' do
+    #   it 'should return true' do
+    #     expect(branch.branch_attached?).to eq(true)
+    #   end
+    # end
+  end
+
+  # describe '#previous_page_title' do
+  #   context 'when there is a single uuid' do
+  #     it 'returns the title of the previous page' do
+  #       expect(branch.foo).to eq('')
+  #     end
+  #   end
+
+  # context 'when dealing with pages containing collections' do
+  #   it 'returns the correct title' do
+  #   end
+  # end
+
+  #   context 'when there are multiple uuids' do
+  #     it 'returns the title from the first uuid' do
+  #     end
+  #   end
+
+  #   context 'when there is no uuid' do
+  #     it 'branch is detached' do
+  #     end
+  #   end
+  # end
 end

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -325,48 +325,59 @@ RSpec.describe Branch do
     end
   end
 
-  describe '#branch_attached?' do
-    subject(:branch) { described_class.new(service: service) }
+  describe '#previous_page_title' do
+    let(:branch_attributes) do
+      {
+        branch_uuid: branch_uuid,
+        service: service
+      }.merge(attributes)
+    end
     let(:latest_metadata) { metadata_fixture(:branching) }
     let(:service) do
       MetadataPresenter::Service.new(latest_metadata)
     end
-    let(:branch_uuid) { '09e91fd9-7a46-4840-adbc-244d545cfef7' }
-    let(:branch_metadata) { service.flow_object(branch_uuid) }
+    let(:branch_uuid) { 'ffadeb22-063b-4e4f-9502-bd753c706b1d' } # Branching Point 2
 
-    context 'when branching point has been detached' do
-      it 'should return false' do
-        expect(branch.branch_attached?).to eq(false)
+    context 'when there are multiple uuids' do
+      let(:metadata) { metadata_fixture(:branching) }
+      let(:latest_metadata) do
+        text_page = metadata['flow']['9e1ba77f-f1e5-42f4-b090-437aa9af7f73'] # Full name
+        text_page['next']['default'] = branch_uuid
+
+        star_wars_page = metadata['flow']['68fbb180-9a2a-48f6-9da6-545e28b8d35a']
+        star_wars_page['next']['default'] = branch_uuid
+
+        content_page = metadata['flow']['2cc66e51-2c14-4023-86bf-ded49887cdb2'] # Loki
+        content_page['next']['default'] = branch_uuid
+
+        metadata
+      end
+
+      it 'returns the title from the first uuid' do
+        expect(branch.previous_page_title).to eq('Full name')
       end
     end
 
-    # context 'when branching point is attached' do
-    #   it 'should return true' do
-    #     expect(branch.branch_attached?).to eq(true)
-    #   end
-    # end
+    context 'when the branch is unconnected' do
+      let(:branch_attributes) do
+        {
+          branch_uuid: branch_uuid,
+          service: service
+        }.merge(attributes)
+      end
+      let(:metadata) { metadata_fixture(:branching) }
+      let(:checkanswers) do
+        metadata['pages'].find { |p| p['_type'] == 'page.checkanswers' }
+      end
+      let(:latest_metadata) do
+        obj = metadata['flow']['0b297048-aa4d-49b6-ac74-18e069118185'] # what is your favourite fruit
+        obj['next']['default'] = checkanswers['_uuid']
+        metadata
+      end
+
+      it 'returns nil' do
+        expect(branch.previous_page_title).to be_nil
+      end
+    end
   end
-
-  # describe '#previous_page_title' do
-  #   context 'when there is a single uuid' do
-  #     it 'returns the title of the previous page' do
-  #       expect(branch.foo).to eq('')
-  #     end
-  #   end
-
-  # context 'when dealing with pages containing collections' do
-  #   it 'returns the correct title' do
-  #   end
-  # end
-
-  #   context 'when there are multiple uuids' do
-  #     it 'returns the title from the first uuid' do
-  #     end
-  #   end
-
-  #   context 'when there is no uuid' do
-  #     it 'branch is detached' do
-  #     end
-  #   end
-  # end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/qbSLj1dF/1928-after-previous-page-text-on-branch-edit-page-does-not-display-after-clicking-the-save-button)

### Add branch_uuid accessor
Currently, when a branch has been saved, is it assigned a branch_uuid. However, we still refer to this as a previous_flow_uuid. This is confusing. So we need to have a branch_uuid and reference it when we are dealing with an existing branch.

### Add method to ensure correct title shows when editing branching points
At present, we do not provide information on the previous page when a user is editing a branching point when we should.
In the event that a branch has been 'unconnected' from the main flow (ie. there is no previous page), we do not show any text.
In the event there are multiple pages pointing to the same branch, we take the first page, note this behaviour will need to be further refined by the team but for now it is the agreed approach.