### PR TITLE
Add or statements between branches

### DIFF
--- a/app/javascript/src/component_branch.js
+++ b/app/javascript/src/component_branch.js
@@ -17,7 +17,7 @@
 
 const utilities = require('./utilities');
 const BranchDestination = require('./component_branch_destination');
-const EVENT_QUESTION_CHANGE = "branchquestionchange";
+const EVENT_QUESTION_CHANGE = "BranchQuestionChange";
 
 
 /* Branch component
@@ -37,9 +37,6 @@ class Branch {
 
     $node.addClass("Branch");
     $node.data("instance", this);
-    $node.on(EVENT_QUESTION_CHANGE, () => {
-      utilities.safelyActivateFunction.call(this, conf.event_question_change);
-    });
 
     this._config = conf;
     this._conditionCount = 0;
@@ -61,7 +58,7 @@ class Branch {
       branch._conditionCount++;
     });
 
-    utilities.safelyActivateFunction(this._config.event_on_create, [this]);
+    $(document).trigger('BranchCreate', this);
   }
 
   get index() {
@@ -253,7 +250,7 @@ class BranchQuestion {
     switch(supported) {
       case true:
            this.condition.update(value, function() {
-             branch.$node.trigger(EVENT_QUESTION_CHANGE);
+             $(document).trigger(EVENT_QUESTION_CHANGE, branch);
            });
            break;
       case false:
@@ -261,7 +258,7 @@ class BranchQuestion {
            break;
       default:
            // Just trigger an event
-           this.condition.branch.$node.trigger(EVENT_QUESTION_CHANGE);
+           $(document).trigger(EVENT_QUESTION_CHANGE, this.condition.branch);
     }
   }
 

--- a/app/javascript/src/component_branch.js
+++ b/app/javascript/src/component_branch.js
@@ -46,7 +46,7 @@ class Branch {
     this._conditions = {}; // Add only conditions that you want deletable to this.
     this.$node = $node;
     this.view = conf.view;
-    this.index = Number(conf.branch_index);
+    this._index = Number(conf.branch_index);
     this.destination = new BranchDestination($node.find(config.selector_destination), conf);
     this.conditionInjector = new BranchConditionInjector($injector, conf);
     this.remover = new BranchRemover($remover, conf);
@@ -64,9 +64,13 @@ class Branch {
     utilities.safelyActivateFunction(this._config.event_on_create, [this]);
   }
 
+  get index() {
+    return this._index;
+  }
+
   addCondition() {
     var template = utilities.stringInject(this._config.template_condition, {
-      branch_index: this.index,
+      branch_index: this._index,
       condition_index: ++this._conditionCount
     });
 
@@ -83,7 +87,7 @@ class Branch {
   }
 
   destroy() {
-    $(document).trigger('branchRemoved', this.$node );
+    $(document).trigger('BranchRemove', this.$node );
     this.$node.remove();
   }
   

--- a/app/javascript/src/component_branch.js
+++ b/app/javascript/src/component_branch.js
@@ -83,8 +83,14 @@ class Branch {
   }
 
   destroy() {
+    // find preceding 'or' text to remove as well
+    var $or = this.$node.prev('.branch-or').first();
     this.$node.remove();
+    if($or) {
+      $or.remove()
+    }
   }
+  
 }
 
 

--- a/app/javascript/src/component_branch.js
+++ b/app/javascript/src/component_branch.js
@@ -42,11 +42,11 @@ class Branch {
     });
 
     this._config = conf;
-    this._index = Number(conf.branch_index);
     this._conditionCount = 0;
     this._conditions = {}; // Add only conditions that you want deletable to this.
     this.$node = $node;
     this.view = conf.view;
+    this.index = Number(conf.branch_index);
     this.destination = new BranchDestination($node.find(config.selector_destination), conf);
     this.conditionInjector = new BranchConditionInjector($injector, conf);
     this.remover = new BranchRemover($remover, conf);
@@ -66,7 +66,7 @@ class Branch {
 
   addCondition() {
     var template = utilities.stringInject(this._config.template_condition, {
-      branch_index: this._index,
+      branch_index: this.index,
       condition_index: ++this._conditionCount
     });
 
@@ -83,12 +83,8 @@ class Branch {
   }
 
   destroy() {
-    // find preceding 'or' text to remove as well
-    var $or = this.$node.prev('.branch-or').first();
+    $(document).trigger('branchRemoved', this.$node );
     this.$node.remove();
-    if($or) {
-      $or.remove()
-    }
   }
   
 }

--- a/app/javascript/src/controller_branches.js
+++ b/app/javascript/src/controller_branches.js
@@ -124,7 +124,7 @@ BranchesController.addBranchMenu = function(args) {
   var first = $(".Branch", $form).get(0) == branch.$node.get(0);
   if(!first) {
     new ActivatedMenu($ul, {
-      activator_text: "Edit branch",
+      activator_text: app.text.branches.branch_edit,
       container_classname: "SomeClassName",
       container_id: utilities.uniqueString("activated-menu-"),
       menu: {

--- a/app/javascript/src/controller_branches.js
+++ b/app/javascript/src/controller_branches.js
@@ -65,7 +65,7 @@ class BranchesController extends DefaultController {
     BranchesController.enhanceBranchInjectors.call(this, $injectors);
     BranchesController.enhanceBranchOtherwise.call(this, $otherwise);
 
-    addBranchEventListeners(view)
+    BranchesController.addBranchEventListeners(view)
   }
 }
 
@@ -179,20 +179,17 @@ BranchesController.createBranch = function($node) {
 
 BranchesController.addBranchCombinator = function(args) {
   var branch = args[0];
-  if( !branch.index == 0 ) {
+  if( branch.index != 0 ) {
     branch.$node.before("<p class=\"branch-or\">or</p>");
   }
 }
 
 BranchesController.removeBranchCombinator = function(node) {
-    var $or = $(node).prev('.branch-or').first();
-    if($or) {
-      $or.remove()
-    }
+    $(node).prev('.branch-or').first().remove();
 }
 
-function addBranchEventListeners(view) {
-  view.$document.on('branchRemoved', function(event, node){
+BranchesController.addBranchEventListeners = function(view) {
+  view.$document.on('BranchRemove', function(event, node){
     BranchesController.removeBranchCombinator.call(view, node);
   });
 }

--- a/app/javascript/src/controller_branches.js
+++ b/app/javascript/src/controller_branches.js
@@ -78,6 +78,11 @@ BranchesController.enhanceCurrentBranches = function($branches) {
     if(index == 0) {
       branch.$node.find(".BranchRemover").eq(0).hide();
     }
+    
+    // Inject or statements between each of the branches 
+    if(index != 0) {
+      branch.$node.before("<p class=\"branch-or\">or</p>");
+    }
   });
 }
 
@@ -119,7 +124,7 @@ BranchesController.addBranchMenu = function(args) {
   var first = $(".Branch", $form).get(0) == branch.$node.get(0);
   if(!first) {
     new ActivatedMenu($ul, {
-      activator_text: "Activator text here",
+      activator_text: "Edit branch",
       container_classname: "SomeClassName",
       container_id: utilities.uniqueString("activated-menu-"),
       menu: {

--- a/app/javascript/src/controller_branches.js
+++ b/app/javascript/src/controller_branches.js
@@ -52,6 +52,8 @@ class BranchesController extends DefaultController {
    /* Setup view for the create (new) action
    **/
   create() {
+    var view = this;
+
     var $branches = $(BRANCH_SELECTOR).not(BRANCH_OTHERWISE_SELECTOR);
     var $injectors = $(BRANCH_INJECTOR_SELECTOR);
     var $otherwise = $(BRANCH_OTHERWISE_SELECTOR + " " + BRANCH_DESTINATION_SELECTOR);
@@ -62,6 +64,8 @@ class BranchesController extends DefaultController {
     BranchesController.enhanceCurrentBranches.call(this, $branches);
     BranchesController.enhanceBranchInjectors.call(this, $injectors);
     BranchesController.enhanceBranchOtherwise.call(this, $otherwise);
+
+    addBranchEventListeners(view)
   }
 }
 
