### PR TITLE
Use browser tools 1.2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   slack: circleci/slack@3.4.2
   ruby: circleci/ruby@1.1.3
   node: circleci/node@4.5.1
-  browser-tools: circleci/browser-tools@1.2.1
+  browser-tools: circleci/browser-tools@1.2.4
   kubernetes: circleci/kubernetes@0.12.0
 
 jobs:
@@ -288,7 +288,8 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install
           command: |
@@ -328,7 +329,8 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install
           command: |
@@ -358,7 +360,8 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install
           command: |


### PR DESCRIPTION
Update browser tools to 1.2.4

Also only install chrome and chrome driver. This stops Firefox and
Geckdriver from installing which should reduce the run time of the
acceptance tests a little bit.