### PR TITLE
Find latest published services for Uptime Checks

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -21,6 +21,13 @@ module Admin
       redirect_to login_path unless moj_forms_dev?
     end
 
+    def published(environment)
+      PublishService.where(deployment_environment: environment)
+                    .group_by(&:service_id)
+                    .map { |p| p.last.last }
+                    .select(&:published?)
+    end
+
     # Override this value to specify the number of elements to display at a time
     # on index pages. Defaults to 20.
     # def records_per_page

--- a/app/controllers/admin/overviews_controller.rb
+++ b/app/controllers/admin/overviews_controller.rb
@@ -20,11 +20,11 @@ module Admin
         },
         {
           name: 'Published to Live',
-          value: published('production')
+          value: published('production').count
         },
         {
           name: 'Published to Test',
-          value: published('dev')
+          value: published('dev').count
         }
       ]
     end
@@ -36,14 +36,6 @@ module Admin
       ActiveRecord::SessionStore::Session.where(
         'updated_at < ?', cutoff_period
       ).count
-    end
-
-    def published(environment)
-      PublishService.where(deployment_environment: environment)
-                    .select('DISTINCT ON ("service_id") *')
-                    .order(:service_id, created_at: :desc)
-                    .select { |ps| ps.status == 'completed' }
-                    .count
     end
   end
 end

--- a/app/controllers/admin/uptime_checks_controller.rb
+++ b/app/controllers/admin/uptime_checks_controller.rb
@@ -64,11 +64,7 @@ module Admin
     end
 
     def published_services_uuids
-      @published_services_uuids ||=
-        PublishService.production
-                      .completed
-                      .select('distinct(service_id)')
-                      .pluck(:service_id)
+      @published_services_uuids ||= published('production').map(&:service_id)
     end
 
     def non_editor_service_checks


### PR DESCRIPTION
Once a service has been unpublished it's status is no longer
'completed'. Therefore we cannot just grab the completed records for
each service.

We need to get the last records which are in production and then check
whether their status is one of the 'published' statuses.