### PR TITLE
Do not show page being changed in destination list

### DIFF
--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -26,11 +26,11 @@ class Destination
   end
 
   def main_destinations
-    destinations_list(flow_objects: grid.ordered_flow)
+    destinations_list(flow_objects: grid.ordered_flow, current_uuid: flow_uuid)
   end
 
   def detached_destinations
-    destinations_list(flow_objects: detached_objects)
+    destinations_list(flow_objects: detached_objects, current_uuid: flow_uuid)
   end
 
   private

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -149,7 +149,6 @@ RSpec.describe Destination do
     end
     let(:expected_destinations) do
       [
-        'Full name',
         'Do you like Star Wars?',
         'Branching point 1',
         'How well do you know Star Wars?',


### PR DESCRIPTION
When a user is changing the destination of a page we do not want that
page to be listed in the destination list. This avoids the user creating
a loop back onto the same page constantly.