### PR TITLE
Acceptance tests for generating new form template and associated warnings

### DIFF
--- a/acceptance/features/add_page_in_the_middle_flow_spec.rb
+++ b/acceptance/features/add_page_in_the_middle_flow_spec.rb
@@ -43,10 +43,6 @@ feature 'Add page in the middle flow' do
     expect(editor.radio_options.size).to be(2)
   end
 
-  def then_I_should_see_the_page_flow_in_order(order:)
-    expect(editor.form_urls.map(&:text)).to eq(order)
-  end
-
   def when_I_update_the_question_name
     and_I_edit_the_question
     when_I_save_my_changes

--- a/acceptance/features/create_page_spec.rb
+++ b/acceptance/features/create_page_spec.rb
@@ -64,8 +64,8 @@ feature 'Create page' do
   scenario 'creating check answers page' do
     then_I_should_see_default_service_pages
     then_I_should_not_be_able_to_add_page(checkanswers)
-    # this will fail when we implement delete warning
     and_I_delete_cya_page
+    then_I_should_see_delete_warning_cya
     then_I_should_be_able_to_add_page(checkanswers)
     given_I_add_a_check_answers_page
     and_I_add_a_page_url
@@ -78,8 +78,8 @@ feature 'Create page' do
   scenario 'creating confirmation page' do
     then_I_should_see_default_service_pages
     then_I_should_not_be_able_to_add_page(confirmation)
-    # this will fail when we implement delete warning
     when_I_delete_confirmation_page
+    then_I_should_see_delete_warning_confirmation
     then_I_should_be_able_to_add_page(confirmation)
     given_I_add_a_confirmation_page
     and_I_add_a_page_url

--- a/acceptance/features/create_service_spec.rb
+++ b/acceptance/features/create_service_spec.rb
@@ -6,6 +6,7 @@ feature 'Create a service' do
   let(:another_service_name) { generate_service_name }
   let(:checkanswers) { 'Check answers page' }
   let(:confirmation) { 'Confirmation page' }
+  let(:add_page) { 'Add page here' }
   let(:exit_url) { 'exit' }
   let(:form_urls) do
     # page url links have the word "Edit" as a visually hidden span element
@@ -48,6 +49,8 @@ feature 'Create a service' do
     then_I_should_see_the_page_flow_in_order(order: form_urls)
     then_I_should_not_be_able_to_add_page(checkanswers)
     then_I_should_not_be_able_to_add_page(confirmation)
+    when_I_three_dots_button_on_the_confirmation_page
+    then_I_should_not_be_able_to_see_add_page_link
   end
 
   scenario 'validates uniqueness of the service name' do
@@ -123,5 +126,15 @@ feature 'Create a service' do
         'Application complete'
       ]
     )
+  end
+
+  def when_I_three_dots_button_on_the_confirmation_page
+    sleep 0.5 # Arbitrary delay, possibly required due to focus issues
+    page.find('.govuk-link', text: 'Application complete').hover
+    editor.three_dots_button.click
+  end
+
+  def then_I_should_not_be_able_to_see_add_page_link
+    expect(editor.text).not_to include(add_page)
   end
 end

--- a/acceptance/features/create_service_spec.rb
+++ b/acceptance/features/create_service_spec.rb
@@ -7,6 +7,15 @@ feature 'Create a service' do
   let(:checkanswers) { 'Check answers page' }
   let(:confirmation) { 'Confirmation page' }
   let(:exit_url) { 'exit' }
+  let(:form_urls) do
+    # page url links have the word "Edit" as a visually hidden span element
+    # associated with them for added accessibility
+    [
+      "Edit:\nService name goes here",
+      "Edit:\nCheck your answers",
+      "Edit:\nApplication complete"
+    ]
+  end
 
   background do
     given_I_am_logged_in
@@ -36,6 +45,7 @@ feature 'Create a service' do
     when_I_create_the_service
     then_I_should_see_the_new_service_name
     then_I_should_see_default_service_pages
+    then_I_should_see_the_page_flow_in_order(order: form_urls)
     then_I_should_not_be_able_to_add_page(checkanswers)
     then_I_should_not_be_able_to_add_page(confirmation)
   end

--- a/acceptance/features/delete_cya_confirmation_pages_spec.rb
+++ b/acceptance/features/delete_cya_confirmation_pages_spec.rb
@@ -6,9 +6,6 @@ feature 'Delete cya confirmation pages' do
   let(:service_name) { generate_service_name }
   let(:page_url) { 'gateau' }
   let(:exit_url) { 'exit' }
-  let(:delete_warning_cya) { I18n.t('pages.flow.delete_warning_cya_page') }
-  let(:delete_warning_confirmation) { I18n.t('pages.flow.delete_warning_confirmation_page') }
-  let(:delete_warning_both) { I18n.t('pages.flow.delete_warning_both_pages') }
 
   background do
     given_I_am_logged_in
@@ -45,23 +42,5 @@ feature 'Delete cya confirmation pages' do
     given_I_add_an_exit_page
     and_I_return_to_flow_page
     then_I_should_see_delete_warning_both
-  end
-
-  def then_I_should_not_see_delete_warnings
-    expect(editor.text).not_to include(delete_warning_cya)
-    expect(editor.text).not_to include(delete_warning_confirmation)
-    expect(editor.text).not_to include(delete_warning_both)
-  end
-
-  def then_I_should_see_delete_warning_cya
-    expect(editor.text).to include(delete_warning_cya)
-  end
-
-  def then_I_should_see_delete_warning_confirmation
-    expect(editor.text).to include(delete_warning_confirmation)
-  end
-
-  def then_I_should_see_delete_warning_both
-    expect(editor.text).to include(delete_warning_both)
   end
 end

