### PR TITLE
Add error message for unsupported component

### DIFF
--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -96,7 +96,9 @@ class Branch
   end
 
   def flow_uuid
-    previous_flow_uuid || branch_uuid
+    return branch_uuid if previous_flow_uuid.blank?
+
+    previous_flow_uuid
   end
 
   def previous_flow_default_next

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -3,6 +3,7 @@ class Expression
   attr_accessor :component, :operator, :field, :page
 
   validates :component, :operator, :page, :field, presence: true
+  validate :unsupported_component
 
   OPERATORS = [
     [I18n.t('operators.is'), 'is'],
@@ -50,5 +51,13 @@ class Expression
 
   def component_object
     @component_object ||= page.find_component_by_uuid(component)
+  end
+
+  def unsupported_component
+    if page.present? && component.present? && !component_object.supports_branching?
+      errors.add(:component, message: I18n.t(
+        'activemodel.errors.messages.unsupported_component'
+      ))
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,6 +260,7 @@ en:
         taken: "Your answer for ‘%{attribute}' is already used by another form. Please modify it."
         unprocessable: 'There is an error in the metadata. Please try again and if the error persists contact us in the #ask-formbuilder channel'
         unsupported: This type of question is not currently supported to create a branching condition. Please select a radio button or checkbox question.
+        unsupported_component: "This type of question is not currently supported to create a branching condition. Please select a radio button or checkbox question for Branch "
   time:
     formats:
       simple: '%d/%m/%Y %H:%M:%S'

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -108,4 +108,51 @@ RSpec.describe Expression do
       ).to eq(expected_id)
     end
   end
+
+  describe '#branching_support' do
+    before do
+      expression.valid?
+    end
+
+    context 'supported component' do
+      let(:metadata) { metadata_fixture(:branching) }
+      let(:service) { MetadataPresenter::Service.new(metadata) }
+      let(:page) { service.find_page_by_url('do-you-like-star-wars') }
+
+      let(:expression_hash) do
+        {
+          'operator': 'is',
+          'page': page,
+          'component': page.components.first.uuid,
+          'field': 'c5571937-9388-4411-b5fa-34ddf9bc4ca0'
+        }
+      end
+
+      it 'saves the metadata' do
+        expect(expression.errors.messages).to be_empty
+      end
+    end
+
+    context 'unsupported component' do
+      let(:page) { service.find_page_by_url('name') }
+      let(:expression_hash) do
+        {
+          'operator': 'is',
+          'page': page,
+          'component': page.components.first.uuid,
+          'field': '27d377a2-6828-44ca-87d1-b83ddac98284'
+        }
+      end
+
+      it 'returns the error message' do
+        errors = expression.errors.messages
+        expect(errors).to be_present
+        expect(errors.values.first).to include(
+          I18n.t(
+            'activemodel.errors.messages.unsupported_component'
+          )
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/icga5Rfp/1985-bug-backend-allows-saving-of-unsupported-questions-operator-and-answers)

Currently, on a branching point, users are able to click save and save unsupported components eg: text, numbers, dates.
This change adds an error on clicking save that prevents this from happening.

<img width="957" alt="Screenshot 2021-10-18 at 10 00 20" src="https://user-images.githubusercontent.com/29227502/137700982-7012e2f8-9dae-4c15-b176-19dc56f54f66.png">
