### PR TITLE
Testable admin service metadata

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -5,6 +5,12 @@
 # If you want to add pagination or other controller-level concerns,
 # you're free to overwrite the RESTful controller actions.
 module Admin
+  class AdminMetadataVersion
+    include ActiveModel::Model
+    include MetadataVersion
+    attr_accessor :service, :metadata
+  end
+
   class ApplicationController < Administrate::ApplicationController
     include ApplicationHelper
     include Auth0Helper

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -22,6 +22,36 @@ module Admin
       @versions = MetadataApiClient::Version.all(@service.service_id)
     end
 
+    def create
+      original_metadata = latest_version(params[:service_id])
+      duplicate_name =  "#{original_metadata['service_name']} - COPY"
+      service_creation = ServiceCreation.new(
+        service_name: duplicate_name,
+        current_user: current_user
+      )
+
+      if service_creation.create
+        duplicate_version = AdminMetadataVersion.new(
+          service: OpenStruct.new(service_id: service_creation.service_id),
+          metadata: original_metadata.merge(duplicate_attributes(service_creation))
+        ).create_version
+
+        if duplicate_version
+          flash[:success] = "#{service_creation.service_name} duplicate successfully created"
+        else
+          flash[:error] = service_creation.errors.full_messages.join("\n")
+        end
+      else
+        flash[:error] = if name_taken?(service_creation)
+                          "'#{original_metadata['service_name']}' has already been duplicated"
+                        else
+                          service_creation.errors.full_messages.join("\n")
+                        end
+      end
+
+      redirect_to admin_services_path
+    end
+
     def search_term
       params[:search] || ''
     end
@@ -42,6 +72,22 @@ module Admin
         service_id: service_id,
         deployment_environment: environment
       ).completed.desc.first
+    end
+
+    def latest_version(service_id)
+      MetadataApiClient::Service.latest_version(service_id)
+    end
+
+    def duplicate_attributes(service_creation)
+      {
+        'service_name' => service_creation.service_name,
+        'service_id' => service_creation.service_id,
+        'created_by' => current_user.id
+      }
+    end
+
+    def name_taken?(service_creation)
+      service_creation.errors.first.type == :taken
     end
 
     def page

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -37,6 +37,13 @@ module Admin
       end
     end
 
+    def published(service_id, environment)
+      PublishService.where(
+        service_id: service_id,
+        deployment_environment: environment
+      ).completed.desc.first
+    end
+
     def page
       @page ||= params[:page] || 1
     end

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -12,12 +12,30 @@ module Admin
       ).page(page).per(per_page)
     end
 
+    def show
+      @latest_metadata = MetadataApiClient::Service.latest_version(params[:id])
+      @service = MetadataPresenter::Service.new(@latest_metadata, editor: true)
+      @service_creator = User.find(@service.created_by)
+      @version_creator = version_creator(@service_creator, @latest_metadata)
+      @published_to_live = published(@service.service_id, 'production')
+      @published_to_test = published(@service.service_id, 'dev')
+      @versions = MetadataApiClient::Version.all(@service.service_id)
+    end
+
     def search_term
       params[:search] || ''
     end
     helper_method :search_term
 
     private
+
+    def version_creator(service_creator, latest_metadata)
+      if service_creator.id == latest_metadata['created_by']
+        service_creator
+      else
+        User.find(latest_metadata['created_by'])
+      end
+    end
 
     def page
       @page ||= params[:page] || 1

--- a/app/controllers/admin/versions_controller.rb
+++ b/app/controllers/admin/versions_controller.rb
@@ -1,0 +1,11 @@
+module Admin
+  class VersionsController < Admin::ApplicationController
+    def show
+      @version = MetadataApiClient::Version.find(
+        service_id: params[:service_id],
+        version_id: params[:id]
+      )
+      @version_creator = User.find(@version.metadata['created_by'])
+    end
+  end
+end

--- a/app/controllers/admin/versions_controller.rb
+++ b/app/controllers/admin/versions_controller.rb
@@ -16,6 +16,7 @@ module Admin
 
       if version
         flash[:success] = 'Successfully updated metadata version'
+        notify_of_update(params[:service_id])
         redirect_to admin_service_path(params[:service_id])
       else
         flash[:error] = 'Unable to update metadata version'
@@ -31,6 +32,14 @@ module Admin
         version_id: params[:id]
       )
       @version_creator = User.find(@version.metadata['created_by'])
