### PR TITLE
Adjust branch condition layout

### DIFF
--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -529,12 +529,12 @@ function createAndPositionFlowItems($overview) {
 function adjustBranchConditionPositions($overview) {
   var strokeWidth = $(".FlowConnectorPath path").eq(0).css("stroke-width") || "";
   var lineHeight = Number(strokeWidth.replace("px", "")) || 0;
-  $overview.find(".flow-expression").each(function() {
+  $overview.find(".flow-expressions").each(function() {
     var $this = $(this);
     var expressionHeight = Number($this.height()) || 0;
     $this.css({
       position: "relative",
-      top: "-" + (expressionHeight + lineHeight) + "px"
+      top: "-" + (expressionHeight + (lineHeight * 2) ) + "px" 
     });
   });
 }

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -512,24 +512,25 @@ html {
     visibility: hidden;
   }
 
-  // Fix z-index issues because calculations for Branch FlowConnectorPath elements start
-  // their lines from centre of a Branch Node, which places them directly over those
-  // elements, without this workaround in place (easier to fix z-index than calculations).
-  .FlowConnectorLine,
-  .FlowConnectorPath {
+  .ui-widget-overlay {
     z-index: 1;
   }
 
-  .FlowConnectorPath.active,
-  .flow-item,
-  .ui-widget-overlay {
+  .FlowConnectorLine,
+  .FlowConnectorPath {
     z-index: 2;
+
+    &.active {
+      z-index: 3;
+    }
   }
 
-  .FlowItemMenu,
-  .PageAdditionMenu,
+  .FlowItemMenu {
+    z-index: 4;
+  }
+
   .ui-dialog {
-    z-index: 3;
+    z-index: 5;
   }
 }
 
@@ -665,14 +666,22 @@ html {
 
   a, span {
     @include govuk-font($size: 16);
+
+    color: $govuk-secondary-text-colour;
     display: inline;
     position: static;
     width: auto;
   }
 
-  .operator {
+ .operator {
     color: $govuk-secondary-text-colour;
+    font-weight: bold;
   }
+
+  .condition-operator {
+    text-transform: uppercase;
+    font-weight: bold;
+  } 
 }
 
 .flow-conditions {

--- a/app/views/services/_flow_layout.html.erb
+++ b/app/views/services/_flow_layout.html.erb
@@ -31,19 +31,24 @@
         <ul class="flow-conditions">
           <% item[:conditionals].each_with_index do |condition, index| %>
             <li class="flow-condition" data-from="<%= "#{item[:uuid]}-#{index}" %>" data-next="<%= condition[:next] %>">
-              <% condition[:expressions].each do |expression| %>
-                <% if expression[:operator].empty? && expression[:answer].empty? %>
-                  <div class="flow-expression" data-otherwise="true">
-                    <span class="question"><%= expression[:question] %></span>
-                  </div>
-                <% else %>
-                  <div class="flow-expression" data-otherwise="false">
-                    <span class="question"><%= expression[:question] %></span>
-                    <span class="operator"><%= expression[:operator] %></span>
-                    <span class="answer"><%= expression[:answer] %></span>
-                  </div>
+             <div class="flow-expressions">
+                <% condition[:expressions].each_with_index do |expression, index| %>
+                  <% if expression[:operator].empty? && expression[:answer].empty? %>
+                    <span class="flow-expression" data-otherwise="true">
+                      <span class="question"><%= expression[:question] %></span>
+                    </span>
+                  <% else %>
+                    <span class="flow-expression" data-otherwise="false">
+                      <span class="question"><%= expression[:question] %></span>
+                      <span class="operator"><%= expression[:operator] %></span>
+                      <span class="answer"><%= expression[:answer] %></span>
+                    </span>
+                  <% end %>
+                  <% if index + 1 < condition[:expressions].size %>
+                    <span class="condition-operator"><%= t("branches.expression.and") -%></span>
+                  <% end %>
                 <% end %>
-              <% end %>
+              </div> 
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
Resolves [ticket #2283](https://trello.com/c/J459SIHl/2283-layout-of-the-condition-14-12-17-46-s)

- [x] Branch condition text no longer blocks arrow hover
- [x] Display "AND" between two or more connections
- [x] Branch condition exprsssions will not overlap

Before:
<img width="667" alt="image" src="https://user-images.githubusercontent.com/595564/155725447-54ba6faa-9da6-4538-88fd-49a9684b29bd.png">

After:
<img width="689" alt="image" src="https://user-images.githubusercontent.com/595564/155731950-e16316f2-8866-48e0-8904-ad1f5fe7e54b.png">



 
 