### PR TITLE
Testable 1752 component menu

### DIFF
--- a/app/javascript/src/component_activated_menu.js
+++ b/app/javascript/src/component_activated_menu.js
@@ -64,10 +64,10 @@ class ActivatedMenu {
   // @position (Object) Optional (jQuery position) object.
   open(position) {
     ActivatedMenu.setMenuOpenPosition.call(this, position);
-    this.activator.$node.addClass("active");
-    this.activator.$node.attr("aria-expanded", true);
     this.container.$node.show();
     this.$node.find(".ui-menu-item:first > :first-child").focus();
+    this.activator.$node.addClass("active");
+    this.activator.$node.attr("aria-expanded", true);
     this._state.open = true;
   }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -427,9 +427,7 @@ html {
 
 // Not nice but trying to work around some margin annoyance caused by GDS css
 [data-fb-pagetype="page.multiplequestions"] {
-  .EditableCollectionFieldComponent,
-  .EditableGroupFieldComponent,
-  .EditableComponentCollectionItem {
+  .EditableCollectionFieldComponent legend {
 
     legend {
       display: contents;


### PR DESCRIPTION
Hard to find fix for vanishing menu activator, when the menu is opened. 
Turned out to be a simple fix by changing the order of events (blur causes required css class to be removed but opening of the menu needs it to be there).

Also contains a fix for wrongly positioned three dot menu on certain component (not part of related ticket).

**Without** the fix
<img width="648" alt="Screenshot 2021-11-02 at 16 44 50" src="https://user-images.githubusercontent.com/76942244/139908846-97a3d732-1111-4052-9f4a-853de9c6c436.png">

**With the fix**
<img width="560" alt="Screenshot 2021-11-02 at 16 44 59" src="https://user-images.githubusercontent.com/76942244/139908874-a90407e0-fce0-4a4b-a9f3-ddcab8228177.png">