+    end
+
+    def notify_of_update(service_id)
+      if ENV['PLATFORM_ENV'] == 'live'
+        NotificationService.notify(
+          "Service ID #{service_id} has been updated using the Admin dashboard by #{current_user.name}"
+        )
+      end
     end
   end
 end

--- a/app/controllers/admin/versions_controller.rb
+++ b/app/controllers/admin/versions_controller.rb
@@ -1,11 +1,48 @@
 module Admin
+  class AdminMetadataVersion
+    include ActiveModel::Model
+    include MetadataVersion
+    attr_accessor :service, :metadata
+  end
+
   class VersionsController < Admin::ApplicationController
-    def show
+    before_action :version_and_user, except: [:update]
+
+    def show; end
+
+    def edit
+      @service_id = params[:service_id]
+    end
+
+    def update
+      version = AdminMetadataVersion.new(
+        service: service,
+        metadata: JSON.parse(params[:version])
+      ).create_version
+
+      if version
+        flash[:success] = 'Successfully updated metadata version'
+      else
+        flash[:error] = 'Unable to update metadata version'
+      end
+
+      redirect_to edit_admin_service_version_path(params[:service_id], params[:id])
+    end
+
+    private
+
+    def version_and_user
       @version = MetadataApiClient::Version.find(
         service_id: params[:service_id],
         version_id: params[:id]
       )
       @version_creator = User.find(@version.metadata['created_by'])
+    end
+
+    def service
+      # :P
+      # Coz we are including MetadataVersion
+      OpenStruct.new(service_id: params[:service_id])
     end
   end
 end

--- a/app/controllers/admin/versions_controller.rb
+++ b/app/controllers/admin/versions_controller.rb
@@ -1,10 +1,4 @@
 module Admin
-  class AdminMetadataVersion
-    include ActiveModel::Model
-    include MetadataVersion
-    attr_accessor :service, :metadata
-  end
-
   class VersionsController < Admin::ApplicationController
     before_action :version_and_user, except: [:update]
 
@@ -16,7 +10,7 @@ module Admin
 
     def update
       version = AdminMetadataVersion.new(
-        service: service,
+        service: OpenStruct.new(service_id: params[:service_id]),
         metadata: JSON.parse(params[:version])
       ).create_version
 
@@ -37,12 +31,6 @@ module Admin
         version_id: params[:id]
       )
       @version_creator = User.find(@version.metadata['created_by'])
-    end
-
-    def service
-      # :P
-      # Coz we are including MetadataVersion
-      OpenStruct.new(service_id: params[:service_id])
     end
   end
 end

--- a/app/controllers/admin/versions_controller.rb
+++ b/app/controllers/admin/versions_controller.rb
@@ -22,11 +22,11 @@ module Admin
 
       if version
         flash[:success] = 'Successfully updated metadata version'
+        redirect_to admin_service_path(params[:service_id])
       else
         flash[:error] = 'Unable to update metadata version'
+        redirect_to edit_admin_service_version_path(params[:service_id], params[:id])
       end
-
-      redirect_to edit_admin_service_version_path(params[:service_id], params[:id])
     end
 
     private

--- a/app/services/metadata_api_client/version.rb
+++ b/app/services/metadata_api_client/version.rb
@@ -9,5 +9,32 @@ module MetadataApiClient
     rescue Faraday::UnprocessableEntityError => e
       error_messages(e)
     end
+
+    def self.all(service_id)
+      response = connection.get(
+        "/services/#{service_id}/versions"
+      )
+
+      Array(response.body['versions']).map { |version| new(version) }
+    rescue Faraday::UnprocessableEntityError => e
+      error_messages(e)
+    end
+
+    def self.find(service_id:, version_id:)
+      response = connection.get(
+        "/services/#{service_id}/versions/#{version_id}"
+      )
+      new(response.body)
+    rescue Faraday::UnprocessableEntityError => e
+      error_messages(e)
+    end
+
+    def version_id
+      metadata['version_id']
+    end
+
+    def created_at
+      metadata['created_at']
+    end
   end
 end

--- a/app/views/admin/overviews/index.html.erb
+++ b/app/views/admin/overviews/index.html.erb
@@ -34,9 +34,16 @@ It renders the `_table` partial to display details about the resources.
 </header>
 
 <section class="main-content__body">
