### PR TITLE
Increase acceptance tests wait time for deletion API calls

### DIFF
--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -336,7 +336,7 @@ module CommonSteps
   end
 
   def and_I_click_on_the_three_dots
-    sleep 0.5 # Arbitrary delay, possibly required due to focus issues
+    sleep 1 # Arbitrary delay, possibly required due to focus issues
     editor.preview_page_images[-2].hover
     editor.three_dots_button.click
   end
@@ -373,20 +373,20 @@ module CommonSteps
   end
 
   def and_I_delete_cya_page
-    sleep 0.5 # Arbitrary delay, possibly required due to focus issues
+    sleep 1 # Arbitrary delay, possibly required due to focus issues
     editor.preview_page_images.last.hover
     editor.three_dots_button.click
     editor.delete_page_link.click
-    sleep 0.5 # Arbitrary delay, possibly required due to focus issues
+    sleep 1 # Arbitrary delay, possibly required due to focus issues
     editor.delete_page_modal_button.click
   end
 
   def when_I_delete_confirmation_page
-    sleep 0.5 # Arbitrary delay, possibly required due to focus issues
+    sleep 1 # Arbitrary delay, possibly required due to focus issues
     page.find('.govuk-link', text: 'Application complete').hover
     editor.three_dots_button.click
     editor.delete_page_link.click
-    sleep 0.5 # Arbitrary delay, possibly required due to focus issues
+    sleep 1 # Arbitrary delay, possibly required due to focus issues
     editor.delete_page_modal_button.click
   end
 


### PR DESCRIPTION
The acceptance tests are a little flaky when running the CYA and
Confirmation page specs. This might be to do with the time it takes to
call the API.

Increase the wait time to see if it improves the running of the tests.