### PR TITLE
Update text in delete component modal

### DIFF
--- a/acceptance/features/edit_check_answers_page_spec.rb
+++ b/acceptance/features/edit_check_answers_page_spec.rb
@@ -66,12 +66,12 @@ feature 'Edit check your answers page' do
     then_I_should_see_my_content(content_component, content_extra_component)
 
     when_I_want_to_select_component_properties('.output', content_component)
-    and_I_want_to_delete_a_component
+    and_I_want_to_delete_a_content_component
     when_I_save_my_changes
     then_I_should_not_see_my_content(content_component)
 
     when_I_want_to_select_component_properties('.output', content_extra_component)
-    and_I_want_to_delete_a_component
+    and_I_want_to_delete_a_content_component
     when_I_save_my_changes
     then_I_should_not_see_my_content(content_extra_component)
 
@@ -86,10 +86,10 @@ feature 'Edit check your answers page' do
     then_I_should_see_my_content(content_component, content_extra_component)
 
     when_I_want_to_select_component_properties('.output', content_component)
-    and_I_want_to_delete_a_component
+    and_I_want_to_delete_a_content_component
 
     when_I_want_to_select_component_properties('.output', content_extra_component)
-    and_I_want_to_delete_a_component
+    and_I_want_to_delete_a_content_component
     when_I_save_my_changes
     then_I_should_not_see_my_content(content_component, content_extra_component)
   end

--- a/acceptance/features/edit_exit_page_spec.rb
+++ b/acceptance/features/edit_exit_page_spec.rb
@@ -59,7 +59,7 @@ feature 'Edit exit pages' do
     and_I_edit_the_page(url: default_exit_page_title)
     then_I_should_see_the_component(content_component)
     when_I_want_to_select_component_properties('.output', content_component)
-    and_I_want_to_delete_a_component
+    and_I_want_to_delete_a_content_component
     then_I_should_not_see_my_content(content_component)
   end
 

--- a/acceptance/features/edit_multiple_questions_page_spec.rb
+++ b/acceptance/features/edit_multiple_questions_page_spec.rb
@@ -53,7 +53,7 @@ feature 'Edit multiple questions page' do
     and_I_change_the_text_component(text_component_question)
     when_I_save_my_changes
     when_I_want_to_select_component_properties('h2', text_component_question)
-    and_I_want_to_delete_a_component
+    and_I_want_to_delete_a_component(text_component_question)
     when_I_save_my_changes
     and_the_text_component_is_deleted
   end
@@ -67,7 +67,7 @@ feature 'Edit multiple questions page' do
     then_I_should_see_my_content(content_component)
 
     when_I_want_to_select_component_properties('.output', content_component)
-    and_I_want_to_delete_a_component
+    and_I_want_to_delete_a_content_component
     when_I_save_my_changes
     then_I_should_not_see_my_content(content_component)
   end

--- a/acceptance/support/multiple_questions_page_helper.rb
+++ b/acceptance/support/multiple_questions_page_helper.rb
@@ -72,8 +72,25 @@ module MultipleQuestionsPageHelper
     end
   end
 
-  def and_I_want_to_delete_a_component
+  def and_I_want_to_delete_a_component(question)
+    and_I_click_the_delete_link
+    expect(editor.find(:css, '#dialog-confirmation-delete h3').text).to include(question)
+    and_I_click_the_delete_button
+  end
+
+  def and_I_want_to_delete_a_content_component
+    and_I_click_the_delete_link
+    expect(
+      editor.find(:css, '#dialog-confirmation-delete h3').text
+    ).to eq(I18n.t('content.dialog.heading_remove'))
+    and_I_click_the_delete_button
+  end
+
+  def and_I_click_the_delete_link
     editor.find('span', text: I18n.t('question.menu.remove')).click
-    editor.find('button', text: I18n.t('dialogs.button_delete_option')).click
+  end
+
+  def and_I_click_the_delete_button
+    editor.find('button', text: I18n.t('dialogs.button_delete_component')).click
   end
 end

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -154,7 +154,7 @@ class DataController {
 
 
 /* Gives add component buttons functionality to select a component type
- * from a drop menu, and update the 'save' form by activation of a 
+ * from a drop menu, and update the 'save' form by activation of a
  * global document event.
  * (see addComponentMenuSelection function)
  **/
@@ -219,7 +219,7 @@ function addQuestionMenuListeners(view) {
     var html = $(templateContent).filter("[data-node=remove]").text();
     view.dialogConfirmationDelete.open({
       heading: html.replace(/#{label}/, question.$heading.text()),
-      ok: view.text.dialogs.button_delete_option
+      ok: view.text.dialogs.button_delete_component
       }, function() {
       // Workaround solution that doesn't require extra backend work
       // 1. First remove component from view
@@ -261,7 +261,7 @@ function addContentMenuListeners(view) {
     var html = $(templateContent).filter("[data-node=remove]").text();
     view.dialogConfirmationDelete.open({
       heading: html.replace(/#{label}/, ""),
-      ok: view.text.dialogs.button_delete_option
+      ok: view.text.dialogs.button_delete_component
       }, function() {
       // Workaround solution that doesn't require extra backend work
       // 1. First remove component from view

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -41,6 +41,7 @@
         button_delete_condition: "<%= t('dialogs.button_delete_condition') %>",
         button_delete_branch: "<%= t('dialogs.button_delete_branch') %>",
         button_delete_option: "<%= t('dialogs.button_delete_option') %>",
+        button_delete_component: "<%= t('dialogs.button_delete_component') %>",
         button_delete_page: "<%= t('dialogs.button_delete_page') %>",
         button_ok: "<%= t('dialogs.button_ok') %>",
         button_publish: "<%= t('publish.dialog.alert_button') %>",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
     button_delete_condition: 'Delete condition'
     button_delete_branch: 'Delete branch'
     button_delete_option: 'Delete option'
+    button_delete_component: 'Delete component'
     button_delete_page: 'Delete page'
     button_ok: 'Ok'
     button_understood: 'Understood'
@@ -170,7 +171,7 @@ en:
       remove: 'Delete...'
       required: 'Required...'
     dialog:
-      heading_remove: "Delete the component? #{label}"
+      heading_remove: Delete the component '#{label}'?
       heading_required: 'Is answering this question required?'
       affirmative: 'Yes'
       negative: 'No'


### PR DESCRIPTION
This updates the text in the delete modal for regular components and for content components.

## Before

![Screenshot 2021-11-01 at 17 35 07](https://user-images.githubusercontent.com/3466862/139714872-26fb9491-d221-483a-a652-a7735ed73dc8.png)

## After

### Delete regular component

![Screenshot 2021-11-01 at 17 31 12](https://user-images.githubusercontent.com/3466862/139714467-0b3d94c6-826e-454a-b423-5ac3d1dd9600.png)


### Delete content component
![Screenshot 2021-11-01 at 17 31 22](https://user-images.githubusercontent.com/3466862/139714484-1c79344e-985a-4321-b467-443a12dbfb8c.png)


https://trello.com/c/wCaAuF2O/2028-delete-model-page-in-the-multiple-question-page
