### PR TITLE
Remove unused module

### DIFF
--- a/app/services/environment_check.rb
+++ b/app/services/environment_check.rb
@@ -1,8 +1,0 @@
-module EnvironmentCheck
-  include ::Publisher::ConfigurationNaming
-  LIVE_PRODUCTION = 'live-production'.freeze
-
-  def live_production?(deployment_environment:, platform_environment: ENV['PLATFORM_ENV'])
-    "#{platform_environment}-#{deployment_environment}" == LIVE_PRODUCTION
-  end
-end


### PR DESCRIPTION
This was intended to be used with the Uptime Checks worker jobs but in
the end was not necessary