### PR TITLE
add correct classes to cancel button to allow it to trigger modal close

### DIFF
--- a/app/views/api/branches/destroy_message.html.erb
+++ b/app/views/api/branches/destroy_message.html.erb
@@ -21,7 +21,8 @@
     <div class="ui-dialog-buttonpane ui-widget-content ui-helper-clearfix">
       <div class="ui-dialog-buttonset">
         <%= f.submit t('branches.delete_modal.submit'), class: 'govuk-button fb-govuk-button' %>
-        <button type="button" class="ui-button ui-corner-all ui-widget"><%= t('dialogs.cancel') %></button>
+        <button type="button" class="govuk-button govuk-button--secondary ui-button"><%= t('dialogs.cancel') %></button>
+
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
Very simple PR to add the correct css classes to the cancle button in the delete branch modal in order ensure the event listener for triggering modal closure is attached. 