### PR TITLE
Add save button feedback to question edit page

### DIFF
--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -58,7 +58,7 @@ class PagesController extends DefaultController {
  * ------------------------------ */
 PagesController.edit = function() {
   var view = this;
-  var dataController = new DataController();
+  var dataController = new DataController(view);
 
   this.$editable = $(".fb-editable");
   this.dataController = dataController;
@@ -129,18 +129,26 @@ PagesController.create = function() {
 
 
 class DataController {
-  constructor() {
+  constructor(view) {
     var controller = this;
     var $form = $("#editContentForm");
+    this.text = view.text;
+
+    $form.find(":submit").on("click", (event) => {
+      $(event.target).prop("value", this.text.actions.saving );
+    });
+
     $form.on("submit", controller.update);
     this.$form = $form;
   }
 
   saveRequired(required) {
-    if(required) {
+    if(required) { 
+      this.$form.find(":submit").prop("value", this.text.actions.save );
       this.$form.find(":submit").prop("disabled", false);
     }
     else {
+      this.$form.find(":submit").prop("value", this.text.actions.saved );
       this.$form.find(":submit").prop("disabled", true);
     }
   }

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -106,6 +106,11 @@ html {
   position: absolute;
   right: 0;
   top: 3px;
+  width: 100px;
+
+  &:disabled:hover {
+    background-color: $govuk-brand-colour;
+  }
 
   @include govuk-media-query($until: tablet) {
     position: static;

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -62,7 +62,9 @@
       },
       actions: {
         edit: "<%= t('actions.edit') %>",
-        save: "<%= t('actions.save') %>"
+        save: "<%= t('actions.save') %>",
+        saving: "<%= t('actions.saving') %>",
+        saved: "<%= t('actions.saved') %>"
       }
     }
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,8 @@ en:
   actions:
     edit: 'Edit'
     save: 'Save'
+    saving: 'Saving...'
+    saved: 'Saved'
     continue: 'Continue'
     add_page: 'Add page here'
     publish_to_test: 'Publish to Test'


### PR DESCRIPTION
Resolves [ticket #2352](https://trello.com/c/g39t07L3/2352-review-save-button-feedback-and-action-s)

Adds in feedback to the save process by updating the button text while saving, and when save is complete.

Also adds a couple of requested tweaks to the button styling.

N.B. This needs further work to be fully accessible - have created and [added a card](https://trello.com/c/ll8Ejn9n/2114-screen-reader-feedback-on-saving-a-question-page) to the accessibiltiy backlog to be addressed once branching is launched.

