### PR TITLE
Testable disconnect cya conf

### DIFF
--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -145,6 +145,9 @@ class EditorApp < SitePrism::Page
   element :change_destination_link, :link, I18n.t('actions.change_destination')
   element :change_next_page_button, :button, I18n.t('dialogs.destination.button_change')
 
+  element :continue_button, :button, I18n.t('actions.continue')
+  element :cancel_button, :button, I18n.t('pages.cancel')
+
   elements :detached_flow, '.flow-detached-group .flow-item'
 
   def unconnected_flow

--- a/app/controllers/api/destinations_controller.rb
+++ b/app/controllers/api/destinations_controller.rb
@@ -24,7 +24,7 @@ module Api
 
     private
 
-    #rubocop:disable Naming/MemoizedInstanceVariableName
+    # rubocop:disable Naming/MemoizedInstanceVariableName
     def destination
       @_destination ||= Destination.new(
         service: service,
@@ -32,6 +32,6 @@ module Api
         destination_uuid: params[:destination_uuid]
       )
     end
-    #rubocop:enable Naming/MemoizedInstanceVariableName
+    # rubocop:enable Naming/MemoizedInstanceVariableName
   end
 end

--- a/app/controllers/api/destinations_controller.rb
+++ b/app/controllers/api/destinations_controller.rb
@@ -9,12 +9,17 @@ module Api
     def create
       destination.metadata
 
-      if destination.cya_and_confirmation_present?
+      if destination.cya_and_confirmation_present? || destination_change_confirmed?
         destination.change
         redirect_to edit_service_path(service.service_id)
       else
         redirect_to edit_service_path(service.service_id, flow_uuid: params[:flow_uuid], destination_uuid: params[:destination_uuid])
       end
+    end
+
+    def destination_change_confirmed?
+      (destination.checkanswers_detached? || destination.confirmation_detached?) &&
+        params[:user_confirmation].present?
     end
 
     private

--- a/app/controllers/api/destinations_controller.rb
+++ b/app/controllers/api/destinations_controller.rb
@@ -1,26 +1,32 @@
 module Api
   class DestinationsController < BranchesController
     def new
-      @destination = build_destination
+      @destination = destination
 
       render :new, layout: false
     end
 
     def create
-      destination = build_destination
+      destination.metadata
 
-      destination.change
-      redirect_to edit_service_path(service.service_id)
+      if destination.cya_and_confirmation_present?
+        destination.change
+        redirect_to edit_service_path(service.service_id)
+      else
+        redirect_to edit_service_path(service.service_id, flow_uuid: params[:flow_uuid], destination_uuid: params[:destination_uuid])
+      end
     end
 
     private
 
