### PR TITLE
Use Alpine 3.13 and Node 14.19.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: Swap node versions
           command: |
             set +e
-            wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
+            wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ jobs:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-            nvm install v16.13.2
-            nvm alias default 16.13.2
+            nvm install v14.19.0
+            nvm alias default 14.19.0
 
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ New editor from the MoJ online.
 
 ## Prerequisites
 * Docker
-* Node (version 16.13.2)
+* Node (version 14.19.0 LTS)
 * Ruby v2.7.5
 * Postgresql
 * Yarn
 
 ## Setup
-Ensure you are running on Node version 16.13.2:
-`nvm use 16.13.2`
+Ensure you are running Node version 14.19.0 LTS. Easiest is to install [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) and then:
+`nvm install 14.19.0`
+`nvm use 14.19.0`
 
 Install gems:
 `bundle`

--- a/acceptance/Dockerfile
+++ b/acceptance/Dockerfile
@@ -1,11 +1,11 @@
-FROM ruby:2.7.5-alpine3.15
+FROM ruby:2.7.5-alpine3.13
 
 ARG UID=1001
 
 RUN apk add git yarn build-base postgresql-contrib postgresql-dev bash libcurl
 RUN apk add build-base bash tzdata chromium-chromedriver chromium zlib-dev xorg-server
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=16.13.2-r0 npm
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs npm
 
 WORKDIR /usr/src/app
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,11 +1,12 @@
-FROM ruby:2.7.5-alpine3.15
+FROM ruby:2.7.5-alpine3.13
 
 ARG UID=1001
 
+RUN apk update
 RUN apk add git yarn build-base postgresql-contrib postgresql-dev \
       bash libcurl curl
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=16.13.2-r0 npm
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs npm
 
 RUN addgroup -g ${UID} -S appgroup && \
   adduser -u ${UID} -S appuser -G appgroup

--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -1,10 +1,10 @@
-FROM ruby:2.7.5-alpine3.15
+FROM ruby:2.7.5-alpine3.13
 
 ARG UID=1001
 
 RUN apk add git yarn build-base postgresql-contrib postgresql-dev bash libcurl curl
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=16.13.2-r0 npm
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs npm
 
 ARG KUBE_VERSION="1.18.2"
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fb_editor",
   "private": true,
   "engines": {
-    "node": "16.13.2"
+    "node": ">=14.19.0"
   },
   "scripts": {
     "jstest": "mocha"


### PR DESCRIPTION
Stop pinning the Node version and just install the LTS version.

Using Alpine 3.13 just passing `nodejs` when adding the APK
package will retrieve version 14.19.0 at time of writing.

Using Alpine 3.15 retrieves version 16.XX.XX. Currently using this
version of Alpine we have an issue where the `WORKDIR` is ignored when
creating the container and dependencies are instead installed to a temp
directory which the container has no permissions to use.

Until we can debug why this is happening further just move back to using
Alpine 3.13 and Node 14.19.0.