### PR TITLE
Wait for editor to load

### DIFF
--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -47,6 +47,7 @@ module CommonSteps
   end
 
   def given_I_want_to_create_a_service
+    expect(page).to have_content(I18n.t('services.create'))
     editor.create_service_button.click
   end
 


### PR DESCRIPTION
This adds an expectation to the method that clicks on the "Create a new
form" button. This expectation makes the tests wait a little bit for the
page to load which will hopefully reduce the brittleness should there be
any performance related issues.