### PR TITLE
Change destination drop down order

### DIFF
--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -73,7 +73,7 @@ class Branch
   end
 
   def destinations
-    all_flow_objects = ordered_pages + detached
+    all_flow_objects = ordered_pages + detached.flow_objects
     destinations_list(flow_objects: all_flow_objects)
   end
 
@@ -82,7 +82,7 @@ class Branch
   end
 
   def detached_destinations
-    destinations_list(flow_objects: detached)
+    destinations_list(flow_objects: detached.ordered_no_branches)
   end
 
   def previous_questions
@@ -151,7 +151,7 @@ class Branch
       service: service,
       main_flow_uuids: grid.page_uuids,
       exclude_branches: true
-    ).flow_objects
+    )
   end
 
   def previous_flow_object

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -30,7 +30,7 @@ class Destination
   end
 
   def detached_destinations
-    destinations_list(flow_objects: ordered_detached_objects, current_uuid: flow_uuid)
+    destinations_list(flow_objects: detached_objects.ordered, current_uuid: flow_uuid)
   end
 
   private
@@ -44,10 +44,5 @@ class Destination
       service: service,
       main_flow_uuids: grid.flow_uuids
     )
-  end
-
-  def ordered_detached_objects
-    all_obj = detached_objects.detached_flows.flatten
-    all_obj.select { |obj| obj.is_a?(MetadataPresenter::Flow) }
   end
 end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -17,7 +17,7 @@ class Destination
   end
 
   def destinations
-    all_flow_objects = grid.ordered_flow + detached_objects
+    all_flow_objects = grid.ordered_flow + detached_objects.flow_objects
     destinations_list(flow_objects: all_flow_objects, current_uuid: flow_uuid)
   end
 
@@ -30,7 +30,7 @@ class Destination
   end
 
   def detached_destinations
-    destinations_list(flow_objects: detached_objects, current_uuid: flow_uuid)
+    destinations_list(flow_objects: ordered_detached_objects, current_uuid: flow_uuid)
   end
 
   private
@@ -43,6 +43,11 @@ class Destination
     Detached.new(
       service: service,
       main_flow_uuids: grid.flow_uuids
-    ).flow_objects
+    )
+  end
+
+  def ordered_detached_objects
+    all_obj = detached_objects.detached_flows.flatten
+    all_obj.select { |obj| obj.is_a?(MetadataPresenter::Flow) }
   end
 end

--- a/app/models/detached.rb
+++ b/app/models/detached.rb
@@ -17,6 +17,15 @@ class Detached
     end
   end
 
+  def ordered
+    all_obj = detached_flows.flatten
+    all_obj.select { |obj| obj.is_a?(MetadataPresenter::Flow) }
+  end
+
+  def ordered_no_branches
+    ordered.select { |obj| obj.type == 'flow.page' }
+  end
+
   private
 
   attr_reader :service, :main_flow_uuids, :exclude_branches

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -424,7 +424,6 @@ RSpec.describe Branch do
     end
     let(:detached_destination_pages) do
       [
-        'Do you like apple juice?',
         'Do you like orange juice?',
         'What is your favourite band?',
         'Which app do you use to listen music?',
@@ -437,9 +436,10 @@ RSpec.describe Branch do
         'Loki',
         'Other quotes',
         'Select all Arnold Schwarzenegger quotes',
-        'You are wrong',
         'You are right',
-        'You are wrong'
+        'You are wrong',
+        'You are wrong',
+        'Do you like apple juice?'
       ]
     end
 

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -177,8 +177,8 @@ RSpec.describe Destination do
         'Other quotes',
         'Select all Arnold Schwarzenegger quotes',
         'Branching point 7',
-        'You are wrong',
         'You are right',
+        'You are wrong',
         'You are wrong'
       ]
     end


### PR DESCRIPTION
[Trello](https://trello.com/c/WSe8eQmT/2341-change-next-page-unconnected-page-order-is-odd-66-s)
Ensure the order for the Change Destination drop down list is the same as the order in the Unconnected section.

### Before
![before](https://user-images.githubusercontent.com/29227502/155138844-391079e4-281f-4f5d-b3f5-66da48091f1c.png)

### After
![after](https://user-images.githubusercontent.com/29227502/155128247-a2c002f6-1926-4efa-9cc1-2bcb122f2fbf.png)