### PR TITLE
Order detached grids by size

### DIFF
--- a/spec/models/detached_spec.rb
+++ b/spec/models/detached_spec.rb
@@ -114,20 +114,6 @@ RSpec.describe Detached do
         [
           [
             [
-              service.flow_object('3a584d15-6805-4a21-bc05-b61c3be47857') # Page G
-            ],
-            [
-              service.flow_object('7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c') # Page H
-            ],
-            [
-              service.flow_object('520fde26-8124-4c67-a550-cd38d2ef304d') # Page I
-            ],
-            [
-              MetadataPresenter::Pointer.new(uuid: check_answers_uuid) # Check answers
-            ]
-          ],
-          [
-            [
               service.flow_object('f475d6fd-0ea4-45d5-985e-e1a7c7a5b992') # Page J
             ],
             [
@@ -140,6 +126,20 @@ RSpec.describe Detached do
             [
               service.flow_object('2c7deb33-19eb-4569-86d6-462e3d828d87'), # Page L
               service.flow_object('393645a4-f037-4e75-8359-51f9b0e360fb') # Page N
+            ],
+            [
+              MetadataPresenter::Pointer.new(uuid: check_answers_uuid) # Check answers
+            ]
+          ],
+          [
+            [
+              service.flow_object('3a584d15-6805-4a21-bc05-b61c3be47857') # Page G
+            ],
+            [
+              service.flow_object('7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c') # Page H
+            ],
+            [
+              service.flow_object('520fde26-8124-4c67-a550-cd38d2ef304d') # Page I
             ],
             [
               MetadataPresenter::Pointer.new(uuid: check_answers_uuid) # Check answers

--- a/spec/models/pages_flow_spec.rb
+++ b/spec/models/pages_flow_spec.rb
@@ -1879,42 +1879,6 @@ RSpec.describe PagesFlow do
             [
               {
                 type: 'page.singlequestion',
-                title: 'Page G',
-                uuid: '3a584d15-6805-4a21-bc05-b61c3be47857',
-                next: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
-                thumbnail: 'text'
-              }
-            ],
-            [
-              {
-                type: 'page.singlequestion',
-                title: 'Page H',
-                uuid: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
-                next: '520fde26-8124-4c67-a550-cd38d2ef304d',
-                thumbnail: 'text'
-              }
-            ],
-            [
-              {
-                type: 'page.singlequestion',
-                title: 'Page I',
-                uuid: '520fde26-8124-4c67-a550-cd38d2ef304d',
-                next: 'e337070b-f636-49a3-a65c-f506675265f0',
-                thumbnail: 'text'
-              }
-            ],
-            [
-              {
-                type: 'pointer',
-                title: 'Check your answers',
-                uuid: 'e337070b-f636-49a3-a65c-f506675265f0'
-              }
-            ]
-          ],
-          [
-            [
-              {
-                type: 'page.singlequestion',
                 title: 'Page J',
                 uuid: 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992',
                 next: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
@@ -1979,6 +1943,42 @@ RSpec.describe PagesFlow do
                 type: 'page.singlequestion',
                 title: 'Page N',
                 uuid: '393645a4-f037-4e75-8359-51f9b0e360fb',
+                next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                thumbnail: 'text'
+              }
+            ],
+            [
+              {
+                type: 'pointer',
+                title: 'Check your answers',
+                uuid: 'e337070b-f636-49a3-a65c-f506675265f0'
+              }
+            ]
+          ],
+          [
+            [
+              {
+                type: 'page.singlequestion',
+                title: 'Page G',
+                uuid: '3a584d15-6805-4a21-bc05-b61c3be47857',
+                next: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
+                thumbnail: 'text'
+              }
+            ],
+            [
+              {
+                type: 'page.singlequestion',
+                title: 'Page H',
+                uuid: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
+                next: '520fde26-8124-4c67-a550-cd38d2ef304d',
+                thumbnail: 'text'
+              }
+            ],
+            [
+              {
+                type: 'page.singlequestion',
+                title: 'Page I',
+                uuid: '520fde26-8124-4c67-a550-cd38d2ef304d',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
                 thumbnail: 'text'
               }


### PR DESCRIPTION
The detached grids need to be ordered by the length of the the flows,
largest being first.

This will prevent any lone objects appearing first.

## Before

<img width="1688" alt="Screenshot 2021-10-13 at 16 30 12" src="https://user-images.githubusercontent.com/3466862/137188679-610e74da-6fe2-48a8-af97-4d279e7ace48.png">


## After

![Screenshot 2021-10-13 at 17 58 03](https://user-images.githubusercontent.com/3466862/137188707-961a750e-b770-45a8-b30a-3174eff3efa8.png)


