### PR TITLE
Add in missing forward-down-forward arrow

### DIFF
--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -948,6 +948,9 @@ function calculateAndCreatePageFlowConnectorPath(points, config) {
           new ConnectorPath.ForwardUpForwardDownPath(points, config);
         }
       }
+      else {
+        new ConnectorPath.ForwardDownForwardPath(points, config);
+      }
     }
     else {
       if(up) {


### PR DESCRIPTION
Adds in the missing forward down forward arrow.

Before:
<img width="908" alt="image" src="https://user-images.githubusercontent.com/595564/152960903-4464ba44-fe84-4a7e-942a-10b736087989.png">


After:
<img width="878" alt="image" src="https://user-images.githubusercontent.com/595564/152960755-60b29ebd-4221-440f-baf0-7b0918a4002e.png">

