### PR TITLE
Configure dependabot to alert for all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
+  allow:
+    - dependency-type: all
   reviewers:
   - tomas-stefano
   - brenetic
@@ -19,6 +21,8 @@ updates:
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
+  allow:
+    - dependency-type: all
   reviewers:
   - mattempty
   - form-builder-developers


### PR DESCRIPTION
This will make it also check dependencies or dependencies instead of
just those listed in the Gemfile and package.json.