### PR TITLE
Add no branching editor deployment and acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,6 +251,24 @@ jobs:
             K8S_NAMESPACE: formbuilder-saas-test
           command: './deploy-scripts/bin/deploy-eks'
       - slack/status: *slack_status
+  deploy_to_test_no_branching:
+    working_directory: ~/circle/git/fb-editor
+    docker: *ecr_image
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 19.03.13
+      - add_ssh_keys: *ssh_keys
+      - run: *base_environment_variables
+      - run: *deploy_scripts
+      - run:
+          name: deploy to test no branching
+          environment:
+            APPLICATION_NAME: fb-editor
+            PLATFORM_ENV: test
+            K8S_NAMESPACE: formbuilder-saas-test
+            DISABLE_BRANCHING: 'true'
+          command: './deploy-scripts/bin/deploy'
   acceptance_tests:
     docker: *test_image
     resource_class: large
@@ -278,22 +296,54 @@ jobs:
             source $BASH_ENV
 
             TESTFILES=$(circleci tests glob "acceptance/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=filename)
+            TO_EXCLUDE=acceptance/features/no_branching_spec.rb
+            FILTERED_TESTFILES=$(printf '%s\n' "${TESTFILES//$TO_EXCLUDE/}")
+
             echo '***********'
-            echo $TESTFILES
+            echo $FILTERED_TESTFILES
             echo '***********'
 
             bundle exec rspec --format progress \
               --format RspecJunitFormatter \
               --out ~/acceptance/acceptance.xml \
-              $TESTFILES
+              $FILTERED_TESTFILES
       - store_test_results:
           path: ~/acceptance
       - slack/status: *slack_status
+  acceptance_tests_no_branching:
+    docker: *test_image
+    resource_class: large
+    environment: *test_environment
+    steps:
+      - checkout
+      - ruby/install-deps
+      - browser-tools/install-browser-tools
+      - run:
+          name: Check browser tools install
+          command: |
+            google-chrome --version
+            chromedriver --version
+      - run: *wait_for_db
+      - run: *db_setup
+      - run:
+          name: Run no branching acceptance tests
+          command: |
+            EDITOR_APP=https://fb-editor-test-no-branching.apps.live-1.cloud-platform.service.justice.gov.uk
+            echo 'export ACCEPTANCE_TESTS_EDITOR_APP=$EDITOR_APP' >> $BASH_ENV
+            echo 'export ACCEPTANCE_TESTS_USER=$ACCEPTANCE_TESTS_USER' >> $BASH_ENV
+            echo 'export ACCEPTANCE_TESTS_PASSWORD=$ACCEPTANCE_TESTS_PASSWORD' >> $BASH_ENV
+            echo 'export CI_MODE=true' >> $BASH_ENV
+            source $BASH_ENV
+
+            bundle exec rspec --format progress \
+              --format RspecJunitFormatter \
+              acceptance/features/no_branching_spec.rb
+      - slack/status: *testable_slack_status
   testable_branch_acceptance_tests:
     docker: *test_image
     resource_class: large
     environment: *test_environment
-    parallelism: 4
+    parallelism: 5
     steps:
       - checkout
       - ruby/install-deps
@@ -402,18 +452,27 @@ workflows:
           requires:
             - build_web_image
             - build_workers_image
+      - deploy_to_test_no_branching:
+          requires:
+            - build_web_image
+            - build_workers_image
       - acceptance_tests:
           requires:
             - deploy_to_test
+      - acceptance_tests_no_branching:
+          requires:
+            - deploy_to_test_no_branching
       - slack/approval-notification:
           message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
           include_job_number_field: false
           requires:
             - acceptance_tests
+            - acceptance_tests_no_branching
       - confirm_live_deploy:
           type: approval
           requires:
             - acceptance_tests
+            - acceptance_tests_no_branching
       - deploy_to_live:
           requires:
             - confirm_live_deploy

--- a/acceptance/features/no_branching_spec.rb
+++ b/acceptance/features/no_branching_spec.rb
@@ -1,0 +1,59 @@
+require_relative '../spec_helper'
+
+feature 'No branching' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+
+  background do
+    given_I_am_logged_in
+    given_I_want_to_create_a_service
+  end
+
+  scenario 'the editor works without the branching feature flag set' do
+    given_I_add_a_service
+    when_I_create_the_service
+    then_I_should_see_the_new_service_name
+    then_I_should_see_the_add_page_button
+    then_I_should_not_see_the_cya_and_confirmation_pages
+    then_I_should_not_see_the_unconnected_section
+
+    then_I_should_not_see_the_change_destination_link
+    then_I_should_not_see_the_add_branching_link
+    then_I_should_not_see_the_add_exit_page_link
+  end
+
+  def then_I_should_see_the_new_service_name
+    expect(editor.service_name.text).to eq(service_name)
+  end
+
+  def then_I_should_see_the_add_page_button
+    expect(page.text).to include(I18n.t('pages.create'))
+  end
+
+  def then_I_should_not_see_the_cya_and_confirmation_pages
+    expect(page.text).not_to include('Check your answers')
+    expect(page.text).not_to include('Application complete')
+  end
+
+  def then_I_should_not_see_the_unconnected_section
+    expect(page.text).not_to include('Unconnected')
+  end
+
+  def then_I_should_not_see_the_change_destination_link
+    editor.hover_preview('Service name goes here')
+    editor.three_dots_button.click
+    expect(page.text).not_to include(I18n.t('actions.change_destination'))
+  end
+
+  def then_I_should_not_see_the_add_branching_link
+    editor.hover_preview('Service name goes here')
+    editor.three_dots_button.click
+    expect(page.text).not_to include(I18n.t('actions.add_branch'))
+  end
+
+  def then_I_should_not_see_the_add_exit_page_link
+    editor.hover_preview('Service name goes here')
+    editor.three_dots_button.click
+    expect(page.text).not_to include(I18n.t('page.exit'))
+  end
+end

--- a/deploy/fb-editor-chart/templates/config_map.yaml
+++ b/deploy/fb-editor-chart/templates/config_map.yaml
@@ -12,4 +12,8 @@ data:
   AUTH0_DOMAIN: moj-forms.eu.auth0.com
   ENCODED_PUBLIC_KEY: {{ .Values.encoded_public_key }}
   METADATA_API_URL: http://fb-metadata-api-svc-{{ .Values.environmentName }}
+  {{ if .Values.disable_branching }}
+  BRANCHING: disabled
+  {{ else }}
   BRANCHING: {{ .Values.branching }}
+  {{ end }}


### PR DESCRIPTION
This adds the deployment steps necessary to create another editor with
container specific configuration which is more inline with what is
running in our Live environment.

We set the `DISABLE_BRANCHING` environment variable in the deploy step.
This is passed into the fb-deploy scripts and a extra argument called
`disable_branching` is passed to the helm command.

In the config_map.yml we check for the existence of that argument. If it
exists then we set the `BRANCHING` environemnt variable to be
'disabled'.

If you open that file in an editor that does any type of yaml file
parsing you will see that it looks like an error. This is not the case.
Helm is able to parse the if/else logic correctly.

<img width="1650" alt="Screenshot 2022-01-18 at 17 32 41" src="https://user-images.githubusercontent.com/3466862/149988651-b33f3e67-5cec-49c4-a775-b4cd09826d0a.png">


<img width="1186" alt="Screenshot 2022-01-18 at 15 13 11" src="https://user-images.githubusercontent.com/3466862/149988581-d7ca2db7-7afa-4bfb-ac75-126a10875376.png">

