### PR TITLE
Fix incorrect flow view heigh in Safari 

### DIFF
--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -365,7 +365,6 @@ function layoutFormFlowOverview(view) {
   if(!view.features.branching) {
     positionAddPageButton();
   }
-
   adjustOverviewHeight($container);
   applyPageFlowConnectorPaths($container);
   applyBranchFlowConnectorPaths($container);
@@ -554,13 +553,15 @@ function adjustOverviewHeight($overview) {
   var topNumbers = [];
   var top, bottom, topOverlap, height;
 
-  $items.each(function() {
+  $items.each(function(index) {
     var $item = $(this);
-    var top = Math.ceil($item.offset().top);
+    // jquery.offset() always returns 0,0 in Safari for scg elements
+    // so we use native getBoundingClientRect instead which returns correct values
+    var top = $item[0].getBoundingClientRect().y + window.scrollY;
     bottomNumbers.push(top + $item.height());
     topNumbers.push(top);
   });
-
+  
   top = utilities.lowestNumber(topNumbers);
   bottom = utilities.highestNumber(bottomNumbers);
   topOverlap = $overview.offset().top - top;
@@ -576,7 +577,7 @@ function adjustOverviewHeight($overview) {
   // Adjustment to make the height over overview area contain the height
   // of all flow items and paths within it.
   if(height > $overview.height()) {
-    $overview.css("height", (bottom - top) + "px");
+    $overview.css("height", height + "px");
   }
 }
 


### PR DESCRIPTION
Resolves [ticket #2290](https://trello.com/c/mki504X3/2290-safari-only-unwanted-large-vertical-gaps-in-flow-view-45)

Using jQuery offset() function on an SVG element always returns 0,0 in Safari [a known jQuery bug, that they won't fix] 

Solved by using native getBoundingClientRect() which works on SVG elements.

Flow heights now match across Safari and Firefox  (within 4px)


**Before:**
<img width="1703" alt="image" src="https://user-images.githubusercontent.com/595564/154670332-90d2de3d-23f0-4031-86c2-d9d205e6ab15.png">



**After:**
<img width="1695" alt="image" src="https://user-images.githubusercontent.com/595564/154670362-23ee1b46-33ea-412c-9cb3-d6a6053e5123.png">


