### PR TITLE
New form template

### DIFF
--- a/acceptance/features/add_page_in_the_middle_flow_spec.rb
+++ b/acceptance/features/add_page_in_the_middle_flow_spec.rb
@@ -11,7 +11,9 @@ feature 'Add page in the middle flow' do
     [
       "Edit:\nService name goes here",
       "Edit:\nWe Both Love Soup And Snow Peas",
-      "Edit:\nQuestion"
+      "Edit:\nQuestion",
+      "Edit:\nCheck your answers",
+      "Edit:\nApplication complete"
     ]
   end
 

--- a/acceptance/features/create_page_spec.rb
+++ b/acceptance/features/create_page_spec.rb
@@ -59,20 +59,6 @@ feature 'Create page' do
     then_I_should_see_the_edit_multiple_question_page
   end
 
-  scenario 'creating a check answers page' do
-    given_I_add_a_check_answers_page
-    and_I_add_a_page_url
-    when_I_add_the_page
-    then_I_should_see_the_edit_check_answers_page
-  end
-
-  scenario 'creating confirmation page' do
-    given_I_add_a_confirmation_page
-    and_I_add_a_page_url
-    when_I_add_the_page
-    then_I_should_see_the_edit_confirmation_page
-  end
-
   context 'existing urls' do
     let(:error_message) { 'You already have a page with that name' }
 

--- a/acceptance/features/deleting_page_spec.rb
+++ b/acceptance/features/deleting_page_spec.rb
@@ -198,6 +198,6 @@ feature 'Deleting page' do
   end
 
   def then_I_should_not_see_the_deleted_page_anymore
-    expect(editor.form_urls.count).to eq(1)
+    expect(editor.form_urls.count).to eq(3)
   end
 end

--- a/acceptance/features/edit_check_answers_page_spec.rb
+++ b/acceptance/features/edit_check_answers_page_spec.rb
@@ -26,13 +26,12 @@ feature 'Edit check your answers page' do
   end
 
   scenario 'editing page info' do
-    given_I_have_a_check_your_answers_page
+    given_I_edit_a_check_your_answers_page
     and_I_change_the_page_heading(heading)
     and_I_change_the_send_heading(send_heading)
     and_I_change_the_send_body(send_body)
     when_I_save_my_changes
     and_I_return_to_flow_page
-    and_I_click_on_the_three_dots
     and_I_edit_the_page(url: heading)
     then_I_should_see_the_page_heading(heading)
     then_I_should_see_the_page_send_heading(send_heading)
@@ -40,7 +39,7 @@ feature 'Edit check your answers page' do
   end
 
   scenario 'adding components' do
-    given_I_have_a_check_your_answers_page
+    given_I_edit_a_check_your_answers_page
     and_I_add_a_content_component(
       content: content_component
     )
@@ -55,7 +54,7 @@ feature 'Edit check your answers page' do
   end
 
   scenario 'deleting components' do
-    given_I_have_a_check_your_answers_page
+    given_I_edit_a_check_your_answers_page
     and_I_add_a_content_component(
       content: content_component
     )
@@ -104,12 +103,14 @@ feature 'Edit check your answers page' do
 
   def and_I_add_a_content_component(content:)
     editor.add_content_area_buttons.last.click
+    editor.page_heading.click
     expect(editor.first_component.text).to eq(optional_content)
     when_I_change_editable_content(editor.first_component, content: content)
   end
 
   def and_I_add_a_content_extra_component(content:)
     editor.add_content_area_buttons.first.click
+    editor.page_heading.click
     expect(editor.first_extra_component.text).to eq(optional_content)
     when_I_change_editable_content(editor.first_extra_component, content: content)
   end

--- a/acceptance/features/edit_confirmation_page_spec.rb
+++ b/acceptance/features/edit_confirmation_page_spec.rb
@@ -3,7 +3,6 @@ require_relative '../spec_helper'
 feature 'Edit confirmation pages' do
   let(:editor) { EditorApp.new }
   let(:service_name) { generate_service_name }
