### PR TITLE
Only show Service URL when it is still published

### DIFF
--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -1,6 +1,11 @@
 class PublishController < FormController
   before_action :assign_form_objects
 
+  def index
+    @published_dev = published?(service.service_id, 'dev')
+    @published_production = published?(service.service_id, 'production')
+  end
+
   def create
     @publish_service_creation = PublishServiceCreation.new(publish_service_params)
 
@@ -39,6 +44,13 @@ class PublishController < FormController
       service_id: service.service_id,
       deployment_environment: 'production'
     )
+  end
+
+  def published?(service_id, environment)
+    PublishService.where(
+      service_id: service_id,
+      deployment_environment: environment
+    ).last&.completed?
   end
 
   def update_form_objects

--- a/app/models/publish_service.rb
+++ b/app/models/publish_service.rb
@@ -21,6 +21,10 @@ class PublishService < ApplicationRecord
   scope :completed, -> { where(status: 'completed') }
   scope :desc, -> { order(created_at: :desc) }
 
+  def completed?
+    status == 'completed'
+  end
+
   def queued?
     status == 'queued'
   end

--- a/app/views/publish/index.html.erb
+++ b/app/views/publish/index.html.erb
@@ -20,7 +20,10 @@
       <%# span class="time version"><%= l(service.created_at.to_time, format: :time) %></span %>
       <%# span class="name by"><%= t('publish.test.by', name: 'C. Smith') %></span %>
     <%# /p %>
-    <p><%= PublishServicePresenter.hostname_for(deployment_environment: 'dev', view: self) %></p>
+
+    <% if @published_dev %>
+      <p><%= PublishServicePresenter.hostname_for(deployment_environment: 'dev', view: self) %></p>
+    <% end %>
 
     <%# TODO: Need an indicator from BE code that shows whether this is first-time publish   %>
     <%#       Currently have hardcoded 'false' value to avoid dialog showing but this should %>
@@ -44,7 +47,9 @@
       <%# span class="name by"><%= t('publish.test.by', name: 'C. Smith') %></span %>
     <%# /p %>
 
-    <p><%= PublishServicePresenter.hostname_for(deployment_environment: 'production', view: self) %></p>
+    <% if @published_production %>
+      <p><%= PublishServicePresenter.hostname_for(deployment_environment: 'production', view: self) %></p>
+    <% end %>
 
     <%# TODO: Hardcoded 'firstpublish' (see comment above) %>
     <%= form_for(@publish_service_creation_production,


### PR DESCRIPTION
We only want to show the URL for a service when it is actually
published. Now that we can unpublish a service we do not want a user to
click on the URL only to visit a page that no longer exists.