### PR TITLE
Add annotations to ingress configurations

### DIFF
--- a/config/publisher/cloud_platform/ingress.yaml.erb
+++ b/config/publisher/cloud_platform/ingress.yaml.erb
@@ -13,6 +13,8 @@ metadata:
         deny all;
         return 401;
       }
+    external-dns.alpha.kubernetes.io/set-identifier: <%= service_slug %>-ingress-<%= namespace %>-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
     - hosts:

--- a/deploy/fb-editor-chart/templates/ingress.yaml
+++ b/deploy/fb-editor-chart/templates/ingress.yaml
@@ -10,6 +10,8 @@ metadata:
         deny all;
         return 401;
       }
+    external-dns.alpha.kubernetes.io/set-identifier: "{{ .Values.app_name }}-ing-{{ .Values.environmentName }}-formbuilder-saas-{{ .Values.environmentName }}-blue"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
   - hosts:

--- a/spec/fixtures/kubernetes_configuration/ingress.yaml
+++ b/spec/fixtures/kubernetes_configuration/ingress.yaml
@@ -13,6 +13,8 @@ metadata:
         deny all;
         return 401;
       }
+    external-dns.alpha.kubernetes.io/set-identifier: acceptance-tests-date-ingress-formbuilder-services-test-dev-blue
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
Leading up to the migration to the managed EKS we need to have some annotations added to any ingress rules.

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/migrate-to-live-ingress-annotation.html#add-external-dns-annotations-to-your-ingress-resource-in-live-1