-  let(:confirmation_url) { 'confirmation' }
   let(:confirmation_heading) { 'Updated confirmation heading' }
   let(:confirmation_lede) { 'Updated confirmation lede' }
   let(:confirmation_body) { 'Updated confirmation body' }
@@ -14,7 +13,7 @@ feature 'Edit confirmation pages' do
   end
 
   scenario 'updates all fields' do
-    given_I_have_a_confirmation_page
+    given_I_edit_a_confirmation_page
     and_I_change_the_page_heading(confirmation_heading)
     and_I_change_the_page_lede(confirmation_lede)
     and_I_change_the_page_body(confirmation_body)
@@ -22,16 +21,10 @@ feature 'Edit confirmation pages' do
     and_I_return_to_flow_page
     and_I_click_on_the_confirmation_page_three_dots
     then_I_should_only_see_three_options_on_page_menu
-    and_I_edit_the_page(url: confirmation_heading)
+    and_I_click_edit_page
     then_I_should_see_the_confirmation_heading(confirmation_heading)
     then_I_should_see_the_confirmation_lede(confirmation_lede)
     then_I_should_see_the_confirmation_body(confirmation_body)
-  end
-
-  def given_I_have_a_confirmation_page
-    given_I_add_a_confirmation_page
-    and_I_add_a_page_url(confirmation_url)
-    when_I_add_the_page
   end
 
   def and_I_change_the_page_body(body)
@@ -50,5 +43,9 @@ feature 'Edit confirmation pages' do
     sleep 0.5 # Arbitrary delay, possibly required due to focus issues
     page.find('.flow-thumbnail', text: confirmation_heading).hover
     editor.three_dots_button.click
+  end
+
+  def and_I_click_edit_page
+    editor.edit_page_button.click
   end
 end

--- a/acceptance/features/edit_exit_page_spec.rb
+++ b/acceptance/features/edit_exit_page_spec.rb
@@ -28,7 +28,7 @@ feature 'Edit exit pages' do
     and_I_change_the_page_lede(exit_lede)
     when_I_save_my_changes
     and_I_return_to_flow_page
-    and_I_click_on_the_three_dots
+    and_I_click_on_the_exit_page_three_dots
     then_I_should_only_see_three_options_on_page_menu
     and_I_edit_the_page(url: exit_heading)
     then_I_see_the_updated_page_heading(exit_heading)
@@ -106,5 +106,11 @@ feature 'Edit exit pages' do
       expect(page.current_path).to include('/preview/exit')
       expect(page.all('button').to_a).to eq([])
     end
+  end
+
+  def and_I_click_on_the_exit_page_three_dots
+    sleep 0.5 # Arbitrary delay, possibly required due to focus issues
+    editor.preview_page_images.last.hover
+    editor.three_dots_button.click
   end
 end

--- a/acceptance/features/edit_multiple_questions_page_spec.rb
+++ b/acceptance/features/edit_multiple_questions_page_spec.rb
@@ -90,11 +90,7 @@ feature 'Edit multiple questions page' do
       page.choose '900 years old', visible: false
       page.check 'Prequels', visible: false
       page.click_button 'Continue'
-
-      # There are no next pages but it means that the continue work and the
-      # multiple question is working since filling the form above worked
-      # gracefully.
-      expect(page.text).to include("The page you were looking for doesn't exist.")
+      expect(page.text).to include("Check your answers")
     end
   end
 

--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -95,15 +95,6 @@ feature 'Preview form' do
     when_I_update_the_question_name('Upload your file')
     and_I_make_the_question_optional
     and_I_return_to_flow_page
-
-    given_I_add_a_check_answers_page
-    and_I_add_a_page_url('cya')
-    when_I_add_the_page
-    and_I_return_to_flow_page
-
-    given_I_add_a_confirmation_page
-    and_I_add_a_page_url('confirmation')
-    when_I_add_the_page
   end
 
   def and_I_add_a_multiple_page_content_component(content:)

--- a/acceptance/features/preview_page_spec.rb
+++ b/acceptance/features/preview_page_spec.rb
@@ -19,8 +19,6 @@ feature 'Preview page' do
   scenario 'preview upload page' do
     given_I_have_a_single_question_page_with_upload
     and_I_return_to_flow_page
