### PR TITLE
Update Published services count by environment in admin dashboard

### DIFF
--- a/app/controllers/admin/overviews_controller.rb
+++ b/app/controllers/admin/overviews_controller.rb
@@ -39,9 +39,11 @@ module Admin
     end
 
     def published(environment)
-      PublishService.where(
-        deployment_environment: environment
-      ).distinct.pluck(:service_id).count
+      PublishService.where(deployment_environment: environment)
+                    .select('DISTINCT ON ("service_id") *')
+                    .order(:service_id, created_at: :desc)
+                    .select { |ps| ps.status == 'completed' }
+                    .count
     end
   end
 end


### PR DESCRIPTION
The way we were counting the actual published services per environment
needed to be updated to only look for the latest record for a distinct
service ID that had the status 'completed'.

Anything later with another status, such as 'unpublishing' or
'unpublished', means that it has been unpublished or is in the process
of being unpublished.