### PR TITLE
Prevent action when clicking 'Question' in Add Component menu on multiquestion page

### DIFF
--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -183,8 +183,10 @@ class AddComponent {
  **/
 AddComponent.MenuSelection = function(event, data) {
   var action = data.activator.data("action");
-  updateHiddenInputOnForm(this.dataController.$form, "page[add_component]", action);
-  this.dataController.$form.submit();
+  if( action != "none" ) {
+    updateHiddenInputOnForm(this.dataController.$form, "page[add_component]", action);
+    this.dataController.$form.submit();
+  }
 }
 
 

--- a/app/views/partials/_add_component_button.html.erb
+++ b/app/views/partials/_add_component_button.html.erb
@@ -2,7 +2,7 @@
   <% if @page.supported_input_components.present? %>
     <div class="component add-component" data-component="add-component">
       <ul class="govuk-navigation">
-        <li>
+        <li data-action="none">
           <span><%= t('components.menu.question') %></span>
           <ul class="govuk-navigation">
             <% @page.supported_input_components.each do |component| %>


### PR DESCRIPTION
Resolves [ticket #2378](https://trello.com/c/8XRdt4z8/2378-add-question-shouldnt-dismiss-the-menu-71-xs)

Apply the same fix as used on the connection menu to prevent an activated menu item with a submenu that appears on hover from triggering an action and closing the menu on click.