### PR TITLE
Page menu disappearing

### DIFF
--- a/app/javascript/src/component_activated_menu.js
+++ b/app/javascript/src/component_activated_menu.js
@@ -5,6 +5,8 @@
  * Enhances jQueryUI Menu component by adding a controlling activator.
  *
  * Documentation:
+ * Wrapper around a jQueryUI menu widget that allows more preferable interaction without
+ * having to write the core widget code from scratch (reason for basing on a widget).
  *
  *     - jQueryUI
  *       https://api.jqueryui.com/menu
@@ -49,7 +51,7 @@ class ActivatedMenu {
                      // for what value(s) are required.
     }
 
-    this.connectedSecondaryMenu = config.connectedSecondaryMenu; // A way to bridge across different component menus
+    this.connectedSecondaryMenu = config.connected_secondary_menu; // A way to bridge across different component menus
     this.container.$node.addClass("ActivatedMenu"); // Also add the main component class.
     this.$node.menu(config.menu); // Bit confusing but is how jQueryUI adds effect to eleemnt.
     this.$node.addClass("ActivatedMenu_Menu");
@@ -162,7 +164,7 @@ ActivatedMenu.bindMenuEventHandlers = function() {
     component.$node.on("menuselect", function(event, ui) {
       var e = event.originalEvent;
 
-      if(component._config.preventDefault) {
+      if(component._config.prevent_default) {
          e.preventDefault();
       }
 

--- a/app/javascript/src/component_activated_menu.js
+++ b/app/javascript/src/component_activated_menu.js
@@ -125,19 +125,21 @@ ActivatedMenu.bindMenuEventHandlers = function() {
   // Main (generated) activator uses this event to
   // open the menu.
 
-  this.$node.on("mouseout", (event) => {
+  this.$node.on("mouseout", (event, remainOpen) => {
     var connectedMenu = this.connectedSecondaryMenu;
     component._state.close = true;
-
-    // IF the mouse is no longer over any part of the menu.
-    // !$.contains(event.currentTarget, event.relatedTarget)
+    // IF remainOpen
+    //    We want to block this event from closing the menu
     //
-    // AND it does not have a connected menu
-    // !connectedMenu
+    // IF !$.contains(event.currentTarget, event.relatedTarget)
+    //    The mouse is no longer over any part of the menu.
     //
-    // OR a connected menu is not open
-    // !connectedMenu.isOpen()
-    if(!$.contains(event.currentTarget, event.relatedTarget) && (!connectedMenu || !connectedMenu.isOpen())) {
+    // AND !connectedMenu
+    //     It does not have a connected menu
+    //
+    // OR !connectedMenu.isOpen()
+    //    A connected menu is not open
+    if(!remainOpen && !$.contains(event.currentTarget, event.relatedTarget) && (!connectedMenu || !connectedMenu.isOpen())) {
       setTimeout(function(e) {
         if(component._state.close) {
           component.close();

--- a/app/javascript/src/component_activated_menu.js
+++ b/app/javascript/src/component_activated_menu.js
@@ -96,6 +96,7 @@ class ActivatedMenu {
 
     this.container.$node.position(this._state.position);
     this.container.$node.show();
+    this.$node.trigger("open");
     this.$node.find(".ui-menu-item:first > :first-child").focus();
     this.activator.$node.addClass("active");
     this.activator.$node.attr("aria-expanded", true);
@@ -108,6 +109,7 @@ class ActivatedMenu {
     this.container.$node.hide();
     this.activator.$node.removeClass("active");
     this.activator.$node.attr("aria-expanded", false);
+    this.$node.trigger("close");
 
     // Reset any externally/temporary setting of
     // component._state.position back to default.

--- a/app/javascript/src/component_activated_menu.js
+++ b/app/javascript/src/component_activated_menu.js
@@ -45,10 +45,11 @@ class ActivatedMenu {
       open: false,
       position: null // Default is empty - update this dynamically by passing
                      // to component.open() - will be reset on component.close()
-                     // See config._position (above) and jQueryUI documentation
+                     // See _private.position (above) and jQueryUI documentation
                      // for what value(s) are required.
     }
 
+    this.connectedSecondaryMenu = config.connectedSecondaryMenu; // A way to bridge across different component menus
     this.container.$node.addClass("ActivatedMenu"); // Also add the main component class.
     this.$node.menu(config.menu); // Bit confusing but is how jQueryUI adds effect to eleemnt.
     this.$node.addClass("ActivatedMenu_Menu");
@@ -59,6 +60,18 @@ class ActivatedMenu {
     ActivatedMenu.setMenuOpenPosition.call(this);
 
     this.close();
+  }
+
+  get connectedSecondaryMenu() {
+    return this._connectedSecondaryMenu;
+  }
+
+  set connectedSecondaryMenu(menu) {
+    this._connectedSecondaryMenu = menu;
+  }
+
+  isOpen() {
+    return this._state.open;
   }
 
   // Opens the menu.
@@ -113,10 +126,18 @@ ActivatedMenu.bindMenuEventHandlers = function() {
   // open the menu.
 
   this.$node.on("mouseout", (event) => {
-    // event.currentTarget will be the menu (UL) element.
-    // check if relatedTarget is not a child element.
+    var connectedMenu = this.connectedSecondaryMenu;
     component._state.close = true;
-    if(!$.contains(event.currentTarget, event.relatedTarget)) {
+
+    // IF the mouse is no longer over any part of the menu.
+    // !$.contains(event.currentTarget, event.relatedTarget)
+    //
+    // AND it does not have a connected menu
+    // !connectedMenu
+    //
+    // OR a connected menu is not open
+    // !connectedMenu.isOpen()
+    if(!$.contains(event.currentTarget, event.relatedTarget) && (!connectedMenu || !connectedMenu.isOpen())) {
       setTimeout(function(e) {
         if(component._state.close) {
           component.close();

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -167,7 +167,7 @@ class AddComponent {
     this.$button = $button;
     this.menu = new ActivatedMenu($list, {
       selection_event: "AddComponentMenuSelection",
-      preventDefault: true, // Stops the default action of triggering element.
+      prevent_default: true, // Stops the default action of triggering element.
       activator: $button,
       menu: {
         position: { at: "right+2 top-2" }

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -181,7 +181,7 @@ class FlowItemMenu extends ActivatedMenu {
 
   // Open the views Page Addition Menu
   addPage(element) {
-    var menu = this._config.view.pageAdditionMenu;
+    var menu = this._config.connectedSecondaryMenu;
     menu.addPageAfter = this.uuid;
     menu.open({
       my: "left top",
@@ -329,7 +329,7 @@ function createPageAdditionMenu(view) {
 function createFlowItemMenus(view) {
   $("[data-component='ItemActionMenu']").each((i, el) => {
     var menu = new FlowItemMenu($(el), {
-      view: view,
+      connectedSecondaryMenu: view.pageAdditionMenu,
       preventDefault: true, // Stops the default action of triggering element.
       menu: {
         position: { at: "right+2 top-2" }

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -183,8 +183,6 @@ class FlowItemMenu extends ActivatedMenu {
   addPage(element) {
     var menu = this.connectedSecondaryMenu;
     menu.addPageAfter = this.uuid;
-    menu.$node.one("open", () => element.attr("aria-haspopup", true) );
-    menu.$node.one("close", () => element.removeAttr("aria-haspopup") );
     menu.open({
       my: "left top",
       at: "right top",

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -183,6 +183,8 @@ class FlowItemMenu extends ActivatedMenu {
   addPage(element) {
     var menu = this._config.connectedSecondaryMenu;
     menu.addPageAfter = this.uuid;
+    menu.$node.one("open", () => element.attr("aria-haspopup", true) );
+    menu.$node.one("close", () => element.removeAttr("aria-haspopup") );
     menu.open({
       my: "left top",
       at: "right top",

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -181,7 +181,7 @@ class FlowItemMenu extends ActivatedMenu {
 
   // Open the views Page Addition Menu
   addPage(element) {
-    var menu = this._config.connectedSecondaryMenu;
+    var menu = this.connectedSecondaryMenu;
     menu.addPageAfter = this.uuid;
     menu.$node.one("open", () => element.attr("aria-haspopup", true) );
     menu.$node.one("close", () => element.removeAttr("aria-haspopup") );
@@ -331,8 +331,8 @@ function createPageAdditionMenu(view) {
 function createFlowItemMenus(view) {
   $("[data-component='ItemActionMenu']").each((i, el) => {
     var menu = new FlowItemMenu($(el), {
-      connectedSecondaryMenu: view.pageAdditionMenu,
-      preventDefault: true, // Stops the default action of triggering element.
+      connected_secondary_menu: view.pageAdditionMenu,
+      prevent_default: true, // Stops the default action of triggering element.
       menu: {
         position: { at: "right+2 top-2" }
       }

--- a/app/javascript/styles/_component_activated_menu.scss
+++ b/app/javascript/styles/_component_activated_menu.scss
@@ -60,6 +60,7 @@
 
   [aria-haspopup] {
     &:after {
+      color: inherit;
       content: ">";
       font-family: monospace;
       font-size: 22px;

--- a/app/javascript/styles/_component_activated_menu.scss
+++ b/app/javascript/styles/_component_activated_menu.scss
@@ -56,18 +56,18 @@
   span {
     padding-right: 30px;
     position: relative;
+  }
 
-    &[aria-haspopup] {
-      &:after {
-        content: ">";
-        font-family: monospace;
-        font-size: 22px;
-        height: 100%;
-        position: absolute;
-        right: 10px;
-        top: 10px;
-        vertical-align: middle;
-      }
+  [aria-haspopup] {
+    &:after {
+      content: ">";
+      font-family: monospace;
+      font-size: 22px;
+      height: 100%;
+      position: absolute;
+      right: 10px;
+      top: 10px;
+      vertical-align: middle;
     }
   }
 
@@ -80,5 +80,10 @@
   .ui-menu-icon {
     /* jQueryUI Menu is adding unwanted icon markup when <a> tags are replaced with <span> tags */
     display: none;
+  }
+
+  .ui-menu-item {
+    color: govuk-colour("blue");
+    position: relative;
   }
 }

--- a/app/views/services/_flow_page_menu.html.erb
+++ b/app/views/services/_flow_page_menu.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 
   <% unless (item[:type] =~ /page.(confirmation|exit)/) %>
-    <li data-action="add"><a href="#add-page-here"><%= t('actions.add_page') %></a></li>
+    <li data-action="add"><a href="#add-page-here" aria-haspopup="true"><%= t('actions.add_page') %></a></li>
   <% end %>
 
   <% unless item[:type] == 'page.start' %>

--- a/test/component_activated_menu_test.js
+++ b/test/component_activated_menu_test.js
@@ -181,7 +181,7 @@ describe("ActivatedMenu", function() {
     /* TODO: Test is on hold because we cannot use jsDom
      * for testing position of elements
      **/
-    it("should set the position values passed in open()");
+    it("should set the position values passed in open() ... Maybe cannot test due to jsDom limitations");
 
     it("should close the menu by the close() method", function() {
       menu.open();
@@ -227,12 +227,12 @@ describe("ActivatedMenu", function() {
     /* TODO: Test is on hold because we cannot use jsDom
      * for testing position of elements
      */
-    it("should reset the position values on close()");
+    it("should reset the position values on close() ... Maybe cannot test due to jsDom limitations");
 
     /* TODO: Test is on hold because we cannot use jsDom
      * for testing mouse events
      **/
-    it("should close the menu on mouseout (not sure if can test)");
+    it("should close the menu on mouseout ... Maybe cannot test due to jsDom limitations");
 
     it("should activate the config.selection_event on menu item selection", function() {
       var value = 1;

--- a/test/component_activated_menu_test.js
+++ b/test/component_activated_menu_test.js
@@ -55,8 +55,8 @@ describe("ActivatedMenu", function() {
       activator_text: config.activator_text,
       container_id: config.container_id,
       container_classname: config.container_classname,
-      connectedSecondaryMenu: config.connectedSecondaryMenu,
-      preventDefault: true,
+      connected_secondary_menu: config.connected_secondary_menu,
+      prevent_default: true,
       selection_event: config.selection_event_name
     });
   }
@@ -110,7 +110,7 @@ describe("ActivatedMenu", function() {
 
     it("should make (public but indicated as) private reference to config", function() {
       expect(menu._config).to.exist;
-      expect(menu._config.preventDefault).to.exist;
+      expect(menu._config.prevent_default).to.exist;
       expect(menu._config.activator_text).to.equal(ACTIVATOR_TEXT);
     });
 
@@ -276,7 +276,7 @@ describe("ActivatedMenu", function() {
 
       it("should make (public but indicated as) private reference to connected menu from config", function() {
         tempMenu = createMenu({
-          connectedSecondaryMenu: connectedMenu
+          connected_secondary_menu: connectedMenu
         });
 
         expect(connectedMenu).to.exist;
@@ -297,7 +297,7 @@ describe("ActivatedMenu", function() {
 
       it("should retrieve any assigned connected menu from publc getter", function() {
         tempMenu = createMenu({
-          connectedSecondaryMenu: connectedMenu
+          connected_secondary_menu: connectedMenu
         });
 
         expect(connectedMenu).to.exist;

--- a/test/component_activated_menu_test.js
+++ b/test/component_activated_menu_test.js
@@ -52,9 +52,10 @@ describe("ActivatedMenu", function() {
     return new ActivatedMenu ($ul, {
       activator: $button,
       activator_classname: config.activator_classname,
+      activator_text: config.activator_text,
       container_id: config.container_id,
       container_classname: config.container_classname,
-      activator_text: config.activator_text,
+      connectedSecondaryMenu: config.connectedSecondaryMenu,
       preventDefault: true,
       selection_event: config.selection_event_name
     });
@@ -127,9 +128,11 @@ describe("ActivatedMenu", function() {
       expect(menu._state.open).to.exist;
     });
 
-    it("should make (public but indicated as) private reference to connected menu");
 
-    it("should retrieve any assigned connected menu");
+    it("should not have (public but indicated as) private reference to connected menu when none passed in config", function() {
+      expect(menu).to.exist;
+      expect(menu._connectedSecondaryMenu).to.equal(undefined);
+    });
 
     it("should open the menu by the open() method", function() {
       simulateClosed(menu);
@@ -215,7 +218,54 @@ describe("ActivatedMenu", function() {
       menu.$node.find("li > a").eq(0).click();
       expect(value).to.equal(2);
     });
+
+    describe(".connectedSecondaryMenu", function() {
+      var connectedMenu;
+      var tempMenu;
+
+      beforeEach(function() {
+        connectedMenu = createMenu({});
+      });
+
+      afterEach(function() {
+        // Cleanup
+        connectedMenu.container.$node.remove();
+        tempMenu.container.$node.remove();
+      });
+
+      it("should make (public but indicated as) private reference to connected menu from config", function() {
+        tempMenu = createMenu({
+          connectedSecondaryMenu: connectedMenu
+        });
+
+        expect(connectedMenu).to.exist;
+        expect(tempMenu).to.exist;
+        expect(tempMenu._connectedSecondaryMenu).to.equal(connectedMenu);
+      });
+
+      it("should make (public but indicated as) private reference to connected menu from public setter", function() {
+        tempMenu = createMenu({});
+
+        expect(connectedMenu).to.exist;
+        expect(tempMenu).to.exist;
+        expect(tempMenu._connectedSecondaryMenu).to.equal(undefined);
+
+        tempMenu.connectedSecondaryMenu = connectedMenu;
+        expect(tempMenu._connectedSecondaryMenu).to.equal(connectedMenu);
+      });
+
+      it("should retrieve any assigned connected menu from publc getter", function() {
+        tempMenu = createMenu({
+          connectedSecondaryMenu: connectedMenu
+        });
+
+        expect(connectedMenu).to.exist;
+        expect(tempMenu).to.exist;
+        expect(tempMenu.connectedSecondaryMenu).to.equal(connectedMenu);
+      });
+    });
   });
+
 
   describe("ActivatedMenuContainer", function() {
     it("should apply the config.container_id to $node", function() {

--- a/test/component_activated_menu_test.js
+++ b/test/component_activated_menu_test.js
@@ -142,8 +142,6 @@ describe("ActivatedMenu", function() {
       expect(menu.container.$node.get(0).style.display).to.equal("");
     });
 
-    it("should trigger an 'open' event when the open() method is run");
-
     it("should set the state.open to true when open() is activated", function() {
       simulateClosed(menu);
       expect(menu._state.open).to.be.false;
@@ -152,7 +150,23 @@ describe("ActivatedMenu", function() {
       expect(menu._state.open).to.be.true;
     });
 
-    it("should return true for isOpen when the menu is open");
+    it("should trigger an 'open' event when the open() method is run", function() {
+      var passed = false;
+
+      simulateClosed(menu);
+      expect(menu._state.open).to.be.false;
+
+      menu.$node.on("open.testingevent1", function() {
+        passed = true;
+      });
+
+      menu.open();
+
+      expect(passed).to.be.true;
+
+      // Remove because we're sharing menu
+      menu.$node.off("open.testingevent1");
+    });
 
     it("should add the class 'active' to the activator on open()", function() {
       simulateClosed(menu);
@@ -187,8 +201,6 @@ describe("ActivatedMenu", function() {
       expect(menu._state.open).to.be.false;
     });
 
-    it("should return false for isOpen when the menu is closed");
-
     it("should remove the class 'active' from the activator on close()", function() {
       menu.open();
       expect(menu.activator.$node.hasClass("active")).to.be.true;
@@ -217,6 +229,11 @@ describe("ActivatedMenu", function() {
 
       menu.$node.find("li > a").eq(0).click();
       expect(value).to.equal(2);
+    });
+
+    describe(".isOpen", function() {
+      it("should return true for isOpen when the menu is open");
+      it("should return false for isOpen when the menu is closed");
     });
 
     describe(".connectedSecondaryMenu", function() {

--- a/test/component_activated_menu_test.js
+++ b/test/component_activated_menu_test.js
@@ -191,7 +191,22 @@ describe("ActivatedMenu", function() {
       expect(menu.container.$node.get(0).style.display).to.equal("none");
     });
 
-    it("should trigger a 'close' event when the close() method is run");
+    it("should trigger a 'close' event when the close() method is run", function() {
+      var passed = false;
+
+      menu.open();
+      expect(menu.activator.$node.hasClass("active")).to.be.true;
+
+      menu.$node.on("close.testingevent2", function() {
+        passed = true;
+      });
+
+      menu.close();
+      expect(passed).to.be.true;
+
+      // Remove because we're sharing menu
+      menu.$node.off("close.testingevent2");
+    });
 
     it("should set the state.open to false when close() is activated", function() {
       menu.open();

--- a/test/component_activated_menu_test.js
+++ b/test/component_activated_menu_test.js
@@ -247,8 +247,17 @@ describe("ActivatedMenu", function() {
     });
 
     describe(".isOpen", function() {
-      it("should return true for isOpen when the menu is open");
-      it("should return false for isOpen when the menu is closed");
+      it("should return true for isOpen when the menu is open", function() {
+        menu.open();
+        expect(menu.activator.$node.hasClass("active")).to.be.true;
+        expect(menu.isOpen()).to.be.true;
+      });
+
+      it("should return false for isOpen when the menu is closed", function() {
+        menu.close();
+        expect(menu.activator.$node.hasClass("active")).to.be.false;
+        expect(menu.isOpen()).to.be.false;
+      });
     });
 
     describe(".connectedSecondaryMenu", function() {

--- a/test/component_activated_menu_test.js
+++ b/test/component_activated_menu_test.js
@@ -1,6 +1,8 @@
 require("./setup");
 
 describe("ActivatedMenu", function() {
+  // jQuery is present in document because the
+  // components use it so we can use it here.
 
   const ActivatedMenu = require("../app/javascript/src/component_activated_menu");
   const COMPONENT_CLASSNAME = "ActivatedMenu";
@@ -23,15 +25,15 @@ describe("ActivatedMenu", function() {
     menu.activator.$node.removeClass("active");
   }
 
-  before(function() {
-    // jQuery is present in document because the
-    // components use it so we can use it here.
-
+  /* Creates and returns a new menu from passed configuration
+   * that will also be added to the testing DOM.
+   */
+  function createMenu(config) {
     var $ul = $(`<ul>
                    <li>
                      <span>Item 1a</span>
                      <ul>
-                       <li><button id="steven" href="#action1">Item 1b</button></li>
+                       <li><a href="#action1">Item 1b</a></li>
                        <li><a href="#action2">Item 2b</a></li>
                        <li><a href="#action3">Item 3b</a></li>
                      </ul>
@@ -41,19 +43,32 @@ describe("ActivatedMenu", function() {
                  </ul>`);
 
     var $button = $("<button></button>");
+
     $button.attr("id", ACTIVATOR_ID);
     $(document.body).append($ul);
     $(document.body).append($button);
 
     $ul.attr("id", MENU_ID);
-    menu = new ActivatedMenu ($ul, {
+    return new ActivatedMenu ($ul, {
       activator: $button,
+      activator_classname: config.activator_classname,
+      container_id: config.container_id,
+      container_classname: config.container_classname,
+      activator_text: config.activator_text,
+      preventDefault: true,
+      selection_event: config.selection_event_name
+    });
+  }
+
+  before(function() {
+    menu = createMenu({
+      activator_id: ACTIVATOR_ID,
       activator_classname: ACTIVATOR_CLASSNAME,
+      activator_text: ACTIVATOR_TEXT,
       container_id: CONTAINER_ID,
       container_classname: CONTAINER_CLASSNAME,
-      activator_text: ACTIVATOR_TEXT,
-      preventDefault: true,
-      selection_event: TEST_SELECTION_EVENT_NAME
+      menu_id: MENU_ID,
+      selection_event_name: TEST_SELECTION_EVENT_NAME
     });
   });
 
@@ -112,6 +127,10 @@ describe("ActivatedMenu", function() {
       expect(menu._state.open).to.exist;
     });
 
+    it("should make (public but indicated as) private reference to connected menu");
+
+    it("should retrieve any assigned connected menu");
+
     it("should open the menu by the open() method", function() {
       simulateClosed(menu);
       expect(menu.container.$node.get(0).style.display).to.equal("none");
@@ -120,6 +139,8 @@ describe("ActivatedMenu", function() {
       expect(menu.container.$node.get(0).style.display).to.equal("");
     });
 
+    it("should trigger an 'open' event when the open() method is run");
+
     it("should set the state.open to true when open() is activated", function() {
       simulateClosed(menu);
       expect(menu._state.open).to.be.false;
@@ -127,6 +148,8 @@ describe("ActivatedMenu", function() {
       menu.open();
       expect(menu._state.open).to.be.true;
     });
+
+    it("should return true for isOpen when the menu is open");
 
     it("should add the class 'active' to the activator on open()", function() {
       simulateClosed(menu);
@@ -151,6 +174,8 @@ describe("ActivatedMenu", function() {
       expect(menu.container.$node.get(0).style.display).to.equal("none");
     });
 
+    it("should trigger a 'close' event when the close() method is run");
+
     it("should set the state.open to false when close() is activated", function() {
       menu.open();
       expect(menu._state.open).to.be.true;
@@ -158,6 +183,8 @@ describe("ActivatedMenu", function() {
       menu.close();
       expect(menu._state.open).to.be.false;
     });
+
+    it("should return false for isOpen when the menu is closed");
 
     it("should remove the class 'active' from the activator on close()", function() {
       menu.open();


### PR DESCRIPTION
Menu was disappearing due to mouseout event (set to close menu) when switching from this menu to the (required but completely separate) page addition menu.

**Was**
Red box outline and question mark indicate the close (disappeared) menu
<img width="796" alt="Screenshot 2022-02-23 at 17 36 29" src="https://user-images.githubusercontent.com/76942244/155376272-a6042195-bb22-4e13-8875-7f5b1372efc0.png">

**Now**
<img width="791" alt="Screenshot 2022-02-23 at 17 37 32" src="https://user-images.githubusercontent.com/76942244/155376359-0d112fa6-7b9d-42e1-a5c5-689d5837fd70.png">
