### PR TITLE
Correctly set flow object default next when adding a new page

### DIFF
--- a/app/generators/new_flow_page_generator.rb
+++ b/app/generators/new_flow_page_generator.rb
@@ -1,7 +1,7 @@
 class NewFlowPageGenerator
-  def initialize(page_uuid:, page_index:, latest_metadata:)
+  def initialize(page_uuid:, latest_metadata:, default_next: nil)
     @page_uuid = page_uuid
-    @page_index = page_index
+    @default_next = default_next
     @latest_metadata = latest_metadata
   end
 
@@ -11,24 +11,12 @@ class NewFlowPageGenerator
 
   private
 
-  attr_reader :page_uuid, :page_index, :latest_metadata
+  attr_reader :page_uuid, :default_next, :latest_metadata
 
   def flow_page_metadata
     flow_page = default_metadata
-    flow_page['next']['default'] = default_next
+    flow_page['next']['default'] = default_next.to_s
     flow_page
-  end
-
-  def default_next
-    next_page.present? ? next_page['_uuid'] : ''
-  end
-
-  def next_page
-    @next_page ||= begin
-      return if page_index.nil?
-
-      latest_metadata['pages'][page_index + 1]
-    end
   end
 
   def default_metadata

--- a/app/generators/new_service_generator.rb
+++ b/app/generators/new_service_generator.rb
@@ -28,7 +28,6 @@ class NewServiceGenerator
   def start_page_flow_object(metadata)
     NewFlowPageGenerator.new(
       page_uuid: metadata['pages'][0]['_uuid'],
-      page_index: 0,
       latest_metadata: metadata
     ).to_metadata
   end

--- a/spec/generators/new_flow_page_generator_spec.rb
+++ b/spec/generators/new_flow_page_generator_spec.rb
@@ -2,10 +2,11 @@ RSpec.describe NewFlowPageGenerator do
   subject(:generator) do
     described_class.new(
       page_uuid: page_uuid,
-      page_index: page_index,
+      default_next: default_next,
       latest_metadata: latest_metadata
     )
   end
+  let(:page_uuid) { SecureRandom.uuid }
   let(:latest_metadata) { metadata_fixture('branching') }
   let(:valid) { true }
 
@@ -34,14 +35,13 @@ RSpec.describe NewFlowPageGenerator do
 
     context 'when there is a next page' do
       it_behaves_like 'a flow page generator' do
-        let(:page_uuid) { latest_metadata['pages'][0]['_uuid'] }
-        let(:page_index) { 0 }
+        let(:default_next) { 'some-uuid' }
         let(:expected_metadata) do
           {
             page_uuid => {
               '_type' => 'flow.page',
               'next' => {
-                'default' => latest_metadata['pages'][1]['_uuid']
+                'default' => default_next
               }
             }
           }
@@ -51,8 +51,7 @@ RSpec.describe NewFlowPageGenerator do
 
     context 'when there is no next page' do
       it_behaves_like 'a flow page generator' do
-        let(:page_uuid) { latest_metadata['pages'].last['_uuid'] }
-        let(:page_index) { nil }
+        let(:default_next) { nil }
         let(:expected_metadata) do
           {
             page_uuid => {

--- a/spec/generators/new_page_generator_spec.rb
+++ b/spec/generators/new_page_generator_spec.rb
@@ -85,11 +85,15 @@ RSpec.describe NewPageGenerator do
           page = service.find_page_by_url('email-address')
           page.uuid
         end
+        let(:expected_default_next) do
+          # parent-name. email-address's page old default next
+          '4b8c6bf3-878a-4446-9198-48351b3e2185'
+        end
         let(:expected_flow_metadata) do
           {
             '_type' => 'flow.page',
             'next' => {
-              'default' => '4b8c6bf3-878a-4446-9198-48351b3e2185'
+              'default' => expected_default_next
             }
           }
         end
@@ -126,6 +130,13 @@ RSpec.describe NewPageGenerator do
         it 'adds new page in last position' do
           expect(generator.to_metadata['pages']).to_not be_blank
           expect(generator.to_metadata['pages'].last).to include(page_attributes)
+        end
+
+        it 'sends a message to Sentry' do
+          expect(Sentry).to receive(:capture_message).with(
+            "Unable to set default next. #{add_page_after} does not exist in service flow"
+          )
+          generator.to_metadata
         end
       end
 


### PR DESCRIPTION
When inserting a page the flow object that represents that page needs to
have its default next point to what the previous object to it was
pointing too.

This has not been a problem until now because we rely on the order of
the pages when presenting the service flow.