### PR TITLE
Automate uptime checks

### DIFF
--- a/app/jobs/uptime_job.rb
+++ b/app/jobs/uptime_job.rb
@@ -1,0 +1,20 @@
+class UptimeJob < ApplicationJob
+  queue_as :default
+
+  def perform(service_id:, action:, service_name: nil, host: nil)
+    Uptime.new(
+      service_id: service_id,
+      service_name: service_name,
+      host: host,
+      adapter: adapter
+    ).method(action).call
+  end
+
+  def adapter
+    if Rails.env.development?
+      Uptime::Adapters::Local
+    else
+      Uptime::Adapters::Pingdom
+    end
+  end
+end

--- a/app/models/uptime_check.rb
+++ b/app/models/uptime_check.rb
@@ -1,0 +1,3 @@
+class UptimeCheck < ApplicationRecord
+  validates :service_id, :check_id, presence: true
+end

--- a/app/services/uptime.rb
+++ b/app/services/uptime.rb
@@ -1,0 +1,41 @@
+class Uptime
+  attr_reader :service_id, :service_name, :host, :adapter
+
+  def initialize(service_id:, service_name:, host:, adapter:)
+    @service_id = service_id
+    @service_name = service_name
+    @host = host
+    @adapter = adapter.new
+  end
+
+  def create
+    if uptime_check.present?
+      update
+    else
+      ActiveSupport::Notifications.instrument('uptime.create') do
+        response = adapter.create(service_name, host)
+        UptimeCheck.new(
+          service_id: service_id,
+          check_id: response['check']['id']
+        ).save
+      end
+    end
+  end
+
+  def update
+    ActiveSupport::Notifications.instrument('uptime.update') do
+      adapter.update(uptime_check.check_id, service_name, host)
+    end
+  end
+
+  def destroy
+    ActiveSupport::Notifications.instrument('uptime.destroy') do
+      adapter.destroy(uptime_check.check_id)
+      uptime_check.destroy
+    end
+  end
+
+  def uptime_check
+    @uptime_check ||= UptimeCheck.find_by(service_id: service_id)
+  end
+end

--- a/app/services/uptime/adapters/local.rb
+++ b/app/services/uptime/adapters/local.rb
@@ -1,0 +1,6 @@
+class Uptime
+  module Adapters
+    class Local
+    end
+  end
+end

--- a/app/services/uptime/adapters/pingdom.rb
+++ b/app/services/uptime/adapters/pingdom.rb
@@ -1,0 +1,56 @@
+class Uptime
+  module Adapters
+    class Pingdom
+      API_URL = 'https://api.pingdom.com/api/3.1'.freeze
+      CHECKS = 'checks'.freeze
+      SUBSCRIPTION = 'uptime.pingdom'.freeze
+      TIMEOUT = 10
+
+      attr_reader :connection
+
+      delegate :get, :post, :put, :delete, to: :connection
+
+      def initialize(root_url: API_URL)
+        @connection = Faraday.new(root_url) do |conn|
+          conn.request :json
+          conn.request(:authorization, 'Bearer', ENV['PINGDOM_TOKEN'])
+          conn.response :json
+          conn.response :raise_error
+          conn.use :instrumentation, name: SUBSCRIPTION
+          conn.options[:open_timeout] = TIMEOUT
+          conn.options[:timeout] = TIMEOUT
+        end
+      end
+
+      def create(service_name, host)
+        post(CHECKS, payload(service_name, host))
+      end
+
+      def update(id, service_name, host)
+        put("#{CHECKS}/#{id}", payload(service_name, host))
+      end
+
+      def destroy(id)
+        delete("#{CHECKS}/#{id}")
+      end
+
+      private
+
+      def payload(service_name, host)
+        {
+          name: "Form Builder - #{service_name}",
+          host: host,
+          type: 'http',
+          encryption: true,
+          integrationids: [ENV['PINGDOM_ALERT_INTEGRATION_ID']], # integrates with slack
+          port: 443,
+          probe_filters: ['region:EU'],
+          resolution: 1,
+          sendnotificationwhendown: 6,
+          tags: [service_name],
+          url: '/health'
+        }
+      end
+    end
+  end
+end

