### PR TITLE
Testable flow overview fixes

### DIFF
--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -1043,7 +1043,7 @@ class DownForwardPath extends FlowConnectorPath {
     super(points, config);
     var dimensions = {
       down: Math.round(this.points.yDifference - CURVE_SPACING),
-      forward: Math.round(this.points.xDifference)
+      forward: Math.round(this.points.xDifference - CURVE_SPACING)
     }
 
     this._dimensions = { original: dimensions };

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -681,7 +681,7 @@ function applyBranchFlowConnectorPaths($overview) {
   $flowItemElements.filter(SELECTOR_FLOW_BRANCH).each(function() {
     var $branch = $(this);
     var branchX = $branch.position().left + $branch.outerWidth() + 1; // + 1 for design gap
-    var branchY = $branch.position().top + (rowHeight / 4);
+    var branchY = $branch.position().top + (rowHeight / 2);
     var branchWidth = $branch.outerWidth();
     var $conditions = $branch.find(SELECTOR_FLOW_CONDITION);
 
@@ -740,7 +740,7 @@ function applyBranchFlowConnectorPaths($overview) {
           // to the x/y coordinates of the related 'next' destination.
           new ConnectorPath.ForwardPath({
             from_x: branchX,
-            from_y: branchY,
+            from_y: branchY - (rowHeight / 4),
             to_x: destinationX,
             to_y: destinationY
           }, config);

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -559,18 +559,17 @@ html {
     fill: none;
     stroke: #949494;
     stroke-width: 2px;
-
-    &:hover {
-
-      &, & + path {
-        stroke-width:4px;
-        stroke: $govuk-link-hover-colour;
-      }
-    }
   }
 
   .arrowPath {
     fill: #949494;
+  }
+
+  &.active {
+    path {
+      stroke-width:4px;
+      stroke: $govuk-link-hover-colour;
+    }
   }
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -588,6 +588,28 @@ html {
   position: relative;
 }
 
+.flow-add-page-button {
+  // TEMPORARY: BRANCHING FEATURE FLAG
+  // This should be display:none only but the other css is required for supporting the
+  // old style view of Add Page button functionality due to shared branching on/off code.
+  border-radius: 0;
+  display: none;
+  height: auto;
+  padding: 5px 10px;
+  text-indent: 0;
+  white-space: nowrap;
+  width: auto;
+
+  &:after {
+    display: none;
+  }
+
+  &:before {
+	  content: "+";
+	  margin-right: 5px;
+  }
+}
+
 .flow-branch {
   height: 125px;
   width: 200px;
@@ -620,26 +642,13 @@ html {
   }
 }
 
-.flow-add-page-button {
-  // TEMPORARY: BRANCHING FEATURE FLAG
-  // This should be display:none only but the other css is required for supporting the
-  // old style view of Add Page button functionality due to shared branching on/off code.
-  border-radius: 0;
-  display: none;
-  height: auto;
-  padding: 5px 10px;
-  text-indent: 0;
-  white-space: nowrap;
-  width: auto;
-
-  &:after {
-    display: none;
-  }
-
-  &:before {
-	  content: "+";
-	  margin-right: 5px;
-  }
+// Bit complicated but necessary for correct Activator hover (without JS intervention)
+.flow-branch a:hover ~ .ActivatedMenu_Activator,
+.flow-branch map:hover ~ .ActivatedMenu_Activator,
+.flow-branch .ActivatedMenu_Activator:hover,
+.flow-page .ActivatedMenu_Activator:hover,
+.flow-thumbnail:hover ~ .ActivatedMenu_Activator {
+  opacity: 1;
 }
 
 .flow-condition {
@@ -673,12 +682,6 @@ html {
 
 .flow-item {
   overflow: visible;
-
-  &:hover {
-    .ActivatedMenu_Activator {
-      opacity: 1;
-    }
-  }
 
   .text {
     word-break: break-word;
@@ -720,6 +723,10 @@ html {
   text-decoration: none;
   width: 196px;
 
+  &:hover {
+    border-color: $govuk-link-hover-colour;
+  }
+
   img {
     display: block;
     width: inherit;
@@ -732,10 +739,6 @@ html {
     font-size: 12px;
     font-weight: bold;
     margin: 0 15px 10px 15px;
-  }
-
-  &:hover {
-    border-color: $govuk-link-hover-colour;
   }
 
   /* Special case for styling the title */


### PR DESCRIPTION
- Fix starting point for BranchCondition paths
- Fix end point for DownForwardPath used in Branch Condition

**Was**
(with unwanted extended line)
<img width="442" alt="Screenshot 2022-01-21 with hover extended line" src="https://user-images.githubusercontent.com/76942244/150778608-e3fecfa5-d7aa-4f57-8c47-b9030d6d1571.png">

**Now**
(without unwanted extended line)
<img width="390" alt="Screenshot 2022-01-24 at 11 44 52" src="https://user-images.githubusercontent.com/76942244/150777363-6aa8d79f-d93a-4ed8-bd30-0f97da28293c.png">

------------------------------------

- Fix incorrect flow-item hover that activated outside thumbnail block

**Was**
(menu activator showed when red arrow hover was over wrong area)
<img width="414" alt="Screenshot 2022-01-21 at 15 52 22" src="https://user-images.githubusercontent.com/76942244/150777691-f76ff3b2-f6a1-4339-bc3a-73647d714853.png">
<img width="357" alt="Screenshot 2022-01-21 at 15 53 28" src="https://user-images.githubusercontent.com/76942244/150777693-9cc6be01-9f59-44d7-8fbe-01d61cbe00ce.png">

**Now**
Cannot show image because nothing should change - menu activator should not be revealed.- when cursor is in vicinity of the red arrows in previous image.

------------------------------------

- Fix partial hover state when activated by arrowhead

**Was**
(on hover of arrowhead)
<img width="528" alt="Screenshot 2022-01-21 activated by arrowhead" src="https://user-images.githubusercontent.com/76942244/150778090-f73d7c59-6e62-40d5-83ef-15450d0e5dd0.png">

**Now**
(on hover of arrowhead)
<img width="455" alt="Screenshot 2022-01-21 activated by line" src="https://user-images.githubusercontent.com/76942244/150778092-4e85bedf-3939-4d8c-8cb7-23fa6e51891b.png">