-    given_I_have_a_check_your_answers_page
-    and_I_return_to_flow_page
     preview_page = when_I_preview_the_upload_page
     then_I_should_upload_my_files(preview_page)
   end
@@ -76,7 +74,7 @@ feature 'Preview page' do
 
   def then_I_should_be_on_the_check_your_answers_page
     then_I_should_not_see_optional_text
-    expect(page.current_url).to include('cya')
+    expect(page.current_url).to include('checkanswers')
   end
 
   def then_I_should_see_that_I_should_add_a_file

--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -4,6 +4,7 @@ feature 'Branching errors' do
   let(:editor) { EditorApp.new }
   let(:service_name) { generate_service_name }
   let(:page_url) { 'palpatine' }
+  let(:exit_url) { 'exit' }
   let(:warning_both) { I18n.t('publish.warning.both_pages') }
   let(:warning_cya) { I18n.t('publish.warning.cya') }
   let(:warning_confirmation) { I18n.t('publish.warning.confirmation') }
@@ -16,20 +17,6 @@ feature 'Branching errors' do
   scenario 'when visiting the publishing page with submitting pages present' do
     given_I_have_a_single_question_page_with_upload
     and_I_return_to_flow_page
-
-    # when we add the new default template,
-    # adding the cya and confirmation pages will not be possible
-    # and this test should fail
-    given_I_add_a_check_answers_page
-    and_I_add_a_page_url('cya')
-    when_I_add_the_page
-    and_I_return_to_flow_page
-
-    given_I_add_a_confirmation_page
-    and_I_add_a_page_url('confirmation')
-    when_I_add_the_page
-
-    and_I_return_to_flow_page
     when_I_visit_the_publishing_page
     then_I_should_be_on_the_publishing_page
     then_I_should_not_see_warning_both_text
@@ -37,11 +24,10 @@ feature 'Branching errors' do
     then_I_should_not_see_warning_confirmation_text
   end
 
-  # when we add the new default template, the cya and confirmation pages will present
-  # and the next 3 tests should fail
   scenario 'when visiting the publishing page without submitting pages present' do
     given_I_have_a_single_question_page_with_upload
     and_I_return_to_flow_page
+    given_I_have_an_exit_page
     when_I_visit_the_publishing_page
     then_I_should_be_on_the_publishing_page
     then_I_should_see_warning_both_text
@@ -52,11 +38,8 @@ feature 'Branching errors' do
   scenario 'when visiting the publishing page without cya page present' do
     given_I_have_a_single_question_page_with_upload
     and_I_return_to_flow_page
-
-    given_I_add_a_confirmation_page
-    and_I_add_a_page_url('confirmation')
-    when_I_add_the_page
-
+    # this will fail when we implement delete warning
+    and_I_delete_cya_page
     when_I_visit_the_publishing_page
     then_I_should_be_on_the_publishing_page
     then_I_should_not_see_warning_both_text
@@ -67,12 +50,8 @@ feature 'Branching errors' do
   scenario 'when visiting the publishing page without confirmation page present' do
     given_I_have_a_single_question_page_with_upload
     and_I_return_to_flow_page
-
-    given_I_add_a_check_answers_page
-    and_I_add_a_page_url('cya')
-    when_I_add_the_page
-    and_I_return_to_flow_page
-
+    # this will fail when we implement disconnected pages warning
+    and_I_add_an_exit_page_after_cya_page
     when_I_visit_the_publishing_page
     then_I_should_be_on_the_publishing_page
     then_I_should_not_see_warning_both_text
@@ -89,6 +68,30 @@ feature 'Branching errors' do
     buttons_text = page.all(:css, 'input.fb-govuk-button', visible: false).map(&:value)
     expect(buttons_text).to include(I18n.t('publish.test.button'))
     expect(buttons_text).to include(I18n.t('publish.live.button'))
