### PR TITLE
Fix publish warning on create

### DIFF
--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -55,6 +55,7 @@ class PublishController < FormController
   end
 
   def update_form_objects
+    @publish_warning = PublishPresenter.new(service)
     if @publish_service_creation.deployment_environment == 'dev'
       @publish_service_creation_dev = @publish_service_creation
     else


### PR DESCRIPTION
When there is an error raised during the entering of a username and
password during the publishing process the controller will redirect back
to index. However the @publish_warning is not there for the template to
render so this needs to be created before rendering the index template.