### PR TITLE
#2222 reconnect confirmation page

### DIFF
--- a/app/javascript/src/component_connection_menu.js
+++ b/app/javascript/src/component_connection_menu.js
@@ -47,8 +47,8 @@ class ConnectionMenu extends ActivatedMenu {
       case "link": 
         this.link(item);
         break;
-      case "destination":
-        this.changeDestination(item);
+      case "reconnect-confirmation":
+        this.reconnectConfirmation(item);
         break;
       default:
         this.addPage(item);
@@ -91,6 +91,15 @@ class ConnectionMenu extends ActivatedMenu {
         }, {
           text: view.text.dialogs.button_cancel
         }]
+      });
+    }
+
+    reconnectConfirmation(element) {
+      var url = element.data('url');
+      var destinationUuid = element.data('destination-uuid');
+
+      utilities.post(url, {
+        'destination_uuid': destinationUuid,
       });
     }
   }

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -468,7 +468,7 @@ function adjustOverviewScrollDimensions($overview, $container) {
  * design, they are excluded from this function and put in one of their own.
  **/
 function applyPageFlowConnectorPaths($overview) {
-  var $items = $overview.find('.flow-page[data-next]:not([data-next="connection"])');
+  var $items = $overview.find('.flow-page[data-next]:not([data-next="trailing-route"])');
   var rowHeight = utilities.maxHeight($items); // There's always a starting page.
 
   $items.each(function() {
@@ -637,15 +637,13 @@ function applyBranchFlowConnectorPaths($overview) {
   });
 }
 function applyRouteEndFlowConnectorPaths($overview) {
-  var $items = $overview.find('.flow-page[data-next="connection"]');
+  var $items = $overview.find('.flow-page[data-next="trailing-route"]');
   var rowHeight = utilities.maxHeight($items); // There's always a starting page.
 
   $items.each(function() {
     var $item = $(this);
-    var next = $item.data("next");
     var fromX = $item.position().left + $item.outerWidth() + 1; // + 1 for design spacing
     var fromY = $item.position().top + (rowHeight / 4);
-    var $next = $("[data-fb-id=" + next + "]", $overview);
     var toX = fromX + 100; // - 1 for design spacing
     var toY = fromY;
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -186,6 +186,7 @@ function layoutFormFlowOverview(view) {
   adjustOverviewHeight($container);
   applyPageFlowConnectorPaths($container);
   applyBranchFlowConnectorPaths($container);
+  applyRouteEndFlowConnectorPaths($container);
   adjustOverlappingFlowConnectorPaths($container);
   adjustBranchConditionPositions($container);
   applyOverviewScroll($container);
@@ -467,7 +468,7 @@ function adjustOverviewScrollDimensions($overview, $container) {
  * design, they are excluded from this function and put in one of their own.
  **/
 function applyPageFlowConnectorPaths($overview) {
-  var $items = $overview.find(".flow-page[data-next]");
+  var $items = $overview.find('.flow-page[data-next]:not([data-next="connection"])');
   var rowHeight = utilities.maxHeight($items); // There's always a starting page.
 
   $items.each(function() {
@@ -635,7 +636,36 @@ function applyBranchFlowConnectorPaths($overview) {
     });
   });
 }
+function applyRouteEndFlowConnectorPaths($overview) {
+  var $items = $overview.find('.flow-page[data-next="connection"]');
+  var rowHeight = utilities.maxHeight($items); // There's always a starting page.
 
+  $items.each(function() {
+    var $item = $(this);
+    var next = $item.data("next");
+    var fromX = $item.position().left + $item.outerWidth() + 1; // + 1 for design spacing
+    var fromY = $item.position().top + (rowHeight / 4);
+    var $next = $("[data-fb-id=" + next + "]", $overview);
+    var toX = fromX + 100; // - 1 for design spacing
+    var toY = fromY;
+
+    new ConnectorPath.ForwardPath({
+        from_x: fromX,
+        from_y: fromY,
+        to_x: toX,
+        to_y: toY,
+        via_x: COLUMN_SPACING - 20 // 25 because we don't want lines to start at edge of column space
+      }, {
+        from: $item.data("instance"),
+        to: $item.data("instance"),
+        container: $overview,
+        top: 0,                     // TODO: Is this and the height below the best way to position
+        bottom: $overview.height()  //       backward and skip forward lines to the boundaries?
+      }); 
+
+    
+  });
+}
 
 /* VIEW HELPER FUNCTION:
  * ---------------------
@@ -655,7 +685,7 @@ function adjustOverlappingFlowConnectorPaths($overview) {
   var $paths = $overview.find(".FlowConnectorPath").not(".ForwardPath, .DownForwardPath"); // Filter out Paths we can ignore to save some processing time
   var somethingMoved;
   var numberOfPaths = $paths.length;
-  var keepChecking = true;
+  var keepChecking = $paths.length > 0; 
   var loopCount = 1;
 
   do {

--- a/app/models/destinations_list.rb
+++ b/app/models/destinations_list.rb
@@ -8,13 +8,9 @@ module DestinationsList
   end
 
   def invalid_destination?(flow_uuid, current_uuid)
-    if current_uuid == checkanswers_uuid
-      flow_uuid != confirmation_uuid
-    else
-      flow_uuid == start_uuid ||
-        flow_uuid == confirmation_uuid ||
-        flow_uuid == current_uuid
-    end
+    flow_uuid == start_uuid ||
+      flow_uuid == confirmation_uuid ||
+      flow_uuid == current_uuid
   end
 
   def start_uuid
@@ -24,10 +20,5 @@ module DestinationsList
   def confirmation_uuid
     @confirmation_uuid ||=
       service.pages.find { |page| page.type == 'page.confirmation' }&.uuid
-  end
-
-  def checkanswers_uuid
-    @checkanswers_uuid ||=
-      service.pages.find { |page| page.type == 'page.checkanswers'}&.uuid
   end
 end

--- a/app/models/destinations_list.rb
+++ b/app/models/destinations_list.rb
@@ -8,9 +8,13 @@ module DestinationsList
   end
 
   def invalid_destination?(flow_uuid, current_uuid)
-    flow_uuid == start_uuid ||
-      flow_uuid == confirmation_uuid ||
-      flow_uuid == current_uuid
+    if current_uuid == checkanswers_uuid
+      flow_uuid != confirmation_uuid
+    else
+      flow_uuid == start_uuid ||
+        flow_uuid == confirmation_uuid ||
+        flow_uuid == current_uuid
+    end
   end
 
   def start_uuid
@@ -20,5 +24,10 @@ module DestinationsList
   def confirmation_uuid
     @confirmation_uuid ||=
       service.pages.find { |page| page.type == 'page.confirmation' }&.uuid
+  end
+
+  def checkanswers_uuid
+    @checkanswers_uuid ||=
+      service.pages.find { |page| page.type == 'page.checkanswers'}&.uuid
   end
 end

--- a/app/presenters/warning_presenter.rb
+++ b/app/presenters/warning_presenter.rb
@@ -44,7 +44,6 @@ class WarningPresenter
     grid.page_uuids.include?(service.checkanswers_page&.uuid)
   end
 
-
   def grid
     @grid ||= MetadataPresenter::Grid.new(service)
   end

--- a/app/presenters/warning_presenter.rb
+++ b/app/presenters/warning_presenter.rb
@@ -16,6 +16,10 @@ class WarningPresenter
       !confirmation_in_main_flow?
   end
 
+  def confirmation_in_main_flow?
+    grid.page_uuids.include?(service.confirmation_page&.uuid)
+  end
+
   private
 
   def submitting_pages_not_present_message
@@ -40,9 +44,6 @@ class WarningPresenter
     grid.page_uuids.include?(service.checkanswers_page&.uuid)
   end
 
-  def confirmation_in_main_flow?
-    grid.page_uuids.include?(service.confirmation_page&.uuid)
-  end
 
   def grid
     @grid ||= MetadataPresenter::Grid.new(service)

--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -42,9 +42,10 @@
       
     <% if service.confirmation_page.present? %>
       <% if !@publish_warning.confirmation_in_main_flow? %>
-        <li data-page-type="confirmation" data-action="destination">
-          <%= link_to 'Reconnect confirmation page',
-                      new_api_service_flow_destination_path(service.service_id, item[:uuid]) %>
+        <li data-action="reconnect-confirmation"
+            data-url="<%= api_service_flow_destinations_path(service.service_id, item[:uuid]) -%>"
+            data-destination-uuid="<%= service.confirmation_page.uuid -%>">
+          <a href="#reconnect-confirmation">Reconnect confirmation page</a>
         </li>
       <% end %>
     <% else %>

--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -40,9 +40,20 @@
       <li data-page-type="checkanswers"><a href="#add-page">Add check answers page</a></li>
     <% end %>
       
-    <% unless service.confirmation_page.present? %>
+    <% if service.confirmation_page.present? %>
+      <% if !@publish_warning.confirmation_in_main_flow? %>
+        <li data-page-type="confirmation" data-action="destination">
+          <%= link_to 'Reconnect confirmation page',
+                      new_api_service_flow_destination_path(service.service_id, item[:uuid]) %>
+        </li>
+      <% end %>
+    <% else %>
       <li data-page-type="confirmation"><a href="#add-page">Add confirmation page</a></li>
     <% end %>
+
+
+
+
 
     <% unless (item[:type] =~ /page.(checkanswers|confirmation|exit)/) || item[:type] == 'flow.branch' %>
       <li data-action="link">

--- a/app/views/services/_flow_layout.html.erb
+++ b/app/views/services/_flow_layout.html.erb
@@ -54,7 +54,7 @@
 
       <% if item[:next].empty? %>
         <%# Likely to be items like the end of a path (e.g. Confirmation page) %>
-        <article class="flow-item flow-page" aria-label="<%= item[:title] %>" data-fb-id="<%= item[:uuid] %>" <%= !(item[:type] =~ /page.(confirmation|exit)/) ? 'data-next=connection' : ''  -%> >
+        <article class="flow-item flow-page" aria-label="<%= item[:title] %>" data-fb-id="<%= item[:uuid] %>" <%= !(item[:type] =~ /page.(confirmation|exit)/) ? 'data-next=trailing-route' : ''  -%> >
           <%= flow_thumbnail_link(item) %>
           <%= flow_text_link(item) %>
           <%= render partial: 'services/flow_page_menu', locals: { item: item } %>

--- a/app/views/services/_flow_layout.html.erb
+++ b/app/views/services/_flow_layout.html.erb
@@ -54,7 +54,7 @@
 
       <% if item[:next].empty? %>
         <%# Likely to be items like the end of a path (e.g. Confirmation page) %>
-        <article class="flow-item flow-page" aria-label="<%= item[:title] %>" data-fb-id="<%= item[:uuid] %>">
+        <article class="flow-item flow-page" aria-label="<%= item[:title] %>" data-fb-id="<%= item[:uuid] %>" <%= !(item[:type] =~ /page.(confirmation|exit)/) ? 'data-next=connection' : ''  -%> >
           <%= flow_thumbnail_link(item) %>
           <%= flow_text_link(item) %>
           <%= render partial: 'services/flow_page_menu', locals: { item: item } %>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -22,8 +22,9 @@
 <% if ENV['BRANCHING'] == 'enabled' && @detached_flows.present? %>
   <section id="flow-detached" data-component="Expander">
     <h2 class="govuk-heading-s"><%= t('pages.flow.detached') %></h2>
+
     <% @detached_flows.each do |detached_flow| %>
-      <div class="flow-detached-group">
+          <div class="flow-detached-group">
         <% detached_flow.each do |column| %>
           <div class="column">
             <% column.each_with_index do |flow, index| %>


### PR DESCRIPTION
This adds a trailing arrow on form routes that don't end in a confirmation page or exit page. 
[Ticket](https://trello.com/c/awSx6IDL/2222-adding-pages-at-the-end-of-the-flow-when-cya-conf-are-not-present-s)

Will show 'Add confirmation page' in the connection menu after a check your answers page
<img width="995" alt="image" src="https://user-images.githubusercontent.com/595564/152129979-58475d4f-d95a-45c8-9479-6a533895868f.png">

Will show 'Reconnect confirmation page' if the confirmation page has become unconnected. This will perform a post request to set the destination of the check your answers page to the confirmation page.
<img width="970" alt="image" src="https://user-images.githubusercontent.com/595564/152128985-01dc9ca1-30d1-4f79-babb-f290b67e1865.png">
