### PR TITLE
Unconnected section layout

### DIFF
--- a/app/javascript/src/component_expander.js
+++ b/app/javascript/src/component_expander.js
@@ -68,12 +68,14 @@ class Expander {
 
   open() {
     this.$node.addClass("open");
+    this.$node.removeClass("close");
     this.$container.slideDown({ duration: this._config.duration });
     this.$container.attr("aria-expanded", true);
     this._config.opened = true;
   }
 
   close() {
+    this.$node.addClass("close");
     this.$node.removeClass("open");
     this.$container.slideUp({ duration: this._config.duration });
     this.$container.attr("aria-expanded", false);

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -424,7 +424,7 @@ function layoutDetachedItemsOveriew(view) {
   $(".flow-detached-group", $container).each(function() {
     var $group = $(this);
     createAndPositionFlowItems($group);
-    adjustOverviewHeight($container);
+    adjustOverviewHeight($group);
     applyPageFlowConnectorPaths($group);
     applyBranchFlowConnectorPaths($group);
     adjustOverlappingFlowConnectorPaths($group);

--- a/app/javascript/styles/_component_expander.scss
+++ b/app/javascript/styles/_component_expander.scss
@@ -13,6 +13,10 @@
 
 
 .Expander {
+  &.close {
+    height: auto;
+  }
+
   &.open .Expander_Activator {
     &:before {
       position: relative;


### PR DESCRIPTION
https://trello.com/c/HHYMcdvi/2254-unconnected-section-layout-1

Reduce spacing below detached area caused by height setting applied to incorrect element, which resulted in messing with the expanding component in play. 


**Open section (before and after fix)**
(ignoring alignment it has changed within PR https://github.com/ministryofjustice/fb-editor/pull/1190)
<img width="1395" alt="Screenshot 2022-02-09 at 14 05 09" src="https://user-images.githubusercontent.com/76942244/153217607-bf4e568e-c0fd-4614-a4b4-eff4d496a0d9.png">


**Was (on closed section)**
<img width="753" alt="Screenshot 2022-02-09 at 14 05 55" src="https://user-images.githubusercontent.com/76942244/153217386-6c97ddb3-a2b0-414d-b0a3-123bb56274a4.png">

**Now (on closed section)**
<img width="1114" alt="Screenshot 2022-02-09 at 14 05 19" src="https://user-images.githubusercontent.com/76942244/153217442-a048f3b0-0fc4-4ef7-8f11-088536715c90.png">
