### PR TITLE
Fix: Optional text bug

### DIFF
--- a/acceptance/features/edit_single_question_page_spec.rb
+++ b/acceptance/features/edit_single_question_page_spec.rb
@@ -10,6 +10,8 @@ feature 'Edit single question page' do
   let(:editable_options) do
     ['Adobe-wan Kenobi', 'PDFinn']
   end
+  let(:section_heading) { 'I open at the close' }
+  let(:default_section_heading) { I18n.t('default_text.section_heading') }
 
   background do
     given_I_am_logged_in
@@ -20,6 +22,8 @@ feature 'Edit single question page' do
     given_I_have_a_single_question_page_with_text
     and_I_have_optional_section_heading_text
     when_I_update_the_question_name
+    when_I_update_the_optional_section_heading
+    when_I_delete_the_optional_section_heading_text
     and_I_return_to_flow_page
     then_I_should_see_my_changes_on_preview
   end
@@ -28,6 +32,8 @@ feature 'Edit single question page' do
     given_I_have_a_single_question_page_with_textarea
     and_I_have_optional_section_heading_text
     when_I_update_the_question_name
+    when_I_update_the_optional_section_heading
+    when_I_delete_the_optional_section_heading_text
     and_I_return_to_flow_page
     then_I_should_see_my_changes_on_preview
   end
@@ -36,6 +42,8 @@ feature 'Edit single question page' do
     given_I_have_a_single_question_page_with_number
     and_I_have_optional_section_heading_text
     when_I_update_the_question_name
+    when_I_update_the_optional_section_heading
+    when_I_delete_the_optional_section_heading_text
     and_I_return_to_flow_page
     then_I_should_see_my_changes_on_preview
   end
@@ -52,6 +60,8 @@ feature 'Edit single question page' do
     given_I_have_a_single_question_page_with_date
     and_I_have_optional_section_heading_text
     when_I_update_the_question_name
+    when_I_update_the_optional_section_heading
+    when_I_delete_the_optional_section_heading_text
     and_I_return_to_flow_page
     then_I_should_see_my_changes_on_preview
   end
@@ -61,6 +71,8 @@ feature 'Edit single question page' do
     and_I_have_optional_section_heading_text
     when_I_update_the_question_name
     and_I_update_the_options
+    when_I_update_the_optional_section_heading
+    when_I_delete_the_optional_section_heading_text
     and_I_return_to_flow_page
     preview_form = then_I_should_see_my_changes_on_preview
     and_I_should_see_the_options_that_I_added(preview_form)
@@ -71,6 +83,8 @@ feature 'Edit single question page' do
     and_I_have_optional_section_heading_text
     when_I_update_the_question_name
     and_I_update_the_options
+    when_I_update_the_optional_section_heading
+    when_I_delete_the_optional_section_heading_text
     and_I_return_to_flow_page
     preview_form = then_I_should_see_my_changes_on_preview
     and_I_should_see_the_options_that_I_added(preview_form)
@@ -80,6 +94,8 @@ feature 'Edit single question page' do
     given_I_have_a_single_question_page_with_email
     and_I_have_optional_section_heading_text
     when_I_update_the_question_name
+    when_I_update_the_optional_section_heading
+    when_I_delete_the_optional_section_heading_text
     and_I_return_to_flow_page
     then_I_should_see_my_changes_on_preview
   end
@@ -118,6 +134,18 @@ feature 'Edit single question page' do
     editor.question_heading.first.set(question)
   end
 
+  def and_I_edit_the_optional_section_heading
+    page.first('.fb-section_heading').set(section_heading)
+  end
+
+  def then_I_should_see_my_updated_section_heading
+    expect(editor.text).to include(section_heading)
+  end
+
+  def then_I_should_see_the_default_section_heading
+    expect(editor.section_heading_hint.text).to eq(default_section_heading)
+  end
+
   def and_I_go_to_the_page_that_I_edit(preview_form)
     within_window(preview_form) do
       page.click_button 'Start now'
@@ -127,6 +155,24 @@ feature 'Edit single question page' do
   def when_I_update_the_question_name
     and_I_edit_the_question
     when_I_save_my_changes
+  end
+
+  def when_I_update_the_optional_section_heading
+    and_I_edit_the_optional_section_heading
+    when_I_save_my_changes
+    then_I_should_see_my_updated_section_heading
+  end
+
+  def when_I_update_first_the_optional_hint_text
+    and_I_edit_the_first_optional_hint_text
+    when_I_save_my_changes
+    then_I_should_see_my_updated_optional_hint_text
+  end
+
+  def when_I_delete_the_optional_section_heading_text
+    editor.section_heading_hint.set(' ')
+    when_I_save_my_changes
+    then_I_should_see_the_default_section_heading
   end
 
   def and_I_edit_the_options
@@ -144,6 +190,7 @@ feature 'Edit single question page' do
 
     and_I_go_to_the_page_that_I_edit(preview_form)
     then_I_should_see_my_changes_in_the_form(preview_form)
+    then_I_should_not_see_optional_text
 
     preview_form
   end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -98,6 +98,7 @@ class EditorApp < SitePrism::Page
   elements :all_hints, '.govuk-hint'
   elements :editable_options, '.EditableComponentCollectionItem label'
   element :question_hint, '.govuk-hint'
+  element :section_heading_hint, '.fb-section_heading'
   data_content_id :section_heading, 'page[section_heading]'
   data_content_id :page_heading, 'page[heading]'
   data_content_id :page_lede, 'page[lede]'

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -132,7 +132,6 @@ class DataController {
     var controller = this;
     var $form = $("#editContentForm");
     $form.on("submit", controller.update);
-
     this.$form = $form;
   }
 
@@ -458,7 +457,7 @@ function createDialogConfiguration() {
 function workaroundForDefaultText(view) {
   $(".govuk-radios__item, .govuk-checkboxes__item").each(function() {
     var $this = $(this);
-    var $span = $this.find("span");
+    var $span = $this.find(".govuk-hint");
     $span.attr("data-" + ATTRIBUTE_DEFAULT_TEXT, view.text.defaults.option_hint);
   });
 }

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -125,8 +125,8 @@ class EditableElement extends EditableBase {
     if(this._content != trimmedContent) {
       this._content = trimmedContent;
 
-      // If something change, let's make sure it's not
-      if(this._content != "" && this._content != this._defaultContent && this._content != this._originalContent) {
+      // If something changed...
+      if(this._content != this._defaultContent && this._content != this._originalContent) {
         this.emitSaveRequired();
       }
     }


### PR DESCRIPTION
Fix for
Trello[2204-bug-optional-text-on-collection-components-is-visible-in-preview-on-subsequent-pages]
[BUG] Optional text on collection components is visible in preview on subsequent pages

Allow 'Save' button to be visible on empty/blank entry of editable text item.
Update code to avoid bug caused by GDS changing tag used on Hint text. 