### PR TITLE
Modify branch updater

### DIFF
--- a/acceptance/features/edit_branch_page_spec.rb
+++ b/acceptance/features/edit_branch_page_spec.rb
@@ -38,9 +38,8 @@ feature 'New branch page' do
       'Which flavours of ice cream have you eaten?'
     )
 
-    # uncomment once missing 'Add condition' on edit pages bug is fixed
-    # when_I_save_my_changes
-    # then_I_should_be_on_the_correct_branch_page('edit')
+    when_I_save_my_changes
+    then_I_should_be_on_the_correct_branch_page('edit')
 
     then_I_can_add_and_delete_conditionals_and_expressions
 

--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -58,7 +58,8 @@ class BranchesController < FormController
   def branch_attributes
     {
       service: service,
-      previous_flow_uuid: previous_flow_uuid
+      previous_flow_uuid: previous_flow_uuid,
+      branch_uuid: params[:branch_uuid]
     }
   end
 

--- a/app/services/branch_updater.rb
+++ b/app/services/branch_updater.rb
@@ -1,12 +1,12 @@
 class BranchUpdater < FlowBranch
   def flow_branch
-    existing_metadata = service.flow[previous_flow_uuid]
+    existing_metadata = service.flow[branch.branch_uuid]
     existing_metadata['next']['default'] = default_next
     existing_metadata['next']['conditionals'] = conditionals.map(&:to_metadata)
 
     OpenStruct.new(
-      to_metadata: { previous_flow_uuid => existing_metadata },
-      uuid: previous_flow_uuid
+      to_metadata: { branch.branch_uuid => existing_metadata },
+      uuid: branch.branch_uuid
     )
   end
 end

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -1,4 +1,5 @@
 <%= f.hidden_field :previous_flow_uuid, value: @branch.previous_flow_uuid %>
+<%= f.hidden_field :branch_uuid, value: @branch.branch_uuid %>
 <%= render 'form_conditionals', f: f %>
 <p class="branch-or">or</p>
 

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -1,7 +1,7 @@
 <script>
   var app = {
     api: {
-      new_conditional: "/api/services/<%= params[:id] %>/branches/<%= @branch && @branch.previous_flow_uuid %>/conditionals/#{conditional_index}",
+      new_conditional: "/api/services/<%= params[:id] %>/branches/<%= @branch && @branch.flow_uuid %>/conditionals/#{conditional_index}",
       get_expression: "/api/services/<%= params[:id] %>/components/#{component_id}/conditionals/#{conditionals_index}/expressions/#{expressions_index}"
     },
     page: {

--- a/spec/services/branch_updater_spec.rb
+++ b/spec/services/branch_updater_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe BranchUpdater, type: :model do
   describe '#metadata' do
     let(:branch) { Branch.new(attributes) }
     let(:default_next) { SecureRandom.uuid }
-    let(:previous_flow_uuid) do
-      '09e91fd9-7a46-4840-adbc-244d545cfef7'
+    let(:branch_uuid) do
+      '09e91fd9-7a46-4840-adbc-244d545cfef7' # Branching point 1
     end
     let(:conditionals_attributes) do
       {
@@ -38,7 +38,7 @@ RSpec.describe BranchUpdater, type: :model do
     let(:attributes) do
       {
         service: service,
-        previous_flow_uuid: previous_flow_uuid,
+        branch_uuid: branch_uuid,
         conditionals_attributes: conditionals_attributes,
         default_next: default_next
       }
@@ -56,7 +56,7 @@ RSpec.describe BranchUpdater, type: :model do
 
     context 'when metadata is valid' do
       let(:valid) { true }
-      let(:flow_object) { branch_updater.metadata['flow'][previous_flow_uuid] }
+      let(:flow_object) { branch_updater.metadata['flow'][branch_uuid] }
       let(:expected_conditionals) do
         [
           {


### PR DESCRIPTION
Relates to [Trello](https://trello.com/c/qbSLj1dF/1928-after-previous-page-text-on-branch-edit-page-does-not-display-after-clicking-the-save-button)

Since we use a `branch_uuid` when the branch is being updated/edited and `previous_flow_uuid` for when the branch is new/created, we will never have a `previous_flow_uuid` in the BranchUpdater.
We will only ever have a `branch_uuid` in the BranchUpdater as this class only deals with the updating/editing of a branch.

As a result of this change, we need to update the API calls to take both `previous_flow_uuid` and `branch_uuid`.