### PR TITLE
Added another domain to the valid email address domains

### DIFF
--- a/app/services/auth0_user_session.rb
+++ b/app/services/auth0_user_session.rb
@@ -4,7 +4,8 @@ class Auth0UserSession
   include ActiveModel::Validations
 
   VALID_EMAIL_DOMAINS = [
-    'justice.gov.uk'
+    'justice.gov.uk',
+    'Justice.gov.uk'
   ].freeze
 
   attr_accessor :user_info, :user_id, :created_at, :new_user


### PR DESCRIPTION
Edge case of a volid email address having a capitialised J which
caused the editor to return an error.

This fix will allow both justice.gov.uk and Justice.gov.uk to be
valid and allow access.