### PR TITLE
Do not show link to add CYA or confirmation pages if they exist

### DIFF
--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -74,9 +74,13 @@
       <li data-page-type="confirmation"><a href="#add-page">Confirmation page</a></li>
     <% end %>
   <% else %>
-    <li data-page-type="checkanswers"><a href="#add-page">Check answers page</a></li>
-    <li data-page-type="confirmation"><a href="#add-page">Confirmation page</a></li>
-  <% end %>
+    <% unless service.checkanswers_page.present? %>
+      <li data-page-type="checkanswers"><a href="#add-page">Check answers page</a></li>
+    <% end %>
+    <% unless service.confirmation_page.present? %>
+      <li data-page-type="confirmation"><a href="#add-page">Confirmation page</a></li>
+    <% end %>
+  <% end%>
   <li data-page-type="content"><a href="#add-page">Content page</a></li>
   <% if ENV['BRANCHING'] == 'enabled' %>
     <li data-page-type="exit"><a href="#add-page">Exit page</a></li>


### PR DESCRIPTION
Regardless of whether branching is enabled or disabled if a CYA or
Confirmation page already exists the user should not be able to add
another one.