### PR TITLE
Don't show 'Add branching' item in connection menu after start page

### DIFF
--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -56,10 +56,12 @@
     <% end %>
 
     <% unless (item[:type] =~ /page.(checkanswers|confirmation|exit)/) || item[:type] == 'flow.branch' %>
-      <li data-action="link">
-        <%= link_to t('services.branch'),
-        new_branches_path(service.service_id, item[:uuid]) %>
-      </li>
+      <% unless item[:type] == 'page.start' %>
+        <li data-action="link">
+          <%= link_to t('services.branch'),
+          new_branches_path(service.service_id, item[:uuid]) %>
+        </li>
+      <% end %>
 
       <li data-action="destination">
         <%= link_to t('actions.change_destination'),


### PR DESCRIPTION
Simple PR to not show 'Add branching' in the connection menu immediately after the start page.

Before:
<img width="572" alt="image" src="https://user-images.githubusercontent.com/595564/155309610-b737ca97-d0a2-418a-b5a9-ac813364211a.png">


After:
<img width="657" alt="image" src="https://user-images.githubusercontent.com/595564/155309474-046dd230-72d9-4f8f-8028-e77899f105c0.png">
