### PR TITLE
Reenable Live deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -591,24 +591,24 @@ workflows:
       - acceptance_tests_no_branching_eks:
           requires:
             - deploy_to_test_no_branching_eks
-      # - slack/approval-notification:
-      #     message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
-      #     include_job_number_field: false
-      #     requires:
-      #       - acceptance_tests_no_branching
-      #       - acceptance_tests_no_branching_eks
-      # - confirm_live_deploy:
-      #     type: approval
-      #     requires:
-      #       - acceptance_tests_no_branching
-      #       - acceptance_tests_no_branching_eks
-      # - deploy_to_live_eks:
-      #     requires:
-      #       - confirm_live_deploy
-      # - deploy_to_live:
-      #     requires:
-      #       - confirm_live_deploy
-      #       - deploy_to_live_eks
+      - slack/approval-notification:
+          message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
+          include_job_number_field: false
+          requires:
+            - acceptance_tests_eks
+            - acceptance_tests_no_branching_eks
+      - confirm_live_deploy:
+          type: approval
+          requires:
+            - acceptance_tests_eks
+            - acceptance_tests_no_branching_eks
+      - deploy_to_live_eks:
+          requires:
+            - confirm_live_deploy
+      - deploy_to_live:
+          requires:
+            - confirm_live_deploy
+            - deploy_to_live_eks
   deploy_testable_branch:
     jobs:
       - build:

--- a/deploy-eks/fb-editor-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-editor-chart/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
         securityContext:
           runAsUser: 1001
         imagePullPolicy: Always
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sleep", "10"]
         ports:
           - containerPort: 3000
         livenessProbe:
@@ -164,6 +168,10 @@ spec:
         securityContext:
           runAsUser: 1001
         imagePullPolicy: Always
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sleep", "10"]
         ports:
           - containerPort: 3000
         # non-secret env vars


### PR DESCRIPTION
This puts back the deployment to the Live environment. The old cluster
ingress is set to 0 so traffic will be diverted to the editor running in
the new cluster.