### PR TITLE
Add publishing warning when CYA and confirmation pages are not in a form

### DIFF
--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -4,15 +4,80 @@ feature 'Branching errors' do
   let(:editor) { EditorApp.new }
   let(:service_name) { generate_service_name }
   let(:page_url) { 'palpatine' }
+  let(:warning_both) { I18n.t('publish.warning.both_pages') }
+  let(:warning_cya) { I18n.t('publish.warning.cya') }
+  let(:warning_confirmation) { I18n.t('publish.warning.confirmation') }
 
   background do
     given_I_am_logged_in
     given_I_have_a_service
   end
 
-  scenario 'when visiting the publishing page' do
+  scenario 'when visiting the publishing page with submitting pages present' do
+    given_I_have_a_single_question_page_with_upload
+    and_I_return_to_flow_page
+
+    # when we add the new default template,
+    # adding the cya and confirmation pages will not be possible
+    # and this test should fail
+    given_I_add_a_check_answers_page
+    and_I_add_a_page_url('cya')
+    when_I_add_the_page
+    and_I_return_to_flow_page
+
+    given_I_add_a_confirmation_page
+    and_I_add_a_page_url('confirmation')
+    when_I_add_the_page
+
+    and_I_return_to_flow_page
     when_I_visit_the_publishing_page
     then_I_should_be_on_the_publishing_page
+    then_I_should_not_see_warning_both_text
+    then_I_should_not_see_warning_cya_text
+    then_I_should_not_see_warning_confirmation_text
+  end
+
+  # when we add the new default template, the cya and confirmation pages will present
+  # and the next 3 tests should fail
+  scenario 'when visiting the publishing page without submitting pages present' do
+    given_I_have_a_single_question_page_with_upload
+    and_I_return_to_flow_page
+    when_I_visit_the_publishing_page
+    then_I_should_be_on_the_publishing_page
+    then_I_should_see_warning_both_text
+    then_I_should_not_see_warning_cya_text
+    then_I_should_not_see_warning_confirmation_text
+  end
+
+  scenario 'when visiting the publishing page without cya page present' do
+    given_I_have_a_single_question_page_with_upload
+    and_I_return_to_flow_page
+
+    given_I_add_a_confirmation_page
+    and_I_add_a_page_url('confirmation')
+    when_I_add_the_page
+
+    when_I_visit_the_publishing_page
+    then_I_should_be_on_the_publishing_page
+    then_I_should_not_see_warning_both_text
+    then_I_should_not_see_warning_confirmation_text
+    then_I_should_see_warning_cya_text
+  end
+
+  scenario 'when visiting the publishing page without confirmation page present' do
+    given_I_have_a_single_question_page_with_upload
+    and_I_return_to_flow_page
+
+    given_I_add_a_check_answers_page
+    and_I_add_a_page_url('cya')
+    when_I_add_the_page
+    and_I_return_to_flow_page
+
+    when_I_visit_the_publishing_page
+    then_I_should_be_on_the_publishing_page
+    then_I_should_not_see_warning_both_text
+    then_I_should_not_see_warning_cya_text
+    then_I_should_see_warning_confirmation_text
   end
 
   def when_I_visit_the_publishing_page
@@ -24,5 +89,29 @@ feature 'Branching errors' do
     buttons_text = page.all(:css, 'input.fb-govuk-button', visible: false).map(&:value)
     expect(buttons_text).to include(I18n.t('publish.test.button'))
     expect(buttons_text).to include(I18n.t('publish.live.button'))
+  end
+
+  def then_I_should_not_see_warning_both_text
+    expect(editor.text).to_not include(warning_both)
+  end
+
+  def then_I_should_not_see_warning_cya_text
+    expect(editor.text).to_not include(warning_cya)
+  end
+
+  def then_I_should_not_see_warning_confirmation_text
+    expect(editor.text).to_not include(warning_confirmation)
+  end
+
+  def then_I_should_see_warning_both_text
+    expect(editor.text).to include(warning_both)
+  end
+
+  def then_I_should_see_warning_cya_text
+    expect(editor.text).to include(warning_cya)
+  end
+
+  def then_I_should_see_warning_confirmation_text
+    expect(editor.text).to include(warning_confirmation)
   end
 end

--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -1,9 +1,11 @@
 class PublishController < FormController
+  include PublishWarningHelper
   before_action :assign_form_objects
 
   def index
     @published_dev = published?(service.service_id, 'dev')
     @published_production = published?(service.service_id, 'production')
+    @warning_message = warning_message
   end
 
   def create
@@ -19,6 +21,13 @@ class PublishController < FormController
       render :index
     end
   end
