### PR TITLE
Distinguish unconnected pages in Change Destination modal

### DIFF
--- a/acceptance/features/change_destination_spec.rb
+++ b/acceptance/features/change_destination_spec.rb
@@ -13,21 +13,35 @@ feature 'Deleting page' do
   scenario 'change destination to another page' do
     given_I_want_to_change_destination_of_a_page('Page b')
     when_I_change_destination_to_page('Page j')
+    then_I_should_not_see_unconnected_pages
     then_page_j_should_be_after_page_b
     then_some_pages_should_be_unconnected
+    given_I_want_to_change_destination_of_a_page('Page b')
+    then_I_should_see_unconnected_pages
   end
 
   scenario 'change destination in the middle of a branch' do
     given_I_want_to_change_destination_of_a_page('Page b')
     when_I_change_destination_to_page('Page d')
+    then_I_should_not_see_unconnected_pages
     then_page_d_should_be_after_page_b
     and_the_branching_should_be_unconnected
+    given_I_want_to_change_destination_of_a_page('Page b')
+    then_I_should_see_unconnected_pages
   end
 
   def given_I_want_to_change_destination_of_a_page(page)
     editor.hover_preview(page)
     editor.three_dots_button.click
     editor.change_destination_link.click
+  end
+
+  def then_I_should_not_see_unconnected_pages
+    expect(editor).not_to have_selector('.destination-optgroup')
+  end
+
+  def then_I_should_see_unconnected_pages
+    expect(editor).to have_selector('.destination-optgroup')
   end
 
   def when_I_change_destination_to_page(page)

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -25,6 +25,14 @@ class Destination
     service.flow_object(flow_uuid).default_next
   end
 
+  def main_destinations
+    destinations_list(flow_objects: grid.ordered_flow)
+  end
+
+  def detached_destinations
+    destinations_list(flow_objects: detached_objects)
+  end
+
   private
 
   def grid
@@ -32,6 +40,9 @@ class Destination
   end
 
   def detached_objects
-    Detached.new(service: service, main_flow_uuids: grid.flow_uuids).flow_objects
+    Detached.new(
+      service: service,
+      main_flow_uuids: grid.flow_uuids
+    ).flow_objects
   end
 end

--- a/app/views/api/destinations/new.html.erb
+++ b/app/views/api/destinations/new.html.erb
@@ -6,17 +6,26 @@
         <%= t('dialogs.destination.lede', title: @destination.title) %>
       </span>
       <span><%= t('dialogs.destination.go_to') %></span>
-      <%= f.select :destination_uuid, @destination.destinations,
-        {
-          include_blank: false,
-          selected: @destination.current_destination
-        },
-        {
-          class: 'govuk-select',
-          name: 'destination_uuid',
-          id: 'destination_uuid'
-        }
-      %>
+       <div class="govuk-form-group">
+        <select class="govuk-select" name="destination_uuid" id="destination_uuid">
+          <%= render partial: "branches/destinations_list",
+                    locals: {
+                      destinations: @destination.main_destinations,
+                      selected: @destination.current_destination
+                    }
+          %>
+          <% if @destination.detached_destinations.present? %>
+            <optgroup class="destination-optgroup" label="<%= t('branches.detached_list') %>">
+              <%= render partial: "branches/destinations_list",
+                        locals: {
+                          destinations: @destination.detached_destinations,
+                          selected: @destination.current_destination
+                        }
+              %>
+            </optgroup>
+          <% end %>
+        </select>
+      </div>
     </div>
     <p><%= t('dialogs.destination.text') %></p>
   <% end %>

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -139,6 +139,56 @@ RSpec.describe Destination do
     end
   end
 
+  describe '#main_destination' do
+    let(:latest_metadata) do
+      metadata = metadata_fixture('branching')
+      checkanswers = metadata['pages'].find { |p| p['_type'] == 'page.checkanswers' }
+      obj = metadata['flow']['0b297048-aa4d-49b6-ac74-18e069118185'] # Favourite fruit
+      obj['next']['default'] = checkanswers['_uuid']
+      metadata
+    end
+    let(:expected_destinations) do
+      [
+        'Full name',
+        'Do you like Star Wars?',
+        'Branching point 1',
+        'How well do you know Star Wars?',
+        'What is your favourite fruit?',
+        'Check your answers'
+      ]
+    end
+
+    it 'returns destinations without detached pages' do
+      expect(destination.main_destinations.map(&:first)).to eq(expected_destinations)
+    end
+  end
+
+  describe '#detached_destinations' do
+    let(:latest_metadata) do
+      metadata = metadata_fixture('branching')
+      checkanswers = metadata['pages'].find { |p| p['_type'] == 'page.checkanswers' }
+      obj = metadata['flow']['dc7454f9-4186-48d7-b055-684d57bbcdc7'] # What is the best Marvel series?
+      obj['next']['default'] = checkanswers['_uuid']
+      metadata
+    end
+    let(:expected_destinations) do
+      [
+        'Branching point 6',
+        'Loki',
+        'Other quotes',
+        'Select all Arnold Schwarzenegger quotes',
+        'Branching point 7',
+        'You are wrong',
+        'You are right',
+        'You are wrong'
+      ]
+    end
+
+    it 'returns destinations without detached pages' do
+      expect(destination.detached_destinations.map(&:first)).to eq(expected_destinations)
+    end
+  end
+
   context 'when there are different branches pointing to the same page' do
     let(:page_flow) do
       service.flow_object(service.find_page_by_url('name').uuid)


### PR DESCRIPTION
[Trello](https://trello.com/c/LcdnNJiz/2284-change-next-page-modal-should-distinguish-pages-that-are-unconnected-2-xs)

# Distinguish unconnected pages in Change Destination modal

## Before
![before list](https://user-images.githubusercontent.com/29227502/153412105-5097fe24-3402-4d9d-948c-c76e3b61b302.png)
![before](https://user-images.githubusercontent.com/29227502/153412117-69302381-853b-48d9-a0d4-7241da0bbcd2.png)

## After
![after list](https://user-images.githubusercontent.com/29227502/153412172-b98a0af9-1f77-448e-b6e0-dd8cecf8ced5.png)
![Screenshot 2022-02-10 at 12 58 15](https://user-images.githubusercontent.com/29227502/153413161-e63c3b75-872b-438e-98cc-9242f0dacd54.png)