### PR TITLE
Fix Misalignment of FlowConnectorPath on page refresh

### DIFF
--- a/acceptance/features/change_destination_spec.rb
+++ b/acceptance/features/change_destination_spec.rb
@@ -36,7 +36,6 @@ feature 'Deleting page' do
   end
 
   def then_cya_and_confirmation_pages_should_be_unconnected
-    editor.unconnected_expand_link.click
     expect(editor.unconnected_flow).to eq(
       [
         'Check your answers',
@@ -58,7 +57,6 @@ feature 'Deleting page' do
   end
 
   def then_some_pages_should_be_unconnected
-    editor.unconnected_expand_link.click
     page.driver.browser.manage.window.resize_to(30000, 1080)
     expect(editor.unconnected_flow).to eq(
       [
@@ -97,7 +95,6 @@ feature 'Deleting page' do
   end
 
   def and_the_branching_should_be_unconnected
-    editor.unconnected_expand_link.click
     page.driver.browser.manage.window.resize_to(30000, 1080)
     expect(editor.unconnected_flow).to eq([
       'Branching point 1',

--- a/acceptance/features/create_service_spec.rb
+++ b/acceptance/features/create_service_spec.rb
@@ -119,7 +119,6 @@ feature 'Create a service' do
   end
 
   def then_some_pages_should_be_unconnected
-    editor.unconnected_expand_link.click
     expect(editor.unconnected_flow).to eq(
       [
         'Check your answers',

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -111,9 +111,9 @@ class EditorApp < SitePrism::Page
   data_content_id :second_component, 'page[components[1]]'
   data_content_id :first_extra_component, 'page[extra_components[0]]'
 
-  elements :form_pages, '.flow-item'
-  elements :form_urls, '.flow-item a.govuk-link'
-  elements :preview_page_images, '.flow-item img.body'
+  elements :form_pages, '#flow-overview .flow-item'
+  elements :form_urls, '#flow-overview .flow-item a.govuk-link'
+  elements :preview_page_images, '#flow-overview .flow-item img.body'
   element :three_dots_button, '.flow-menu-activator'
   element :preview_page_link, :link, I18n.t('actions.preview_page')
   element :add_page_here_link, :link, I18n.t('actions.add_page')
@@ -183,7 +183,7 @@ class EditorApp < SitePrism::Page
     page_flow_item(html_class, content).hover
   end
 
-  def page_flow_items(html_class = '.flow-thumbnail')
+  def page_flow_items(html_class = '#flow-overview .flow-thumbnail')
     page.all(html_class).map do |page_flow|
       page_flow.text.gsub("Edit:\n", '')
     end

--- a/app/javascript/src/component_expander.js
+++ b/app/javascript/src/component_expander.js
@@ -43,6 +43,7 @@ class Expander {
     $container.attr("id", id);
     $container.addClass("Expander_container");
     $node.addClass("Expander");
+    $node.data("instance", this);
 
     this._config = conf;
     this.$node = $node;

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -586,7 +586,6 @@ function adjustOverviewWidth($overview) {
  * when there are too many thumbnails to fix on the one page view.
  **/
 function applyOverviewScroll($overview) {
-  const margin = 30; // TODO: Maybe we can get this number from something??
   var $container = $("<div></div>");
   var $main = $("#main-content");
   var timeout;

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -376,11 +376,10 @@ function layoutDetachedItemsOveriew(view) {
   var $container = view.$flowDetached;
   var $title = $("h2", $container);
   var offsetLeft = $container.offset().left;
-  var $expander = $(".Expander_container");
-  var display = $expander.css("display");
+  var expander = $container.data("instance"); // Element is set as an Expander Component.
 
-  // display:none objects have no height in jQuery
-  $expander.css("display", "block");
+  // Make sure it's open on page load
+  expander.open();
 
   // Expand the width of the section.
   $container.css({
@@ -407,9 +406,6 @@ function layoutDetachedItemsOveriew(view) {
     adjustOverviewWidth($group);
     applyOverviewScroll($group);
   });
-
-  // Reset to original state
-  $expander.css("display", display);
 }
 
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -30,6 +30,7 @@ const COLUMN_SPACING = 100;
 const SELECTOR_FLOW_BRANCH = ".flow-branch";
 const SELECTOR_FLOW_CONDITION = ".flow-condition";
 const SELECTOR_FLOW_ITEM = ".flow-item";
+const SELECTOR_FLOW_LINE_PATH = ".FlowConnectorPath path:first-child";
 
 
 class ServicesController extends DefaultController {
@@ -343,6 +344,18 @@ function createFlowItemMenus(view) {
 /* VIEW SETUP FUNCTION:
  * --------------------
  * Create the main overview layout for form to get the required design.
+ *
+ * IMPORTANT: We are intentionally calling adjustOverviewHeight() twice.
+ *            Reason for this is because some lines are not getting their
+ *            correct dimensions (observed DownForwardDownBackwardsUp).
+ *            Calling adjustOverviewHeight() after positioning Flow items
+ *            means the container expands to the height of items. Then,
+ *            calling it a second time, after the FlowConnectorPaths have
+ *            been drawn, recalculates the height of container to include
+ *            any lines that have gone outside the original boundary. This
+ *            is a little annoying but, without the first call, things
+ *            appear to position correctly with the noticed exception of
+ *            the line type mentioned earlier. Double call is quickfix.
 **/
 function layoutFormFlowOverview(view) {
   var $container = view.$flowOverview;
@@ -353,6 +366,7 @@ function layoutFormFlowOverview(view) {
     positionAddPageButton();
   }
 
+  adjustOverviewHeight($container);
   applyPageFlowConnectorPaths($container);
   applyBranchFlowConnectorPaths($container);
   adjustOverlappingFlowConnectorPaths($container);
@@ -371,6 +385,18 @@ function layoutFormFlowOverview(view) {
  * also the expander effect to take into account. This means we need
  * to jump through a couple hoops by changing the section width and
  * compensating for that with positioning the section title.
+ *
+ * IMPORTANT: We are intentionally calling adjustOverviewHeight() twice.
+ *            Reason for this is because some lines are not getting their
+ *            correct dimensions (observed DownForwardDownBackwardsUp).
+ *            Calling adjustOverviewHeight() after positioning Flow items
+ *            means the container expands to the height of items. Then,
+ *            calling it a second time, after the FlowConnectorPaths have
+ *            been drawn, recalculates the height of container to include
+ *            any lines that have gone outside the original boundary. This
+ *            is a little annoying but, without the first call, things
+ *            appear to position correctly with the noticed exception of
+ *            the line type mentioned earlier. Double call is quickfix.
 **/
 function layoutDetachedItemsOveriew(view) {
   var $container = view.$flowDetached;
@@ -398,6 +424,7 @@ function layoutDetachedItemsOveriew(view) {
   $(".flow-detached-group", $container).each(function() {
     var $group = $(this);
     createAndPositionFlowItems($group);
+    adjustOverviewHeight($container);
     applyPageFlowConnectorPaths($group);
     applyBranchFlowConnectorPaths($group);
     adjustOverlappingFlowConnectorPaths($group);
@@ -522,7 +549,7 @@ function adjustBranchConditionPositions($overview) {
  * apply dimensional adjustments. 
  **/
 function adjustOverviewHeight($overview) {
-  var $items = $(SELECTOR_FLOW_ITEM + ", .FlowConnectorPath path:first-child", $overview);
+  var $items = $([SELECTOR_FLOW_ITEM, SELECTOR_FLOW_CONDITION, SELECTOR_FLOW_LINE_PATH].join(", "), $overview);
   var bottomNumbers = [];
   var topNumbers = [];
   var top, bottom, topOverlap, height;
@@ -562,7 +589,7 @@ function adjustOverviewHeight($overview) {
  * based on calculations of content positions.
  **/
 function adjustOverviewWidth($overview) {
-  var $items = $(SELECTOR_FLOW_ITEM + ", .FlowConnectorPath path:first-child", $overview);
+  var $items = $([SELECTOR_FLOW_ITEM, SELECTOR_FLOW_CONDITION, SELECTOR_FLOW_LINE_PATH].join(", "), $overview);
   var leftNumbers = [];
   var rightNumbers = [];
   var left, right;

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -291,6 +291,53 @@ function difference(a, b) {
 }
 
 
+/* Returns a sorted copy of the passed array starting from low to high.
+ * If input was detected to be not worthy, you'll get an empty in response.
+ * @numbers (Array) Array of numbers
+ **/
+function sortNumberArrayValues(numbers) {
+  var result = [];
+  if(arguments.length && (typeof(numbers) === 'array' || numbers instanceof Array) && numbers.length) {
+    result = numbers.slice();
+    result.sort(function(a, b) {
+      return a - b;
+    });
+  }
+  return result;
+}
+
+
+/* Returns the lowest detected number from a passed array of numbers.
+ * @numbers (Array) Array of numbers
+ **/
+function lowestNumber(numbers) {
+  var sorted = sortNumberArrayValues(numbers);
+  var result;
+
+  if(sorted.length) {
+    result = sorted[0];
+  }
+
+  return result;
+}
+
+
+/* Returns the highest detected number from a passed array of numbers.
+ * @numbers (Array) Array of numbers
+ **/
+function highestNumber(numbers) {
+  var sorted = sortNumberArrayValues(numbers);
+  var result;
+
+  if(sorted.length) {
+    result = sorted[sorted.length - 1];
+  }
+
+  return result;
+}
+
+
+
 // Make available for importing.
 module.exports  = { 
   mergeObjects: mergeObjects,
@@ -309,5 +356,8 @@ module.exports  = {
   stringInject: stringInject,
   maxHeight: maxHeight,
   maxWidth: maxWidth,
-  difference: difference
+  difference: difference,
+  sortNumberArrayValues: sortNumberArrayValues,
+  lowestNumber:lowestNumber,
+  highestNumber: highestNumber
 }

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -297,7 +297,7 @@ function difference(a, b) {
  **/
 function sortNumberArrayValues(numbers) {
   var result = [];
-  if(arguments.length && (typeof(numbers) === 'array' || numbers instanceof Array) && numbers.length) {
+  if(arguments.length && (numbers.constructor == (new Array).constructor) && numbers.length) {
     result = numbers.slice();
     result.sort(function(a, b) {
       return a - b;

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -571,6 +571,10 @@ html {
       stroke-width:4px;
       stroke: $govuk-link-hover-colour;
     }
+
+    .arrowPath {
+      fill: $govuk-link-hover-colour;
+    }
   }
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -583,9 +583,10 @@ html {
   top: calc(125px - 43px);
 }
 
-.FlowOverviewScrollingFrame {
-  height: 100%;
-  overflow: visible;
+.FlowOverviewScrollFrame {
+  // Dimensions are calculated by JS
+  overflow-x: auto;
+  overflow-y: hidden;
   position: relative;
 }
 
@@ -777,6 +778,10 @@ html {
     display: inline-block;
   }
 
+  .Expander_container {
+    @include govuk-width-container($govuk-page-width);
+  }
+
   .flow-detached-group {
     margin: 0 30px 250px 30px;
     position: relative;
@@ -786,7 +791,6 @@ html {
 #flow-overview {
   margin-bottom: 100px;
   min-height: 200px; // Temporary workaround of intermittent height calculation issues
-  overflow: scroll;
   position: relative;
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -787,7 +787,7 @@ html {
   }
 
   .flow-detached-group {
-    margin: 0 30px 250px 30px;
+    margin: 0 30px;
     position: relative;
   }
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,7 +130,7 @@ en:
   pages:
     flow:
       heading: 'Pages flow'
-      detached: 'Unconnected'
+      detached: 'Unconnected pages'
       delete_warning_both_pages: 'You won’t receive any user data without a check answers page and a confirmation page'
       delete_warning_cya_page: 'You won’t receive any user data without a check answers page'
       delete_warning_confirmation_page: 'You won’t receive any user data without a confirmation page'


### PR DESCRIPTION
- Fixes issue when reloading a form overview page after scrolling or when things are redrawn on browser resize.
- Change to make the detached flow section open on page load.
- Tweaks to unconnected group spacing and title content

### Tickets
https://trello.com/c/J81Q6pQe/2011-unconnected-pages-section-to-default-to-expanded-open-61-xs
https://trello.com/c/oSDI1ZMx/2248-bug-misalignment-of-flowconnectorpath-on-page-refresh-s
https://trello.com/c/HHYMcdvi/2254-unconnected-section-layout-1

### Screenshots

**(with bug/was)**
<img width="2048" alt="Screenshot 2022-01-21 zoomed out but after scroll page reload" src="https://user-images.githubusercontent.com/76942244/152021837-c1972320-0c99-4e44-9e2f-3fe020e1a6ba.png">

**(fixed/now)**
<img width="2040" alt="Screenshot 2022-01-21 zoomed out but initial page load" src="https://user-images.githubusercontent.com/76942244/152021913-44b2408b-af65-487d-ad92-405dad4b11df.png">