+
+  def warning_message
+    submitting_pages_not_present ||
+      confirmation_page_not_present ||
+      cya_page_not_present
+  end
+  helper_method :warning_message
 
   private
 

--- a/app/helpers/publish_warning_helper.rb
+++ b/app/helpers/publish_warning_helper.rb
@@ -1,0 +1,47 @@
+module PublishWarningHelper
+  def submitting_pages_not_present
+    if !checkanswers_present? && !confirmation_present?
+      I18n.t('publish.warning.both_pages')
+    end
+  end
+
+  def cya_page_not_present
+    if !checkanswers_present? && confirmation_present?
+      I18n.t('publish.warning.cya')
+    end
+  end
+
+  def confirmation_page_not_present
+    if checkanswers_present? && !confirmation_present?
+      I18n.t('publish.warning.confirmation')
+    end
+  end
+
+  def checkanswers_present?
+    grid.page_uuids.include?(find_page_uuid('page.checkanswers'))
+  end
+
+  def confirmation_present?
+    grid.page_uuids.include?(find_page_uuid('page.confirmation'))
+  end
+
+  def find_page_uuid(page_type)
+    if service_includes_page?(page_type)
+      matched_page =
+        service.pages.find do |page|
+          page.type == page_type
+        end
+      matched_page.uuid
+    end
+  end
+
+  def service_includes_page?(page)
+    service.pages
+      .map(&:type)
+      .include?(page)
+  end
+
+  def grid
+    @grid ||= MetadataPresenter::Grid.new(service)
+  end
+end

--- a/app/views/publish/index.html.erb
+++ b/app/views/publish/index.html.erb
@@ -9,6 +9,16 @@
   <%# last updated by <span class="name by">C. Smith</span      %>
 </p>
 
+<% if @warning_message.present? %>
+  <div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive"><%= t('publish.warning.heading') %></span>
+    <%= @warning_message %>
+  </strong>
+</div>
+<% end %>
+
 <dl id="publish-environments">
   <dt class="environment govuk-heading-l"><%= t('publish.test.heading') %></dt>
   <dd>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -199,6 +199,11 @@ en:
   publish:
     name: 'Publishing'
     heading: 'Publishing'
+    warning:
+      heading: 'Warning'
+      confirmation: 'Your form has no confirmation page - you won’t receive any user data without one'
+      cya: 'Your form has no check answers page - you won’t receive any user data without one'
+      both_pages: 'Your form has no check answers page or confirmation page - you won’t receive any user data without them'
     dialog:
       heading: Publish to Test?
       option_1: Allow anyone with the link to view

