### PR TITLE
Change testable Editors to deploy to EKS cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
             APPLICATION_NAME: fb-editor
             PLATFORM_ENV: test
             K8S_NAMESPACE: formbuilder-saas-test
-          command: './deploy-scripts/bin/deploy'
+          command: './deploy-scripts/bin/deploy-eks'
       - slack/status: *testable_slack_status
   remove_testable_editors:
     docker:
@@ -462,7 +462,7 @@ jobs:
       - run:
           name: Run acceptance tests
           command: |
-            EDITOR_APP=https://${CIRCLE_BRANCH}.apps.live-1.cloud-platform.service.justice.gov.uk
+            EDITOR_APP=https://${CIRCLE_BRANCH}.apps.live.cloud-platform.service.justice.gov.uk
             echo 'export ACCEPTANCE_TESTS_EDITOR_APP=$EDITOR_APP' >> $BASH_ENV
             echo 'export ACCEPTANCE_TESTS_USER=$ACCEPTANCE_TESTS_USER' >> $BASH_ENV
             echo 'export ACCEPTANCE_TESTS_PASSWORD=$ACCEPTANCE_TESTS_PASSWORD' >> $BASH_ENV
@@ -656,7 +656,7 @@ workflows:
           requires:
             - deploy_testable_branch
       - slack/approval-notification:
-          message: ":test_tube: :test_tube: :test_tube:\nSuccessfully deployed branch\nVisit: https://${CIRCLE_BRANCH}.apps.live-1.cloud-platform.service.justice.gov.uk\n:test_tube: :test_tube: :test_tube:"
+          message: ":test_tube: :test_tube: :test_tube:\nSuccessfully deployed branch\nVisit: https://${CIRCLE_BRANCH}.apps.live.cloud-platform.service.justice.gov.uk\n:test_tube: :test_tube: :test_tube:"
           include_job_number_field: false
           requires:
             - testable_branch_acceptance_tests


### PR DESCRIPTION
[Trello](https://trello.com/c/yWwe3NRo/2325-change-testable-editors-to-deploy-to-the-new-eks-cluster)

The testable editors currently only deploy to the old cluster.
The CircleCi config has been changed so that they deploy to the new EKS cluster instead.

Co-authored-by: Chris Pymm <chris.pymm@digital.justice.gov.uk>

![Screenshot 2022-02-21 at 15 26 19](https://user-images.githubusercontent.com/29227502/154985343-3a86d37e-d7fc-4e7a-b986-65de2f9eabff.png)