### PR TITLE
Delete branch by choosing a destination

### DIFF
--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -43,6 +43,21 @@ class BranchesController < FormController
   end
   helper_method :conditional_index
 
+  def destroy
+    destination_uuid = params
+      .require(:branch_destroyer)
+      .permit(:destination_uuid)[:destination_uuid]
+
+    @branch_destroyer = BranchDestroyer.new(
+      service: service,
+      branch_uuid: params[:branch_uuid],
+      destination_uuid: destination_uuid,
+      latest_metadata: service_metadata
+    )
+    @branch_destroyer.destroy
+    head :ok
+  end
+
   private
 
   def branch_metadata

--- a/app/models/branch_destroyer.rb
+++ b/app/models/branch_destroyer.rb
@@ -2,14 +2,40 @@ class BranchDestroyer
   include ActiveModel::Model
   include PreviousPageTitle
   include ApplicationHelper
-  attr_accessor :service, :branch_uuid
+  attr_accessor :service, :branch_uuid, :latest_metadata
+  attr_writer :destination_uuid
 
   delegate :branches, to: :service
   delegate :title, to: :flow
 
+  def destination_uuid
+    @destination_uuid || destinations.first.try(:uuid) # Always the first selected
+  end
+
   def destinations
     flow.all_destination_uuids.map do |uuid|
       service.find_page_by_uuid(uuid)
+    end
+  end
+
+  def destroy
+    MetadataApiClient::Version.create(
+      service_id: service.service_id,
+      payload: destroyed_branch_metadata
+    )
+  end
+
+  def destroyed_branch_metadata
+    metadata = latest_metadata.to_h.deep_dup
+
+    metadata.tap do
+      metadata['flow'].each do |_flow_id, flow_hash|
+        if flow_hash['next'] && flow_hash['next']['default'] == branch_uuid
+          flow_hash['next']['default'] = destination_uuid
+        end
+      end
+
+      metadata['flow'].delete(branch_uuid)
     end
   end
 

--- a/app/views/api/branches/destroy_message.html.erb
+++ b/app/views/api/branches/destroy_message.html.erb
@@ -7,11 +7,15 @@
     <%= t('branches.after', page_title: @branch.previous_page_title) %>
   </p>
 
-  <%= form_for @branch, url: '/some-url-to-destroy-the-branch-which-does-not-exist-yet', method: :delete do |f| %>
-    <%= f.govuk_collection_radio_buttons :destinations, @branch.destinations,
+  <%= form_for @branch,
+    url: branch_path(service.service_id, @branch.branch_uuid),
+    method: :delete do |f| %>
+    <%= f.govuk_collection_radio_buttons(
+      :destination_uuid,
+      @branch.destinations,
       :uuid,
       :title,
-      legend: { text: t('branches.delete_modal.destinations') }
+      legend: { text: t('branches.delete_modal.destinations') })
     %>
 
   <p data-node="content"><%= t('branches.delete_modal.before_submit') %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
     member do
       resources :publish, only: [:index, :create]
       resources :pages, param: :page_uuid, only: [:create, :edit, :update, :destroy]
-      resources :branches, param: :branch_uuid, only: [:create, :edit, :update] do
+      resources :branches, param: :branch_uuid, only: [:create, :edit, :update, :destroy] do
         collection do
           get '/:previous_flow_uuid/new', to: 'branches#new', as: 'new'
         end

--- a/spec/models/branch_destroyer_spec.rb
+++ b/spec/models/branch_destroyer_spec.rb
@@ -2,11 +2,14 @@ RSpec.describe BranchDestroyer do
   subject(:branch_destroyer) do
     described_class.new(
       service: service,
-      branch_uuid: branch_uuid
+      branch_uuid: branch_uuid,
+      destination_uuid: destination_uuid,
+      latest_metadata: service_metadata
     )
   end
   let(:service_metadata) { metadata_fixture(:branching_2) }
   let(:branch_uuid) { '09e91fd9-7a46-4840-adbc-244d545cfef7' }
+  let(:destination_uuid) { service.find_page_by_url('page-c').uuid }
 
   describe '#title' do
     it 'returns branch title' do
@@ -29,6 +32,67 @@ RSpec.describe BranchDestroyer do
       expect(branch_destroyer.destinations).to eq([
         page_c, page_g, page_j
       ])
+    end
+  end
+
+  describe '#destination_uuid' do
+    context 'when is present' do
+      let(:destination_uuid) do
+        service.find_page_by_url('page-j').uuid
+      end
+
+      it 'returns uuid' do
+        expect(branch_destroyer.destination_uuid).to eq(destination_uuid)
+      end
+    end
+
+    context 'when is blank' do
+      let(:destination_uuid) { nil }
+
+      it 'returns uuid of the first route' do
+        expect(branch_destroyer.destination_uuid).to eq(
+          service.find_page_by_url('page-c').uuid
+        )
+      end
+    end
+  end
+
+  describe '#destroy' do
+    it 'creates a new version with branch destroyed' do
+      expect(MetadataApiClient::Version).to receive(:create)
+        .with(
+          service_id: service.service_id,
+          payload: branch_destroyer.destroyed_branch_metadata
+        )
+      branch_destroyer.destroy
+    end
+  end
+
+  describe '#destroyed_branch_metadata' do
+    let(:destroyed_branch_metadata) do
+      MetadataPresenter::Service.new(
+        branch_destroyer.destroyed_branch_metadata
+      )
+    end
+    let(:flow_object_before_branch) do
+      destroyed_branch_metadata
+        .flow_object('68fbb180-9a2a-48f6-9da6-545e28b8d35a')
+    end
+
+    it 'changes all pages before branch to point to the new destination' do
+      expect(flow_object_before_branch.default_next).to eq(destination_uuid)
+    end
+
+    it 'removes branch from the flow object' do
+      # before deleting
+      expect(
+        service.flow[branch_uuid]
+      ).to_not be_nil
+
+      # after calling the deletion
+      expect(
+        destroyed_branch_metadata.flow[branch_uuid]
+      ).to be_nil
     end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/XUTF8upu/1983-deleting-a-branch)

## Context

There is a modal that will allow a user to choose which of the
branch destinations they want to keep.
That selected destination then needs to be set as the destination for
all the flow objects that were pointing to the branch that is
being deleted.