--- a/acceptance/features/deleting_page_spec.rb
+++ b/acceptance/features/deleting_page_spec.rb
@@ -22,12 +22,14 @@ feature 'Deleting page' do
   scenario 'when try to delete a page which has a branching conditional' do
     given_I_have_a_form_with_pages
     when_I_try_to_delete_a_page_which_has_a_branching_conditional
+    sleep 0.5 # Allow time for the page to reload after deleting the page
     then_I_should_see_a_message_that_is_not_possible_to_delete_the_page
   end
 
   scenario 'when try to delete a page which result with a stack branch' do
     given_I_have_a_form_with_pages
     when_I_try_to_delete_a_page_which_result_in_a_stack_branch
+    sleep 0.5 # Allow time for the page to reload after deleting the page
     then_I_should_see_a_message_that_is_not_possible_to_create_stack_branches
   end
 
@@ -35,6 +37,7 @@ feature 'Deleting page' do
     given_I_have_a_form_with_pages
     and_I_want_to_delete_a_branch_destination_page
     when_I_delete_the_branch_destination_page
+    sleep 0.5 # Allow time for the page to reload after deleting the page
     then_I_should_not_see_the_deleted_page_in_the_flow
     and_I_should_see_the_new_destination_as_next_page_after_the_deleted_page
   end
@@ -44,6 +47,7 @@ feature 'Deleting page' do
     and_I_click_to_delete_branching_point_one
     and_I_choose_page_c_to_connect_the_forms
     when_I_delete_the_branching_point
+    sleep 0.5 # Allow time for the page to reload after deleting the page
     then_I_should_see_branch_pointing_one_deleted
   end
 

--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -38,8 +38,8 @@ feature 'Branching errors' do
   scenario 'when visiting the publishing page without cya page present' do
     given_I_have_a_single_question_page_with_upload
     and_I_return_to_flow_page
-    # this will fail when we implement delete warning
     and_I_delete_cya_page
+    then_I_should_see_delete_warning_cya
     when_I_visit_the_publishing_page
     then_I_should_be_on_the_publishing_page
     then_I_should_not_see_warning_both_text

--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -60,6 +60,7 @@ feature 'Branching errors' do
   end
 
   def when_I_visit_the_publishing_page
+    sleep 0.5 # Allow time for the page to load
     editor.publishing_link.click
   end
 

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -358,6 +358,10 @@ module CommonSteps
     expect(editor.form_urls.count).to eq(3)
   end
 
+  def then_I_should_see_the_page_flow_in_order(order:)
+    expect(editor.form_urls.map(&:text)).to eq(order)
+  end
+
   def and_I_delete_cya_page
     sleep 0.5 # Arbitrary delay, possibly required due to focus issues
     editor.preview_page_images.last.hover

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -6,6 +6,11 @@ module CommonSteps
     I18n.t('default_text.option_hint')
   ].freeze
   ERROR_MESSAGE = 'There is a problem'.freeze
+  DELETE_WARNING = [
+    I18n.t('pages.flow.delete_warning_cya_page'),
+    I18n.t('pages.flow.delete_warning_confirmation_page'),
+    I18n.t('pages.flow.delete_warning_both_pages')
+  ].freeze
 
   def given_I_am_logged_in
     editor.load
@@ -378,5 +383,23 @@ module CommonSteps
     editor.delete_page_link.click
     sleep 0.5 # Arbitrary delay, possibly required due to focus issues
     editor.delete_page_modal_button.click
+  end
+
+  def then_I_should_not_see_delete_warnings
+    expect(editor.text).not_to include(DELETE_WARNING[0])
+    expect(editor.text).not_to include(DELETE_WARNING[1])
+    expect(editor.text).not_to include(DELETE_WARNING[2])
+  end
+
+  def then_I_should_see_delete_warning_cya
+    expect(editor.text).to include(DELETE_WARNING[0])
+  end
+
+  def then_I_should_see_delete_warning_confirmation
+    expect(editor.text).to include(DELETE_WARNING[1])
+  end
+
+  def then_I_should_see_delete_warning_both
+    expect(editor.text).to include(DELETE_WARNING[2])
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/gSgyLJSe/2123-acceptance-test-generate-cya-and-confirmation-page-with-when-creating-a-new-form-7-7)

#### Add additional acceptance tests:
- Add test for new default form pages
- Check new page cannot be added after confirmation page

#### Add sleeps to allow time for API calls and for increased parallelism

#### Other acceptance tests completed as features were added:
- [Publishing warnings](https://github.com/ministryofjustice/fb-editor/pull/926/commits/08419acd49f35a16169801a16605f737e9dbf4f6)
- [New form template](https://github.com/ministryofjustice/fb-editor/pull/935/commits/9e821d5053658fd617f58dd5212928c7c3fb944e)
- [Prevent duplicate pages](https://github.com/ministryofjustice/fb-editor/pull/947/commits/b73a79dd148ba62017bbf2be6b33511c58717a44)
- [Delete warning](https://github.com/ministryofjustice/fb-editor/pull/969/commits/4d4a3283ea63464ca4b5475226cb0c48e849c287)
