### PR TITLE
add conditional_uuid into create page modal on branching condition

### DIFF
--- a/app/javascript/src/component_connection_menu.js
+++ b/app/javascript/src/component_connection_menu.js
@@ -20,18 +20,9 @@ class ConnectionMenu extends ActivatedMenu {
 
     this.activator.$node.addClass("ConnectionMenuActivator");
     this.container.$node.addClass("ConnectionMenu");
-    //this.uuid = $node.data("uuid");
     this.title = $node.data("title");
-
     this.addPageAfter = $node.data("uuid");
-  }
-
-  set addPageAfter(uuid) {
-    this._uuid = uuid;
-  }
-
-  get addPageAfter() {
-    return this._uuid
+    this.addPageAfterCondition = $node.data("condition-uuid");
   }
 
   selection(event, item) {
@@ -63,7 +54,11 @@ class ConnectionMenu extends ActivatedMenu {
       
         // Set the 'add_page_here' value to mark point of new page inclusion.
         // Should be a uuid of previous page or blank if at end of form.
+        // If we are on a branch condition, then also set the condition uuid 
         utilities.updateHiddenInputOnForm($form, "page[add_page_after]", this.addPageAfter);
+        if(this.addPageAfterCondition) {
+          utilities.updateHiddenInputOnForm($form, "page[conditional_uuid]", this.addPageAfterCondition);
+        }
 
         // Then add any required values.
         utilities.updateHiddenInputOnForm($form, "page[page_type]", element.data("page-type"));

--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -3,7 +3,8 @@
     data-activator-classname="<%= item[:type] == 'flow.branch' ? 'branch-' : '' -%>connection-menu-activator"
     data-component="ConnectionMenu"
     data-title="<%= item[:title] %>"
-    data-uuid="<%= item[:uuid] %>">
+    data-uuid="<%= item[:uuid] %>"
+    data-condition-uuid="<%= item[:type] == 'flow.branch' ? condition[:uuid] : '' -%>">
 
     <% if ENV['BRANCHING'] == 'enabled' %>
       <% unless item[:type] == 'page.checkanswers' %>

--- a/app/views/services/_flow_layout.html.erb
+++ b/app/views/services/_flow_layout.html.erb
@@ -31,7 +31,7 @@
         <ul class="flow-conditions">
           <% item[:conditionals].each_with_index do |condition, index| %>
             <li class="flow-condition" data-from="<%= "#{item[:uuid]}-#{index}" %>" data-next="<%= condition[:next] %>">
-              <%= render partial: 'services/connection_menu', locals: { item: item } %>
+              <%= render partial: 'services/connection_menu', locals: { item: item, condition: condition } %>
               <% condition[:expressions].each do |expression| %>
                 <% if expression[:operator].empty? && expression[:answer].empty? %>
                   <div class="flow-expression" data-otherwise="true">


### PR DESCRIPTION
Adds the frontend work required to complete [ticket #2249](https://trello.com/c/ty7Eg0cn/2249-enable-add-page-after-a-branching-point-from-the-connection-menu-s)

When on a branch conditional the connection menu populates the hidden form field with the current conditional_uuid allowing the new page to be created in the correct place in the grid.

<img width="868" alt="image" src="https://user-images.githubusercontent.com/595564/152142390-be643939-4ce3-459a-a996-320a0b893f64.png">

<img width="1018" alt="image" src="https://user-images.githubusercontent.com/595564/152142470-7be764ae-a3b7-4094-93a7-332e4f68d7a6.png">
