### PR TITLE
Fix radios and checkboxes components deletion

### DIFF
--- a/acceptance/features/edit_single_checkboxes_question_page_spec.rb
+++ b/acceptance/features/edit_single_checkboxes_question_page_spec.rb
@@ -1,0 +1,167 @@
+
+require_relative '../spec_helper'
+
+feature 'Edit single radios question page' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:page_url) { 'star-wars-question' }
+  let(:question) do
+    'Which program do Jedi use to open PDF files?'
+  end
+  let(:initial_options) do
+    ['Adobe-wan Kenobi', 'PDFinn']
+  end
+  let(:options_after_addition) do
+    ['Adobe-wan Kenobi', 'PDFinn', 'Jar Jar Binks']
+  end
+  let(:options_after_deletion) do
+    ['Adobe-wan Kenobi', 'PDFinn']
+  end
+  let(:section_heading) { 'I open at the close' }
+  let(:default_section_heading) { I18n.t('default_text.section_heading') }
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'when editing the checkbox component' do
+    given_I_have_a_single_question_page_with_checkboxes
+    and_I_have_optional_section_heading_text
+    when_I_update_the_question_name
+    and_I_update_the_options
+    when_I_update_the_optional_section_heading
+    when_I_delete_the_optional_section_heading_text
+    and_I_return_to_flow_page
+    preview_form = then_I_should_see_my_changes_on_preview
+    and_I_should_see_the_options_that_I_added(preview_form, initial_options)
+  end
+
+  scenario 'when adding an option to the checkbox component' do
+    given_I_have_a_single_question_page_with_checkboxes
+    when_I_update_the_question_name
+    and_I_update_the_options
+    and_I_add_an_option('Jar Jar Binks')
+    then_I_should_see_the_options(options_after_addition)
+    and_I_return_to_flow_page
+    preview_form = then_I_should_see_my_changes_on_preview
+    and_I_should_see_the_options_that_I_added(preview_form, options_after_addition)
+  end
+
+  scenario 'when deleting an option from the checkbox component' do
+    given_I_have_a_single_question_page_with_checkboxes
+    when_I_update_the_question_name
+    and_I_update_the_options
+    and_I_add_an_option('Jar Jar Binks')
+    then_I_should_see_the_options(options_after_addition)
+    and_I_delete_an_option('Jar Jar Binks')
+    then_I_should_see_the_options(options_after_deletion)
+    and_I_return_to_flow_page
+    preview_form = then_I_should_see_my_changes_on_preview
+    and_I_should_see_the_options_that_I_added(preview_form, options_after_deletion)
+  end
+
+  def given_I_have_a_single_question_page_with_checkboxes
+    given_I_add_a_single_question_page_with_checkboxes
+    and_I_add_a_page_url
+    when_I_add_the_page
+  end
+
+  def when_I_update_the_optional_section_heading
+    and_I_edit_the_optional_section_heading
+    when_I_save_my_changes
+    then_I_should_see_my_updated_section_heading
+  end
+
+  def when_I_delete_the_optional_section_heading_text
+    editor.section_heading_hint.set(' ')
+    when_I_save_my_changes
+    then_I_should_see_the_default_section_heading
+  end
+
+  def when_I_update_the_question_name
+    and_I_edit_the_question
+    when_I_save_my_changes
+  end
+  
+  def and_I_edit_the_question
+    editor.question_heading.first.set(question)
+  end
+
+  def and_I_edit_the_optional_section_heading
+    page.first('.fb-section_heading').set(section_heading)
+  end
+
+  def and_I_update_the_options
+    and_I_edit_the_options
+    when_I_save_my_changes
+  end
+
+  def and_I_edit_the_options
+    editor.editable_options.first.set(initial_options.first)
+    editor.editable_options.last.set(initial_options.last)
+  end
+
+  def and_I_add_an_option(option_label)
+    click_button(I18n.t('actions.option_add'))
+    page.find('label', text: I18n.t('default_text.option')).base.send_keys(option_label)
+    when_I_save_my_changes
+  end
+
+  def and_I_delete_an_option(option_label)
+    when_I_want_to_select_component_properties('label', option_label)
+    click_button(I18n.t('question.menu.remove'))
+    expect(page).to have_selector('.DialogConfirmation')
+    click_button(I18n.t('dialogs.button_delete_option'))
+    expect(page).to_not have_text(option_label)
+  end
+
+  def and_I_have_optional_section_heading_text
+    expect(page.text).to include(I18n.t('default_text.section_heading'))
+  end
+
+  def and_I_go_to_the_page_that_I_edit(preview_form)
+    within_window(preview_form) do
+      page.click_button 'Start now'
+    end
+  end
+
+  def then_I_should_see_my_updated_section_heading
+    expect(editor.text).to include(section_heading)
+  end
+
+  def then_I_should_see_the_default_section_heading
+    expect(editor.section_heading_hint.text).to eq(default_section_heading)
+  end
+
+  def then_I_should_see_the_options(options)
+    expect(editor.checkboxes_options.size).to eql options.size
+    options.each do |option|
+      expect(page.text).to include(option)
+    end
+  end
+
+  def then_I_should_see_my_changes_on_preview
+    preview_form = and_I_preview_the_form
+
+    and_I_go_to_the_page_that_I_edit(preview_form)
+    then_I_should_see_my_changes_in_the_form(preview_form)
+    then_I_should_not_see_optional_text
+
+    preview_form
+  end
+
+  def then_I_should_see_my_changes_in_the_form(preview_form)
+    within_window(preview_form) do
+      expect(page.text).to include(question)
+    end
+  end
+
+  def and_I_should_see_the_options_that_I_added(preview_form, options)
+    within_window(preview_form) do
+      options.each do |option|
+        expect(page.text).to include(option)
+      end
+    end
+  end
+end

