### PR TITLE
Remove branching acceptance tests temporarily

### DIFF
--- a/acceptance/features/edit_branch_error_summaries_spec.rb
+++ b/acceptance/features/edit_branch_error_summaries_spec.rb
@@ -12,6 +12,7 @@ feature 'Branching errors' do
   end
 
   scenario 'when no required fields are filled in' do
+    skip
     given_I_add_all_pages_for_a_form_with_branching
     and_I_return_to_flow_page
     and_I_want_to_add_branching(page_url)
@@ -24,6 +25,7 @@ feature 'Branching errors' do
   end
 
   scenario 'when the "Go to" field is not filled in' do
+    skip
     given_I_add_all_pages_for_a_form_with_branching
     and_I_return_to_flow_page
     and_I_want_to_add_branching(page_url)
@@ -72,6 +74,7 @@ feature 'Branching errors' do
   end
 
   scenario 'when there are two conditional objects to a branching point' do
+    skip
     given_I_add_all_pages_for_a_form_with_branching
     and_I_return_to_flow_page
     and_I_want_to_add_branching(page_url)

--- a/acceptance/features/edit_branch_page_spec.rb
+++ b/acceptance/features/edit_branch_page_spec.rb
@@ -11,6 +11,7 @@ feature 'New branch page' do
   end
 
   scenario 'when editing the branch page' do
+    skip
     given_I_add_all_pages_for_a_form_with_branching
     and_I_return_to_flow_page
     and_I_want_to_add_branching(page_url)
@@ -52,6 +53,7 @@ feature 'New branch page' do
   end
 
   scenario 'when editing with unconnected pages' do
+    skip
     given_I_add_all_pages_for_a_form_with_branching
     and_I_return_to_flow_page
 

--- a/acceptance/features/new_branch_page_spec.rb
+++ b/acceptance/features/new_branch_page_spec.rb
@@ -11,6 +11,7 @@ feature 'New branch page' do
   end
 
   scenario 'when all required fields are filled in' do
+    skip
     given_I_add_all_pages_for_a_form_with_branching
     and_I_return_to_flow_page
     and_I_want_to_add_branching(page_url)

--- a/app/views/services/_flow_page_menu.html.erb
+++ b/app/views/services/_flow_page_menu.html.erb
@@ -16,11 +16,7 @@
     </li>
   <% end %>
 
-  <% if ENV['BRANCHING'] == 'enabled' %>
-    <% unless (item[:type] =~ /page.(confirmation|exit)/) %>
-      <li data-action="add"><a href="#add-page-here"><%= t('actions.add_page') %></a></li>
-    <% end %>
-  <% else %>
+  <% unless (item[:type] =~ /page.(confirmation|exit)/) %>
     <li data-action="add"><a href="#add-page-here"><%= t('actions.add_page') %></a></li>
   <% end %>
 
@@ -34,12 +30,12 @@
   <% end %>
 
   <% if ENV['BRANCHING'] == 'enabled' %>
-  <% unless (item[:type] =~ /page.(checkanswers|confirmation|exit)/) %>
-    <li data-action="none">
-      <%= link_to t('services.branch'),
-      new_branches_path(service.service_id, item[:uuid]) %>
-    </li>
-  <% end %>
+    <% unless (item[:type] =~ /page.(checkanswers|confirmation|exit)/) %>
+      <li data-action="none">
+        <%= link_to t('services.branch'),
+        new_branches_path(service.service_id, item[:uuid]) %>
+      </li>
+    <% end %>
 
     <% unless (item[:type] =~ /page.(checkanswers|confirmation|exit)/) %>
       <li data-action="destination">


### PR DESCRIPTION
## Temporarily remove branching acceptance tests 

These tests will never pass when BRANCHING is set to disabled. We have
disabled it in the Test environment temporarily while we release a
version of the Editor that uses the new pages flow logic, but for
services without any branches.

Not use the `--exclude-pattern` because the the CircleCI config splits
the files by name to take advantage of parallelisation instead of just
running the entire acceptance tests suite in one command.

## Do not show 'Add page here' in Confirmation dropdown menu 

We do not want to allow the adding of a page after the Confirmation page
regardless of whether BRANCHING is enabled or not.