+  end
+
+  def and_I_delete_cya_page
+    sleep 0.5 # Arbitrary delay, possibly required due to focus issues
+    editor.preview_page_images.last.hover
+    editor.three_dots_button.click
+    editor.delete_page_link.click
+    sleep 0.5 # Arbitrary delay, possibly required due to focus issues
+    editor.delete_page_modal_button.click
+  end
+
+  def and_I_add_an_exit_page_after_cya_page
+    editor.preview_page_images.last.hover
+    editor.three_dots_button.click
+    editor.add_page_here_link.click
+    editor.add_exit.click
+    and_I_add_a_page_url(exit_url)
+    when_I_add_the_page
+  end
+
+  def given_I_have_an_exit_page
+    given_I_add_an_exit_page
+    and_I_add_a_page_url(exit_url)
+    when_I_add_the_page
   end
 
   def then_I_should_not_see_warning_both_text

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -37,6 +37,7 @@ class EditorApp < SitePrism::Page
   element :form_name_field, :field, I18n.t('settings.form_information_label')
   element :save_button, :button, I18n.t('actions.save')
   element :preview_form_button, :link, I18n.t('actions.preview_form')
+  element :edit_page_button, :link, I18n.t('actions.edit_page')
 
   element :submission_settings_link, :link, I18n.t('settings.submission.name')
 

--- a/acceptance/support/branching_steps.rb
+++ b/acceptance/support/branching_steps.rb
@@ -26,15 +26,6 @@ module BranchingSteps
     when_I_add_the_page
     when_I_update_the_question_name('Favourite sewing project')
     and_I_return_to_flow_page
-
-    given_I_add_a_check_answers_page
-    and_I_add_a_page_url('cya')
-    when_I_add_the_page
-    and_I_return_to_flow_page
-
-    given_I_add_a_confirmation_page
-    and_I_add_a_page_url('confirmation')
-    when_I_add_the_page
   end
 
   def then_I_can_add_and_delete_conditionals_and_expressions

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -102,9 +102,8 @@ module CommonSteps
     editor.add_checkboxes.click
   end
 
-  def given_I_add_a_check_answers_page
-    given_I_want_to_add_a_page
-    editor.add_check_answers.click
+  def given_I_edit_a_check_your_answers_page
+    page.find('.govuk-link', text: 'Check your answers').click
   end
 
   def given_I_add_a_content_page
@@ -117,9 +116,8 @@ module CommonSteps
     editor.add_multiple_question.click
   end
 
-  def given_I_add_a_confirmation_page
-    given_I_want_to_add_a_page
-    editor.add_confirmation.click
+  def given_I_edit_a_confirmation_page
+    page.find('.govuk-link', text: 'Application complete').click
   end
 
   def given_I_add_an_exit_page
@@ -184,7 +182,7 @@ module CommonSteps
   end
 
   def when_I_preview_the_page
-    editor.preview_page_images.last.hover
+    editor.preview_page_images[-2].hover
     when_I_click_preview_page
   end
 
@@ -315,7 +313,7 @@ module CommonSteps
 
   def and_I_click_on_the_three_dots
     sleep 0.5 # Arbitrary delay, possibly required due to focus issues
-    editor.preview_page_images.last.hover
+    editor.preview_page_images[-2].hover
     editor.three_dots_button.click
   end
 

--- a/spec/generators/new_service_generator_spec.rb
+++ b/spec/generators/new_service_generator_spec.rb
@@ -1,5 +1,90 @@
 RSpec.describe NewServiceGenerator do
   describe '#to_metadata' do
