### PR TITLE
Conditionally show hide answers on branch conditions

### DIFF
--- a/acceptance/features/new_branch_page_spec.rb
+++ b/acceptance/features/new_branch_page_spec.rb
@@ -48,7 +48,16 @@ feature 'New branch page' do
       'is answered'
     )
 
-    and_I_select_the_field_dropdown
+    then_I_should_not_see_field_options('Hiking')
+
+    and_I_select_the_operator_dropdown
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][operator]',
+      'is'
+    )
+
+    then_I_should_see_the_first_field_options('Hiking')
+
     then_I_should_see_the_correct_number_of_options(
       '#branch_conditionals_attributes_0_expressions_attributes_0_field',
       2
@@ -75,7 +84,7 @@ feature 'New branch page' do
     then_I_should_be_on_the_correct_branch_page('edit')
     then_I_should_see_previous_saved_choices(
       'branch[conditionals_attributes][0][expressions_attributes][0][operator]',
-      'is answered'
+      'is'
     )
     then_I_should_see_previous_saved_choices(
       'branch[conditionals_attributes][0][expressions_attributes][0][field]',

--- a/acceptance/support/branching_steps.rb
+++ b/acceptance/support/branching_steps.rb
@@ -92,6 +92,14 @@ module BranchingSteps
     expect(options.length).to eq(amount)
   end
 
+  def then_I_should_not_see_field_options(text)
+    page_without_css('.govuk-select', text)
+  end
+
+  def then_I_should_see_the_first_field_options(text)
+    expect(page).to have_css('.govuk-select', text: text)
+  end
+
   def and_I_choose_an_option(name, option)
     select(option, from: name)
   end

--- a/app/javascript/src/component_branch.js
+++ b/app/javascript/src/component_branch.js
@@ -312,6 +312,24 @@ class BranchAnswer {
     $node.data("instance", this);
     this._config = conf;
     this.$node = $node;
+    
+    this.showHideAnswers();
+
+    this.$node.find('[data-expression-operator]').on('change', (event) =>  {
+      this.showHideAnswers();
+    }); 
+  }
+
+  showHideAnswers() {
+    var $condition = this.$node.find('[data-expression-operator]');
+    var $answer = this.$node.find('[data-expression-answer]');
+    var hideAnswers = $condition.find(':selected').data('hide-answers');
+
+    if(hideAnswers) {
+      $answer.hide();
+    } else {
+      $answer.show();
+    }
   }
 }
 

--- a/app/javascript/src/component_branch.js
+++ b/app/javascript/src/component_branch.js
@@ -327,6 +327,7 @@ class BranchAnswer {
 
     if(hideAnswers) {
       $answer.hide();
+      $answer.val([]);
     } else {
       $answer.show();
     }

--- a/app/javascript/src/component_branch.js
+++ b/app/javascript/src/component_branch.js
@@ -330,6 +330,7 @@ class BranchAnswer {
       $answer.val([]);
     } else {
       $answer.show();
+      $answer.val( $answer.find('option:first').val() );
     }
   }
 }

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -2,8 +2,8 @@ class Expression
   include ActiveModel::Model
   attr_accessor :component, :operator, :field, :page
 
-  validates :component, :operator, :page, :field, presence: true
-  validate :unsupported_component
+  validates :component, :operator, :page, presence: true
+  validate :unsupported_component, :blank_field
 
   OPERATORS = [
     [I18n.t('operators.is'), 'is', { 'data-hide-answers': 'false' }],
@@ -17,7 +17,7 @@ class Expression
       'operator' => operator,
       'page' => page&.uuid,
       'component' => component,
-      'field' => field
+      'field' => field_answer
     }
   end
 
@@ -57,6 +57,24 @@ class Expression
     if page.present? && component.present? && !component_object.supports_branching?
       errors.add(:component, message: I18n.t(
         'activemodel.errors.messages.unsupported_component'
+      ))
+    end
+  end
+
+  def field_answer
+    return field.to_s unless field_required?
+
+    field
+  end
+
+  def field_required?
+    operator == I18n.t('operators.is') || operator == I18n.t('operators.is_not')
+  end
+
+  def blank_field
+    if field_required? && field.nil?
+      errors.add(:operator, message: I18n.t(
+        'activemodel.errors.messages.blank'
       ))
     end
   end

