### PR TITLE
Use form with hidden fields

### DIFF
--- a/app/views/admin/uptime_checks/index.html.erb
+++ b/app/views/admin/uptime_checks/index.html.erb
@@ -36,10 +36,11 @@
               <%= service.service_slug %>
             </td>
             <td class="govuk-table__cell">
-              <%= link_to 'Create',
-                  admin_uptime_checks_path(id: service.service_id),
-                  method: :post,
-                  class: 'govuk-button fb-govuk-button' %>
+              <%= form_with url: admin_uptime_checks_path,
+                  method: :post do |form| %>
+                  <%= form.hidden_field(:id, value: service.service_id) %>
+                  <%= form.submit('Create', class: 'govuk-button fb-govuk-button') %>
+              <% end %>
             </td>
           </tr>
         <% end %>
@@ -76,10 +77,10 @@
               <%= check['status'] %>
             </td>
             <td class="govuk-table__cell">
-              <%= link_to 'Delete',
-                admin_uptime_check_path(id: check['id']),
-                  method: :delete,
-                  class: 'govuk-button govuk-button--warning' %>
+              <%= form_with url: admin_uptime_check_path(check['id']),
+                  method: :delete do |form| %>
+                  <%= form.submit('Delete', class: 'govuk-button govuk-button--warning') %>
+              <% end %>
             </td>
           </tr>
         <% end %>


### PR DESCRIPTION
We do not load in rails/ujs in administrate. It is required for Rails to
differentuate between POST and DELETE requests.

Therefore swap to using a form with a submit button and hidden fields.