### PR TITLE
Default check answers and confirmation urls

### DIFF
--- a/acceptance/features/preview_page_spec.rb
+++ b/acceptance/features/preview_page_spec.rb
@@ -74,7 +74,7 @@ feature 'Preview page' do
 
   def then_I_should_be_on_the_check_your_answers_page
     then_I_should_not_see_optional_text
-    expect(page.current_url).to include('checkanswers')
+    expect(page.current_url).to include('check-answers')
   end
 
   def then_I_should_see_that_I_should_add_a_file

--- a/app/generators/new_service_generator.rb
+++ b/app/generators/new_service_generator.rb
@@ -78,11 +78,11 @@ class NewServiceGenerator
   def add_cya_and_confirmation(metadata)
     cya_metadata = DefaultMetadata['page.checkanswers']
       .merge('_uuid' => SecureRandom.uuid)
-      .merge('url' => 'checkanswers')
+      .merge('url' => 'check-answers')
 
     confirmation_metadata = DefaultMetadata['page.confirmation']
       .merge('_uuid' => SecureRandom.uuid)
-      .merge('url' => 'confirmation')
+      .merge('url' => 'form-sent')
 
     metadata['pages'].push(cya_metadata)
     metadata['pages'].push(confirmation_metadata)

--- a/spec/generators/new_service_generator_spec.rb
+++ b/spec/generators/new_service_generator_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe NewServiceGenerator do
         expect(service_metadata['pages']).to be_present
         expect(service_metadata['pages'][1]).to include(
           '_type' => 'page.checkanswers',
-          'url' => 'checkanswers'
+          'url' => 'check-answers'
         )
       end
 
@@ -149,7 +149,7 @@ RSpec.describe NewServiceGenerator do
         expect(service_metadata['pages']).to be_present
         expect(service_metadata['pages'][2]).to include(
           '_type' => 'page.confirmation',
-          'url' => 'confirmation'
+          'url' => 'form-sent'
         )
       end
 


### PR DESCRIPTION
The default service template now includes check answers and confirmation pages.
After discussion with the team, we have decided to use `check-answers` and `form-sent` as the default urls.