### PR TITLE
#2222 reconnect confirmation page

### DIFF
--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -36,13 +36,13 @@
         <li data-page-type="exit"><a href="#add-page">Add exit page</a></li>
     <% end %>
 
-    <% unless service.checkanswers_page.present? %>
+    <% if !service.checkanswers_page.present? && item[:type] != 'flow.branch' && item[:next].blank?  %>
       <li data-page-type="checkanswers"><a href="#add-page">Add check answers page</a></li>
     <% end %>
       
     <% if item[:type] == 'page.checkanswers' %>
       <% if service.confirmation_page.present? %>
-        <% if !@publish_warning.confirmation_in_main_flow? %>
+        <% if !@publish_warning&.confirmation_in_main_flow? %>
           <li data-action="reconnect-confirmation"
               data-url="<%= api_service_flow_destinations_path(service.service_id, item[:uuid]) -%>"
               data-destination-uuid="<%= service.confirmation_page.uuid -%>">

--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -40,21 +40,19 @@
       <li data-page-type="checkanswers"><a href="#add-page">Add check answers page</a></li>
     <% end %>
       
-    <% if service.confirmation_page.present? %>
-      <% if !@publish_warning.confirmation_in_main_flow? %>
-        <li data-action="reconnect-confirmation"
-            data-url="<%= api_service_flow_destinations_path(service.service_id, item[:uuid]) -%>"
-            data-destination-uuid="<%= service.confirmation_page.uuid -%>">
-          <a href="#reconnect-confirmation">Reconnect confirmation page</a>
-        </li>
+    <% if item[:type] == 'page.checkanswers' %>
+      <% if service.confirmation_page.present? %>
+        <% if !@publish_warning.confirmation_in_main_flow? %>
+          <li data-action="reconnect-confirmation"
+              data-url="<%= api_service_flow_destinations_path(service.service_id, item[:uuid]) -%>"
+              data-destination-uuid="<%= service.confirmation_page.uuid -%>">
+            <a href="#reconnect-confirmation">Reconnect confirmation page</a>
+          </li>
+        <% end %>
+      <% else %>
+        <li data-page-type="confirmation"><a href="#add-page">Add confirmation page</a></li>
       <% end %>
-    <% else %>
-      <li data-page-type="confirmation"><a href="#add-page">Add confirmation page</a></li>
     <% end %>
-
-
-
-
 
     <% unless (item[:type] =~ /page.(checkanswers|confirmation|exit)/) || item[:type] == 'flow.branch' %>
       <li data-action="link">


### PR DESCRIPTION
Updates on [ticket #2222](https://trello.com/c/awSx6IDL/2222-adding-pages-at-the-end-of-the-flow-when-cya-conf-are-not-present-s)

 - 'Add confirmation page' should only be present in the connection menu after a cya page, if there is no unconnected confirmation page, else it would be 'reconnect confirmation page'

 - All other connection menus would never contain 'Add confirmation page'

 - Other connection menus could contain 'Add check your answers page' if one is not already present in the form (connected or unconnected)

 - As an extra bonus, this should now only show the cya page as an option if you are at the end of the flow.

<img width="635" alt="image" src="https://user-images.githubusercontent.com/595564/152378720-ea820aa2-1037-4243-9da3-dc06d75e7ea7.png">

<img width="815" alt="image" src="https://user-images.githubusercontent.com/595564/152378788-50e2244e-99bc-440e-962c-48e10e393e30.png">

