### PR TITLE
Update scrolling method to match latest design requirement

### DIFF
--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -886,7 +886,7 @@ function adjustOverlappingFlowConnectorPaths($overview) {
   var $paths = $overview.find(".FlowConnectorPath").not(".ForwardPath, .DownForwardPath"); // Filter out Paths we can ignore to save some processing time
   var somethingMoved;
   var numberOfPaths = $paths.length;
-  var keepChecking = true;
+  var keepChecking = $paths.length > 1;
   var loopCount = 1;
 
   do {

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -653,6 +653,7 @@ function applyContentScrolling(view) {
     timeout = setTimeout(function() {
       $container.get(0).style = ""; // reset everything
       adjustScrollDimensionsAndPosition($container);
+      $container.css("padding-bottom", spacing + "px"); // HACK! Seems to be losing this on resize so just adding it here
       $main.css("visibility", "visible");
     }, 750);
   });
@@ -674,7 +675,7 @@ function adjustScrollDimensionsAndPosition($container) {
     // position container width to max left and constrain width
     $container.css({
       left: ~(offsetLeft - margin) + "px",
-      padding: "0 " + menuSpacer + " 0 0", // 100 is just arbitrary  extra spacing for opening menus
+      "padding-right": menuSpacer + "px",
       width: viewWidth + "px"
     });
   }

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -409,19 +409,6 @@ function layoutDetachedItemsOveriew(view) {
   // Make sure it's open on page load
   expander.open();
 
-  // Expand the width of the section.
-  $container.css({
-    left:  ~(offsetLeft),
-    position: "relative",
-    width: window.innerWidth
-  });
-
-  // Compensate for previous change.
-  $title.css({
-    left: offsetLeft + "px",
-    position: "relative"
-  });
-
   // Add required scrolling to layout groups.
   $(".flow-detached-group", $container).each(function() {
     var $group = $(this);

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -54,6 +54,7 @@ ServicesController.edit = function() {
   var view = this; // Just making it easlier to understand the context.
   view.$flowOverview = $("#flow-overview");
   view.$flowDetached = $("#flow-detached");
+  view.$flowStandalone = $("#flow-standalone-pages");
 
   createPageAdditionDialog(view);
   createPageAdditionMenu(view);
@@ -66,6 +67,8 @@ ServicesController.edit = function() {
   if(view.$flowDetached.length) {
     layoutDetachedItemsOveriew(view);
   }
+
+  applyContentScrolling(view);
 
   // Reverse the Brief flash of content quickfix.
   $("#main-content").css("visibility", "visible");
@@ -373,7 +376,6 @@ function layoutFormFlowOverview(view) {
   adjustBranchConditionPositions($container);
   adjustOverviewHeight($container);
   adjustOverviewWidth($container);
-  applyOverviewScroll($container);
 }
 
 
@@ -431,7 +433,6 @@ function layoutDetachedItemsOveriew(view) {
     adjustBranchConditionPositions($group);
     adjustOverviewHeight($group);
     adjustOverviewWidth($group);
-    applyOverviewScroll($group);
   });
 }
 
@@ -609,20 +610,43 @@ function adjustOverviewWidth($overview) {
 
 /* VIEW HELPER FUNCTION:
  * ---------------------
- * To try and fix scrolling issues for the form overview
- * when there are too many thumbnails to fix on the one page view.
+ * To try and fix scrolling issues for the ServicresEdit page
+ * when flow overview areas extend beyond the restricted width
+ * of the main content area.
+ * @view (Object) Reference to the overall view instance of Services#edit action.
  **/
-function applyOverviewScroll($overview) {
+function applyContentScrolling(view) {
   var $container = $("<div></div>");
   var $main = $("#main-content");
+  var $footer = $("footer");
+  var marginBottomMain = Number($main.css("margin-bottom").replace("px", ""));
+  var paddingBottomMain = Number($main.css("padding-bottom").replace("px", ""));
+  var paddingTopFooter = Number($footer.css("padding-top").replace("px", ""));
+  var spacing = marginBottomMain + paddingBottomMain + paddingTopFooter;
   var timeout;
 
-  $container.addClass("FlowOverviewScrollFrame");
-  $overview.before($container);
-  $container.append($overview);
+  // Make adjustments to layout elements.
+  $container.addClass("ServicesContentScrollContainer");
+  view.$flowOverview.before($container);
+  $container.append(view.$flowOverview);
+  $container.append(view.$flowDetached);
+  $container.append(view.$flowStandalone);
 
+  // Would prefer this in stylesheet but doing it here
+  // to detect and copy any GDS dynamic values in use.
+  $container.css("padding-bottom", spacing + "px");
+  $footer.css("padding-top", 0);
+  $main.css({
+    "margin-bottom": 0,
+    "padding-bottom": 0
+  });
+
+
+  // Make adjustments based on content.
   adjustScrollDimensionsAndPosition($container);
 
+
+  // So the dimension self-correct upon browser resizing (or tablet rotate).
   $(window).on("resize", function() {
     clearTimeout(timeout);
     $main.css("visibility", "hidden");
@@ -630,7 +654,7 @@ function applyOverviewScroll($overview) {
       $container.get(0).style = ""; // reset everything
       adjustScrollDimensionsAndPosition($container);
       $main.css("visibility", "visible");
-    }, 1500);
+    }, 750);
   });
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -533,6 +533,13 @@ html {
   }
 }
 
+.ServicesContentScrollContainer {
+  // Due to layout element of GDS templates, the scroll dimensions
+  // need to be calculated by JS (cannot just use width:100%).
+  overflow-x: auto;
+  overflow-y: hidden;
+  position: relative;
+}
 
 .FlowConnectorLine,
 .FlowConnectorPath {
@@ -585,13 +592,6 @@ html {
   overflow: hidden;
   position: absolute;
   top: calc(125px - 43px);
-}
-
-.FlowOverviewScrollFrame {
-  // Dimensions are calculated by JS
-  overflow-x: auto;
-  overflow-y: hidden;
-  position: relative;
 }
 
 .flow-add-page-button {
@@ -787,7 +787,6 @@ html {
   }
 
   .flow-detached-group {
-    margin: 0 30px;
     position: relative;
   }
 }

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -42,16 +42,6 @@ html {
 #main-content {
   position: relative;
   min-height: 55vh;
-
-  // Quickfix for Brief flash of content not ready for display.
-  // This can be reversed when slow or view reliant JS has
-  // finished running. We're using the controller name + action
-  // so we can use it only where actually needed. Find the
-  // corresponding JS controller+action function to see where it
-  // is turned off/reversed.
-  &.services-edit {
-    visibility: hidden;
-  }
 }
 
 
@@ -780,10 +770,6 @@ html {
 
   h2 {
     display: inline-block;
-  }
-
-  .Expander_container {
-    @include govuk-width-container($govuk-page-width);
   }
 
   .flow-detached-group {


### PR DESCRIPTION
**Possibly not going to be used as an alternative method (in development) may be used instead.**

Scroll area now surrounds the content between the page title and footer.
Things look different depending on what kind of content is within a form. 
Some examples:

<img width="2048" alt="Screenshot 2022-02-09 at 09 40 28" src="https://user-images.githubusercontent.com/76942244/153169944-3cc2014e-e037-47ef-ac0e-592b220d1528.png">

<img width="2048" alt="Screenshot 2022-02-09 at 09 40 35" src="https://user-images.githubusercontent.com/76942244/153169991-77908dcf-6286-4684-97ac-eef3d429128d.png">

<img width="2048" alt="Screenshot 2022-02-09 at 09 40 42" src="https://user-images.githubusercontent.com/76942244/153170007-6db85eea-3503-4985-8ad9-c43b0dcdea97.png">

<img width="2048" alt="Screenshot 2022-02-09 at 09 40 48" src="https://user-images.githubusercontent.com/76942244/153170016-509eef78-324a-49aa-a7a2-100956acac70.png">

<img width="2048" alt="Screenshot 2022-02-09 at 09 40 55" src="https://user-images.githubusercontent.com/76942244/153170020-1e3c85d0-a5e3-47df-a867-bdb0158c7e08.png">

<img width="2048" alt="Screenshot 2022-02-09 at 09 41 01" src="https://user-images.githubusercontent.com/76942244/153170022-274c422d-364e-4213-b785-98492e7dd182.png">

