### PR TITLE
reconnect confirmation page

### DIFF
--- a/app/javascript/src/component_connection_menu.js
+++ b/app/javascript/src/component_connection_menu.js
@@ -47,6 +47,9 @@ class ConnectionMenu extends ActivatedMenu {
       case "link": 
         this.link(item);
         break;
+      case "destination":
+        this.changeDestination(item); 
+        break;
       case "reconnect-confirmation":
         this.reconnectConfirmation(item);
         break;

--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -36,13 +36,13 @@
         <li data-page-type="exit"><a href="#add-page">Add exit page</a></li>
     <% end %>
 
-    <% unless service.checkanswers_page.present? %>
+    <% if !service.checkanswers_page.present? && item[:type] != 'flow.branch' && item[:next].blank?  %>
       <li data-page-type="checkanswers"><a href="#add-page">Add check answers page</a></li>
     <% end %>
       
     <% if item[:type] == 'page.checkanswers' %>
       <% if service.confirmation_page.present? %>
-        <% if !@publish_warning.confirmation_in_main_flow? %>
+        <% if !@publish_warning&.confirmation_in_main_flow? %>
           <li data-action="reconnect-confirmation"
               data-url="<%= api_service_flow_destinations_path(service.service_id, item[:uuid]) -%>"
               data-destination-uuid="<%= service.confirmation_page.uuid -%>">

--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -8,36 +8,36 @@
     <% if ENV['BRANCHING'] == 'enabled' %>
       <% unless item[:type] == 'page.checkanswers' %>
         <li data-action="none">
-          <span>Add single question page</span>
+          <span><%= t('actions.add_single_question') -%></span>
           <ul class="govuk-navigation">
             <li data-page-type="singlequestion"
-                data-component-type="text"><a href="#add-page">Text</a></li>
+                data-component-type="text"><a href="#add-page"><%= t('components.list.text') -%></a></li>
             <li data-page-type="singlequestion"
-                data-component-type="textarea"><a href="#add-page">Textarea</a></li>
+                data-component-type="textarea"><a href="#add-page"><%= t('components.list.textarea') -%></a></li>
             <li data-page-type="singlequestion"
-                data-component-type="email"><a href="#add-page">Email address</a></li>
+                data-component-type="email"><a href="#add-page"><%= t('components.list.email') -%></a></li>
             <li data-page-type="singlequestion"
-                data-component-type="number"><a href="#add-page">Number</a></li>
+                data-component-type="number"><a href="#add-page"><%= t('components.list.number') -%></a></li>
             <li data-page-type="singlequestion"
-                data-component-type="date"><a href="#add-page">Date</a></li>
+                data-component-type="date"><a href="#add-page"><%= t('components.list.date') -%></a></li>
             <li data-page-type="singlequestion"
-                data-component-type="radios"><a href="#add-page">Radio buttons</a></li>
+                data-component-type="radios"><a href="#add-page"><%= t('components.list.radios') -%></a></li>
             <li data-page-type="singlequestion"
-                data-component-type="checkboxes"><a href="#add-page">Checkboxes</a></li>
+                data-component-type="checkboxes"><a href="#add-page"><%= t('components.list.checkboxes') -%></a></li>
             <li data-page-type="singlequestion"
-                data-component-type="upload"><a href="#add-page">File upload</a></li>
+                data-component-type="upload"><a href="#add-page"><%= t('components.list.upload') -%></a></li>
           </ul>
         </li>
         
-        <li data-page-type="multiplequestions"><a href="#add-page">Add multiple question page</a></li>
+        <li data-page-type="multiplequestions"><a href="#add-page"><%= t('actions.add_multi_question') -%></a></li>
         
-        <li data-page-type="content"><a href="#add-page">Add content page</a></li>
+        <li data-page-type="content"><a href="#add-page"><%= t('actions.add_content') -%></a></li>
 
-        <li data-page-type="exit"><a href="#add-page">Add exit page</a></li>
+        <li data-page-type="exit"><a href="#add-page"><%= t('actions.add_exit') -%></a></li>
     <% end %>
 
     <% if !service.checkanswers_page.present? && item[:type] != 'flow.branch' && item[:next].blank?  %>
-      <li data-page-type="checkanswers"><a href="#add-page">Add check answers page</a></li>
+      <li data-page-type="checkanswers"><a href="#add-page"><%= t('actions.add_check_answers') -%></a></li>
     <% end %>
       
     <% if item[:type] == 'page.checkanswers' %>
@@ -46,11 +46,11 @@
           <li data-action="reconnect-confirmation"
               data-url="<%= api_service_flow_destinations_path(service.service_id, item[:uuid]) -%>"
               data-destination-uuid="<%= service.confirmation_page.uuid -%>">
-            <a href="#reconnect-confirmation">Reconnect confirmation page</a>
+              <a href="#reconnect-confirmation"><%= t('actions.reconnect_confirmation') -%></a>
           </li>
         <% end %>
       <% else %>
-        <li data-page-type="confirmation"><a href="#add-page">Add confirmation page</a></li>
+        <li data-page-type="confirmation"><a href="#add-page"><%= t('actions.add_confirmation') -%></a></li>
       <% end %>
     <% end %>
 
@@ -71,38 +71,38 @@
     <% unless item[:type] == 'page.checkanswers' %>
 
       <li data-action="none">
-        <span>Add single question page</span>
+        <span><%= t('actions.add_single_question') -%></span>
         <ul class="govuk-navigation">
           <li data-page-type="singlequestion"
-              data-component-type="text"><a href="#add-page">Text</a></li>
+              data-component-type="text"><a href="#add-page"><%= t('components.list.text') -%></a></li>
           <li data-page-type="singlequestion"
-              data-component-type="textarea"><a href="#add-page">Textarea</a></li>
+              data-component-type="textarea"><a href="#add-page"><%= t('components.list.textarea') -%></a></li>
           <li data-page-type="singlequestion"
-              data-component-type="email"><a href="#add-page">Email address</a></li>
+              data-component-type="email"><a href="#add-page"><%= t('components.list.email') -%></a></li>
           <li data-page-type="singlequestion"
-              data-component-type="number"><a href="#add-page">Number</a></li>
+              data-component-type="number"><a href="#add-page"><%= t('components.list.number') -%></a></li>
           <li data-page-type="singlequestion"
-              data-component-type="date"><a href="#add-page">Date</a></li>
+              data-component-type="date"><a href="#add-page"><%= t('components.list.date') -%></a></li>
           <li data-page-type="singlequestion"
-              data-component-type="radios"><a href="#add-page">Radio buttons</a></li>
+              data-component-type="radios"><a href="#add-page"><%= t('components.list.radios') -%></a></li>
           <li data-page-type="singlequestion"
-              data-component-type="checkboxes"><a href="#add-page">Checkboxes</a></li>
+              data-component-type="checkboxes"><a href="#add-page"><%= t('components.list.checkboxes') -%></a></li>
           <li data-page-type="singlequestion"
-              data-component-type="upload"><a href="#add-page">File upload</a></li>
+              data-component-type="upload"><a href="#add-page"><%= t('components.list.upload') -%></a></li>
         </ul>
       </li>
       
-      <li data-page-type="multiplequestions"><a href="#add-page">Add multiple question page</a></li>
+      <li data-page-type="multiplequestions"><a href="#add-page"><%= t('actions.add_multi_question') -%></a></li>
       
-      <li data-page-type="content"><a href="#add-page">Add content page</a></li>
+      <li data-page-type="content"><a href="#add-page"><%= t('actions.add_content') -%></a></li>
     <% end %>
 
     <% unless service.checkanswers_page.present? %>
-      <li data-page-type="checkanswers"><a href="#add-page">Add check answers page</a></li>
+      <li data-page-type="checkanswers"><a href="#add-page"><%= t('actions.add_check_answers') -%></a></li>
     <% end %>
  
     <% unless service.confirmation_page.present? %>
-      <li data-page-type="confirmation"><a href="#add-page">Add confirmation page</a></li>
+      <li data-page-type="confirmation"><a href="#add-page"><%= t('actions.add_confirmation') -%></a></li>
     <% end %>
   <% end %>
 </ul>

--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -40,21 +40,19 @@
       <li data-page-type="checkanswers"><a href="#add-page">Add check answers page</a></li>
     <% end %>
       
-    <% if service.confirmation_page.present? %>
-      <% if !@publish_warning.confirmation_in_main_flow? %>
-        <li data-action="reconnect-confirmation"
-            data-url="<%= api_service_flow_destinations_path(service.service_id, item[:uuid]) -%>"
-            data-destination-uuid="<%= service.confirmation_page.uuid -%>">
-          <a href="#reconnect-confirmation">Reconnect confirmation page</a>
-        </li>
+    <% if item[:type] == 'page.checkanswers' %>
+      <% if service.confirmation_page.present? %>
+        <% if !@publish_warning.confirmation_in_main_flow? %>
+          <li data-action="reconnect-confirmation"
+              data-url="<%= api_service_flow_destinations_path(service.service_id, item[:uuid]) -%>"
+              data-destination-uuid="<%= service.confirmation_page.uuid -%>">
+            <a href="#reconnect-confirmation">Reconnect confirmation page</a>
+          </li>
+        <% end %>
+      <% else %>
+        <li data-page-type="confirmation"><a href="#add-page">Add confirmation page</a></li>
       <% end %>
-    <% else %>
-      <li data-page-type="confirmation"><a href="#add-page">Add confirmation page</a></li>
     <% end %>
-
-
-
-
 
     <% unless (item[:type] =~ /page.(checkanswers|confirmation|exit)/) || item[:type] == 'flow.branch' %>
       <li data-action="link">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,13 @@ en:
     option_add: 'Add option'
     option_remove: 'Delete...'
     change_destination: 'Change next page...'
+    add_single_question: 'Add single question page'
+    add_multi_question: 'Add multiple question page'
+    add_content: 'Add content page'
+    add_exit: 'Add exit page'
+    add_check_answers: 'Add check answers page'
+    add_confirmation: 'Add confirmation page'
+    reconnect_confirmation: 'Reconnect confirmation page'
     ok: 'Ok'
   branches:
     branch_add: 'Add another branch'


### PR DESCRIPTION
Updates on [ticket #2222](https://trello.com/c/awSx6IDL/2222-adding-pages-at-the-end-of-the-flow-when-cya-conf-are-not-present-s)

 - 'Add confirmation page' should only be present in the connection menu after a cya page, if there is no unconnected confirmation page, else it would be 'reconnect confirmation page'

 - All other connection menus would never contain 'Add confirmation page'

 - Other connection menus could contain 'Add check your answers page' if one is not already present in the form (connected or unconnected)

 - As an extra bonus, this should now only show the cya page as an option if you are at the end of the flow.

<img width="635" alt="image" src="https://user-images.githubusercontent.com/595564/152378720-ea820aa2-1037-4243-9da3-dc06d75e7ea7.png">

<img width="815" alt="image" src="https://user-images.githubusercontent.com/595564/152378788-50e2244e-99bc-440e-962c-48e10e393e30.png">

