### PR TITLE
Add data-hide-answers attribute to operators

### DIFF
--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -6,10 +6,10 @@ class Expression
   validate :unsupported_component
 
   OPERATORS = [
-    [I18n.t('operators.is'), 'is'],
-    [I18n.t('operators.is_not'), 'is_not'],
-    [I18n.t('operators.is_answered'), 'is_answered'],
-    [I18n.t('operators.is_not_answered'), 'is_not_answered']
+    [I18n.t('operators.is'), 'is', { 'data-hide-answers': 'false' }],
+    [I18n.t('operators.is_not'), 'is_not', { 'data-hide-answers': 'false' }],
+    [I18n.t('operators.is_answered'), 'is_answered', { 'data-hide-answers': 'true' }],
+    [I18n.t('operators.is_not_answered'), 'is_not_answered', { 'data-hide-answers': 'true' }]
   ].freeze
 
   def to_metadata

--- a/spec/requests/api/expressions_spec.rb
+++ b/spec/requests/api/expressions_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe 'Expressions spec', type: :request do
       let(:expressions_index) { 1 }
       let(:expected_operators) do
         [
-          '<option value="is">is</option>',
-          '<option value="is_not">is not</option>',
-          '<option value="is_answered">is answered</option>',
-          '<option value="is_not_answered">is not answered</option>'
+          '<option data-hide-answers="false" value="is">is</option>',
+          '<option data-hide-answers="false" value="is_not">is not</option>',
+          '<option data-hide-answers="true" value="is_answered">is answered</option>',
+          '<option data-hide-answers="true" value="is_not_answered">is not answered</option>'
         ]
       end
       let(:expected_answers) do


### PR DESCRIPTION
This allows the front end to hide the answers for the `is_answered` and `is_not_answered` operators.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk

<img width="683" alt="Screenshot 2022-02-01 at 16 50 22" src="https://user-images.githubusercontent.com/29227502/152016054-22166b03-ae7e-4aff-947e-a15c1c2737f7.png">