### PR TITLE
Additional configuration naming

### DIFF
--- a/app/services/publisher/configuration_naming.rb
+++ b/app/services/publisher/configuration_naming.rb
@@ -21,7 +21,15 @@ class Publisher
     end
 
     def namespace
-      "formbuilder-services-#{platform_deployment}"
+      sprintf(
+        Rails.application.config.platform_environments[:common][:namespace],
+        platform_environment: platform_environment,
+        deployment_environment: deployment_environment
+      )
+    end
+
+    def platform_deployment
+      "#{platform_environment}-#{deployment_environment}"
     end
   end
 end

--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -35,10 +35,6 @@ class Publisher
 
     delegate :service_name, to: :service
 
-    def namespace
-      sprintf(Rails.application.config.platform_environments[:common][:namespace], platform_environment: platform_environment, deployment_environment: deployment_environment)
-    end
-
     def container_port
       Rails.application.config.platform_environments[:common][:container_port]
     end
@@ -117,10 +113,6 @@ class Publisher
           version_id: version_id
         ).metadata
       )
-    end
-
-    def platform_deployment
-      "#{platform_environment}-#{deployment_environment}"
     end
 
     def platform_app_url(app_name)

--- a/app/services/unpublisher/adapters/cloud_platform.rb
+++ b/app/services/unpublisher/adapters/cloud_platform.rb
@@ -41,6 +41,7 @@ class Unpublisher
       alias_method :networkpolicy, :service_monitor_network_policy_name
       alias_method :secret, :secret_name
       alias_method :servicemonitor, :service_monitor_name
+      delegate :deployment_environment, to: :publish_service
 
       def config_present?(config:, name:)
         Publisher::Utils::Shell.output_of(
@@ -51,11 +52,6 @@ class Unpublisher
         return false if e.message.include?(NOT_FOUND)
 
         raise e
-      end
-
-      def platform_deployment
-        @platform_deployment ||=
-          "#{platform_environment}-#{publish_service.deployment_environment}"
       end
 
       def removal_service


### PR DESCRIPTION
The namespace method was declared twice, so just declare it once in the
ConfigurationNaming module.

Also move the platform_deployment method there as well.