--- a/acceptance/features/edit_single_question_page_spec.rb
+++ b/acceptance/features/edit_single_question_page_spec.rb
@@ -66,30 +66,6 @@ feature 'Edit single question page' do
     then_I_should_see_my_changes_on_preview
   end
 
-  scenario 'when editing radio component' do
-    given_I_have_a_single_question_page_with_radio
-    and_I_have_optional_section_heading_text
-    when_I_update_the_question_name
-    and_I_update_the_options
-    when_I_update_the_optional_section_heading
-    when_I_delete_the_optional_section_heading_text
-    and_I_return_to_flow_page
-    preview_form = then_I_should_see_my_changes_on_preview
-    and_I_should_see_the_options_that_I_added(preview_form)
-  end
-
-  scenario 'when editing checkboxes component' do
-    given_I_have_a_single_question_page_with_checkboxes
-    and_I_have_optional_section_heading_text
-    when_I_update_the_question_name
-    and_I_update_the_options
-    when_I_update_the_optional_section_heading
-    when_I_delete_the_optional_section_heading_text
-    and_I_return_to_flow_page
-    preview_form = then_I_should_see_my_changes_on_preview
-    and_I_should_see_the_options_that_I_added(preview_form)
-  end
-
   scenario 'when editing email component' do
     given_I_have_a_single_question_page_with_email
     and_I_have_optional_section_heading_text
@@ -118,11 +94,6 @@ feature 'Edit single question page' do
     when_I_add_the_page
   end
 
-  def given_I_have_a_single_question_page_with_checkboxes
-    given_I_add_a_single_question_page_with_checkboxes
-    and_I_add_a_page_url
-    when_I_add_the_page
-  end
 
   def given_I_have_a_single_question_page_with_email
     given_I_add_a_single_question_page_with_email

