### PR TITLE
Reference deployments in HPA configuration

### DIFF
--- a/deploy-eks/fb-editor-chart/templates/hpa.yaml
+++ b/deploy-eks/fb-editor-chart/templates/hpa.yaml
@@ -2,13 +2,13 @@
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: fb-editor-{{ .Values.environmentName }}
+  name: fb-editor-web-{{ .Values.environmentName }}
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: fb-editor-{{ .Values.environmentName }}
+    name: fb-editor-web-{{ .Values.environmentName }}
   minReplicas: {{ .Values.hpa.web.minReplicas }}
   maxReplicas: {{ .Values.hpa.web.maxReplicas }}
   targetCPUUtilizationPercentage: {{ .Values.hpa.web.targetCPUUtilizationPercentage }}


### PR DESCRIPTION
The Editor has two types of deployments; web and workers. When
configuring a HPA it needs to be correctly pointed to the corresponding
deployment configuration otherwise it will not be applied correctly