### PR TITLE
Make no branching acceptance tests requirement for Live deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -485,10 +485,12 @@ workflows:
           include_job_number_field: false
           requires:
             - acceptance_tests
+            - acceptance_tests_no_branching
       - confirm_live_deploy:
           type: approval
           requires:
             - acceptance_tests
+            - acceptance_tests_no_branching
       - deploy_to_live:
           requires:
             - confirm_live_deploy


### PR DESCRIPTION
This adds the CircleCI configuration to make the no acceptance tests a
requirement for the manual gate for deploying to Live.