### PR TITLE
Testable legacy name validator

### DIFF
--- a/app/controllers/admin/legacy_service_names_controller.rb
+++ b/app/controllers/admin/legacy_service_names_controller.rb
@@ -1,0 +1,4 @@
+module Admin
+  class LegacyServiceNamesController < Admin::ApplicationController
+  end
+end

--- a/app/dashboards/legacy_service_name_dashboard.rb
+++ b/app/dashboards/legacy_service_name_dashboard.rb
@@ -1,0 +1,60 @@
+require 'administrate/base_dashboard'
+
+class LegacyServiceNameDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::String,
+    name: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    name
+    id
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    name
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    name
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how users are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(user)
+  #   "User ##{user.id}"
+  # end
+end

--- a/app/models/legacy_service_name.rb
+++ b/app/models/legacy_service_name.rb
@@ -1,2 +1,3 @@
 class LegacyServiceName < ApplicationRecord
+  validates :name, presence: true
 end

--- a/app/models/legacy_service_name.rb
+++ b/app/models/legacy_service_name.rb
@@ -1,0 +1,2 @@
+class LegacyServiceName < ApplicationRecord
+end

--- a/app/services/editor/service.rb
+++ b/app/services/editor/service.rb
@@ -6,6 +6,7 @@ module Editor
     validates :service_name, presence: true
     validates :service_name, length: { minimum: 3, maximum: 128 }, allow_blank: true
     validates :service_name, format: { with: /\A[\sa-zA-Z0-9-]*\z/ }, allow_blank: true
+    validates :service_name, legacy_service_name: true
 
     def add_errors(service)
       service.errors.each do |_error_message|

--- a/app/validators/legacy_service_name_validator.rb
+++ b/app/validators/legacy_service_name_validator.rb
@@ -1,0 +1,9 @@
+class LegacyServiceNameValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    legacy_service_names = LegacyServiceName.pluck(:name)
+
+    if value.in?(legacy_service_names)
+      record.errors.add(attribute, :taken)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :admin do
     resources :overviews, only: [:index]
+    resources :legacy_service_names
     resources :services, only: [:index, :show, :create] do
       post '/unpublish/:publish_service_id/:deployment_environment',
         to: 'services#unpublish', as: :unpublish

--- a/db/migrate/20211203152636_create_legacy_service_names.rb
+++ b/db/migrate/20211203152636_create_legacy_service_names.rb
@@ -1,0 +1,9 @@
+class CreateLegacyServiceNames < ActiveRecord::Migration[6.1]
+  def change
+    create_table :legacy_service_names do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_10_204320) do
+ActiveRecord::Schema.define(version: 2021_12_03_152636) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -40,6 +40,12 @@ ActiveRecord::Schema.define(version: 2021_11_10_204320) do
     t.index ["email"], name: "index_identities_on_email"
     t.index ["provider", "uid"], name: "index_identities_on_provider_and_uid"
     t.index ["user_id"], name: "index_identities_on_user_id"
+  end
+
+  create_table "legacy_service_names", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "publish_services", force: :cascade do |t|

--- a/spec/factories/legacy_service_names.rb
+++ b/spec/factories/legacy_service_names.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :legacy_service_name do
+    name { 'So you want to be a jedi' }
+  end
+end

--- a/spec/models/legacy_service_name_spec.rb
+++ b/spec/models/legacy_service_name_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe LegacyServiceName, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/legacy_service_name_spec.rb
+++ b/spec/models/legacy_service_name_spec.rb
@@ -1,5 +1,9 @@
-require 'rails_helper'
-
 RSpec.describe LegacyServiceName, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    context 'name' do
+      it 'do not allow blank' do
+        should_not allow_values('').for(:name)
+      end
+    end
+  end
 end

--- a/spec/services/service_creation_spec.rb
+++ b/spec/services/service_creation_spec.rb
@@ -1,5 +1,8 @@
 RSpec.describe ServiceCreation do
-  subject(:service_creation) { described_class.new(attributes) }
+  subject(:service_creation) do
+    described_class.new(attributes)
+  end
+  let(:current_user) { double(id: '1') }
 
   describe '#create' do
     context 'when is invalid' do
@@ -21,6 +24,18 @@ RSpec.describe ServiceCreation do
 
       context 'when name is too long' do
         let(:attributes) { { service_name: 'E' * 129 } }
+
+        it 'returns false' do
+          expect(service_creation.create).to be_falsey
+        end
+      end
+
+      context 'when name is in the legacy' do
+        let(:service_name) { 'So you want to become an avenger' }
+        let(:attributes) { { service_name: service_name } }
+        let!(:legacy_service_name) do
+          create(:legacy_service_name, name: service_name)
+        end
 
         it 'returns false' do
           expect(service_creation.create).to be_falsey


### PR DESCRIPTION
## Context

[Trello card](https://trello.com/c/tH5wcW1d/2098-create-validator-for-form-builder-form-names)

We need to ensure that users cannot generate the same URLs for a form and as we allow people to define their form name this is a risk.

To prevent this from happening we currently check all form names on MoJ Forms but we should also be checking forms on legacy Form Builder too.

To do this we need to run a validation prior to allowing users to save a new form name to ensure we're preventing duplicates.

This will be done by inserting the names in the admin and use a validator to consume from the db.
