### PR TITLE
Testable 2380 flow arrow issue

### DIFF
--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module CommonSteps
   OPTIONAL_TEXT = [
     I18n.t('default_text.section_heading'),
@@ -171,6 +172,10 @@ module CommonSteps
 
   def and_I_return_to_flow_page
     editor.pages_link.click
+    using_wait_time 6 do
+      # ... Changed Capybara.default_wait_time in this block scope.
+      find("#main-content.jsdone")
+    end
   end
 
   def and_I_change_the_page_heading(heading)

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -143,7 +143,7 @@ class FlowConnectorPath {
     //             var up = (nU * NUDGE_SPACING);
     //
     // For more examples, see the actual nudge() functions already in place or (at time of
-    // writing) the following code that is used for the simplistic ForwardUpPath class.
+    // writing) the following code that is used for the simplistic ForwardUpForwardPath class.
     //
     //   nudge(nH, nV) {
     //     var dimensions = {
@@ -280,17 +280,17 @@ class ForwardPath extends FlowConnectorPath {
 }
 
 
-class ForwardUpPath extends FlowConnectorPath {
+class ForwardUpForwardPath extends FlowConnectorPath {
   constructor(points, config) {
     super(points, config);
     var dimensions = {
       forward1: Math.round(this.points.via_x - CURVE_SPACING),
       up: Math.round(this.points.yDifference - (CURVE_SPACING * 2)),
-      forward2: Math.round(utilities.difference((this.points.from_x + this.points.via_x) - CURVE_SPACING, this.points.to_x))
+      forward2: Math.round(utilities.difference((this.points.from_x + this.points.via_x), this.points.to_x) - (CURVE_SPACING * 2))
     }
 
     this._dimensions = { original: dimensions }; // dimensions.current will be added in set path()
-    this.type = "ForwardUpPath";
+    this.type = "ForwardUpForwardPath";
     this.path = dimensions;
     this.build();
   }
@@ -1340,7 +1340,7 @@ function xy(x, y) {
 module.exports = {
   FlowConnectorPath: FlowConnectorPath,
   ForwardPath: ForwardPath,
-  ForwardUpPath: ForwardUpPath,
+  ForwardUpForwardPath: ForwardUpForwardPath,
   ForwardUpForwardDownPath: ForwardUpForwardDownPath,
   ForwardDownForwardPath: ForwardDownForwardPath,
   ForwardDownBackwardUpPath: ForwardDownBackwardUpPath,

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -595,7 +595,7 @@ class ForwardDownForwardPath extends FlowConnectorPath {
     var dimensions = {
       forward1: Math.round(this.points.via_x - CURVE_SPACING),
       down: Math.round(utilities.difference(this.points.from_y, this.points.to_y) - (CURVE_SPACING * 2)),
-      forward2: Math.round( utilities.difference( this.points.from_x + this.points.via_x, this.points.to_x ) - CURVE_SPACING),
+      forward2: Math.round( utilities.difference( this.points.from_x + this.points.via_x, this.points.to_x ) - (CURVE_SPACING * 2)),
     }
 
     this._dimensions = { original: dimensions };

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -691,7 +691,7 @@ function applyPageFlowConnectorPaths($overview) {
       from_y: fromY,
       to_x: toX,
       to_y: toY,
-      via_x: COLUMN_SPACING - 20 // 25 because we don't want lines to start at edge of column space
+      via_x: COLUMN_SPACING - 20 // 20 because we don't want lines to start at edge of column space
       }, {
       from: $item.data("instance"),
       to: $next.data("instance"),
@@ -815,7 +815,7 @@ function applyBranchFlowConnectorPaths($overview) {
             if(up) {
               if(nextColumn) {
 
-                new ConnectorPath.DownForwardUpPath({
+                new ConnectorPath.DownForwardUpForwardPath({
                   from_x: branchX - (branchWidth / 2),
                   from_y: branchY,
                   to_x: destinationX,
@@ -957,7 +957,7 @@ function calculateAndCreatePageFlowConnectorPath(points, config) {
     if(forward) {
       if(up) {
         if(destinationInNextColumn) {
-          new ConnectorPath.ForwardUpPath(points, config);
+          new ConnectorPath.ForwardUpForwardPath(points, config);
         }
         else {
           new ConnectorPath.ForwardUpForwardDownPath(points, config);

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -31,6 +31,7 @@ const SELECTOR_FLOW_BRANCH = ".flow-branch";
 const SELECTOR_FLOW_CONDITION = ".flow-condition";
 const SELECTOR_FLOW_ITEM = ".flow-item";
 const SELECTOR_FLOW_LINE_PATH = ".FlowConnectorPath path:first-child";
+const JS_ENHANCEMENT_DONE = "jsdone";
 
 
 class ServicesController extends DefaultController {
@@ -68,7 +69,7 @@ ServicesController.edit = function() {
   }
 
   // Reverse the Brief flash of content quickfix.
-  $("#main-content").css("visibility", "visible");
+  $("#main-content").addClass(JS_ENHANCEMENT_DONE);
 }
 
 
@@ -626,11 +627,11 @@ function applyOverviewScroll($overview) {
 
   $(window).on("resize", function() {
     clearTimeout(timeout);
-    $main.css("visibility", "hidden");
+    $main.removeClass(JS_ENHANCEMENT_DONE);
     timeout = setTimeout(function() {
       $container.get(0).style = ""; // reset everything
       adjustScrollDimensionsAndPosition($container);
-      $main.css("visibility", "visible");
+      $main.addClass(JS_ENHANCEMENT_DONE);
     }, 1500);
   });
 }

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -736,8 +736,9 @@ function applyBranchFlowConnectorPaths($overview) {
 
       var destinationX = $destination.position().left;
       var destinationY = $destination.position().top + (rowHeight / 4);
-      var conditionX = (branchWidth / 2) + $condition.outerWidth(true) - 25 // 25 because we don't want lines to start at edge of column space
+      var conditionX = $condition.outerWidth(true) - 25 // 25 because we don't want lines to start at edge of column space
       var conditionY = $branch.position().top + $condition.position().top;
+      var halfBranchNodeWidth = (branchWidth / 2);
       var conditionColumn = condition.column;
       var conditionRow = condition.row;
       var destinationColumn = destination.column;
@@ -759,15 +760,27 @@ function applyBranchFlowConnectorPaths($overview) {
 
       if(backward || sameColumn) {
 
-        // If on the same row but destination  behind the current condition
-        new ConnectorPath.DownForwardDownBackwardUpPath({
-          from_x: branchX - (branchWidth / 2),
-          from_y: branchY,
-          to_x: destinationX,
-          to_y: destinationY,
-          via_x: conditionX,
-          via_y: conditionY
-        }, config);
+        // If on the same row but destination behind the current condition
+        if(firstConditionItem) {
+          new ConnectorPath.ForwardDownBackwardUpPath({
+            from_x: branchX,
+            from_y: branchY - (rowHeight / 4),
+            to_x: destinationX,
+            to_y: destinationY,
+            via_x: conditionX,
+            via_y: conditionY
+          }, config);
+        }
+        else {
+          new ConnectorPath.DownForwardDownBackwardUpPath({
+            from_x: branchX - (branchWidth / 2),
+            from_y: branchY,
+            to_x: destinationX,
+            to_y: destinationY,
+            via_x: conditionX + halfBranchNodeWidth,
+            via_y: conditionY
+          }, config);
+        }
       }
       else {
         // FORWARD
@@ -807,18 +820,19 @@ function applyBranchFlowConnectorPaths($overview) {
                   from_y: branchY,
                   to_x: destinationX,
                   to_y: destinationY,
-                  via_x: conditionX,
+                  via_x: conditionX + halfBranchNodeWidth,
                   via_y: conditionY
                 }, config);
               }
               else {
                 // NOT NEXT COLUMN
+
                 new ConnectorPath.DownForwardUpForwardDownPath({
                   from_x: branchX - (branchWidth / 2),
                   from_y: branchY,
                   to_x: destinationX,
                   to_y: destinationY,
-                  via_x: conditionX,
+                  via_x: conditionX + halfBranchNodeWidth,
                   via_y: conditionY
                 }, config);
               }
@@ -831,7 +845,7 @@ function applyBranchFlowConnectorPaths($overview) {
                 from_y: branchY,
                 to_x: destinationX,
                 to_y: destinationY,
-                via_x: conditionX,
+                via_x: conditionX + halfBranchNodeWidth,
                 via_y: conditionY
               }, config);
             }

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -815,7 +815,7 @@ function applyBranchFlowConnectorPaths($overview) {
             if(up) {
               if(nextColumn) {
 
-                new ConnectorPath.DownForwardUpForwardPath({
+                new ConnectorPath.DownForwardUpPath({
                   from_x: branchX - (branchWidth / 2),
                   from_y: branchY,
                   to_x: destinationX,

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -501,7 +501,6 @@ html {
  * ------------------------ */
 
 .services-edit {
-
   main {
     // Quickfix for Brief flash of content not ready for display.
     // This can be reversed when slow or view reliant JS has
@@ -510,6 +509,10 @@ html {
     // corresponding JS controller+action function to see where it
     // is turned off/reversed.
     visibility: hidden;
+
+    &.jsdone {
+      visibility: visible;
+    }
   }
 
   .ui-widget-overlay {


### PR DESCRIPTION
1. Add ForwardDownBackwardUpPath scenario for first condition item.
2. Rename ForwardUpPath to ForwardUpForwardPath to better reflect actual lines used.
3. (Additional bonus) Fix end point calculation of ForwardUpForwardPath causing overlap of destination FlowItem.
4. (Additional bonus) Fix end point calculation of ForwardUpForwardPath to avoid squared off arrow tip.
5. (Additional bonus) Fix end point calculation of ForwardDownForwardPath showing same issue with squared off point.

**Was (1):**
![Screenshot_2022-02-21_at_13 26 16](https://user-images.githubusercontent.com/76942244/156178678-867c485c-5ad4-4556-ac45-b46b12f2eef0.png)

**Now (1):**
<img width="1748" alt="Screenshot 2022-03-01 at 13 36 13" src="https://user-images.githubusercontent.com/76942244/156179857-778864a7-5712-424a-be46-035562ad2fa8.png">

**Was (3):**
<img width="451" alt="Screenshot 2022-03-01 at 13 44 44" src="https://user-images.githubusercontent.com/76942244/156180271-a36bc9f6-7047-4400-a66c-e407517f7961.png">

**Now (3):**
<img width="435" alt="Screenshot 2022-03-01 at 13 45 17" src="https://user-images.githubusercontent.com/76942244/156180305-61fcc9fc-9620-43c9-9e79-a9acc297d0a4.png">