-  <div>
+  <dl class="govuk-summary-list">
     <% @stats.each do |stat| %>
-      <p><strong><%= stat[:name] %>:</strong> <%= stat[:value] %></p>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= stat[:name] %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= stat[:value] %>
+        </dd>
+      </div>
     <% end %>
-  </div>
+  </dl>
 </section>

--- a/app/views/admin/services/index.html.erb
+++ b/app/views/admin/services/index.html.erb
@@ -29,7 +29,9 @@ It renders the `_table` partial to display details about the resources.
 
 <header class="main-content__header" role="banner">
   <h1 class="main-content__page-title" id="page-title">
-    <%= content_for(:title) %> - (<%= @services.limit_value %> of <%= @services.total_count %>)
+    <%= content_for(:title) %>
+    - <%= @services.count < @services.limit_value ? @services.count : @services.limit_value %>
+    of <%= @services.total_count %>
   </h1>
 
   <%= render(
@@ -50,8 +52,12 @@ It renders the `_table` partial to display details about the resources.
     <tbody class="govuk-table__body">
       <% @services.each do |service| %>
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><%= service.name %></td>
-          <td class="govuk-table__cell"><%= service.id %></td>
+          <td class="govuk-table__cell">
+            <%= link_to service.name, admin_service_path(service.id) %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= link_to service.id, admin_service_path(service.id) %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/services/index.html.erb
+++ b/app/views/admin/services/index.html.erb
@@ -47,6 +47,7 @@ It renders the `_table` partial to display details about the resources.
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Name</th>
         <th scope="col" class="govuk-table__header">Service ID</th>
+        <th scope="col" class="govuk-table__header"></th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -55,9 +56,16 @@ It renders the `_table` partial to display details about the resources.
           <td class="govuk-table__cell">
             <%= link_to service.name, admin_service_path(service.id) %>
           </td>
-          <td class="govuk-table__cell">
+          <td class="govuk-table__cell" id="service-id">
             <%= link_to service.id, admin_service_path(service.id) %>
           </td>
+          <% if Rails.env.development? %>
+          <td class="govuk-table__cell">
+            <%= link_to 'Duplicate',
+                admin_services_path(service.id, service_id: service.id),
+                method: :post %>
+          </td>
+          <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/services/show.html.erb
+++ b/app/views/admin/services/show.html.erb
@@ -46,6 +46,9 @@
           Published at
         </dt>
         <dd class="govuk-summary-list__value">
+          <% if @published_to_live.present? %>
+            <%= l(@published_to_live.created_at.to_time) %>
+          <% end %>
         </dd>
       </div>
       <div class="govuk-summary-list__row">

--- a/app/views/admin/services/show.html.erb
+++ b/app/views/admin/services/show.html.erb
@@ -119,6 +119,9 @@
         </dd>
       </div>
     </dl>
+
+    <a href="<%= edit_admin_service_version_path(@service.service_id, @latest_metadata['version_id']) %>" class="govuk-button fb-govuk-button">Edit</a>
+
     <pre class="govuk-!-padding-right-5" style="white-space:pre-wrap;">
       <%= JSON.pretty_generate(@latest_metadata) %>
     </pre>

--- a/app/views/admin/services/show.html.erb
+++ b/app/views/admin/services/show.html.erb
@@ -1,0 +1,145 @@
+<% content_for(:title) do %>
+  <%= display_resource_name('Service') %>
+<% end %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title" id="page-title">
+    <%= @service.service_name %>
+  </h1>
+  <h2>Service ID: <%= @service.service_id %></h2>
+</header>
+
+<section class="main-content__body main-content__body--flush">
+  <div class="govuk-!-margin-left-5">
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Service created by
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @service_creator.name %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Service created at
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= l(@versions.last.created_at.to_time) %>
+        </dd>
+      </div>
+    </dl>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-5">
+      Published to Live
+    </h2>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Published by
+        </dt>
+        <dd class="govuk-summary-list__value">
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Published at
+        </dt>
+        <dd class="govuk-summary-list__value">
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Version ID
+        </dt>
+        <dd class="govuk-summary-list__value">
+        </dd>
+      </div>
+    </dl>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-5">
+      Published to Test
+    </h2>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Published by
+        </dt>
+        <dd class="govuk-summary-list__value">
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Published at
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <% if @published_to_test.present? %>
+            <%= l(@published_to_test.created_at.to_time) %>
+          <% end %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Version ID
+        </dt>
+        <dd class="govuk-summary-list__value">
+        </dd>
+      </div>
+    </dl>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-5">
+      Latest Metadata
+    </h2>
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Version created by
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @version_creator.name %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Version created at
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= l(@latest_metadata['created_at'].to_time) %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Version ID
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @latest_metadata['version_id'] %>
+        </dd>
+      </div>
+    </dl>
+    <pre class="govuk-!-padding-right-5" style="white-space:pre-wrap;">
+      <%= JSON.pretty_generate(@latest_metadata) %>
+    </pre>
+
+    <table class="govuk-table govuk-!-margin-top-5">
+      <caption class="govuk-table__caption govuk-table__caption--m">Versions</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Version ID</th>
+          <th scope="col" class="govuk-table__header">Created at</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @versions.each do |version| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <%= link_to version.version_id, admin_service_version_path(@service.service_id, version.version_id) %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= link_to l(version.created_at.to_time), admin_service_version_path(@service.service_id, version.version_id) %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</section>

--- a/app/views/admin/versions/edit.html.erb
+++ b/app/views/admin/versions/edit.html.erb
@@ -1,0 +1,45 @@
+<% content_for(:title) do %>
+  <%= display_resource_name('Service') %>
+<% end %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title" id="page-title">
+    <%= @version.name %>
+  </h1>
+
+  <h2>Version ID: <%= @version.id %></h2>
+</header>
+
+<section class="main-content__body main-content__body--flush">
+  <div class="govuk-!-margin-left-5">
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Created by
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @version_creator.name %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Created at
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= l(@version.metadata['created_at'].to_time) %>
+        </dd>
+      </div>
+    </dl>
+
+    <%= form_with(
+        url: admin_service_version_path(@service_id, @version.version_id),
+        method: :put) do |f| %>
+      <%= f.submit 'Save', class: 'govuk-button fb-govuk-button', id: 'version-save' %>
+      <div class="govuk-form-group">
+        <textarea class="govuk-textarea" id="version" name="version" rows="100" aria-describedby="version-hint">
+          <%= JSON.pretty_generate(@version.metadata) %>
+        </textarea>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/views/admin/versions/edit.html.erb
+++ b/app/views/admin/versions/edit.html.erb
@@ -33,7 +33,8 @@
 
     <%= form_with(
         url: admin_service_version_path(@service_id, @version.version_id),
-        method: :put) do |f| %>
+        method: :put,
+        local: true) do |f| %>
       <%= f.submit 'Save', class: 'govuk-button fb-govuk-button', id: 'version-save' %>
       <div class="govuk-form-group">
         <textarea class="govuk-textarea" id="version" name="version" rows="100" aria-describedby="version-hint">

