### PR TITLE
Add reconnect page help link to unconnected section

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -806,6 +806,14 @@ html {
     display: inline-block;
   }
 
+  p.help {
+    margin: 0 0 38px 0;
+  } 
+
+  .Expander_container {
+    @include govuk-width-container($govuk-page-width);
+  }
+
   .flow-detached-group {
     position: relative;
   }

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -23,7 +23,7 @@
   <section id="flow-detached" data-component="Expander">
     <h2 class="govuk-heading-s"><%= t('pages.flow.detached') %></h2>
     <p class="help">
-      <a target="_blank" href="https://moj-forms.service.justice.gov.uk/user-guide/branching-and-flow-management.html#reconnect-unconnected" class="govuk-link">How do I reconnect these?</a>
+      <a target="_blank" href="https://moj-forms.service.justice.gov.uk/branching#reconnect-unconnected" class="govuk-link"><%= t('pages.flow.reconnect_hint') -%></a>
     </p>
     <% @detached_flows.each do |detached_flow| %>
           <div class="flow-detached-group">

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -22,7 +22,9 @@
 <% if ENV['BRANCHING'] == 'enabled' && @detached_flows.present? %>
   <section id="flow-detached" data-component="Expander">
     <h2 class="govuk-heading-s"><%= t('pages.flow.detached') %></h2>
-
+    <p class="help">
+      <a target="_blank" href="https://moj-forms.service.justice.gov.uk/user-guide/branching-and-flow-management.html#reconnect-unconnected" class="govuk-link">How do I reconnect these?</a>
+    </p>
     <% @detached_flows.each do |detached_flow| %>
           <div class="flow-detached-group">
         <% detached_flow.each do |column| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,7 @@ en:
       delete_warning_both_pages: 'You won’t receive any user data without a check answers page and a confirmation page'
       delete_warning_cya_page: 'You won’t receive any user data without a check answers page'
       delete_warning_confirmation_page: 'You won’t receive any user data without a confirmation page'
+      reconnect_hint: 'How do I reconnect these?'
     name: 'Pages'
     create: 'Add page'
     cancel: 'Cancel'


### PR DESCRIPTION
Resolves [ticket #2374](https://trello.com/c/qhfZLxnH/2374-add-link-to-guidance-for-reconnecting-pages-in-the-unconnected-pages-section)

Adds in a link into the unconnected section with a link to the appropriate section in the user guide to help users in reconnecting pages back into their form.
