### PR TITLE
Increase capybara default wait time

### DIFF
--- a/acceptance/support/capybara.rb
+++ b/acceptance/support/capybara.rb
@@ -11,3 +11,4 @@ Capybara.current_session.driver.reset!
 Capybara.default_host = ENV['ACCEPTANCE_TESTS_EDITOR_APP']
 Capybara.app_host = ENV['ACCEPTANCE_TESTS_EDITOR_APP']
 Capybara.run_server = false
+Capybara.default_max_wait_time = 4


### PR DESCRIPTION
Double the wait time to 4 seconds to see if it improves test performance