### PR TITLE
Exit pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.5.1'
+gem 'metadata_presenter', '2.6.2'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    metadata_presenter (2.5.1)
+    metadata_presenter (2.6.2)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -391,7 +391,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.5.1)
+  metadata_presenter (= 2.6.2)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.0)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
     ffi (1.15.3)
     globalid (0.5.2)
       activesupport (>= 5.0)
-    govuk_design_system_formbuilder (2.7.4)
+    govuk_design_system_formbuilder (2.7.5)
       actionview (>= 6.0)
       activemodel (>= 6.0)
       activesupport (>= 6.0)

--- a/acceptance/features/edit_confirmation_page_spec.rb
+++ b/acceptance/features/edit_confirmation_page_spec.rb
@@ -32,10 +32,6 @@ feature 'Edit confirmation pages' do
     when_I_add_the_page
   end
 
-  def and_I_change_the_page_lede(lede)
-    editor.page_lede.set(lede)
-  end
-
   def and_I_change_the_page_body(body)
     when_I_change_editable_content(editor.page_body, content: body)
   end

--- a/acceptance/features/edit_exit_page_spec.rb
+++ b/acceptance/features/edit_exit_page_spec.rb
@@ -1,0 +1,91 @@
+require_relative '../spec_helper'
+
+feature 'Edit exit pages' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:exit_url) { 'exit' }
+  let(:exit_heading) { 'Updated heading' }
+  let(:exit_section_heading) { 'Updated section heading' }
+  let(:exit_lede) { 'Updated lede' }
+  let(:content_component) do
+    'Give me content'
+  end
+  let(:optional_content) do
+    I18n.t('default_text.content')
+  end
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'updates all fields' do
+    given_I_have_an_exit_page
+    then_I_should_not_see_the_continue_button
+    and_I_change_the_page_heading(exit_heading)
+    and_I_change_the_page_section_heading(exit_section_heading)
+    and_I_change_the_page_lede(exit_lede)
+    when_I_save_my_changes
+    and_I_return_to_flow_page
+    and_I_edit_the_page(url: exit_url)
+    then_I_see_the_updated_page_heading(exit_heading)
+    then_I_see_the_updated_page_section_heading(exit_section_heading)
+    then_I_see_the_updated_page_lede(exit_lede)
+  end
+
+  scenario 'adding components' do
+    given_I_have_an_exit_page
+    then_I_should_not_see_the_continue_button
+    and_I_add_a_content_component(
+      content: content_component
+    )
+    when_I_save_my_changes
+    and_I_return_to_flow_page
+    and_I_edit_the_page(url: exit_url)
+    then_I_should_see_the_component(content_component)
+  end
+
+  scenario 'deleting components' do
+    given_I_have_an_exit_page
+    then_I_should_not_see_the_continue_button
+    and_I_add_a_content_component(
+      content: content_component
+    )
+    when_I_save_my_changes
+    and_I_return_to_flow_page
+    and_I_edit_the_page(url: exit_url)
+    then_I_should_see_the_component(content_component)
+    when_I_want_to_select_component_properties('.output', content_component)
+    and_I_want_to_delete_a_component
+    then_I_should_not_see_my_content(content_component)
+  end
+
+  def given_I_have_an_exit_page
+    given_I_add_an_exit_page
+    and_I_add_a_page_url(exit_url)
+    when_I_add_the_page
+  end
+
+  def and_I_add_a_content_component(content:)
+    editor.add_content_area_buttons.first.click
+    and_the_content_component_has_the_optional_content
+    when_I_change_editable_content(editor.first_component, content: content)
+  end
+
+  def then_I_should_see_the_component(content)
+    expect(editor.first_component.text).to eq(content)
+  end
+
+  def then_I_should_not_see_the_continue_button
+    expect(page).not_to have_content(I18n.t('actions.continue'))
+  end
+
+  def and_the_content_component_has_the_optional_content
+    editor.service_name.click # click outside to close the editable component
+
+    # the output element p tag of a content component is the thing which has
+    # the actual text in it
+    output_component = editor.first_component.find('.output p', visible: false)
+    expect(output_component.text).to eq(optional_content)
+  end
+end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -59,6 +59,9 @@ class EditorApp < SitePrism::Page
   element :add_content_page,
           :xpath,
           "//a[@class='ui-menu-item-wrapper' and contains(.,'Content page')]"
+  element :add_exit,
+          :xpath,
+          "//a[@class='ui-menu-item-wrapper' and contains(.,'Exit page')]"
 
   element :add_a_component_button, :link, I18n.t('components.actions.add_component')
   element :question_component,

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -122,6 +122,11 @@ module CommonSteps
     editor.add_confirmation.click
   end
 
+  def given_I_add_an_exit_page
+    given_I_want_to_add_a_page
+    editor.add_exit.click
+  end
+
   def given_I_want_to_add_a_single_question_page
     given_I_want_to_add_a_page
     editor.add_single_question.hover
@@ -146,6 +151,26 @@ module CommonSteps
 
   def and_I_change_the_page_heading(heading)
     editor.page_heading.set(heading)
+  end
+
+  def then_I_see_the_updated_page_heading(heading)
+    expect(editor.page_heading.text).to eq(heading)
+  end
+
+  def and_I_change_the_page_section_heading(section_heading)
+    editor.section_heading.set(section_heading)
+  end
+
+  def then_I_see_the_updated_page_section_heading(section_heading)
+    editor.section_heading.set(section_heading)
+  end
+
+  def and_I_change_the_page_lede(lede)
+    editor.page_lede.set(lede)
+  end
+
+  def then_I_see_the_updated_page_lede(lede)
+    editor.page_lede.set(lede)
   end
 
   def when_I_create_the_service

