### PR TITLE
Ignore multiple ActiveRecord::ConcurrentMigrationError during deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
           name: Database setup
           command: |
             bundle exec rails db:setup
-            bundle exec rails db:migrate
+            bundle exec rails db:migrate:ignore_concurrent
       - run:
           name: Running the tests
           command: |

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -39,4 +39,4 @@ ARG RAILS_ENV=production
 RUN yarn install --production --check-files
 RUN ./bin/webpack
 RUN RAILS_ENV=${RAILS_ENV} SECRET_KEY_BASE=$(bin/rake secret) bundle exec rake assets:precompile --trace
-CMD bundle exec rake db:migrate && bundle exec rails s -e ${RAILS_ENV} -p ${APP_PORT} --binding=0.0.0.0
+CMD bundle exec rake db:migrate:ignore_concurrent && bundle exec rails s -e ${RAILS_ENV} -p ${APP_PORT} --binding=0.0.0.0

--- a/lib/tasks/migrate_ignore_concurrent.rake
+++ b/lib/tasks/migrate_ignore_concurrent.rake
@@ -1,0 +1,15 @@
+namespace :db do
+  namespace :migrate do
+    desc 'Run db:migrate but ignore ActiveRecord::ConcurrentMigrationError errors'
+    task ignore_concurrent: :environment do
+      # DB migrations are called as the entry command in the Dockerfile
+      # Since we have multiple pods for the Editor we only need the first migration
+      # to run and any proceeding ActiveRecord::ConcurrentMigrationError
+      # can rescued instead of sending a Sentry alert.
+
+      Rake::Task['db:migrate'].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Move along
+    end
+  end
+end


### PR DESCRIPTION
We have multiple pods for the Editor running in each of our
namespaces. Each time we deploy we throw an ActiveRecord::ConcurrentMigrationError
as the first pod available will be the one that manages to successfully
run the migration. Any following pods will just throw an error.

We can mitigate this by catching the ActiveRecord::ConcurrentMigrationError
and this should not trigger any Sentry alerts.