### PR TITLE
Exit page thumbnail

### DIFF
--- a/app/models/pages_flow.rb
+++ b/app/models/pages_flow.rb
@@ -88,7 +88,7 @@ class PagesFlow
   def use_flow_type?(obj)
     obj.components.blank? ||
       obj.branch? ||
-      obj.type =~ /page.(start|checkanswers|confirmation)/
+      %w[start checkanswers confirmation exit].any? { |type| obj.type.include?(type) }
   end
 
   def branch_conditionals(conditionals)

--- a/spec/models/pages_flow_spec.rb
+++ b/spec/models/pages_flow_spec.rb
@@ -1684,7 +1684,7 @@ RSpec.describe PagesFlow do
                 title: 'Page G',
                 uuid: '3a584d15-6805-4a21-bc05-b61c3be47857',
                 next: '',
-                thumbnail: 'content'
+                thumbnail: 'exit'
               }
             ],
             [


### PR DESCRIPTION
[Trello](https://trello.com/c/xRoJ7LWM/1970-be-adding-the-logic-to-deal-with-exit-pages-in-the-editor)

Currently the exit page uses the content page thumbnail.
This change ensures the correct thumbnail is used for an exit page in the flow view.
