### PR TITLE
Fix unwanted HTML comment in editable content

### DIFF
--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -797,8 +797,9 @@ class EditableCollectionItemRemover {
  * Includes clean up of HTML by stripping attributes and unwanted trailing spaces.
  **/
 function convertToMarkdown(html) {
-  html = sanitiseHtml(html);
-  return converter.makeMarkdown(html);
+  var cleaned = sanitiseHtml(html);
+  var markdown = converter.makeMarkdown(cleaned);
+  return sanitiseMarkdown(markdown);
 }
 
 /* Extremely simple function to safely convert target elements, 
@@ -810,6 +811,15 @@ function convertToMarkdown(html) {
 function sanitiseHtml(html) {
   html = html.replace(/<([\/\s])?script[^\<\>]*?>/mig, "&lt;$1script&gt;");
   return html;
+}
+
+/* Opportunity safely strip out anything that we don't want here.
+ * 1. Something in makeMarkdown is adding <!-- --> markup to the result so we're trying to get rid of it.
+ * 2. ...
+ **/
+function sanitiseMarkdown(markdown) {
+  markdown = markdown.replace(/\n<!--.*?-->/mig, "");
+  return markdown;
 }
 
 /* Convert Markdown to HTML by tapping into third-party code.


### PR DESCRIPTION
Fix unwanted HTML comment being injected by Showdown's markdown converter code.

**Was:**
<img width="720" alt="Screenshot 2022-03-01 at 21 01 17" src="https://user-images.githubusercontent.com/76942244/156248508-d0949c12-9739-4a0e-a024-31bd61f19fd9.png">

**Now:**
<img width="755" alt="Screenshot 2022-03-01 at 21 04 13" src="https://user-images.githubusercontent.com/76942244/156248682-6deda88b-44e9-4bed-8b58-de382db9f114.png">