+    context 'when branching is disabled' do
+      before do
+        allow(ENV).to receive(:[])
+        allow(ENV).to receive(:[]).with('BRANCHING').and_return('disabled')
+      end
+
+      context 'valid service metadata' do
+        let(:valid) { true }
+        let(:service_name) { 'Razorback' }
+        let(:current_user) { double(id: '1234') }
+        let(:service_metadata) do
+          NewServiceGenerator.new(
+            service_name: service_name,
+            current_user: current_user
+          ).to_metadata
+        end
+        let(:expected_service_flow) do
+          {
+            service_metadata['pages'][0]['_uuid'] => {
+              '_type' => 'flow.page',
+              'next' => {
+                'default' => ''
+              }
+            }
+          }
+        end
+
+        it 'creates a valid service metadata' do
+          expect(
+            MetadataPresenter::ValidateSchema.validate(
+              service_metadata, 'service.base'
+            )
+          ).to be(valid)
+        end
+
+        it 'creates start page' do
+          expect(service_metadata['pages']).to be_present
+          expect(service_metadata['pages'][0]).to include(
+            '_type' => 'page.start',
+            'url' => '/'
+          )
+        end
+
+        it 'creates the start page flow object' do
+          expect(service_metadata['flow']).to be_present
+          expect(service_metadata['flow']).to eq(expected_service_flow)
+        end
+
+        it 'creates the default footer pages' do
+          expect(service_metadata['standalone_pages'].count).to eq(3)
+
+          urls = service_metadata['standalone_pages'].map { |page| page['url'] }
+          I18n.t('footer').each do |page|
+            expect(urls).to include(page[:url])
+          end
+        end
+
+        it 'creates valid pages' do
+          all_pages = service_metadata['pages'] + service_metadata['standalone_pages']
+          all_pages.each do |page|
+            expect(
+              MetadataPresenter::ValidateSchema.validate(page, page['_type'])
+            ).to be(valid)
+          end
+        end
+      end
+
+      context 'invalid metadata' do
+        it 'raises a schema validation error' do
+          expect {
+            MetadataPresenter::ValidateSchema.validate(
+              { foo: 'bar' }, 'service.base'
+            )
+          }.to raise_error(JSON::Schema::ValidationError)
+        end
+      end
+    end
+  end
+
+  context 'when branching is enabled' do
+    before do
+      allow(ENV).to receive(:[])
+      allow(ENV).to receive(:[]).with('BRANCHING').and_return('enabled')
+    end
+
     context 'valid service metadata' do
       let(:valid) { true }
       let(:service_name) { 'Razorback' }
@@ -10,12 +95,27 @@ RSpec.describe NewServiceGenerator do
           current_user: current_user
         ).to_metadata
       end
+      let(:start_page_uuid) { service_metadata['pages'][0]['_uuid'] }
+      let(:cya_page_uuid) { service_metadata['pages'][1]['_uuid'] }
+      let(:confirmation_page_uuid) { service_metadata['pages'][2]['_uuid'] }
       let(:expected_service_flow) do
         {
-          service_metadata['pages'][0]['_uuid'] => {
-            '_type' => 'flow.page',
-            'next' => {
-              'default' => ''
+          start_page_uuid => {
+            '_type': 'flow.page',
+            'next': {
+              'default': cya_page_uuid
+            }
+          },
+          cya_page_uuid => {
+            '_type': 'flow.page',
+            'next': {
+              'default': confirmation_page_uuid
+            }
+          },
+          confirmation_page_uuid => {
+            '_type': 'flow.page',
+            'next': {
+              'default': ''
             }
           }
         }
@@ -37,7 +137,23 @@ RSpec.describe NewServiceGenerator do
         )
       end
 
-      it 'creates the start page flow object' do
+      it 'creates check answers page' do
+        expect(service_metadata['pages']).to be_present
+        expect(service_metadata['pages'][1]).to include(
+          '_type' => 'page.checkanswers',
+          'url' => 'checkanswers'
+        )
+      end
+
+      it 'creates confirmation page' do
+        expect(service_metadata['pages']).to be_present
+        expect(service_metadata['pages'][2]).to include(
+          '_type' => 'page.confirmation',
+          'url' => 'confirmation'
+        )
+      end
+
+      it 'creates the page flow object' do
         expect(service_metadata['flow']).to be_present
         expect(service_metadata['flow']).to eq(expected_service_flow)
       end


### PR DESCRIPTION
[Trello](https://trello.com/c/G4HR2IxT/2117-change-new-form-default-template-to-have-cya-and-confirmation-5-7)
### New form template 
This adds the CYA and Confirmation pages to the default service template.
This is hidden behind a feature flag so will only appear once branching is released, this is because we require the connection menus to be present.

### Update Acceptance tests 
Tests have been updated to accommodate the new service default template.