--- a/spec/controllers/publish_controller_spec.rb
+++ b/spec/controllers/publish_controller_spec.rb
@@ -1,0 +1,175 @@
+RSpec.describe PublishController do
+  let(:checkanswers_uuid) { 'e337070b-f636-49a3-a65c-f506675265f0' }
+  let(:confirmation_uuid) { '778e364b-9a7f-4829-8eb2-510e08f156a3' }
+  let(:checkanswers_page) do
+    metadata['flow']['e337070b-f636-49a3-a65c-f506675265f0']
+  end
+  let(:arnold_incomplete_answers) do
+    metadata['flow']['941137d7-a1da-43fd-994a-98a4f9ea6d46']
+  end
+  let(:arnold_right_answers) do
+    metadata['flow']['56e80942-d0a4-405a-85cd-bd1b100013d6']
+  end
+  let(:arnold_wrong_answers) do
+    metadata['flow']['6324cca4-7770-4765-89b9-1cdc41f49c8b']
+  end
+  let(:warning_both_pages) do
+    I18n.t('publish.warning.both_pages')
+  end
+  let(:warning_cya_page) do
+    I18n.t('publish.warning.cya')
+  end
+  let(:warning_confirmation_page) do
+    I18n.t('publish.warning.confirmation')
+  end
+
+  describe '#submitting_pages_not_present' do
+    before do
+      allow(controller).to receive(:service).and_return(service)
+    end
+    let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+    let(:latest_metadata) { metadata_fixture(:branching) }
+
+    context 'when there is both a check answers and confirmation page' do
+      it 'returns nil' do
+        expect(controller.submitting_pages_not_present).to be_nil
+      end
+    end
+
+    context 'when there is neither a check answers or confirmation page' do
+      let(:service) do
+        MetadataPresenter::Service.new(metadata_fixture(:exit_only_service))
+      end
+
+      it 'returns the correct warning' do
+        expect(controller.submitting_pages_not_present).to eq(warning_both_pages)
+      end
+    end
+
+    context 'when there is no check answers page' do
+      let(:metadata) { metadata_fixture(:branching) }
+      let(:latest_metadata) do
+        arnold_incomplete_answers['next']['default'] = confirmation_uuid
+        arnold_right_answers['next']['default'] = confirmation_uuid
+        arnold_wrong_answers['next']['default'] = confirmation_uuid
+        metadata
+      end
+
+      it 'returns nil' do
+        expect(controller.submitting_pages_not_present).to be_nil
+      end
+    end
+
+    context 'when there is no confirmation page' do
+      let(:metadata) { metadata_fixture(:branching) }
+      let(:latest_metadata) do
+        checkanswers_page['next']['default'] = '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' # name
+        metadata
+      end
+
+      it 'returns nil' do
+        expect(controller.submitting_pages_not_present).to be_nil
+      end
+    end
+  end
+
+  describe '#cya_page_not_present' do
+    before do
+      allow(controller).to receive(:service).and_return(service)
+    end
+    let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+    let(:latest_metadata) { metadata_fixture(:branching) }
+
+    context 'when there is both a check answers and confirmation page' do
+      it 'returns nil' do
+        expect(controller.cya_page_not_present).to be_nil
+      end
+    end
+
+    context 'when there is neither a check answers or confirmation page' do
+      let(:service) do
+        MetadataPresenter::Service.new(metadata_fixture(:exit_only_service))
+      end
+
+      it 'returns nil' do
+        expect(controller.cya_page_not_present).to be_nil
+      end
+    end
+
+    context 'when there is no check answers page' do
+      let(:metadata) { metadata_fixture(:branching) }
+      let(:latest_metadata) do
+        arnold_incomplete_answers['next']['default'] = confirmation_uuid
+        arnold_right_answers['next']['default'] = confirmation_uuid
+        arnold_wrong_answers['next']['default'] = confirmation_uuid
+        metadata
+      end
+
+      it 'returns the correct warning' do
+        expect(controller.cya_page_not_present).to eq(warning_cya_page)
+      end
+    end
+
+    context 'when there is no confirmation page' do
+      let(:metadata) { metadata_fixture(:branching) }
+      let(:latest_metadata) do
+        checkanswers_page['next']['default'] = '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' # name
+        metadata
+      end
+
+      it 'returns nil' do
+        expect(controller.cya_page_not_present).to be_nil
+      end
+    end
+  end
+
+  describe '#confirmation_page_not_present' do
+    before do
+      allow(controller).to receive(:service).and_return(service)
+    end
+    let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+    let(:latest_metadata) { metadata_fixture(:branching) }
+
+    context 'when there is both a check answers and confirmation page' do
+      it 'returns nil' do
+        expect(controller.confirmation_page_not_present).to be_nil
+      end
+    end
+
+    context 'when there is neither a check answers or confirmation page' do
+      let(:service) do
+        MetadataPresenter::Service.new(metadata_fixture(:exit_only_service))
+      end
+
+      it 'returns nil' do
+        expect(controller.confirmation_page_not_present).to be_nil
+      end
+    end
+
+    context 'when there is no check answers page' do
+      let(:metadata) { metadata_fixture(:branching) }
+      let(:latest_metadata) do
+        arnold_incomplete_answers['next']['default'] = confirmation_uuid
+        arnold_right_answers['next']['default'] = confirmation_uuid
+        arnold_wrong_answers['next']['default'] = confirmation_uuid
+        metadata
+      end
+
+      it 'returns nil' do
+        expect(controller.confirmation_page_not_present).to be_nil
+      end
+    end
+
+    context 'when there is no confirmation page' do
+      let(:metadata) { metadata_fixture(:branching) }
+      let(:latest_metadata) do
+        checkanswers_page['next']['default'] = '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' # name
+        metadata
+      end
+
+      it 'returns the correct warning' do
+        expect(controller.confirmation_page_not_present).to eq(warning_confirmation_page)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/hG2LDEua/2119-add-warning-about-publishing-with-cya-and-confirmation-pages-1-7)

### Add publishing warning when CYA and confirmation pages are not in a main flow of a form
- Warning appears when either the CYA or confirmation page are not present in a form at all
- The warning is also triggered when CYA or pages become disconnected
- Acceptance tests

<img width="1532" alt="Screenshot 2021-12-01 at 14 57 21" src="https://user-images.githubusercontent.com/29227502/144259577-c7941627-6d44-443f-a162-3c99d6e8b66a.png">
<img width="1532" alt="Screenshot 2021-12-01 at 14 57 42" src="https://user-images.githubusercontent.com/29227502/144259598-d0dd5031-8d44-432c-83f7-7756889c6afa.png">
<img width="1532" alt="Screenshot 2021-12-01 at 14 57 53" src="https://user-images.githubusercontent.com/29227502/144259601-56ac0b76-828a-409b-8f60-a96bcdb11cb9.png">