### PR TITLE
Increase viewport size in change destination acceptance tests

### DIFF
--- a/acceptance/features/change_destination_spec.rb
+++ b/acceptance/features/change_destination_spec.rb
@@ -59,6 +59,7 @@ feature 'Deleting page' do
 
   def then_some_pages_should_be_unconnected
     editor.unconnected_expand_link.click
+    page.driver.browser.manage.window.resize_to(30000, 1080)
     expect(editor.unconnected_flow).to eq(
       [
         'Branching point 1',
@@ -97,6 +98,7 @@ feature 'Deleting page' do
 
   def and_the_branching_should_be_unconnected
     editor.unconnected_expand_link.click
+    page.driver.browser.manage.window.resize_to(30000, 1080)
     expect(editor.unconnected_flow).to eq([
       'Branching point 1',
       'Page b is Thor',


### PR DESCRIPTION
This is a bit of a hack, but currently the Unconnected section does not
have scrolling functionality. This means that Capybara is unable to
"see" any of the pages off screen.

Increase the viewport size in the tests. This is temporary until the
scrolling function is added.