### PR TITLE
Only hide service URL when unpublished

### DIFF
--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -50,7 +50,7 @@ class PublishController < FormController
     PublishService.where(
       service_id: service_id,
       deployment_environment: environment
-    ).last&.completed?
+    ).last&.published?
   end
 
   def update_form_objects

--- a/app/models/publish_service.rb
+++ b/app/models/publish_service.rb
@@ -36,4 +36,8 @@ class PublishService < ApplicationRecord
   def unpublished?
     status == 'unpublished'
   end
+
+  def published?
+    !(unpublishing? || unpublished?)
+  end
 end

--- a/spec/models/publish_service_spec.rb
+++ b/spec/models/publish_service_spec.rb
@@ -90,4 +90,36 @@ RSpec.describe PublishService, type: :model do
       expect(publish_service.unpublished?).to be_truthy
     end
   end
+
+  describe '#published?' do
+    context 'when published' do
+      let(:publish_service) do
+        create(:publish_service, :dev, :completed)
+      end
+
+      it 'returns true' do
+        expect(publish_service.published?).to be_truthy
+      end
+    end
+
+    context 'when unpublishing' do
+      let(:publish_service) do
+        create(:publish_service, :dev, :unpublishing)
+      end
+
+      it 'returns false' do
+        expect(publish_service.published?).to be_falsey
+      end
+    end
+
+    context 'when unpublished' do
+      let(:publish_service) do
+        create(:publish_service, :dev, :unpublished)
+      end
+
+      it 'returns false' do
+        expect(publish_service.published?).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
Only checking for the `completed` status for a PublishService is not
enough as there is also other statuses that are used during the
publishing process.

Therefore hide the URL if the status is either `unpublishing` or
`unpublished` or if there is no PublishService associated with that
Service at all (i.e first publishing).

https://trello.com/c/ulDEPT1P/2036-test-url-disappears-after-republishing

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>