--- a/db/migrate/20211110204320_add_uptime_checks.rb
+++ b/db/migrate/20211110204320_add_uptime_checks.rb
@@ -1,0 +1,11 @@
+class AddUptimeChecks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :uptime_checks do |t|
+      t.uuid :service_id, :null => false
+      t.string :check_id, :null => false
+
+      t.timestamps
+    end
+    add_index :uptime_checks, :service_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_18_140522) do
+ActiveRecord::Schema.define(version: 2021_11_10_204320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -85,6 +85,14 @@ ActiveRecord::Schema.define(version: 2021_10_18_140522) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["service_id", "deployment_environment"], name: "submission_settings_id_and_environment"
     t.index ["service_id"], name: "index_submission_settings_on_service_id"
+  end
+
+  create_table "uptime_checks", force: :cascade do |t|
+    t.uuid "service_id", null: false
+    t.string "check_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["service_id"], name: "index_uptime_checks_on_service_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/deploy-eks/fb-editor-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-editor-chart/templates/deployment.yaml
@@ -215,6 +215,16 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: slack_publish_webhook
+          - name: PINGDOM_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: pingdom_token
+          - name: PINGDOM_ALERT_INTEGRATION_ID
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: pingdom_alert_integration_id
       volumes:
         - name: tmp-files
           emptyDir: {}

--- a/deploy/fb-editor-chart/templates/deployment.yaml
+++ b/deploy/fb-editor-chart/templates/deployment.yaml
@@ -215,6 +215,16 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: slack_publish_webhook
+          - name: PINGDOM_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: pingdom_token
+          - name: PINGDOM_ALERT_INTEGRATION_ID
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: pingdom_alert_integration_id
       volumes:
         - name: tmp-files
           emptyDir: {}

--- a/deploy/fb-editor-chart/templates/secrets.yaml
+++ b/deploy/fb-editor-chart/templates/secrets.yaml
@@ -16,3 +16,5 @@ data:
   service_sentry_dsn_test: {{ .Values.service_sentry_dsn_test }}
   service_sentry_dsn_live: {{ .Values.service_sentry_dsn_live }}
   slack_publish_webhook: {{ .Values.slack_publish_webhook }}
+  pingdom_token: {{ .Values.pingdom_token }}
+  pingdom_alert_integration_id: {{ .Values.pingdom_alert_integration_id }}

--- a/spec/factories/uptime_check.rb
+++ b/spec/factories/uptime_check.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :uptime_check do
+    service_id { SecureRandom.uuid }
+    check_id { SecureRandom.uuid }
+  end
+end

--- a/spec/services/uptime/adapters/pingdom_spec.rb
+++ b/spec/services/uptime/adapters/pingdom_spec.rb
@@ -1,0 +1,85 @@
+RSpec.describe Uptime::Adapters::Pingdom do
+  subject(:pingdom) do
+    described_class.new(root_url: pingdom_api)
+  end
+  let(:pingdom_api) { 'https://pingdom-api.com' }
+  let(:service_name) { 'My awesome service' }
+  let(:host) { 'my-awesome-service' }
+  let(:alert_integration_id) { '1234' }
+  let(:expected_payload) do
+    {
+      name: "Form Builder - #{service_name}",
+      host: host,
+      type: 'http',
+      encryption: true,
+      integrationids: [alert_integration_id],
+      port: 443,
+      probe_filters: ['region:EU'],
+      resolution: 1,
+      sendnotificationwhendown: 6,
+      tags: [service_name],
+      url: '/health'
+    }
+  end
+  let(:checks) { Uptime::Adapters::Pingdom::CHECKS }
+  let(:pingdom_stub) do
+    stub_request(action, pingdom_api_url)
+      .with(
+        body: expected_payload.to_json,
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type' => 'application/json',
+          'User-Agent' => 'Faraday v1.8.0'
+        }
+      )
+  end
+  let(:check_id) { '9876' }
+
+  before do
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[]).with('PINGDOM_TOKEN').and_return(SecureRandom.uuid)
+    allow(ENV).to receive(:[]).with('PINGDOM_ALERT_INTEGRATION_ID').and_return(alert_integration_id)
+    pingdom_stub
+  end
+
+  # might remove
+  describe '#check' do
+  end
+
+  describe '#create' do
+    let(:action) { :post }
+    let(:pingdom_api_url) { "#{pingdom_api}/#{checks}" }
+
+    it 'sends the correct payload when creating a pingdom check' do
+      expect_any_instance_of(Faraday::Connection).to receive(
+        :post
+      ).with(checks, expected_payload)
+      pingdom.create(service_name, host)
+    end
+  end
+
+  describe '#update' do
+    let(:action) { :put }
+    let(:pingdom_api_url) { "#{pingdom_api}/#{checks}/#{check_id}" }
+
+    it 'sends the correct payload when creating a pingdom check' do
+      expect_any_instance_of(Faraday::Connection).to receive(
+        :put
+      ).with("#{checks}/#{check_id}", expected_payload)
+      pingdom.update(check_id, service_name, host)
+    end
+  end
+
+  describe '#destroy' do
+    let(:action) { :destroy }
+    let(:pingdom_api_url) { "#{pingdom_api}/#{checks}/#{check_id}" }
+
+    it 'sends the correct payload when creating a pingdom check' do
+      expect_any_instance_of(Faraday::Connection).to receive(
+        :delete
+      ).with("#{checks}/#{check_id}")
+      pingdom.destroy(check_id)
+    end
+  end
+end


### PR DESCRIPTION
During publishing and unpublishing of a Service we need to create and
destroy Uptime Checks relating to that Service.

Currently we use Pingdom so there is a specific adapter relating to the
intereaction with their API.

When creating a new Pingdom check the url endpoint that we use is
/health. This is already used by Kubernetes to check the health of
services so we can just reuse this instead of creating another endpoint.

This PR does not set the uptime job yet. The reason is because we have disparity of code between testable editors and editors than run on the `main` branch.