### PR TITLE
Publish forms to EKS cluster

### DIFF
--- a/config/publisher/cloud_platform/ingress.yaml.erb
+++ b/config/publisher/cloud_platform/ingress.yaml.erb
@@ -13,7 +13,7 @@ metadata:
         deny all;
         return 401;
       }
-    external-dns.alpha.kubernetes.io/set-identifier: <%= service_slug %>-ingress-<%= namespace %>-blue
+    external-dns.alpha.kubernetes.io/set-identifier: <%= service_slug %>-ingress-<%= namespace %>-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:

--- a/spec/fixtures/kubernetes_configuration/ingress.yaml
+++ b/spec/fixtures/kubernetes_configuration/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
         deny all;
         return 401;
       }
-    external-dns.alpha.kubernetes.io/set-identifier: acceptance-tests-date-ingress-formbuilder-services-test-dev-blue
+    external-dns.alpha.kubernetes.io/set-identifier: acceptance-tests-date-ingress-formbuilder-services-test-dev-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:


### PR DESCRIPTION
Set the identifier to green in order for ingress to point to the EKS
cluster when a service is published out.