### PR TITLE
Change content on change destination modal

### DIFF
--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -7,6 +7,10 @@ class Destination
 
   alias_method :change, :create_version
 
+  def title
+    service.find_page_by_uuid(flow_uuid).title
+  end
+
   def metadata
     service.flow[flow_uuid]['next']['default'] = destination_uuid
     service.metadata.to_h.deep_stringify_keys

--- a/app/views/api/destinations/new.html.erb
+++ b/app/views/api/destinations/new.html.erb
@@ -2,7 +2,10 @@
   <%= form_for @destination, url: api_service_flow_destinations_path(service.service_id, @destination.flow_uuid) do |f| %>
     <div class="govuk-form-group ">
       <%= f.label :destination_uuid, t('dialogs.destination.label'), class: "govuk-label govuk-label--m"  %>
-      <span class="govuk-hint"><%= t('dialogs.destination.hint') %></span>
+      <span class="govuk-hint">
+        <%= t('dialogs.destination.lede', title: @destination.title) %>
+      </span>
+      <span><%= t('dialogs.destination.go_to') %></span>
       <%= f.select :destination_uuid, @destination.destinations,
         {
           include_blank: false,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,7 +105,7 @@ en:
       if: 'If'
       and: 'And'
     goto: Go to
-    select_destination: '--- Select a destination page ---'
+    select_destination: '--- Select next page ---'
     select_question: '--Select a question--'
     conditional_title: 'Branch '
     title_otherwise: 'Otherwise'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,10 +50,11 @@ en:
     message_delete_branch: 'This cannot be undone'
     message_delete_condition: 'This cannot be undone'
     destination:
-      button_change: Change destination
-      label: 'Change destination'
-      hint: 'Update this connection to lead to the following page:'
-      text: 'The page that was previously following (and attached to it) will be moved to the unconnected pages'
+      button_change: Change next page
+      label: 'Change next page'
+      lede: 'After: "%{title}"'
+      go_to: 'Go to: '
+      text: 'Any pages that are left without a connection to your form will be moved to the unconnected pages section.'
   header:
     service_name: "MoJ Forms"
     home_link_text: "Back to Home"

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe Destination do
   let(:flow_uuid) { '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' } # Full name
   let(:destination_uuid) { 'e337070b-f636-49a3-a65c-f506675265f0' }
 
+  describe '#title' do
+    it 'returns title of the page' do
+      expect(destination.title).to eq('Full name')
+    end
+  end
+
   describe '#change' do
     context 'when changing the flow object destination' do
       let(:version) { double(errors?: false, errors: [], metadata: updated_metadata) }

--- a/spec/requests/api/destination_spec.rb
+++ b/spec/requests/api/destination_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe 'Destinations spec', type: :request do
       let(:invalid_destinations) do
         [
           'Service name goes here',
-          'Full name',
           'Confirmation'
         ]
       end


### PR DESCRIPTION
## Context

Now we will be adding the After "X" x is the current page the user wants to change the destination.

Also change the label, the button and the hint message.

I create a specific card to [add acceptance tests to change destination feature](https://trello.com/c/86sNF7WT/1790-add-acceptance-tests-for-change-destination).