--- a/acceptance/features/edit_single_radios_question_page_spec.rb
+++ b/acceptance/features/edit_single_radios_question_page_spec.rb
@@ -1,0 +1,162 @@
+require_relative '../spec_helper'
+
+feature 'Edit single radios question page' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:page_url) { 'star-wars-question' }
+  let(:question) do
+    'Which program do Jedi use to open PDF files?'
+  end
+  let(:initial_options) do
+    ['Adobe-wan Kenobi', 'PDFinn']
+  end
+  let(:options_after_addition) do
+    ['Adobe-wan Kenobi', 'PDFinn', 'Jar Jar Binks']
+  end
+  let(:options_after_deletion) do
+    ['Adobe-wan Kenobi', 'PDFinn']
+  end
+  let(:section_heading) { 'I open at the close' }
+  let(:default_section_heading) { I18n.t('default_text.section_heading') }
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service
+  end
+
+  scenario 'when editing the radio component' do
+    given_I_have_a_single_question_page_with_radio
+    and_I_have_optional_section_heading_text
+    when_I_update_the_question_name
+    and_I_update_the_options
+    when_I_update_the_optional_section_heading
+    when_I_delete_the_optional_section_heading_text
+    and_I_return_to_flow_page
+    preview_form = then_I_should_see_my_changes_on_preview
+    and_I_should_see_the_options_that_I_added(preview_form, initial_options)
+  end
+
+  scenario 'when adding an option to the radio component' do
+    given_I_have_a_single_question_page_with_radio
+    when_I_update_the_question_name
+    and_I_update_the_options
+    and_I_add_an_option('Jar Jar Binks')
+    then_I_should_see_the_options(options_after_addition)
+    and_I_return_to_flow_page
+    preview_form = then_I_should_see_my_changes_on_preview
+    and_I_should_see_the_options_that_I_added(preview_form, options_after_addition)
+  end
+
+  scenario 'when deleting an option from the radio component' do
+    given_I_have_a_single_question_page_with_radio
+    when_I_update_the_question_name
+    and_I_update_the_options
+    and_I_add_an_option('Jar Jar Binks')
+    then_I_should_see_the_options(options_after_addition)
+    and_I_delete_an_option('Jar Jar Binks')
+    then_I_should_see_the_options(options_after_deletion)
+    and_I_return_to_flow_page
+    preview_form = then_I_should_see_my_changes_on_preview
+    and_I_should_see_the_options_that_I_added(preview_form, options_after_deletion)
+  end
+
+
+  def when_I_update_the_optional_section_heading
+    and_I_edit_the_optional_section_heading
+    when_I_save_my_changes
+    then_I_should_see_my_updated_section_heading
+  end
+
+  def when_I_delete_the_optional_section_heading_text
+    editor.section_heading_hint.set(' ')
+    when_I_save_my_changes
+    then_I_should_see_the_default_section_heading
+  end
+
+  def when_I_update_the_question_name
+    and_I_edit_the_question
+    when_I_save_my_changes
+  end
+  
+  def and_I_edit_the_question
+    editor.question_heading.first.set(question)
+  end
+
+  def and_I_edit_the_optional_section_heading
+    page.first('.fb-section_heading').set(section_heading)
+  end
+
+  def and_I_update_the_options
+    and_I_edit_the_options
+    when_I_save_my_changes
+  end
+
+  def and_I_edit_the_options
+    editor.editable_options.first.set(initial_options.first)
+    editor.editable_options.last.set(initial_options.last)
+  end
+
+  def and_I_add_an_option(option_label)
+    click_button(I18n.t('actions.option_add'))
+    # editor.editable_options.last.find('label').base.send_keys(option_label)
+    page.find('label', text: I18n.t('default_text.option')).base.send_keys(option_label)
+    when_I_save_my_changes
+  end
+
+  def and_I_delete_an_option(option_label)
+    when_I_want_to_select_component_properties('label', option_label)
+    click_button(I18n.t('question.menu.remove'))
+    expect(page).to have_selector('.DialogConfirmation')
+    click_button(I18n.t('dialogs.button_delete_option'))
+    expect(page).to_not have_text(option_label)
+  end
+
+  def and_I_have_optional_section_heading_text
+    expect(page.text).to include(I18n.t('default_text.section_heading'))
+  end
+
+  def and_I_go_to_the_page_that_I_edit(preview_form)
+    within_window(preview_form) do
+      page.click_button 'Start now'
+    end
+  end
+
+  def then_I_should_see_my_updated_section_heading
+    expect(editor.text).to include(section_heading)
+  end
+
+  def then_I_should_see_the_default_section_heading
+    expect(editor.section_heading_hint.text).to eq(default_section_heading)
+  end
+
+  def then_I_should_see_the_options(options)
+    expect(editor.radio_options.size).to eql options.size
+    options.each do |option|
+      expect(page.text).to include(option)
+    end
+  end
+
+  def then_I_should_see_my_changes_on_preview
+    preview_form = and_I_preview_the_form
+
+    and_I_go_to_the_page_that_I_edit(preview_form)
+    then_I_should_see_my_changes_in_the_form(preview_form)
+    then_I_should_not_see_optional_text
+
+    preview_form
+  end
+
+  def then_I_should_see_my_changes_in_the_form(preview_form)
+    within_window(preview_form) do
+      expect(page.text).to include(question)
+    end
+  end
+
+  def and_I_should_see_the_options_that_I_added(preview_form, options)
+    within_window(preview_form) do
+      options.each do |option|
+        expect(page.text).to include(option)
+      end
+    end
+  end
+end