--- a/app/views/branches/_expression_answers.html.erb
+++ b/app/views/branches/_expression_answers.html.erb
@@ -6,6 +6,7 @@
     },
     {
       class: 'govuk-select',
+      'data-expression-operator': '',
       name: expression.name_attr(
         conditional_index: conditional_index,
         expression_index: expression_index,
@@ -26,6 +27,7 @@
     },
     {
       class: 'govuk-select',
+      'data-expression-answer': '',
       name: expression.name_attr(
         conditional_index: conditional_index,
         expression_index: expression_index,

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -5,25 +5,50 @@ RSpec.describe Expression do
   let(:expression_hash) { {} }
 
   describe '#to_metadata' do
-    let(:expression_hash) do
-      {
-        'operator': 'is',
-        'page': double(uuid: 'some-page-uuid'),
-        'component': 'some-component-uuid',
-        'field': 'some-field-uuid'
-      }
-    end
-    let(:expected_expression) do
-      {
-        'operator' => 'is',
-        'page' => 'some-page-uuid',
-        'component' => 'some-component-uuid',
-        'field' => 'some-field-uuid'
-      }
+    context 'when field has an answer' do
+      let(:expression_hash) do
+        {
+          'operator': 'is',
+          'page': double(uuid: 'some-page-uuid'),
+          'component': 'some-component-uuid',
+          'field': 'some-field-uuid'
+        }
+      end
+      let(:expected_expression) do
+        {
+          'operator' => 'is',
+          'page' => 'some-page-uuid',
+          'component' => 'some-component-uuid',
+          'field' => 'some-field-uuid'
+        }
+      end
+
+      it 'returns the correct structure' do
+        expect(expression.to_metadata).to eq(expected_expression)
+      end
     end
 
-    it 'returns the correct structure' do
-      expect(expression.to_metadata).to eq(expected_expression)
+    context 'when field is nil' do
+      let(:expression_hash) do
+        {
+          'operator': 'is_answered',
+          'page': double(uuid: 'some-page-uuid'),
+          'component': 'some-component-uuid',
+          'field': nil
+        }
+      end
+      let(:expected_expression) do
+        {
+          'operator' => 'is_answered',
+          'page' => 'some-page-uuid',
+          'component' => 'some-component-uuid',
+          'field' => ''
+        }
+      end
+
+      it 'returns the correct structure' do
+        expect(expression.to_metadata).to eq(expected_expression)
+      end
     end
   end
 
@@ -150,6 +175,29 @@ RSpec.describe Expression do
         expect(errors.values.first).to include(
           I18n.t(
             'activemodel.errors.messages.unsupported_component'
+          )
+        )
+      end
+    end
+
+    context '#blank_field' do
+      let(:page) { service.find_page_by_url('do-you-like-star-wars') }
+      let(:expression_hash) do
+        {
+          'operator': 'is',
+          'page': page,
+          'component': page.components.first.uuid,
+          'field': nil
+        }
+      end
+
+      it 'returns the error message' do
+        errors = expression.errors.messages
+        expect(errors).to be_present
+        expect(errors.values.first).to include(
+          I18n.t(
+            'activemodel.errors.messages.blank',
+            attribute: Expression.human_attribute_name(:operator)
           )
         )
       end


### PR DESCRIPTION
Resolves [ticket #2252](https://trello.com/c/xFN9c4L4/2252-condition-using-a-checkbox-or-radio-button-operator-is-isnt-answered-shouldnt-have-the-answers-displayed-39-7-s)

When changing a condition to be `is_answered` or `is_not_answered` the question answers will be hidden, and the answer value set to empty.

When changing a branch back from `is_answered` or `is_not_answered` to `is` or `is_not` the answers will be revealed and the first option auto-selected.

Backend fixes ahve been applied to allow the answer value to be blank.  This also resolves [#2298](https://trello.com/c/h7jC72fU/2298-validation-of-condition-using-a-checkbox-or-radio-button-operator-is-isnt-answereds)

Before:
<img width="800" alt="image" src="https://user-images.githubusercontent.com/595564/154668341-871d0ee6-f808-4fb5-83b7-40c0240e2030.png">

After
<img width="758" alt="image" src="https://user-images.githubusercontent.com/595564/154668401-940c5829-9bd3-47aa-bee2-6615ab780e36.png">

<img width="634" alt="image" src="https://user-images.githubusercontent.com/595564/154669302-8d440d99-e437-438b-b3b4-2cb41b6d4da7.png">
