### PR TITLE
Accept single quotes and apostrophe to service names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.11.0'
+gem 'metadata_presenter', '2.12.0'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.11.0)
+    metadata_presenter (2.12.0)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -425,7 +425,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.11.0)
+  metadata_presenter (= 2.12.0)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.0)
   pg (>= 0.18, < 2.0)

--- a/app/services/editor/service.rb
+++ b/app/services/editor/service.rb
@@ -5,7 +5,7 @@ module Editor
 
     validates :service_name, presence: true
     validates :service_name, length: { minimum: 3, maximum: 128 }, allow_blank: true
-    validates :service_name, format: { with: /\A[\sa-zA-Z0-9-]*\z/ }, allow_blank: true
+    validates :service_name, format: { with: /\A[\sa-zA-Z0-9-'’]*\z/ }, allow_blank: true
     validates :service_name, legacy_service_name: true
 
     def add_errors(service)

--- a/spec/services/service_creation_spec.rb
+++ b/spec/services/service_creation_spec.rb
@@ -83,11 +83,12 @@ RSpec.describe ServiceCreation do
 
     context 'when is valid' do
       let(:attributes) do
-        { service_name: 'Moff Gideon', current_user: double(id: '1') }
+        { service_name: "Secure Children's Home", current_user: double(id: '1') }
       end
       let(:service) do
         double(id: '05e12a93-3978-4624-a875-e59893f2c262', errors?: false)
       end
+
       before do
         expect(
           MetadataApiClient::Service
@@ -105,6 +106,27 @@ RSpec.describe ServiceCreation do
         expect(
           service_creation.service_id
         ).to eq('05e12a93-3978-4624-a875-e59893f2c262')
+      end
+    end
+
+    context 'when service name has an apostrophe' do
+      let(:attributes) do
+        { service_name: 'Secure Children’s Home', current_user: double(id: '1') }
+      end
+      let(:service) do
+        double(id: '05e12a93-3978-4624-a875-e59893f2c262', errors?: false)
+      end
+
+      before do
+        expect(
+          MetadataApiClient::Service
+        ).to receive(:create).and_return(service)
+
+        expect_any_instance_of(DefaultConfiguration).to receive(:create)
+      end
+
+      it 'returns true' do
+        expect(service_creation.create).to be_truthy
       end
     end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/gEognZYS/2133-allow-special-characters-like-apostrophe-in-the-form-name)

## Context

We need to accept service names with single quotes/apostrophe so adding specs and the validation