### PR TITLE
Fixes 2331 branch edit update

### DIFF
--- a/app/javascript/src/controller_branches.js
+++ b/app/javascript/src/controller_branches.js
@@ -239,10 +239,33 @@ class BranchInjector {
  * It also alters the HTML by swapping in target points for adding
  * the required information in the right places.
  *
+ * IMPORTANT: There should always be at least one .condition element in
+ * the page content. This code fell over when, possibly due to an unfixed
+ * bug, the html variable couldn't get some code, due to the target node
+ * not having a .condition to find. To compensate (without fixing any
+ * underlying issue that is in a separate ticket) the code has been
+ * updated to try and find any .condition element if the preferred item
+ * cannot be found. This is purely a second-chance addition and will
+ * likely not fix the page should an incorrect scenario occur. It will,
+ * however, have a chance to make it look better (less broken).
+ *
  * @$node (jQuery Node) HTML that will form the Branch
  **/
 function createBranchConditionTemplate($node) {
-  var html = $node.find(".condition").get(0).outerHTML;
+  var $condition = $node.find(".condition");
+  var html = "";
+
+  // See IMPORTANT, above.
+  if($condition.length == 0) {
+    $condition = $(".condition");
+  }
+
+  // We hope to have something but wrapping in test just in case we do not.
+  if($condition.length) {
+    html = $(".condition").get(0).outerHTML;
+  }
+
+  // html is a string, either empty or populated, so we should be safe from here.
   html = html.replace(
           /branch_conditionals_attributes_0_expressions_attributes_0_component/mig,
           "branch_conditionals_attributes_#{branch_index}_expressions_attributes_#{condition_index}_component");

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -167,6 +167,12 @@ html {
     right: govuk-spacing(4);
     top: govuk-spacing(5);
   }
+
+  .name {
+    span {
+      display: inline;
+    }
+  }
 }
 
 .BranchAnswer {

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -363,6 +363,14 @@ html {
       position: static;
     }
   }
+
+  h1 {
+    margin-bottom: govuk-spacing(7);
+  }
+
+  .govuk-form-group {
+    margin-bottom: govuk-spacing(4);
+  }
 }
 
 

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -37,6 +37,7 @@
         <% end %>
       </select>
     </div>
+    <p class="govuk-!-font-weight-bold"><%= t('branches.hint_otherwise') %></p>
   </div>
 </div>
 

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -9,7 +9,10 @@
 <p class="branch-or">or</p>
 
 <div class="branch" id="branch-otherwise">
-  <p class="govuk-heading-l"><%= t('branches.title_otherwise') %></p>
+  <p class="name govuk-heading-l">
+    <%= t('branches.title_otherwise') %>
+    <span class="name govuk-heading-m"><%= t('branches.hint_otherwise') %></span>
+  </p>
   <div class="destination">
     <div class="govuk-form-group <%= @branch.errors[:default_next].empty? ? '' : 'govuk-form-group--error' %>">
 
@@ -37,7 +40,6 @@
         <% end %>
       </select>
     </div>
-    <p class="govuk-!-font-weight-bold"><%= t('branches.hint_otherwise') %></p>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,8 +125,8 @@ en:
     select_destination: '--- Select next page ---'
     select_question: '--Select a question--'
     conditional_title: 'Branch '
-    title_otherwise: 'Otherwise'
-    hint_otherwise: 'In any other case'
+    title_otherwise: 'Otherwise,'
+    hint_otherwise: 'if none of the above'
     detached_list: 'Unconnected page'
     delete_modal:
       destinations: 'Go to:'


### PR DESCRIPTION
Basically just changing some text on the Otherwise Branch but does also include some defensive coding to help prevent the CSS getting knocked out by an issue when no Branch Condition is found. The underlying cause for that is actually due to another issue that's already documented in a separate ticket so not trying to fix that here, just helping limit the damage. 

**Was**
<img width="874" alt="Screenshot 2022-03-07 at 21 14 47" src="https://user-images.githubusercontent.com/76942244/157119234-fdc237ea-8b83-4949-b6f2-7af29d7d5757.png">

**Now**
<img width="942" alt="Screenshot 2022-03-07 at 21 14 10" src="https://user-images.githubusercontent.com/76942244/157119261-539c1228-5f2d-4931-af1c-251bbbc4c0ed.png">