--- a/acceptance/support/capybara.rb
+++ b/acceptance/support/capybara.rb
@@ -1,6 +1,6 @@
 Capybara.register_driver :selenium do |app|
   chrome_options = Selenium::WebDriver::Chrome::Options.new.tap do |o|
-    # o.add_argument '--headless'
+    o.add_argument '--headless'
     o.add_argument '--no-sandbox'
   end
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options)
@@ -11,4 +11,4 @@ Capybara.current_session.driver.reset!
 Capybara.default_host = ENV['ACCEPTANCE_TESTS_EDITOR_APP']
 Capybara.app_host = ENV['ACCEPTANCE_TESTS_EDITOR_APP']
 Capybara.run_server = false
-Capybara.default_max_wait_time = 10
+Capybara.default_max_wait_time = 8

--- a/acceptance/support/capybara.rb
+++ b/acceptance/support/capybara.rb
@@ -1,6 +1,6 @@
 Capybara.register_driver :selenium do |app|
   chrome_options = Selenium::WebDriver::Chrome::Options.new.tap do |o|
-    o.add_argument '--headless'
+    # o.add_argument '--headless'
     o.add_argument '--no-sandbox'
   end
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: chrome_options)
@@ -11,3 +11,4 @@ Capybara.current_session.driver.reset!
 Capybara.default_host = ENV['ACCEPTANCE_TESTS_EDITOR_APP']
 Capybara.app_host = ENV['ACCEPTANCE_TESTS_EDITOR_APP']
 Capybara.run_server = false
+Capybara.default_max_wait_time = 10

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -170,6 +170,7 @@ module CommonSteps
   end
 
   def and_I_return_to_flow_page
+    page.find('#main-content', visible: true)
     editor.pages_link.click
   end
 
@@ -336,10 +337,10 @@ module CommonSteps
   end
 
   def and_I_click_on_the_three_dots
-    #sleep 1 # Arbitrary delay, possibly required due to focus issues
+    # sleep 1 # Arbitrary delay, possibly required due to focus issues
     # assuming the last two pages are checkanswers and confirmation, always pick
     # the page directly before the checkanswers page
-    editor.wait_until_preview_page_images_visible
+    find('#main-content', visible: true)
     editor.preview_page_images[-2].hover
     editor.three_dots_button.click
   end
@@ -354,6 +355,7 @@ module CommonSteps
   end
 
   def then_I_should_not_be_able_to_add_page(page)
+    find('#main-content', visible: true)
     editor.preview_page_images.first.hover
     editor.three_dots_button.click
     editor.add_page_here_link.click
@@ -361,6 +363,8 @@ module CommonSteps
   end
 
   def then_I_should_be_able_to_add_page(page)
+    # expect(page).to have_selector('#main-content', visible: true)
+    find('#main-content', visible: true)
     editor.preview_page_images.first.hover
     editor.three_dots_button.click
     editor.add_page_here_link.click

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -336,9 +336,10 @@ module CommonSteps
   end
 
   def and_I_click_on_the_three_dots
-    sleep 1 # Arbitrary delay, possibly required due to focus issues
+    #sleep 1 # Arbitrary delay, possibly required due to focus issues
     # assuming the last two pages are checkanswers and confirmation, always pick
     # the page directly before the checkanswers page
+    editor.wait_until_preview_page_images_visible
     editor.preview_page_images[-2].hover
     editor.three_dots_button.click
   end

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -386,6 +386,20 @@ function enhanceQuestions(view) {
         }
       },
 
