### PR TITLE
Fix exit page default next when adding into the middle of the flow

### DIFF
--- a/app/generators/new_page_generator.rb
+++ b/app/generators/new_page_generator.rb
@@ -38,10 +38,11 @@ class NewPageGenerator
   end
 
   def add_flow_page
-    default_next = previous_default_next
+    next_flow_object = default_next
+
     latest_metadata.tap do
       latest_metadata['flow'][previous_page_uuid]['next']['default'] = page_metadata['_uuid']
-      latest_metadata['flow'].merge!(new_flow_page_metadata(default_next))
+      latest_metadata['flow'].merge!(new_flow_page_metadata(next_flow_object))
       latest_metadata['pages'].insert(pages_index, page_metadata)
     end
   end
@@ -112,6 +113,14 @@ class NewPageGenerator
       latest_metadata['pages'].last['_uuid']
     else
       page_to_be_inserted_after['_uuid']
+    end
+  end
+
+  def default_next
+    if page_metadata['_type'] == 'page.exit'
+      ''
+    else
+      previous_default_next
     end
   end
 end

--- a/spec/generators/new_page_generator_spec.rb
+++ b/spec/generators/new_page_generator_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe NewPageGenerator do
       page_uuid: page_uuid
     )
   end
+  let(:service_metadata) { latest_metadata }
   let(:add_page_after) { nil }
   let(:page_uuid) { SecureRandom.uuid }
   let(:valid) { true }
@@ -156,6 +157,19 @@ RSpec.describe NewPageGenerator do
 
       it 'should return just the page metadata' do
         expect(generator.to_metadata['_type']).to eq('page.standalone')
+      end
+    end
+
+    context 'when adding an exit page into the middle of the flow' do
+      let(:latest_metadata) { metadata_fixture(:branching_2) }
+      let(:page_type) { 'exit' }
+      let(:component_type) { '' }
+      let(:add_page_after) { service.find_page_by_url('page-d').uuid }
+
+      it 'saves exit page with the next default as empty' do
+        expect(
+          generator.to_metadata['flow']['mandalorian-123']['next']['default']
+        ).to eq('')
       end
     end
 


### PR DESCRIPTION
When adding an exit page into the middle of the flow the default next
of the exit page should be blank because the exit page should not
point to any page next.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>