### PR TITLE
Fix incorrect calculation causing unconnected path

### DIFF
--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -896,7 +896,7 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
     var dimensions = {
       down1: Math.round(utilities.difference(points.from_y, this.points.via_y) - CURVE_SPACING),
       forward1: Math.round(points.via_x - (CURVE_SPACING * 2)),
-      up: Math.round(utilities.difference(points.from_y, this.points.via_y) + utilities.difference(points.from_y, this.points.to_y) + utilities.difference(points.to_y, config.top)),
+      up: Math.round(utilities.difference(this.points.via_y, this._config.top)),
       forward2: Math.round(utilities.difference(points.from_x + this.points.via_x, this.points.to_x) - (CURVE_SPACING * 4)),
       down2: Math.round(points.to_y),
       forward3: 0 // start value


### PR DESCRIPTION
Not sure why this calculation was now showing an unconnected line.
Bit worried that by fixing this something else gets broken but, in theory at least, that should not be.
Fixed it by simplifying calculation and basing it on similar one used for ForwardUpForwardDownPath.

**Was**
<img width="1415" alt="Screenshot 2022-03-07 at 14 50 01" src="https://user-images.githubusercontent.com/76942244/157057458-1e868bae-84dc-43cb-85c2-1be8db4cc54d.png">

**Now**
<img width="1426" alt="Screenshot 2022-03-07 at 14 50 39" src="https://user-images.githubusercontent.com/76942244/157057487-5eb41701-6eb5-4a2e-8914-205dc41a711f.png">