--- a/app/views/partials/_add_content_button.html.erb
+++ b/app/views/partials/_add_content_button.html.erb
@@ -1,4 +1,4 @@
-<% if ['checkanswers', 'confirmation', 'content'].include? @page._type.gsub('page.', '') %>
+<% if ['checkanswers', 'confirmation', 'content', 'exit'].include? @page._type.gsub('page.', '') %>
   <% if @page.supported_content_components.present? %>
     <div class="component add-content" data-component="add-content">
       <%# TODO: This will be basis of v2 code %>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -37,7 +37,9 @@
             File.join(preview_service_path(service.service_id), page.url),
             target: '_blank' %>
           </li>
+          <% unless (page.type =~ /page.(checkanswers|confirmation|exit)/) %>
           <li data-action="add"><a href="#add-page-here"><%= t('actions.add_page') %></a></li>
+          <% end %>
           <li data-action="delete">
             <% unless page.type == 'page.start' %>
               <%= link_to t('actions.delete_page'),
@@ -50,7 +52,7 @@
               <%= link_to t('services.branch'),
                 new_branches_path(service.service_id, page.uuid) %>
             </li>
-            <% unless (page.type =~ /page.(checkanswers|confirmation)/) %>
+            <% unless (page.type =~ /page.(checkanswers|confirmation|exit)/) %>
               <li data-action="edit">
                 <%= link_to t('actions.change_destination'),
                   new_api_service_flow_destination_path(service.service_id, page.uuid) %>
@@ -105,6 +107,7 @@
       <li><a href="#add-page" data-page-type="checkanswers">Check answers page</a></li>
       <li><a href="#add-page" data-page-type="confirmation">Confirmation page</a></li>
       <li><a href="#add-page" data-page-type="content">Content page</a></li>
+      <li><a href="#add-page" data-page-type="exit">Exit page</a></li>
     </ul>
 
     <div class="component-dialog-form"

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -107,7 +107,9 @@
       <li><a href="#add-page" data-page-type="checkanswers">Check answers page</a></li>
       <li><a href="#add-page" data-page-type="confirmation">Confirmation page</a></li>
       <li><a href="#add-page" data-page-type="content">Content page</a></li>
-      <li><a href="#add-page" data-page-type="exit">Exit page</a></li>
+      <% if ENV['BRANCHING'] == 'enabled' %>
+        <li><a href="#add-page" data-page-type="exit">Exit page</a></li>
+      <% end %>
     </ul>
 
     <div class="component-dialog-form"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,7 @@ en:
   actions:
     edit: 'Edit'
     save: 'Save'
+    continue: 'Continue'
     add_page: 'Add page here'
     publish_to_test: 'Publish to Test'
     publish_to_live: 'Publish to Live'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
       checkanswers: Check your answers page
       confirmation: Confirmation page
       content: Content page
+      exit: Exit page
   default_text:
     section_heading: '[Optional section heading]'
     lede: '[Optional lede paragraph]'

--- a/spec/generators/new_page_generator_spec.rb
+++ b/spec/generators/new_page_generator_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe NewPageGenerator do
         end
 
         context 'pages without components when first generated' do
-          %w[multiplequestions checkanswers confirmation].each do |page|
+          %w[multiplequestions checkanswers confirmation exit].each do |page|
             context "when #{page} page" do
               let(:page_type) { page }
               let(:component_type) { nil }
@@ -267,7 +267,7 @@ RSpec.describe NewPageGenerator do
         end
 
         context 'pages that allow only content components' do
-          %w[content checkanswers confirmation].each do |page|
+          %w[content checkanswers confirmation exit].each do |page|
             context "when #{page} page" do
               let(:page_type) { page }
               let(:component_type) { 'content' }
@@ -316,7 +316,7 @@ RSpec.describe NewPageGenerator do
 
       context 'when metadata is invalid' do
         context 'pages that only allow content components' do
-          %w[content checkanswers confirmation].each do |page|
+          %w[content checkanswers confirmation exit].each do |page|
             %w[checkboxes date number radios text textarea].each do |type|
               context "#{page} page and #{type} component" do
                 let(:page_type) { page }

--- a/spec/models/pages_flow_spec.rb
+++ b/spec/models/pages_flow_spec.rb
@@ -1680,11 +1680,11 @@ RSpec.describe PagesFlow do
                 thumbnail: 'text'
               },
               {
-                type: 'page.singlequestion',
+                type: 'page.exit',
                 title: 'Page G',
                 uuid: '3a584d15-6805-4a21-bc05-b61c3be47857',
                 next: '',
-                thumbnail: 'text'
+                thumbnail: 'content'
               }
             ],
             [


### PR DESCRIPTION
[Trello](https://trello.com/c/xRoJ7LWM/1970-be-adding-the-logic-to-deal-with-exit-pages-in-the-editor)

### Exit pages
- Exit pages can now be added to a form and edited.
- Remove the ability to "Change destination" or "Add page" from an exit page.

### Exit pages should not be available in live production
We will release exit pages to live prod when we release branching.
For now, we only want exit pages to be visible in test.

### Bump presenter 2.6.2
__________

### Editing an exit page 
![Screenshot 2021-10-07 at 17 27 59](https://user-images.githubusercontent.com/29227502/136427112-86d241ca-047b-4c8d-ba36-350fd209b066.png)
