### PR TITLE
Add modal for deleting branch destination with no default next 

### DIFF
--- a/app/models/destroy_page_modal.rb
+++ b/app/models/destroy_page_modal.rb
@@ -8,6 +8,7 @@ class DestroyPageModal
     potential_stacked_branches?: 'stack_branches_not_supported',
     delete_page_used_for_branching?: 'delete_page_used_for_branching_not_supported',
     branch_destination?: 'delete_branch_destination_page',
+    branch_destination_no_default_next?: 'delete_branch_destination_page_no_default_next',
     default?: 'delete'
   }.freeze
 
@@ -28,7 +29,11 @@ class DestroyPageModal
   end
 
   def branch_destination?
-    page.uuid.in?(branch_destinations)
+    page.uuid.in?(branch_destinations) && service.flow_object(page.uuid).default_next.present?
+  end
+
+  def branch_destination_no_default_next?
+    page.uuid.in?(branch_destinations) && service.flow_object(page.uuid).default_next.blank?
   end
 
   # If the other checks returns false it means the page can be deleted

--- a/app/models/destroy_page_modal.rb
+++ b/app/models/destroy_page_modal.rb
@@ -7,7 +7,7 @@ class DestroyPageModal
   PARTIALS = {
     potential_stacked_branches?: 'stack_branches_not_supported',
     delete_page_used_for_branching?: 'delete_page_used_for_branching_not_supported',
-    branch_destination?: 'delete_branch_destination_page',
+    branch_destination_with_default_next?: 'delete_branch_destination_page',
     branch_destination_no_default_next?: 'delete_branch_destination_page_no_default_next',
     default?: 'delete'
   }.freeze
@@ -28,12 +28,12 @@ class DestroyPageModal
     next_flow_is_a_branch? && previous_flow_is_a_branch?
   end
 
-  def branch_destination?
-    page.uuid.in?(branch_destinations) && service.flow_object(page.uuid).default_next.present?
+  def branch_destination_with_default_next?
+    branch_destination? && page_flow_object.default_next.present?
   end
 
   def branch_destination_no_default_next?
-    page.uuid.in?(branch_destinations) && service.flow_object(page.uuid).default_next.blank?
+    branch_destination? && page_flow_object.default_next.blank?
   end
 
   # If the other checks returns false it means the page can be deleted
@@ -45,8 +45,16 @@ class DestroyPageModal
 
   private
 
+  def branch_destination?
+    @branch_destination ||= page.uuid.in?(branch_destinations)
+  end
+
+  def page_flow_object
+    @page_flow_object ||= service.flow_object(page.uuid)
+  end
+
   def next_flow_is_a_branch?
-    default_next = service.flow_object(page.uuid).default_next
+    default_next = page_flow_object.default_next
 
     default_next && service.flow_object(default_next).branch?
   end

--- a/app/views/api/pages/_delete_branch_destination_page_no_default_next_modal.html.erb
+++ b/app/views/api/pages/_delete_branch_destination_page_no_default_next_modal.html.erb
@@ -1,0 +1,16 @@
+<div class="component component-dialog component-dialog-api-request dialog-delete"
+     data-component="DialogApiRequest">
+
+  <h3 data-node="heading" class="govuk-label govuk-label--m">
+    <%= t('dialogs.heading_delete_no_default_next') %>
+  </h3>
+  <p data-node="content">
+    <%= t('pages.delete_modal.delete_branch_destination_page_no_default_next_message') %>
+  </p>
+
+  <div>
+    <button class="govuk-button fb-govuk-button">
+      <%= t('dialogs.button_understood') %>
+    </button>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
     button_update: 'Update'
     heading: General heading here
     heading_delete: 'Delete "%{label}"?'
+    heading_delete_no_default_next: 'You cannot delete this page yet'
     heading_delete_branch: Delete branch?
     heading_delete_condtition: Delete condition?
     heading_delete_option: 'Delete the option "%{option label}"?'
@@ -141,6 +142,7 @@ en:
     delete_modal:
       delete_page: 'Deletes "%{title}"'
       delete_branch_destination_page_message: 'One of your branches leads to this page. We will update the branching point to lead to the next page in your flow.'
+      delete_branch_destination_page_no_default_next_message: 'You cannot delete this page because it is used in a branching condition. Update the branching point first, then try again.'
       delete_and_update_branching: 'Delete and update branching'
       you_cannot_delete_this_page: 'You cannot delete this page yet'
       delete_page_used_for_branching_not_supported_message: 'You cannot delete this page because it is used in a branching condition. Update the branching point first, then try again.'

--- a/spec/models/destroy_page_modal_spec.rb
+++ b/spec/models/destroy_page_modal_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe DestroyPageModal do
       end
     end
 
+    # used for branch conditionals
     context 'when there is a branch that depends on the page' do
       let(:page) { service.find_page_by_url('page-b') }
 

--- a/spec/models/destroy_page_modal_spec.rb
+++ b/spec/models/destroy_page_modal_spec.rb
@@ -10,12 +10,24 @@ RSpec.describe DestroyPageModal do
   describe '#to_partial_path' do
     subject(:partial) { destroy_page_modal.to_partial_path }
 
+    # branch destinations
     context 'when after branch' do
       context 'when there is no branch sequentially after the page' do
-        let(:page) { service.find_page_by_url('page-c') }
+        context 'when the destination has a default next' do
+          let(:page) { service.find_page_by_url('page-c') }
+
+          it 'returns deleting branch destination page partial' do
+            expect(partial).to eq('api/pages/delete_branch_destination_page_modal')
+          end
+        end
+      end
+
+      context 'when the destination has no default next' do
+        let(:service_metadata) { metadata_fixture(:branching_7) }
+        let(:page) { service.find_page_by_url('page-g') }
 
         it 'returns deleting branch destination page partial' do
-          expect(partial).to eq('api/pages/delete_branch_destination_page_modal')
+          expect(partial).to eq('api/pages/delete_branch_destination_page_no_default_next_modal')
         end
       end
 


### PR DESCRIPTION
When a page which is the destination of a branching condition has no
default next if a user was to delete it there is nothing to take its'
place. This isn't really the state we want a branching point to ever get
to.

Instead we will check if the branch destination being deleted has a
default next. If it does not we show the user a modal letting them know
they cannot delete the page until they update the branch to point to a
different page manually.

![Screenshot 2022-02-03 at 15 52 31](https://user-images.githubusercontent.com/3466862/152378367-e5a52743-bcfb-4ed7-aabd-944792957782.png)


Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>