### PR TITLE
Testable 1747 footer flashing

### DIFF
--- a/app/javascript/src/component_expander.js
+++ b/app/javascript/src/component_expander.js
@@ -32,6 +32,7 @@ class Expander {
     var conf = utilities.mergeObjects({
       activator_text: "Toggle", // Text for any self-created activator button.
       auto_open: false, // Set whether open on creation.
+      duration: 0, // Number determining how long the animation will run
       $activator: null // Pass in the jQuery element you want to toggle open/close.
     }, config);
 
@@ -66,14 +67,14 @@ class Expander {
 
   open() {
     this.$node.addClass("open");
-    this.$container.slideDown();
+    this.$container.slideDown({ duration: this._config.duration });
     this.$container.attr("aria-expanded", true);
     this._config.opened = true;
   }
 
   close() {
     this.$node.removeClass("open");
-    this.$container.slideUp();
+    this.$container.slideUp({ duration: this._config.duration });
     this.$container.attr("aria-expanded", false);
     this._config.opened = false;
   }

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -52,6 +52,9 @@ ServicesController.edit = function() {
 
   layoutFormFlowOverview();
   layoutDetachedItemsOveriew();
+
+  // Reverse the Brief flash of content quickfix.
+  $("#main-content").css("visibility", "visible");
 }
 
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -45,13 +45,20 @@ class ServicesController extends DefaultController {
  **/
 ServicesController.edit = function() {
   var view = this; // Just making it easlier to understand the context.
+  var $flowOverview = $("#flow-overview");
+  var $flowDetached = $("#flow-detached");
 
   createPageAdditionDialog(view);
   createPageAdditionMenu(view);
   createFlowItemMenus(view);
 
-  layoutFormFlowOverview();
-  layoutDetachedItemsOveriew();
+  if($flowOverview.length) {
+    layoutFormFlowOverview($flowOverview);
+  }
+
+  if($flowDetached.length) {
+    layoutDetachedItemsOveriew($flowDetached);
+  }
 
   // Reverse the Brief flash of content quickfix.
   $("#main-content").css("visibility", "visible");
@@ -341,8 +348,7 @@ function createFlowItemMenus(view) {
  * --------------------
  * Create the main overview layout for form to get the required design.
 **/
-function layoutFormFlowOverview() {
-  var $overview = $("#flow-overview");
+function layoutFormFlowOverview($overview) {
   positionFlowItems($overview);
   positionConditionsByDestination($overview);
   adjustOverviewHeight($overview);
@@ -360,8 +366,7 @@ function layoutFormFlowOverview() {
  * to jump through a couple hoops by changing the section width and
  * compensating for that with positioning the section title.
 **/
-function layoutDetachedItemsOveriew() {
-  var $overview = $("#flow-detached");
+function layoutDetachedItemsOveriew($overview) {
   var $title = $("h2", $overview);
   var offsetLeft = $overview.offset().left;
 
@@ -588,8 +593,6 @@ function adjustOverviewScrollDimensions($overview, $container) {
 
     $container.css("width", maxWidth + "px");
   }
-
-
 }
 
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -381,10 +381,16 @@ function layoutDetachedItemsOveriew() {
   // Add required scrolling to layout groups.
   $(".flow-detached-group").each(function() {
     var $group = $(this);
+    var $expander = $(".Expander_container");
+    var display = $expander.css("display");
+    $expander.css("display", "block"); // display:none objects have no height in jQuery
+
     positionFlowItems($group);
     positionConditionsByDestination($group);
     adjustOverviewHeight($group);
     applyOverviewScroll($group);
+
+    $expander.css("display", display); // Reset to original state
   });
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -42,6 +42,16 @@ html {
 #main-content {
   position: relative;
   min-height: 55vh;
+
+  // Quickfix for Brief flash of content not ready for display.
+  // This can be reversed when slow or view reliant JS has
+  // finished running. We're using the controller name + action
+  // so we can use it only where actually needed. Find the
+  // corresponding JS controller+action function to see where it
+  // is turned off/reversed.
+  &.services-edit {
+    visibility: hidden;
+  }
 }
 
 

--- a/app/views/layouts/form.html.erb
+++ b/app/views/layouts/form.html.erb
@@ -14,7 +14,8 @@
     <%= render partial: 'partials/header' %>
     <%= render partial: 'partials/form-navigation' %>
 
-    <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing govuk-width-container govuk-body-m" id="main-content" role="main">
+    <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing govuk-width-container govuk-body-m <%= "#{controller_name}-#{action_name}" %>"
+          id="main-content" role="main">
 
       <%= yield %>
     </main>


### PR DESCRIPTION
No screenshots to show the problem but on flow overview page, due to the increased amount of JS computations and display rearrangements, content that is not yet ready (not styled or not positioned properly) can be briefly seen before JS finishes it's thing. This fix/workaround should prevent that but, since the problem has only been seen on the flow overview page, the fix has been isolated to just that view. 