### PR TITLE
Parameterize url before validation

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -43,7 +43,7 @@ class PagesController < FormController
       :page
     ).permit(
       :page_url, :page_type, :component_type, :add_page_after, :conditional_uuid
-    ).merge(common_params)
+    ).merge(parameterize_url).merge(common_params)
   end
 
   def page_update_params
@@ -138,5 +138,9 @@ class PagesController < FormController
 
   def component_collection
     add_extra_component ? EXTRA_COMPONENTS : COMPONENTS
+  end
+
+  def parameterize_url
+    { page_url: params[:page][:page_url].parameterize }
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -124,4 +124,49 @@ RSpec.describe PagesController do
       end
     end
   end
+
+  describe '#page_creation_params' do
+    let(:common_params) { {} }
+    let(:params) do
+      {
+        add_page_after: '67890',
+        page_type: 'singlequestion',
+        component_type: 'text',
+        page_url: 'my first page'
+      }
+    end
+
+    before do
+      allow(controller).to receive(:params).and_return(
+        ActionController::Parameters.new(page: params).merge(common_params)
+      )
+      allow(controller).to receive(:service_metadata).and_return(service_metadata)
+    end
+
+    context 'when page url includes spaces' do
+      let(:expected_url) { 'my-first-page' }
+
+      it 'parameterizes the page_url param' do
+        expect(controller.page_creation_params.fetch(:page_url)).to eq(expected_url)
+      end
+    end
+
+    context 'when page url has special characters' do
+      let(:params) { { page_url: '(£$%*hello@£$hello£$@$' } }
+      let(:expected_url) { 'hello-hello' }
+
+      it 'parameterizes the page_url param' do
+        expect(controller.page_creation_params.fetch(:page_url)).to eq(expected_url)
+      end
+    end
+
+    context 'when page url has only special characters' do
+      let(:params) { { page_url: '(£$%*@£$£$@$' } }
+      let(:expected_url) { '' }
+
+      it 'parameterizes the page_url param' do
+        expect(controller.page_creation_params.fetch(:page_url)).to eq(expected_url)
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/8nAk5oTE/2373-auto-generate-url-from-user-input)

Attempted to do this previously with a `before_validation` callback in the PageCreation class, however, the validation continues to be triggered.

Making this change in the controller means we do not trigger the special characters validation in the PageCreation class and allows us to preserve all validations in the PageCreation class.