+      onItemRemoveConfirmation: function(item) {
+        // @item (EditableComponentItem) Item to be deleted.
+        // Runs before onItemRemove when removing an editable Collection item.
+        // Currently not used but added for future option and consistency
+        // with onItemAdd (provides an opportunity for clean up).
+        view.dialogConfirmationDelete.open({
+          heading: view.text.dialogs.heading_delete_option.replace(/%{option label}/, item._elements.label.$node.text()),
+          ok: view.text.dialogs.button_delete_option
+          }, function() {
+          item.component.removeItem(item);
+        });
+      }
+
+
     });
     view.addLastPointHandler(question.menu.activator.$node);
   });
@@ -404,6 +418,20 @@ function enhanceQuestions(view) {
           answers: view.text.aria.answers
         }
       },
+
+      onItemRemoveConfirmation: function(item) {
+        // @item (EditableComponentItem) Item to be deleted.
+        // Runs before onItemRemove when removing an editable Collection item.
+        // Currently not used but added for future option and consistency
+        // with onItemAdd (provides an opportunity for clean up).
+        view.dialogConfirmationDelete.open({
+          heading: view.text.dialogs.heading_delete_option.replace(/%{option label}/, item._elements.label.$node.text()),
+          ok: view.text.dialogs.button_delete_option
+          }, function() {
+          item.component.removeItem(item);
+        });
+      }
+
 
     });
     view.addLastPointHandler(question.menu.activator.$node);

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -725,7 +725,6 @@ class EditableComponentCollectionItem extends EditableComponentBase {
   }
 
   remove() {
-    console.log('sdjkm,bkjd');
     if(this._config.onItemRemoveConfirmation) {
       // If we have confirgured a way to confirm first...
       safelyActivateFunction(this._config.onItemRemoveConfirmation, this);

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -725,6 +725,7 @@ class EditableComponentCollectionItem extends EditableComponentBase {
   }
 
   remove() {
+    console.log('sdjkm,bkjd');
     if(this._config.onItemRemoveConfirmation) {
       // If we have confirgured a way to confirm first...
       safelyActivateFunction(this._config.onItemRemoveConfirmation, this);

--- a/app/javascript/src/question_radios.js
+++ b/app/javascript/src/question_radios.js
@@ -79,6 +79,10 @@ class RadiosQuestion extends Question {
           activatedMenu.container.$node.remove();
         }
       },
+      onItemRemoveConfirmation: function(item) {
+        // @item (EditableComponentItem) Item to be deleted.
+        // Runs before onItemRemove when removing an editable Collection item.
+      }
 
     }, config));
 

--- a/app/javascript/src/question_radios.js
+++ b/app/javascript/src/question_radios.js
@@ -71,6 +71,7 @@ class RadiosQuestion extends Question {
         // @item (EditableComponentItem) Item to be deleted.
         // Runs before removing an editable Collection item.
         // Provides an opportunity for clean up.
+        console.log('remove');
         var activatedMenu = item.$node.data("ActivatedMenu");
         if(activatedMenu) {
           activatedMenu.activator.$node.remove();
@@ -78,10 +79,7 @@ class RadiosQuestion extends Question {
           activatedMenu.container.$node.remove();
         }
       },
-      onItemRemoveConfirmation: function(item) {
-        // @item (EditableComponentItem) Item to be deleted.
-        // Runs before onItemRemove when removing an editable Collection item.
-      }
+
     }, config));
 
     $node.addClass("RadiosQuestion");


### PR DESCRIPTION
Fix for [ticket #2375](https://trello.com/c/0T5Rt3u1/2375-bug-cant-delete-extra-radio-and-checkboxes-options-69-s)

Reinstates the code deleted previously to trigger confirm modal on attempting to delete an option from radio or checkbox components.

Also add in tests for option addition and deletion

**N.B.**
I am aware that the test refactoring here is not very DRY (at all!)

However when I attempted to dry it up and extract shared methods it uncovered a bit of a pandoras box - turns out there are at least 4 methods `when_I_update_the_question_name` some defined with an argument and others not, and it became hard to know which one was being called...  So in a bid not to refactor too much in a tiny bugfix I left this at the simplest implementation I could get away with to test the addition and deletion of the options.


