### PR TITLE
Add `contains` and `does_not_contain` operator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.15.10'
+gem 'metadata_presenter', '2.15.11'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.15.10)
+    metadata_presenter (2.15.11)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -427,7 +427,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.15.10)
+  metadata_presenter (= 2.15.11)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/acceptance/features/change_destination_spec.rb
+++ b/acceptance/features/change_destination_spec.rb
@@ -75,8 +75,8 @@ feature 'Deleting page' do
     expect(editor.unconnected_flow).to eq(
       [
         'Branching point 1',
-        'Page b is Thor',
-        'Page b is Hulk',
+        'Page b contains Thor',
+        'Page b contains Hulk',
         'Otherwise',
         'Page c',
         'Page d',
@@ -84,7 +84,7 @@ feature 'Deleting page' do
         'Page f',
         'Page g',
         'Branching point 2',
-        'Question 2 is Thor',
+        'Question 2 contains Thor',
         'Page h',
         'Page i',
         'Page j'
@@ -112,8 +112,8 @@ feature 'Deleting page' do
     page.driver.browser.manage.window.resize_to(30000, 1080)
     expect(editor.unconnected_flow).to eq([
       'Branching point 1',
-      'Page b is Thor',
-      'Page b is Hulk',
+      'Page b contains Thor',
+      'Page b contains Hulk',
       'Otherwise',
       'Page c',
       'Page e',

--- a/acceptance/support/branching_steps.rb
+++ b/acceptance/support/branching_steps.rb
@@ -260,14 +260,14 @@ module BranchingSteps
     # Go to page c if Page b is Thor
     editor.destination_options.select('Page c')
     editor.conditional_options.select('Page b')
-    editor.operator_options.select('is')
+    editor.operator_options.select('contains')
     editor.field_options.select('Thor')
 
     # Go to Page e if Page b is Hulk
     and_I_add_another_branch
     editor.second_destination_options.select('Page e')
     editor.second_conditional_options.select('Page b')
-    editor.second_operator_options.select('is')
+    editor.second_operator_options.select('contains')
     editor.second_field_options.select('Hulk')
 
     # Otherise go to Page g
@@ -286,8 +286,10 @@ module BranchingSteps
 
     # Go to page h if Page g is Thor
     editor.destination_options.select('Page h')
-    editor.conditional_options.select('Question 2')
+    editor.conditional_options.select('Question 1')
     editor.operator_options.select('is')
+    editor.conditional_options.select('Question 2')
+    editor.operator_options.select('contains')
     editor.field_options.select('Thor')
     #
     # Otherise go to Page i

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -8,6 +8,8 @@ class Expression
   OPERATORS = [
     [I18n.t('operators.is'), 'is', { 'data-hide-answers': 'false' }],
     [I18n.t('operators.is_not'), 'is_not', { 'data-hide-answers': 'false' }],
+    [I18n.t('operators.contains'), 'contains', { 'data-hide-answers': 'false' }],
+    [I18n.t('operators.does_not_contain'), 'does_not_contain', { 'data-hide-answers': 'false' }],
     [I18n.t('operators.is_answered'), 'is_answered', { 'data-hide-answers': 'true' }],
     [I18n.t('operators.is_not_answered'), 'is_not_answered', { 'data-hide-answers': 'true' }]
   ].freeze
@@ -29,7 +31,7 @@ class Expression
     component_object.items.map { |item| [item.label, item.uuid] }
   end
 
-  def operators
+  def all_operators
     OPERATORS
   end
 
@@ -45,6 +47,12 @@ class Expression
   def id_attr(conditional_index:, expression_index:, attribute:)
     "branch_conditionals_attributes_#{conditional_index}_" \
     "expressions_attributes_#{expression_index}_#{attribute}"
+  end
+
+  def operators
+    return contains_operators if is_checkbox?
+
+    is_operators
   end
 
   private
@@ -77,5 +85,21 @@ class Expression
         'activemodel.errors.messages.blank'
       ))
     end
+  end
+
+  def contains_operators
+    @contains_operators ||= all_operators.select do |operator|
+      operator.exclude?(I18n.t('operators.is')) && operator.exclude?(I18n.t('operators.is_not'))
+    end
+  end
+
+  def is_operators
+    @is_operators ||= all_operators.select do |operator|
+      operator.exclude?(I18n.t('operators.contains')) && operator.exclude?(I18n.t('operators.does_not_contain'))
+    end
+  end
+
+  def is_checkbox?
+    component_type == 'checkboxes'
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -299,6 +299,8 @@ en:
   operators:
     is: is
     is_not: is not
+    contains: contains
+    does_not_contain: does not contain
     is_answered: is answered
     is_not_answered: is not answered
   footer:

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -77,11 +77,66 @@ RSpec.describe Expression do
     end
   end
 
-  describe '#operators' do
+  describe '#all_operators' do
     let(:expected_operators) { Expression::OPERATORS }
 
     it 'returns all the operators' do
-      expect(expression.operators).to eq(expected_operators)
+      expect(expression.all_operators).to eq(expected_operators)
+    end
+  end
+
+  describe '#operators' do
+    let(:metadata) { metadata_fixture(:branching) }
+    let(:service) { MetadataPresenter::Service.new(metadata) }
+
+    context 'when component type is checkboxes' do
+      let(:page) { service.find_page_by_url('burgers') }
+      let(:component) { page.components.find { |component| component.type == 'checkboxes' } }
+      let(:expression_hash) do
+        {
+          'operator': 'contains',
+          'page': page,
+          'component': component.uuid,
+          'field': 'some-field-uuid'
+        }
+      end
+      let(:expected_operators) do
+        [
+          [I18n.t('operators.contains'), 'contains', { 'data-hide-answers': 'false' }],
+          [I18n.t('operators.does_not_contain'), 'does_not_contain', { 'data-hide-answers': 'false' }],
+          [I18n.t('operators.is_answered'), 'is_answered', { 'data-hide-answers': 'true' }],
+          [I18n.t('operators.is_not_answered'), 'is_not_answered', { 'data-hide-answers': 'true' }]
+        ]
+      end
+
+      it 'returns the expected operators' do
+        expect(expression.operators).to eq(expected_operators)
+      end
+    end
+
+    context 'when component type is radios' do
+      let(:page) { service.find_page_by_url('star-wars-knowledge') }
+      let(:component) { page.components.find { |component| component.type == 'radios' } }
+      let(:expression_hash) do
+        {
+          'operator': 'contains',
+          'page': page,
+          'component': component.uuid,
+          'field': 'some-field-uuid'
+        }
+      end
+      let(:expected_operators) do
+        [
+          [I18n.t('operators.is'), 'is', { 'data-hide-answers': 'false' }],
+          [I18n.t('operators.is_not'), 'is_not', { 'data-hide-answers': 'false' }],
+          [I18n.t('operators.is_answered'), 'is_answered', { 'data-hide-answers': 'true' }],
+          [I18n.t('operators.is_not_answered'), 'is_not_answered', { 'data-hide-answers': 'true' }]
+        ]
+      end
+
+      it 'returns the expected operators' do
+        expect(expression.operators).to eq(expected_operators)
+      end
     end
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/5LKINamZ/2334-condition-using-a-checkbox-operator-is-incorrect-is-isnt-instead-of-contains-doesnt-contain-38-s)

This is a change as a result of user testing.
When the component is a checkbox, we should use `contains` and `does_not_contain` instead of `is` and `is_not` options.

### Checkboxes
![Screenshot 2022-02-18 at 13 35 21](https://user-images.githubusercontent.com/29227502/154724150-45256aa8-fd19-4757-ad90-99f89f94a4de.png)

### Radios
![Screenshot 2022-02-18 at 13 34 46](https://user-images.githubusercontent.com/29227502/154724153-4487683b-4ae5-4138-bb7b-9418951a5721.png)