--- a/app/views/admin/versions/edit.html.erb
+++ b/app/views/admin/versions/edit.html.erb
@@ -12,6 +12,10 @@
 
 <section class="main-content__body main-content__body--flush">
   <div class="govuk-!-margin-left-5">
+    <a href="<%= admin_service_path(@service_id) %>" class="govuk-back-link">
+      Back to service
+    </a>
+
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/app/views/admin/versions/show.html.erb
+++ b/app/views/admin/versions/show.html.erb
@@ -1,0 +1,37 @@
+<% content_for(:title) do %>
+  <%= display_resource_name('Service') %>
+<% end %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title" id="page-title">
+    <%= @version.name %>
+  </h1>
+
+  <h2>Version ID: <%= @version.id %></h2>
+</header>
+
+<section class="main-content__body main-content__body--flush">
+  <div class="govuk-!-margin-left-5">
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Created by
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @version_creator.name %>
+        </dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Created at
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= l(@version.metadata['created_at'].to_time) %>
+        </dd>
+      </div>
+    </dl>
+    <pre class="govuk-!-padding-right-5" style="white-space:pre-wrap;">
+      <%= JSON.pretty_generate(@version.metadata) %>
+    </pre>
+  </div>
+</section>

--- a/app/views/admin/versions/show.html.erb
+++ b/app/views/admin/versions/show.html.erb
@@ -12,6 +12,10 @@
 
 <section class="main-content__body main-content__body--flush">
   <div class="govuk-!-margin-left-5">