@@ -78,11 +82,7 @@ BranchesController.enhanceCurrentBranches = function($branches) {
     if(index == 0) {
       branch.$node.find(".BranchRemover").eq(0).hide();
     }
-    
-    // Inject or statements between each of the branches 
-    if(index != 0) {
-      branch.$node.before("<p class=\"branch-or\">or</p>");
-    }
+
   });
 }
 
@@ -156,6 +156,7 @@ BranchesController.createBranch = function($node) {
     template_condition: this._branchConditionTemplate,
     event_on_create: function(branch) {
       BranchesController.addBranchMenu(branch);
+      BranchesController.addBranchCombinator(branch);
     },
     event_question_change: function() {
       if(this.$node.find(".BranchAnswer").length > 0) {
@@ -174,6 +175,26 @@ BranchesController.createBranch = function($node) {
   }
   this._branchCount++;
   return branch;
+}
+
+BranchesController.addBranchCombinator = function(args) {
+  var branch = args[0];
+  if( !branch.index == 0 ) {
+    branch.$node.before("<p class=\"branch-or\">or</p>");
+  }
+}
+
+BranchesController.removeBranchCombinator = function(node) {
+    var $or = $(node).prev('.branch-or').first();
+    if($or) {
+      $or.remove()
+    }
+}
+
+function addBranchEventListeners(view) {
+  view.$document.on('branchRemoved', function(event, node){
+    BranchesController.removeBranchCombinator.call(view, node);
+  });
 }
 
 
@@ -206,7 +227,6 @@ class BranchInjector {
       type: "after",
       done: function ($node) {
         BranchesController.createBranch.call(view, $node);
-        $node.before("<p class=\"branch-or\">or</p>");
       }
     });
   }

