### PR TITLE
Update capybara config again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ jobs:
     docker: *test_image
     resource_class: large
     environment: *test_environment
-    parallelism: 7
+    parallelism: 5
     steps:
       - checkout
       - ruby/install-deps
@@ -333,7 +333,7 @@ jobs:
     docker: *test_image
     resource_class: large
     environment: *test_environment
-    parallelism: 7
+    parallelism: 5
     steps:
       - checkout
       - ruby/install-deps

--- a/acceptance/support/capybara.rb
+++ b/acceptance/support/capybara.rb
@@ -11,4 +11,4 @@ Capybara.current_session.driver.reset!
 Capybara.default_host = ENV['ACCEPTANCE_TESTS_EDITOR_APP']
 Capybara.app_host = ENV['ACCEPTANCE_TESTS_EDITOR_APP']
 Capybara.run_server = false
-Capybara.default_max_wait_time = 4
+Capybara.default_max_wait_time = 5


### PR DESCRIPTION
Bump default max wait time up to 5 seconds.

Reduce the number of parallel runs of the acceptance tests