### PR TITLE
Move connection menu to the right of the branch condition

### DIFF
--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -55,7 +55,6 @@ ServicesController.edit = function() {
 
   createPageAdditionDialog(view);
   createPageMenus(view);
-  createConnectionMenus(view); 
 
   if(view.$flowOverview.length) {
     layoutFormFlowOverview(view);
@@ -64,6 +63,8 @@ ServicesController.edit = function() {
   if(view.$flowDetached.length) {
     layoutDetachedItemsOveriew(view);
   }
+
+  createConnectionMenus(view); 
 
   // Reverse the Brief flash of content quickfix.
   $("#main-content").css("visibility", "visible");

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -666,7 +666,7 @@ html {
   top: 46px;
 
   &.branch-connection-menu-activator {
-    left: -10px;
+    left: calc(100% - 24px);
     top: -17px;
   }
   
@@ -678,7 +678,8 @@ html {
 
 .flow-condition {
   @include list_reset;
-  margin: 0 50px;
+  margin: 0 100px 0 0;
+  padding: 0 25px;
   text-align: center;
   width: 300px;
 

--- a/app/views/services/_flow_layout.html.erb
+++ b/app/views/services/_flow_layout.html.erb
@@ -31,7 +31,6 @@
         <ul class="flow-conditions">
           <% item[:conditionals].each_with_index do |condition, index| %>
             <li class="flow-condition" data-from="<%= "#{item[:uuid]}-#{index}" %>" data-next="<%= condition[:next] %>">
-              <%= render partial: 'services/connection_menu', locals: { item: item, condition: condition } %>
               <% condition[:expressions].each do |expression| %>
                 <% if expression[:operator].empty? && expression[:answer].empty? %>
                   <div class="flow-expression" data-otherwise="true">
@@ -45,6 +44,7 @@
                   </div>
                 <% end %>
               <% end %>
+              <%= render partial: 'services/connection_menu', locals: { item: item, condition: condition } %>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
Resolves [ticket #2359](https://trello.com/c/iLTHKxCv/2359-move-connection-menu-to-the-right-of-the-branch-condition) 

This PR simply moves the connection menu activator to the right of the branch condition text on the flow view.

It also slightly adjusts where/when the menu is rendered to the screen to help with source ordering/stacking contexts in order to play nice when merged with other work done on `main`.

Before:
<img width="656" alt="image" src="https://user-images.githubusercontent.com/595564/155723601-0d46616a-9250-4b18-82ef-c041ec78d275.png">


After: 
<img width="533" alt="image" src="https://user-images.githubusercontent.com/595564/155723528-3998550f-bb90-4fee-89a0-e648f14b41f5.png">