+    <a href="<%= admin_service_path(@version.metadata['service_id']) %>" class="govuk-back-link">
+      Back to service
+    </a>
+
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -1,0 +1,44 @@
+<%#
+# Application Layout
+
+This view template is used as the layout
+for every page that Administrate generates.
+
+By default, it renders:
+- Navigation
+- Content for a search bar
+  (if provided by a `content_for` block in a nested page)
+- Flashes
+- Links to stylesheets and JavaScripts
+%>
+
+<!DOCTYPE html>
+<html lang="<%= I18n.locale %>">
+  <head>
+    <meta charset="utf-8">
+    <meta name="ROBOTS" content="NOODP">
+    <meta name="viewport" content="initial-scale=1">
+    <title>
+      <%= content_for(:title) %> - MoJ Forms Editor
+    </title>
+    <%= render "stylesheet" %>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag if defined?(csp_meta_tag) %>
+    <%= stylesheet_pack_tag 'application', media: 'all' %>
+    <%= javascript_pack_tag 'application' %>
+  </head>
+  <body>
+    <%= render "icons" %>
+
+    <div class="app-container">
+      <%= render "navigation" -%>
+
+      <main class="main-content" role="main">
+        <%= render "flashes" -%>
+        <%= yield %>
+      </main>
+    </div>
+
+    <%= render "javascript" %>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   namespace :admin do
     resources :overviews, only: [:index]
-    resources :services, only: [:index]
+    resources :services, only: [:index, :show] do
+      resources :versions, only: [:show]
+    end
     resources :users
 
     root to: "overviews#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :admin do
     resources :overviews, only: [:index]
-    resources :services, only: [:index, :show] do
+    resources :services, only: [:index, :show, :create] do
       resources :versions, only: [:update, :edit, :show]
     end
     resources :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :overviews, only: [:index]
     resources :services, only: [:index, :show] do
-      resources :versions, only: [:show]
+      resources :versions, only: [:update, :edit, :show]
     end
     resources :users
 

--- a/spec/services/metadata_api_client/service_spec.rb
+++ b/spec/services/metadata_api_client/service_spec.rb
@@ -19,6 +19,34 @@ RSpec.describe MetadataApiClient::Service do
     allow(ENV).to receive(:[]).with('METADATA_API_URL').and_return(metadata_api_url)
   end
 
+  describe '.all_services' do
+    let(:expected_url) { "#{metadata_api_url}/services?page=1&per_page=20" }
+    let(:expected_body) do
+      {
+        "services": [service_attributes],
+        "total_services": '1'
+      }
+    end
+    let(:expected_result) do
+      {
+        total_services: '1',
+        services: [
+          MetadataApiClient::Service.new(service_attributes.stringify_keys)
+        ]
+      }
+    end
+
+    before do
+      stub_request(:get, expected_url)
+        .to_return(status: 200, body: expected_body.to_json, headers: {})
+    end
+
+    it 'returns a list of all the services' do
+      services = described_class.all_services(page: 1, per_page: 20)
+      expect(services).to eq(expected_result)
+    end
+  end
+
   describe '.all' do
     let(:expected_url) { "#{metadata_api_url}/services/users/12345" }
 


### PR DESCRIPTION
This adds the admin dashboard page for Services in the Editor app.

A developer can edit service metadata directly and also duplicate services.

## Screenshots

<img width="1662" alt="Screenshot 2021-10-14 at 15 31 41" src="https://user-images.githubusercontent.com/3466862/137763102-1fa939a6-385c-4421-b449-a6c607e7a4fb.png">

<img width="1288" alt="Screenshot 2021-10-18 at 16 32 31" src="https://user-images.githubusercontent.com/3466862/137763119-ead4416f-7e41-40df-96fa-94077544d666.png">

<img width="1290" alt="Screenshot 2021-10-18 at 16 32 39" src="https://user-images.githubusercontent.com/3466862/137763136-3cf85f8c-a334-4898-bd8d-9102a8fc3131.png">

<img width="1228" alt="Screenshot 2021-10-18 at 16 32 58" src="https://user-images.githubusercontent.com/3466862/137763153-84dd3f09-0ae7-468b-9c32-107b696176cf.png">

<img width="1219" alt="Screenshot 2021-10-18 at 16 33 08" src="https://user-images.githubusercontent.com/3466862/137763159-973d3f02-169e-4915-8178-369e53bec2b7.png">

