### PR TITLE
Disable question select until API request returns

### DIFF
--- a/app/javascript/src/component_branch.js
+++ b/app/javascript/src/component_branch.js
@@ -231,6 +231,7 @@ class BranchQuestion {
     $node.find("select").on("change.branchquestion", (e) => {
       var select = e.currentTarget;
       var supported = $(select.selectedOptions).data("supports-branching");
+      this.disable();
       this.change(supported, select.value);
     });
 
@@ -243,18 +244,28 @@ class BranchQuestion {
     this.$node = $node;
   }
 
+  disable() {
+    this.$node.find('select').prop('disabled', true);
+  }
+
+  enable() {
+    this.$node.find('select').prop('disabled', false);
+  }
+
   change(supported, value) {
     var branch = this.condition.branch;
     this.clearErrorState();
     this.condition.clear();
     switch(supported) {
       case true:
-           this.condition.update(value, function() {
+           this.condition.update(value, () =>  {
              $(document).trigger(EVENT_QUESTION_CHANGE, branch);
+             this.enable();
            });
            break;
       case false:
            this.error("unsupported");
+           this.enable(); 
            break;
       default:
            // Just trigger an event


### PR DESCRIPTION
Fixes [ticket #1984](https://trello.com/c/TWXgseDr/1984-bug-operator-and-answer-list-bug)

On changing the value of the condition select, disable the select field until the action is complete.

In the case of selecting an unsupported answer, this is basically instant. However, in the case of selecting a valid question for branching the select will be disabled until the API request is complete and the UI has been updated with the operator and answer select elements.

This prevents the user changing the condition select while the API request is in-flight which resulted in them potentially being presented with the 'question type unsupported' error and then the API request completing and updating the UI with the operator and answer fields.

