### PR TITLE
Fix footer height when too small to reach base of page

### DIFF
--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -58,7 +58,7 @@ ServicesController.edit = function() {
 
   createPageAdditionDialog(view);
   createPageMenus(view);
-
+  createConnectionMenus(view);
   if(view.$flowOverview.length) {
     layoutFormFlowOverview(view);
   }
@@ -67,7 +67,6 @@ ServicesController.edit = function() {
     layoutDetachedItemsOveriew(view);
   }
 
-  createConnectionMenus(view);
   addServicesContentScrollContainer(view);
 
   // Reverse the Brief flash of content quickfix.
@@ -554,8 +553,8 @@ function adjustScrollDimensionsAndPositions($body, $container, $main, $header, $
   }
 
   // If content length is not enought we need to stretch the footer vertically.
-  if($body.height() < window.outerHeight) {
-    $footer.height(window.outerHeight - $body.height() + 30); // Hack! 30px extra is guess as not adding up.
+  if($body.outerHeight() < window.innerHeight) {
+    $footer.height($footer.height() + (window.innerHeight - $body.outerHeight()));
   }
 
   // Make sure the content aligns to left as thought centred to viewport not full width of scroll.


### PR DESCRIPTION
Due to changes required for the latest scrolling, the standard footer background (normally a grey background on <html> element) cannot hide the white gap between the base of footer and bottom of page. This is a correction to the calculation previously trying (and failing) to stretch the footer height to compensate).

**Was**
<img width="1453" alt="Screenshot 2022-03-06 at 15 05 15" src="https://user-images.githubusercontent.com/76942244/156929055-42878479-ac10-49c5-97db-b2aaf24ad3b2.png">

**Now**
<img width="1387" alt="Screenshot 2022-03-06 at 15 05 33" src="https://user-images.githubusercontent.com/76942244/156929063-d0c79b74-5f1e-443b-af49-800c5332585d.png">
