### PR TITLE
replace action for change destination in connection menu

### DIFF
--- a/app/javascript/src/component_connection_menu.js
+++ b/app/javascript/src/component_connection_menu.js
@@ -47,6 +47,9 @@ class ConnectionMenu extends ActivatedMenu {
       case "link": 
         this.link(item);
         break;
+      case "destination":
+        this.changeDestination(item); 
+        break;
       case "reconnect-confirmation":
         this.reconnectConfirmation(item);
         break;


### PR DESCRIPTION
Fixes mistaken removal of the change destination action on the connection menu.