-    def build_destination
-      Destination.new(
+    #rubocop:disable Naming/MemoizedInstanceVariableName
+    def destination
+      @_destination ||= Destination.new(
         service: service,
         flow_uuid: params[:flow_uuid],
         destination_uuid: params[:destination_uuid]
       )
     end
+    #rubocop:enable Naming/MemoizedInstanceVariableName
   end
 end

--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -4,7 +4,7 @@ class PublishController < FormController
   def index
     @published_dev = published?(service.service_id, 'dev')
     @published_production = published?(service.service_id, 'production')
-    @publish_warning = PublishWarningPresenter.new(service, :publish)
+    @publish_warning = PublishPresenter.new(service)
   end
 
   def create

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -21,6 +21,7 @@ class ServicesController < PermissionsController
     @publish_warning = PublishWarningPresenter.new(service, :publish)
     @detached_flows = flow.detached_flows
     @page_creation = PageCreation.new
+    @disconnecting_message = true
   end
 
   def services

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -18,10 +18,19 @@ class ServicesController < PermissionsController
   def edit
     flow = PagesFlow.new(service)
     @pages_flow = flow.build
-    @publish_warning = PublishWarningPresenter.new(service, :publish)
+    @publish_warning = PublishPresenter.new(service)
     @detached_flows = flow.detached_flows
     @page_creation = PageCreation.new
-    @disconnecting_message = true
+
+    if params[:flow_uuid].present?
+      @change_destination_confirmation = DisconnectPresenter.new(
+        Destination.new(
+          service: service,
+          flow_uuid: params[:flow_uuid],
+          destination_uuid: params[:destination_uuid]
+        )
+      )
+    end
   end
 
   def services

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -24,6 +24,7 @@ const post = utilities.post;
 const ActivatedMenu = require('./component_activated_menu');
 const DialogApiRequest = require('./component_dialog_api_request');
 const DefaultController = require('./controller_default');
+const Dialog = require('./component_dialog');
 
 
 class ServicesController extends DefaultController {
@@ -49,6 +50,7 @@ ServicesController.edit = function() {
   view.$flowDetached = $("#flow-detached");
 
   createPageAdditionDialog(view);
+  disconnectDialog(view);
   createPageAdditionMenu(view);
   createFlowItemMenus(view);
 
@@ -668,5 +670,17 @@ function positionAddPageButton() {
   });
 }
 
+function disconnectDialog(view) {
+  var $dialog = $("[data-component='DisconnectDialog']"); // Expect only one
+  var $form = $dialog.find("form");
+  // var $change = $dialog.find(".disconnect-message");
+ if ($dialog.length){
+  view.disconnectDialog = new Dialog($dialog, {
+    autoOpen: true,
+    view: view,
+    cancelText: $dialog.attr("data-cancel-text")
+  });
+  }
+}
 
 module.exports = ServicesController;

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -24,7 +24,6 @@ const post = utilities.post;
 const ActivatedMenu = require('./component_activated_menu');
 const DialogApiRequest = require('./component_dialog_api_request');
 const DefaultController = require('./controller_default');
-const Dialog = require('./component_dialog');
 
 
 class ServicesController extends DefaultController {
@@ -50,9 +49,9 @@ ServicesController.edit = function() {
   view.$flowDetached = $("#flow-detached");
 
   createPageAdditionDialog(view);
-  disconnectDialog(view);
   createPageAdditionMenu(view);
   createFlowItemMenus(view);
+  createDisconnectDialog(view);
 
   if(view.$flowOverview.length) {
     layoutFormFlowOverview(view);
@@ -186,7 +185,6 @@ class FlowItemMenu extends ActivatedMenu {
     });
   }
 }
-
 
 /* VIEW SPECIFIC COMPONENT:
  * ------------------------
@@ -345,6 +343,21 @@ function createFlowItemMenus(view) {
   });
 }
 
+/* VIEW SETUP FUNCTION:
+ * --------------------
+ * Create the menu effect and required functionality for disconnecting CYA or Confirmation
+ * page through 'Change Destination'.
+ **/
+function createDisconnectDialog(view) {
+  var $dialog = $("[data-component='DisconnectDialog']"); // Expect only one
+  if ($dialog.length){
+    view.createDisconnectDialog = new FormDialog($dialog, {
+      autoOpen: true,
+      view: view,
+      cancelText: $dialog.attr("data-cancel-text")
+    });
+  }
+}
 
 /* VIEW SETUP FUNCTION:
  * --------------------
@@ -668,19 +681,6 @@ function positionAddPageButton() {
       });
     }
   });
-}
-
-function disconnectDialog(view) {
-  var $dialog = $("[data-component='DisconnectDialog']"); // Expect only one
-  var $form = $dialog.find("form");
-  // var $change = $dialog.find(".disconnect-message");
- if ($dialog.length){
-  view.disconnectDialog = new Dialog($dialog, {
-    autoOpen: true,
-    view: view,
-    cancelText: $dialog.attr("data-cancel-text")
-  });
-  }
 }
 
 module.exports = ServicesController;

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -3,7 +3,7 @@ class Destination
   include ApplicationHelper
   include DestinationsList
   include MetadataVersion
-  attr_accessor :service, :flow_uuid, :destination_uuid, :latest_metadata
+  attr_accessor :service, :flow_uuid, :destination_uuid
 
   alias_method :change, :create_version
 

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -3,7 +3,7 @@ class Destination
   include ApplicationHelper
   include DestinationsList
   include MetadataVersion
-  attr_accessor :service, :flow_uuid, :destination_uuid
+  attr_accessor :service, :flow_uuid, :destination_uuid, :latest_metadata
 
   alias_method :change, :create_version
 
@@ -12,8 +12,10 @@ class Destination
   end
 
   def metadata
-    service.flow[flow_uuid]['next']['default'] = destination_uuid
-    service.metadata.to_h.deep_stringify_keys
+    @metadata ||= begin
+      service.flow[flow_uuid]['next']['default'] = destination_uuid
+      service.metadata.to_h.deep_stringify_keys
+    end
   end
 
   def destinations
@@ -23,6 +25,19 @@ class Destination
 
   def current_destination
     service.flow_object(flow_uuid).default_next
+  end
+
+  def cya_and_confirmation_present?
+    grid.flow_uuids.include?(service.checkanswers_page.uuid) &&
+      grid.flow_uuids.include?(service.confirmation_page.uuid)
+  end
+
+  def checkanswers_detached?
+    !grid.flow_uuids.include?(service.checkanswers_page.uuid)
+  end
+
+  def confirmation_detached?
+    !grid.flow_uuids.include?(service.confirmation_page.uuid)
   end
 
   private

--- a/app/models/pages_flow.rb
+++ b/app/models/pages_flow.rb
@@ -93,7 +93,7 @@ class PagesFlow
   def warning(_)
     {
       type: 'warning',
-      content: PublishWarningPresenter.new(service, :delete).message
+      content: DeletePresenter.new(service).message
     }
   end
 

--- a/app/presenters/delete_presenter.rb
+++ b/app/presenters/delete_presenter.rb
@@ -1,0 +1,12 @@
+class DeletePresenter < WarningPresenter
+  attr_reader :messages
+
+  def initialize(service)
+    @messages = {
+      both_pages: I18n.t('pages.flow.delete_warning_both_pages'),
+      cya_page: I18n.t('pages.flow.delete_warning_cya_page'),
+      confirmation_page: I18n.t('pages.flow.delete_warning_confirmation_page')
+    }
+    super
+  end
+end

--- a/app/presenters/disconnect_presenter.rb
+++ b/app/presenters/disconnect_presenter.rb
@@ -12,6 +12,8 @@ class DisconnectPresenter < WarningPresenter
     super(updated_service)
   end
 
+  private
+
   # we need a service which represents what the metadata WOULD look like
   # if the user changed the destination
   def updated_service

--- a/app/presenters/disconnect_presenter.rb
+++ b/app/presenters/disconnect_presenter.rb
@@ -1,0 +1,21 @@
+class DisconnectPresenter < WarningPresenter
+  attr_reader :destination, :messages
+
+  def initialize(destination)
+    @destination = destination
+    @messages = {
+      both_pages: I18n.t('pages.disconnecting_modal.both_pages'),
+      cya_page: I18n.t('pages.disconnecting_modal.cya'),
+      confirmation_page: I18n.t('pages.disconnecting_modal.confirmation')
+    }
+    @service = updated_service
+    super(updated_service)
+  end
+
+  # we need a service which represents what the metadata WOULD look like
+  # if the user changed the destination
+  def updated_service
+    @updated_service ||=
+      MetadataPresenter::Service.new(destination.metadata)
+  end
+end

--- a/app/presenters/publish_presenter.rb
+++ b/app/presenters/publish_presenter.rb
@@ -1,0 +1,12 @@
+class PublishPresenter < WarningPresenter
+  attr_reader :messages
+
+  def initialize(service)
+    @messages = {
+      both_pages: I18n.t('publish.warning.both_pages'),
+      cya_page: I18n.t('publish.warning.cya'),
+      confirmation_page: I18n.t('publish.warning.confirmation')
+    }
+    super
+  end
+end

--- a/app/presenters/publish_warning_presenter.rb
+++ b/app/presenters/publish_warning_presenter.rb
@@ -11,6 +11,11 @@ class PublishWarningPresenter
       both_pages: I18n.t('pages.flow.delete_warning_both_pages'),
       cya_page: I18n.t('pages.flow.delete_warning_cya_page'),
       confirmation_page: I18n.t('pages.flow.delete_warning_confirmation_page')
+    },
+    disconnect: {
+      both_pages: I18n.t('pages.disconnecting_modal.both_pages'),
+      cya_page: I18n.t('pages.disconnecting_modal.cya'),
+      confirmation_page: I18n.t('pages.disconnecting_modal.confirmation')
     }
   }.freeze
 

--- a/app/presenters/warning_presenter.rb
+++ b/app/presenters/warning_presenter.rb
@@ -1,27 +1,8 @@
-class PublishWarningPresenter
+class WarningPresenter
   attr_reader :service, :action
 
-  MESSAGE = {
-    publish: {
-      both_pages: I18n.t('publish.warning.both_pages'),
-      cya_page: I18n.t('publish.warning.cya'),
-      confirmation_page: I18n.t('publish.warning.confirmation')
-    },
-    delete: {
-      both_pages: I18n.t('pages.flow.delete_warning_both_pages'),
-      cya_page: I18n.t('pages.flow.delete_warning_cya_page'),
-      confirmation_page: I18n.t('pages.flow.delete_warning_confirmation_page')
-    },
-    disconnect: {
-      both_pages: I18n.t('pages.disconnecting_modal.both_pages'),
-      cya_page: I18n.t('pages.disconnecting_modal.cya'),
-      confirmation_page: I18n.t('pages.disconnecting_modal.confirmation')
-    }
-  }.freeze
-
-  def initialize(service, action)
+  def initialize(service = nil)
     @service = service
-    @action = action
   end
 
   def message
@@ -34,19 +15,19 @@ class PublishWarningPresenter
 
   def submitting_pages_not_present_message
     if !checkanswers_in_main_flow? && !confirmation_in_main_flow?
-      MESSAGE[action][:both_pages]
+      messages[:both_pages]
     end
   end
 
   def cya_page_not_present_message
     if !checkanswers_in_main_flow? && confirmation_in_main_flow?
-      MESSAGE[action][:cya_page]
+      messages[:cya_page]
     end
   end
 
   def confirmation_page_not_present_message
     if checkanswers_in_main_flow? && !confirmation_in_main_flow?
-      MESSAGE[action][:confirmation_page]
+      messages[:confirmation_page]
     end
   end
 

--- a/app/presenters/warning_presenter.rb
+++ b/app/presenters/warning_presenter.rb
@@ -11,10 +11,15 @@ class WarningPresenter
       cya_page_not_present_message
   end
 
+  def cya_and_confirmation_missing?
+    !checkanswers_in_main_flow? &&
+      !confirmation_in_main_flow?
+  end
+
   private
 
   def submitting_pages_not_present_message
-    if !checkanswers_in_main_flow? && !confirmation_in_main_flow?
+    if cya_and_confirmation_missing?
       messages[:both_pages]
     end
   end

--- a/app/views/partials/_disconnect_page_modal.html.erb
+++ b/app/views/partials/_disconnect_page_modal.html.erb
@@ -1,0 +1,22 @@
+<% if params[:flow_uuid].present? %>
+<div class="component-dialog-form"
+     data-component="DisconnectDialog"
+     data-cancel-text="<%= t('pages.cancel') %>">
+   <%= form_with url: api_service_flow_destinations_path(
+                        service.service_id, params[:flow_uuid]),
+                 method: :post do |form| %>
+                  <%= form.submit(t('actions.continue'), class: 'govuk-button') %>
+    <%= form.hidden_field :destination_uuid, value: params[:destination_uuid] %>
+    <%= form.hidden_field :user_confirmation, value: 'true' %>
+    <%= form.label @change_destination_confirmation.message, class: "govuk-label govuk-label--m" %>
+    <span class="govuk-hint">
+      <% if @change_destination_confirmation.cya_and_confirmation_missing? %>
+        <%= t('pages.disconnecting_modal.unconnected_pages_message') %>
+      <% else %>
+        <%= t('pages.disconnecting_modal.unconnected_single_page_message') %>
+      <% end %>
+    </span>
+    <span class="govuk-hint"><%= t('pages.disconnecting_modal.no_data_message') %></span>
+  <% end %>
+</div>
+<% end %>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -113,7 +113,11 @@
                         service.service_id, params[:flow_uuid]),
                  method: :post do |form| %>
                   <%= form.submit('Understood', class: 'govuk-button') %>
-<%= form.hidden_field :destination_uuid, value: params[:destination_uuid] %>
+    <%= form.hidden_field :destination_uuid, value: params[:destination_uuid] %>
+    <%= form.hidden_field :user_confirmation, value: 'true' %>
+    <%= form.label :page_url, class: "govuk-label govuk-label--m" %>
+    <span class="govuk-hint"><%= t('pages.disconnecting_modal.unconnected_pages_message') %></span>
+    <span class="govuk-hint"><%= t('pages.disconnecting_modal.no_data_message') %></span>
   <% end %>
 </div>
 <% end %>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -103,3 +103,17 @@
     <%= f.submit t('pages.create'), class: "govuk-button fb-govuk-button" %>
   <% end %>
 </div>
+
+<% if params[:flow_uuid].present? %>
+<div class="component-dialog-form"
+     data-component="DisconnectDialog"
+     data-cancel-text="<%= t('pages.cancel') %>">
+     <p class="disconnect-message">Disconnect Dialog</p>
+   <%= form_with url: api_service_flow_destinations_path(
+                        service.service_id, params[:flow_uuid]),
+                 method: :post do |form| %>
+                  <%= form.submit('Understood', class: 'govuk-button') %>
+<%= form.hidden_field :destination_uuid, value: params[:destination_uuid] %>
+  <% end %>
+</div>
+<% end %>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -104,19 +104,4 @@
   <% end %>
 </div>
 
-<% if params[:flow_uuid].present? %>
-<div class="component-dialog-form"
-     data-component="DisconnectDialog"
-     data-cancel-text="<%= t('pages.cancel') %>">
-   <%= form_with url: api_service_flow_destinations_path(
-                        service.service_id, params[:flow_uuid]),
-                 method: :post do |form| %>
-                  <%= form.submit('Understood', class: 'govuk-button') %>
-    <%= form.hidden_field :destination_uuid, value: params[:destination_uuid] %>
-    <%= form.hidden_field :user_confirmation, value: 'true' %>
-    <%= form.label @change_destination_confirmation.message, class: "govuk-label govuk-label--m" %>
-    <span class="govuk-hint"><%= t('pages.disconnecting_modal.unconnected_pages_message') %></span>
-    <span class="govuk-hint"><%= t('pages.disconnecting_modal.no_data_message') %></span>
-  <% end %>
-</div>
-<% end %>
+<%= render partial: './partials/disconnect_page_modal' %>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -108,14 +108,13 @@
 <div class="component-dialog-form"
      data-component="DisconnectDialog"
      data-cancel-text="<%= t('pages.cancel') %>">
-     <p class="disconnect-message">Disconnect Dialog</p>
    <%= form_with url: api_service_flow_destinations_path(
                         service.service_id, params[:flow_uuid]),
                  method: :post do |form| %>
                   <%= form.submit('Understood', class: 'govuk-button') %>
     <%= form.hidden_field :destination_uuid, value: params[:destination_uuid] %>
     <%= form.hidden_field :user_confirmation, value: 'true' %>
-    <%= form.label :page_url, class: "govuk-label govuk-label--m" %>
+    <%= form.label @change_destination_confirmation.message, class: "govuk-label govuk-label--m" %>
     <span class="govuk-hint"><%= t('pages.disconnecting_modal.unconnected_pages_message') %></span>
     <span class="govuk-hint"><%= t('pages.disconnecting_modal.no_data_message') %></span>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,6 +145,12 @@ en:
       you_cannot_delete_this_page: 'You cannot delete this page yet'
       delete_page_used_for_branching_not_supported_message: 'You cannot delete this page because it is used in a branching condition. Update the branching point first, then try again.'
       stack_branches_not_supported_message: 'Deleting this page would result in 2 branching points in a row, which is not currently possible. Try combining your branching rules into 1 branching point.'
+    disconnecting_modal:
+      both_pages: 'This will remove the check answers and confirmation pages'
+      cya: 'This will remove the check answers page'
+      confirmation: 'This will remove the confirmation page'
+      unconnected_pages_message: 'It will be moved to the unconnected pages section.'
+      no_data_message: 'You won’t receive any user data without a check answers page and confirmation page connected to your form.'
     destination:
       heading: 'Change destination'
       lede: 'Update this connection to lead to the following page:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,7 +149,8 @@ en:
       both_pages: 'This will remove the check answers and confirmation pages'
       cya: 'This will remove the check answers page'
       confirmation: 'This will remove the confirmation page'
-      unconnected_pages_message: 'It will be moved to the unconnected pages section.'
+      unconnected_single_page_message: 'It will be moved to the unconnected pages section.'
+      unconnected_pages_message: 'They will be moved to the unconnected pages section.'
       no_data_message: 'You won’t receive any user data without a check answers page and confirmation page connected to your form.'
     destination:
       heading: 'Change destination'

--- a/spec/presenters/delete_presenter_spec.rb
+++ b/spec/presenters/delete_presenter_spec.rb
@@ -1,13 +1,4 @@
-RSpec.describe PublishWarningPresenter do
-  let(:publish_warning_both_pages) do
-    I18n.t('publish.warning.both_pages')
-  end
-  let(:publish_warning_cya_page) do
-    I18n.t('publish.warning.cya')
-  end
-  let(:publish_warning_confirmation_page) do
-    I18n.t('publish.warning.confirmation')
-  end
+RSpec.describe DeletePresenter do
   let(:delete_warning_both_pages) do
     I18n.t('pages.flow.delete_warning_both_pages')
   end
@@ -32,100 +23,9 @@ RSpec.describe PublishWarningPresenter do
     metadata['flow']['6324cca4-7770-4765-89b9-1cdc41f49c8b']
   end
 
-  describe 'publish warning' do
+  describe '#message' do
     let(:presenter) do
-      PublishWarningPresenter.new(service, :publish)
-    end
-    context 'check presence of cya and confirmation page' do
-      context 'when there is both a check answers and confirmation page' do
-        let(:service) { MetadataPresenter::Service.new(latest_metadata) }
-        let(:latest_metadata) { metadata_fixture(:branching) }
-        it 'returns nil' do
-          expect(presenter.message).to be_nil
-        end
-      end
-
-      context 'when there is no check answers or confirmation page' do
-        let(:service) do
-          MetadataPresenter::Service.new(metadata_fixture(:exit_only_service))
-        end
-
-        it 'returns the correct warning' do
-          expect(presenter.message).to eq(publish_warning_both_pages)
-        end
-      end
-    end
-
-    context 'check presence of cya page' do
-      let(:service) { MetadataPresenter::Service.new(latest_metadata) }
-      let(:metadata) { metadata_fixture(:branching) }
-
-      context 'when there is no check answers page' do
-        let(:latest_metadata) do
-          arnold_incomplete_answers['next']['default'] = confirmation_uuid
-          arnold_right_answers['next']['default'] = confirmation_uuid
-          arnold_wrong_answers['next']['default'] = confirmation_uuid
-          metadata['flow'].delete(checkanswers_uuid)
-          metadata['pages'] = metadata['pages'].reject do |page|
-            page['_uuid'] == checkanswers_uuid
-          end
-          metadata
-        end
-
-        it 'returns the correct warning' do
-          expect(presenter.message).to eq(publish_warning_cya_page)
-        end
-      end
-
-      context 'when check answers page is disconnected' do
-        let(:latest_metadata) do
-          arnold_incomplete_answers['next']['default'] = confirmation_uuid
-          arnold_right_answers['next']['default'] = confirmation_uuid
-          arnold_wrong_answers['next']['default'] = confirmation_uuid
-          metadata
-        end
-
-        it 'returns the correct message' do
-          expect(presenter.message).to eq(publish_warning_cya_page)
-        end
-      end
-    end
-
-    context 'check presence of confirmation page' do
-      let(:service) { MetadataPresenter::Service.new(latest_metadata) }
-      let(:metadata) { metadata_fixture(:branching) }
-
-      context 'when there is no confirmation page' do
-        let(:latest_metadata) do
-          checkanswers_page['next']['default'] = '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' # name
-          metadata['flow'].delete(confirmation_uuid)
-          metadata['pages'] = metadata['pages'].reject do |page|
-            page['_uuid'] == confirmation_uuid
-          end
-          metadata
-        end
-
-        it 'returns the correct warning' do
-          expect(presenter.message).to eq(publish_warning_confirmation_page)
-        end
-      end
-
-      context 'when confirmation page is disconnected' do
-        let(:latest_metadata) do
-          checkanswers_page['next']['default'] = ''
-          metadata
-        end
-
-        it 'returns the correct warning' do
-          expect(presenter.message).to eq(publish_warning_confirmation_page)
-        end
-      end
-    end
-  end
-
-  describe 'delete warning' do
-    let(:presenter) do
-      PublishWarningPresenter.new(service, :delete)
+      DeletePresenter.new(service)
     end
 
     context 'check presence of cya and confirmation page' do

--- a/spec/presenters/disconnect_presenter_spec.rb
+++ b/spec/presenters/disconnect_presenter_spec.rb
@@ -1,0 +1,116 @@
+RSpec.describe DisconnectPresenter do
+  let(:disconnect_warning_both_pages) do
+    I18n.t('pages.disconnecting_modal.both_pages')
+  end
+  let(:disconnect_warning_cya_page) do
+    I18n.t('pages.disconnecting_modal.cya')
+  end
+  let(:disconnect_warning_confirmation_page) do
+    I18n.t('pages.disconnecting_modal.confirmation')
+  end
+  let(:confirmation_uuid) { '778e364b-9a7f-4829-8eb2-510e08f156a3' }
+  let(:checkanswers_uuid) { 'e337070b-f636-49a3-a65c-f506675265f0' }
+  let(:checkanswers_page) do
+    metadata['flow']['e337070b-f636-49a3-a65c-f506675265f0']
+  end
+  let(:arnold_incomplete_answers) do
+    metadata['flow']['941137d7-a1da-43fd-994a-98a4f9ea6d46']
+  end
+  let(:arnold_right_answers) do
+    metadata['flow']['56e80942-d0a4-405a-85cd-bd1b100013d6']
+  end
+  let(:arnold_wrong_answers) do
+    metadata['flow']['6324cca4-7770-4765-89b9-1cdc41f49c8b']
+  end
+
+  describe '#message' do
+    let(:presenter) do
+      DisconnectPresenter.new(service)
+    end
+    context 'check presence of cya and confirmation page' do
+      context 'when there is both a check answers and confirmation page' do
+        let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+        let(:latest_metadata) { metadata_fixture(:branching) }
+        it 'returns nil' do
+          expect(presenter.message).to be_nil
+        end
+      end
+
+      context 'when there is no check answers or confirmation page' do
+        let(:service) do
+          MetadataPresenter::Service.new(metadata_fixture(:exit_only_service))
+        end
+
+        it 'returns the correct warning' do
+          expect(presenter.message).to eq(disconnect_warning_both_pages)
+        end
+      end
+    end
+
+    context 'check presence of cya page' do
+      let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+      let(:metadata) { metadata_fixture(:branching) }
+
+      context 'when there is no check answers page' do
+        let(:latest_metadata) do
+          arnold_incomplete_answers['next']['default'] = confirmation_uuid
+          arnold_right_answers['next']['default'] = confirmation_uuid
+          arnold_wrong_answers['next']['default'] = confirmation_uuid
+          metadata['flow'].delete(checkanswers_uuid)
+          metadata['pages'] = metadata['pages'].reject do |page|
+            page['_uuid'] == checkanswers_uuid
+          end
+          metadata
+        end
+
+        it 'returns the correct warning' do
+          expect(presenter.message).to eq(disconnect_warning_cya_page)
+        end
+      end
+
+      context 'when check answers page is disconnected' do
+        let(:latest_metadata) do
+          arnold_incomplete_answers['next']['default'] = confirmation_uuid
+          arnold_right_answers['next']['default'] = confirmation_uuid
+          arnold_wrong_answers['next']['default'] = confirmation_uuid
+          metadata
+        end
+
+        it 'returns the correct message' do
+          expect(presenter.message).to eq(disconnect_warning_cya_page)
+        end
+      end
+    end
+
+    context 'check presence of confirmation page' do
+      let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+      let(:metadata) { metadata_fixture(:branching) }
+
+      context 'when there is no confirmation page' do
+        let(:latest_metadata) do
+          checkanswers_page['next']['default'] = '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' # name
+          metadata['flow'].delete(confirmation_uuid)
+          metadata['pages'] = metadata['pages'].reject do |page|
+            page['_uuid'] == confirmation_uuid
+          end
+          metadata
+        end
+
+        it 'returns the correct warning' do
+          expect(presenter.message).to eq(disconnect_warning_confirmation_page)
+        end
+      end
+
+      context 'when confirmation page is disconnected' do
+        let(:latest_metadata) do
+          checkanswers_page['next']['default'] = ''
+          metadata
+        end
+
+        it 'returns the correct warning' do
+          expect(presenter.message).to eq(disconnect_warning_confirmation_page)
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/publish_presenter_spec.rb
+++ b/spec/presenters/publish_presenter_spec.rb
@@ -1,0 +1,116 @@
+RSpec.describe PublishPresenter do
+  let(:publish_warning_both_pages) do
+    I18n.t('publish.warning.both_pages')
+  end
+  let(:publish_warning_cya_page) do
+    I18n.t('publish.warning.cya')
+  end
+  let(:publish_warning_confirmation_page) do
+    I18n.t('publish.warning.confirmation')
+  end
+  let(:confirmation_uuid) { '778e364b-9a7f-4829-8eb2-510e08f156a3' }
+  let(:checkanswers_uuid) { 'e337070b-f636-49a3-a65c-f506675265f0' }
+  let(:checkanswers_page) do
+    metadata['flow']['e337070b-f636-49a3-a65c-f506675265f0']
+  end
+  let(:arnold_incomplete_answers) do
+    metadata['flow']['941137d7-a1da-43fd-994a-98a4f9ea6d46']
+  end
+  let(:arnold_right_answers) do
+    metadata['flow']['56e80942-d0a4-405a-85cd-bd1b100013d6']
+  end
+  let(:arnold_wrong_answers) do
+    metadata['flow']['6324cca4-7770-4765-89b9-1cdc41f49c8b']
+  end
+
+  describe '#message' do
+    let(:presenter) do
+      PublishPresenter.new(service)
+    end
+    context 'check presence of cya and confirmation page' do
+      context 'when there is both a check answers and confirmation page' do
+        let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+        let(:latest_metadata) { metadata_fixture(:branching) }
+        it 'returns nil' do
+          expect(presenter.message).to be_nil
+        end
+      end
+
+      context 'when there is no check answers or confirmation page' do
+        let(:service) do
+          MetadataPresenter::Service.new(metadata_fixture(:exit_only_service))
+        end
+
+        it 'returns the correct warning' do
+          expect(presenter.message).to eq(publish_warning_both_pages)
+        end
+      end
+    end
+
+    context 'check presence of cya page' do
+      let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+      let(:metadata) { metadata_fixture(:branching) }
+
+      context 'when there is no check answers page' do
+        let(:latest_metadata) do
+          arnold_incomplete_answers['next']['default'] = confirmation_uuid
+          arnold_right_answers['next']['default'] = confirmation_uuid
+          arnold_wrong_answers['next']['default'] = confirmation_uuid
+          metadata['flow'].delete(checkanswers_uuid)
+          metadata['pages'] = metadata['pages'].reject do |page|
+            page['_uuid'] == checkanswers_uuid
+          end
+          metadata
+        end
+
+        it 'returns the correct warning' do
+          expect(presenter.message).to eq(publish_warning_cya_page)
+        end
+      end
+
+      context 'when check answers page is disconnected' do
+        let(:latest_metadata) do
+          arnold_incomplete_answers['next']['default'] = confirmation_uuid
+          arnold_right_answers['next']['default'] = confirmation_uuid
+          arnold_wrong_answers['next']['default'] = confirmation_uuid
+          metadata
+        end
+
+        it 'returns the correct message' do
+          expect(presenter.message).to eq(publish_warning_cya_page)
+        end
+      end
+    end
+
+    context 'check presence of confirmation page' do
+      let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+      let(:metadata) { metadata_fixture(:branching) }
+
+      context 'when there is no confirmation page' do
+        let(:latest_metadata) do
+          checkanswers_page['next']['default'] = '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' # name
+          metadata['flow'].delete(confirmation_uuid)
+          metadata['pages'] = metadata['pages'].reject do |page|
+            page['_uuid'] == confirmation_uuid
+          end
+          metadata
+        end
+
+        it 'returns the correct warning' do
+          expect(presenter.message).to eq(publish_warning_confirmation_page)
+        end
+      end
+
+      context 'when confirmation page is disconnected' do
+        let(:latest_metadata) do
+          checkanswers_page['next']['default'] = ''
+          metadata
+        end
+
+        it 'returns the correct warning' do
+          expect(presenter.message).to eq(publish_warning_confirmation_page)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/destination_spec.rb
+++ b/spec/requests/api/destination_spec.rb
@@ -53,4 +53,76 @@ RSpec.describe 'Destinations spec', type: :request do
       end
     end
   end
+
+  describe 'POST /api/services/:service_id/flow/:flow_uuid/destinations/create' do
+    let(:service) { MetadataPresenter::Service.new(metadata) }
+    let(:metadata) { metadata_fixture(:branching_2) }
+    let(:request) do
+      post "/api/services/#{service.service_id}/flow/#{flow_uuid}/destinations",
+           params: { destination_uuid: destination_uuid }
+    end
+    let(:flow_uuid) { '393645a4-f037-4e75-8359-51f9b0e360fb' }
+    let(:destination_uuid) { '68fbb180-9a2a-48f6-9da6-545e28b8d35a' }
+    let(:version) do
+      double(errors?: false, metadata: metadata)
+    end
+
+    before do
+      allow_any_instance_of(
+        Api::DestinationsController
+      ).to receive(:require_user!).and_return(true)
+
+      allow_any_instance_of(
+        Api::DestinationsController
+      ).to receive(:service).and_return(service)
+
+      allow(MetadataApiClient::Version).to receive(:create).and_return(
+        version
+      )
+    end
+
+    context 'when the change does not disconnect the CYA or confirmation pages' do
+      it 'changes the destination' do
+        expect_any_instance_of(Destination).to receive(:change)
+        request
+      end
+    end
+
+    shared_examples 'change destination redirect' do
+      it 'does not change the destination' do
+        expect_any_instance_of(Destination).not_to receive(:change)
+        request
+      end
+
+      it 'redirects with the correct params' do
+        request
+        expect(response).to redirect_to(expected_redirect_url)
+      end
+    end
+
+    context 'disconnecting CYA and confirmation pages' do
+      let(:metadata) { metadata_fixture(:version) }
+      let(:expected_redirect_url) { "/services/#{service.service_id}/edit?destination_uuid=#{destination_uuid}&flow_uuid=#{flow_uuid}" }
+
+      context 'when the change disconnects CYA page' do
+        it_behaves_like 'change destination redirect' do
+          let(:flow_uuid) { '2ef7d11e-0307-49e9-9fe2-345dc528dd66' } # dog-picture
+          let(:destination_uuid) { '778e364b-9a7f-4829-8eb2-510e08f156a3' } # confirmation page
+        end
+      end
+
+      context 'when the change disconnects the confirmation page' do
+        it_behaves_like 'change destination redirect' do
+          let(:flow_uuid) { 'e337070b-f636-49a3-a65c-f506675265f0' } # checkanswers
+          let(:destination_uuid) { 'cf6dc32f-502c-4215-8c27-1151a45735bb' } # start page
+        end
+      end
+
+      context 'when the change disconnects both CYA and confirmation pages' do
+        it_behaves_like 'change destination redirect' do
+          let(:flow_uuid) { '2ef7d11e-0307-49e9-9fe2-345dc528dd66' } # dog-picture
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/destination_spec.rb
+++ b/spec/requests/api/destination_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe 'Destinations spec', type: :request do
 
     context 'disconnecting CYA and confirmation pages' do
       let(:metadata) { metadata_fixture(:version) }
-      
+
       context 'without user confirmation' do
         shared_examples 'redirect with confirmation modal' do
           it 'does not change the destination' do
@@ -142,9 +142,9 @@ RSpec.describe 'Destinations spec', type: :request do
         let(:request) do
           post "/api/services/#{service.service_id}/flow/#{flow_uuid}/destinations",
                params: {
-                destination_uuid: destination_uuid,
-                user_confirmation: 'true'
-              }
+                 destination_uuid: destination_uuid,
+                 user_confirmation: 'true'
+               }
         end
         let(:expected_redirect_url) { "/services/#{service.service_id}/edit" }
 

--- a/spec/requests/api/destination_spec.rb
+++ b/spec/requests/api/destination_spec.rb
@@ -88,39 +88,84 @@ RSpec.describe 'Destinations spec', type: :request do
       end
     end
 
-    shared_examples 'change destination redirect' do
-      it 'does not change the destination' do
-        expect_any_instance_of(Destination).not_to receive(:change)
-        request
-      end
-
-      it 'redirects with the correct params' do
-        request
-        expect(response).to redirect_to(expected_redirect_url)
-      end
-    end
-
     context 'disconnecting CYA and confirmation pages' do
       let(:metadata) { metadata_fixture(:version) }
-      let(:expected_redirect_url) { "/services/#{service.service_id}/edit?destination_uuid=#{destination_uuid}&flow_uuid=#{flow_uuid}" }
+      
+      context 'without user confirmation' do
+        shared_examples 'redirect with confirmation modal' do
+          it 'does not change the destination' do
+            expect_any_instance_of(Destination).not_to receive(:change)
+            request
+          end
 
-      context 'when the change disconnects CYA page' do
-        it_behaves_like 'change destination redirect' do
-          let(:flow_uuid) { '2ef7d11e-0307-49e9-9fe2-345dc528dd66' } # dog-picture
-          let(:destination_uuid) { '778e364b-9a7f-4829-8eb2-510e08f156a3' } # confirmation page
+          it 'redirects with the correct params' do
+            request
+            expect(response).to redirect_to(expected_redirect_url)
+          end
+        end
+        let(:expected_redirect_url) { "/services/#{service.service_id}/edit?destination_uuid=#{destination_uuid}&flow_uuid=#{flow_uuid}" }
+
+        context 'when the change disconnects CYA page' do
+          it_behaves_like 'redirect with confirmation modal' do
+            let(:flow_uuid) { '2ef7d11e-0307-49e9-9fe2-345dc528dd66' } # dog-picture
+            let(:destination_uuid) { '778e364b-9a7f-4829-8eb2-510e08f156a3' } # confirmation page
+          end
+        end
+
+        context 'when the change disconnects the confirmation page' do
+          it_behaves_like 'redirect with confirmation modal' do
+            let(:flow_uuid) { 'e337070b-f636-49a3-a65c-f506675265f0' } # checkanswers
+            let(:destination_uuid) { 'cf6dc32f-502c-4215-8c27-1151a45735bb' } # start page
+          end
+        end
+
+        context 'when the change disconnects both CYA and confirmation pages' do
+          it_behaves_like 'redirect with confirmation modal' do
+            let(:flow_uuid) { '2ef7d11e-0307-49e9-9fe2-345dc528dd66' } # dog-picture
+          end
         end
       end
 
-      context 'when the change disconnects the confirmation page' do
-        it_behaves_like 'change destination redirect' do
-          let(:flow_uuid) { 'e337070b-f636-49a3-a65c-f506675265f0' } # checkanswers
-          let(:destination_uuid) { 'cf6dc32f-502c-4215-8c27-1151a45735bb' } # start page
-        end
-      end
+      context 'with user confirmation' do
+        shared_examples 'change destination with user confirmation' do
+          it 'does change the destination' do
+            expect_any_instance_of(Destination).to receive(:change)
+            request
+          end
 
-      context 'when the change disconnects both CYA and confirmation pages' do
-        it_behaves_like 'change destination redirect' do
-          let(:flow_uuid) { '2ef7d11e-0307-49e9-9fe2-345dc528dd66' } # dog-picture
+          it 'redirects with the correct params' do
+            request
+            expect(response).to redirect_to(expected_redirect_url)
+          end
+        end
+
+        let(:request) do
+          post "/api/services/#{service.service_id}/flow/#{flow_uuid}/destinations",
+               params: {
+                destination_uuid: destination_uuid,
+                user_confirmation: 'true'
+              }
+        end
+        let(:expected_redirect_url) { "/services/#{service.service_id}/edit" }
+
+        context 'change disconnects CYA page' do
+          it_behaves_like 'change destination with user confirmation' do
+            let(:flow_uuid) { '2ef7d11e-0307-49e9-9fe2-345dc528dd66' } # dog-picture
+            let(:destination_uuid) { '778e364b-9a7f-4829-8eb2-510e08f156a3' } # confirmation page
+          end
+        end
+
+        context 'change disconnects confirmation page' do
+          it_behaves_like 'change destination with user confirmation' do
+            let(:flow_uuid) { 'e337070b-f636-49a3-a65c-f506675265f0' } # checkanswers
+            let(:destination_uuid) { 'cf6dc32f-502c-4215-8c27-1151a45735bb' } # start page
+          end
+        end
+
+        context 'change disconnects CYA and confirmation pages' do
+          it_behaves_like 'change destination with user confirmation' do
+            let(:flow_uuid) { '2ef7d11e-0307-49e9-9fe2-345dc528dd66' } # dog-picture
+          end
         end
       end
     end


### PR DESCRIPTION
[Trello](https://trello.com/c/HCs5OfQ0/2122-add-warning-when-cya-and-confirmation-pages-are-disconnected-from-main-flow-via-change-destination-6-7)
### Change destination disconnecting cya/confirmation pages
 
### Add user confirmation param
 
### Refactor PublishWarningPresenter 
We have refactored the presenter out into 3 different classes, `PublishPresenter`, `DeletePresenter` and `DisconnectPresenter`. All of these inherit from the `WarningPresenter`.
We did this because the `DisconnectPresenter`, required a way to understand what the service would look like if a user changed the destination.

### Add 'Confirm' and 'Cancel' buttons to modal
 
### Add acceptance test

![Screenshot 2021-12-30 at 17 08 27](https://user-images.githubusercontent.com/29227502/147773253-5688283f-7bd5-42b5-8e36-6d8332b5f73a.png)