### PR TITLE
Fix bug resetting answer field value

### DIFF
--- a/acceptance/features/edit_branch_page_spec.rb
+++ b/acceptance/features/edit_branch_page_spec.rb
@@ -46,8 +46,35 @@ feature 'New branch page' do
 
     then_I_can_add_and_delete_conditionals_and_expressions
 
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][operator]',
+      'is answered'
+    )
+    then_I_should_not_see_field_options('branch[conditionals_attributes][0][expressions_attributes][0][field]')
+
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][operator]',
+      'is'
+    )
+
+    then_I_should_see_the_field_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][field]', 
+      'Hiking'
+    )
+    
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][field]',
+      'Sewing'
+    )
+
     when_I_save_my_changes
     then_I_should_see_the_previous_page_title('What is your favourite hobby?')
+     
+    then_I_should_see_the_field_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][field]', 
+      'Hiking'
+    )
+
     then_I_should_see_no_errors
   end
 

--- a/acceptance/features/new_branch_page_spec.rb
+++ b/acceptance/features/new_branch_page_spec.rb
@@ -56,7 +56,7 @@ feature 'New branch page' do
       'is'
     )
 
-    then_I_should_see_the_first_field_options('Hiking')
+    then_I_should_see_the_field_option('branch_conditionals_attributes_0_expressions_attributes_0_field', 'Hiking')
 
     then_I_should_see_the_correct_number_of_options(
       '#branch_conditionals_attributes_0_expressions_attributes_0_field',

--- a/acceptance/support/branching_steps.rb
+++ b/acceptance/support/branching_steps.rb
@@ -92,12 +92,12 @@ module BranchingSteps
     expect(options.length).to eq(amount)
   end
 
-  def then_I_should_not_see_field_options(text)
-    page_without_css('.govuk-select', text)
+  def then_I_should_not_see_field_options(name)
+    expect(page).to have_no_select(name)
   end
 
-  def then_I_should_see_the_first_field_options(text)
-    expect(page).to have_css('.govuk-select', text: text)
+  def then_I_should_see_the_field_option(name, text)
+    expect(page).to have_select(name, text: text)
   end
 
   def and_I_choose_an_option(name, option)

--- a/app/javascript/src/component_branch.js
+++ b/app/javascript/src/component_branch.js
@@ -330,7 +330,9 @@ class BranchAnswer {
       $answer.val([]);
     } else {
       $answer.show();
-      $answer.val( $answer.find('option:first').val() );
+      if( !$answer.val() ) {
+        $answer.val( $answer.find('option:first').val() );
+      }
     }
   }
 }


### PR DESCRIPTION
Resolves [ticket 2367](https://trello.com/c/Us1MyGoN/2367-branching-state-conflict-logic-defaulting-to-first-value-added-xs) 

Fixes bug introduced in [PR 1251](https://github.com/ministryofjustice/fb-editor/pull/1251) that would reset the value of the `field` dropdown on branch edit save.

Added the required conditional to only reset the value on the dropdown if there is no value (i.e. after we have switched from the `is answered` or `is not answered` operator back to an `is` or `is not` operator)

Added in acceptance tests to validate the behaviour.