--- a/app/javascript/src/controller_branches.js
+++ b/app/javascript/src/controller_branches.js
@@ -52,8 +52,6 @@ class BranchesController extends DefaultController {
    /* Setup view for the create (new) action
    **/
   create() {
-    var view = this;
-
     var $branches = $(BRANCH_SELECTOR).not(BRANCH_OTHERWISE_SELECTOR);
     var $injectors = $(BRANCH_INJECTOR_SELECTOR);
     var $otherwise = $(BRANCH_OTHERWISE_SELECTOR + " " + BRANCH_DESTINATION_SELECTOR);
@@ -61,11 +59,10 @@ class BranchesController extends DefaultController {
     this._branchCount = 0;
     this._branchConditionTemplate = createBranchConditionTemplate($branches.eq(0));
 
+    BranchesController.addBranchEventListeners(this)
     BranchesController.enhanceCurrentBranches.call(this, $branches);
     BranchesController.enhanceBranchInjectors.call(this, $injectors);
     BranchesController.enhanceBranchOtherwise.call(this, $otherwise);
-
-    BranchesController.addBranchEventListeners(view)
   }
 }
 
@@ -117,8 +114,8 @@ BranchesController.enhanceBranchOtherwise = function($otherwise) {
 /* Find branch menu element and wrap with ActivatedMenu
  * functionality.
  **/
-BranchesController.addBranchMenu = function(args) {
-  var branch = args[0];
+BranchesController.addBranchMenu = function(branch) {
+  //var branch = args[0];
   var $form = branch.$node.parent("form");
   var $ul = branch.$node.find(".component-activated-menu");
   var first = $(".Branch", $form).get(0) == branch.$node.get(0);
@@ -154,18 +151,6 @@ BranchesController.createBranch = function($node) {
     expression_url: this.api.get_expression,
     question_label: this.text.branches.label_question_and,
     template_condition: this._branchConditionTemplate,
-    event_on_create: function(branch) {
-      BranchesController.addBranchMenu(branch);
-      BranchesController.addBranchCombinator(branch);
-    },
-    event_question_change: function() {
-      if(this.$node.find(".BranchAnswer").length > 0) {
-        this.$node.find(".BranchConditionInjector").show();
-      }
-      else {
-        this.$node.find(".BranchConditionInjector").hide();
-      }
-    },
     dialog_delete: view.dialogConfirmationDelete,
     view: view
   });
@@ -177,8 +162,7 @@ BranchesController.createBranch = function($node) {
   return branch;
 }
 
-BranchesController.addBranchCombinator = function(args) {
-  var branch = args[0];
+BranchesController.addBranchCombinator = function(branch) {
   if( branch.index != 0 ) {
     branch.$node.before("<p class=\"branch-or\">or</p>");
   }
@@ -191,6 +175,20 @@ BranchesController.removeBranchCombinator = function(node) {
 BranchesController.addBranchEventListeners = function(view) {
   view.$document.on('BranchRemove', function(event, node){
     BranchesController.removeBranchCombinator.call(view, node);
+  });
+
+  view.$document.on('BranchCreate', function(event, branch) {
+    BranchesController.addBranchMenu(branch);
+    BranchesController.addBranchCombinator(branch);
+  });
+
+  view.$document.on('BranchQuestionChange', function(event, branch) {
+    if(branch.$node.find(".BranchAnswer").length > 0) {
+      branch.$node.find(".BranchConditionInjector").show();
+    }
+    else {
+      branch.$node.find(".BranchConditionInjector").hide();
+    }
   });
 }
 

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -24,6 +24,7 @@
         section_heading: "<%= t('aria.section_heading') %>"
       },
       branches: {
+        branch_edit: "<%= t('branches.branch_edit') %>",
         branch_add: "<%= t('branches.branch_add') %>",
         condition_add: "<%= t('branches.condition_add') %>",
         condition_remove: "<%= t('branches.condition_remove') %>",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,6 +103,7 @@ en:
     ok: 'Ok'
   branches:
     branch_add: 'Add another branch'
+    branch_edit: 'Edit branch'
     branch_remove: 'Delete...'
     condition_add: 'Add condition'
     condition_remove: 'Remove condition'

--- a/test/component_branch_test.js
+++ b/test/component_branch_test.js
@@ -148,14 +148,14 @@ describe("Branch", function () {
       expect(global_test_branch.conditionInjector).to.exist;
     });
 
+    it("should make the index value public", function() {
+      expect(global_test_branch.index).to.exist;
+      expect(global_test_branch.index).to.equal(INDEX_BRANCH);
+    });
+
     it("should make (public but indicated as) private reference to config", function() {
       expect(global_test_branch._config).to.exist;
       expect(global_test_branch._config.selector_condition).to.equal(BRANCH_CONDITION_SELECTOR);
-    });
-
-    it("should make (public but indicated as) private reference to index value", function() {
-      expect(global_test_branch._index).to.exist;
-      expect(global_test_branch._index).to.equal(INDEX_BRANCH);
     });
 
     it("should make (public but indicated as) private reference to condition counter value", function() {

--- a/test/component_branch_test.js
+++ b/test/component_branch_test.js
@@ -162,6 +162,11 @@ describe("Branch", function () {
       expect(global_test_branch._conditionCount).to.exist;
       expect(global_test_branch._conditionCount).to.equal(1);
     });
+
+    it("should make (public but indicated as) private index value", function() {
+      expect(global_test_branch._index).to.exist;
+      expect(global_test_branch._index).to.equal(INDEX_BRANCH);
+    });
   });
 
   describe("BranchCondition", function() {


### PR DESCRIPTION
Injects 'ors' between branches when editing an existing branching point. [ticket 2255](https://trello.com/c/AGJrD9N8/2255-or-statement-doesnt-show-between-branches-4-xs)

Before:
<img width="739" alt="image" src="https://user-images.githubusercontent.com/595564/152163877-2505538d-8b8a-43a3-a878-007146d8ad41.png">

After:
<img width="770" alt="image" src="https://user-images.githubusercontent.com/595564/152163954-28d5373e-39bf-4478-aca6-6da67f77a6d5.png">

Also removes the 'ors' when deleting a branch.  This also fixes a bug where if you added and then deleted a branch when creating branching, you'd see double 'ors'

Result after adding and immediately deleting a branch before:
<img width="806" alt="image" src="https://user-images.githubusercontent.com/595564/152164231-4e7ebb0f-c228-4c24-874c-8428de20e721.png">

Now:
<img width="779" alt="image" src="https://user-images.githubusercontent.com/595564/152164412-d76e62e6-e6b1-4f35-8ed5-6a59b4aa163b.png">



