### PR TITLE
Increase parallelism in acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ jobs:
     docker: *test_image
     resource_class: large
     environment: *test_environment
-    parallelism: 5
+    parallelism: 7
     steps:
       - checkout
       - ruby/install-deps
@@ -333,7 +333,7 @@ jobs:
     docker: *test_image
     resource_class: large
     environment: *test_environment
-    parallelism: 5
+    parallelism: 3
     steps:
       - checkout
       - ruby/install-deps


### PR DESCRIPTION
Use 7 concurrent tests containers. With the horizontal scaling
configuration set for the editor and the metadata api it should be able
to cater for it.

However we need to lower the number of containers for the testable
editors as they tend to overwhelm the pods. This will increase the time
for the testable editor tests unfortunately. We can add auto scaling to
them at some point in the future.