### PR TITLE
Add CYA page link before confirmation page

### DIFF
--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -37,7 +37,7 @@
         <li data-page-type="exit"><a href="#add-page"><%= t('actions.add_exit') -%></a></li>
     <% end %>
 
-    <% if !service.checkanswers_page.present? && item[:type] != 'flow.branch' && item[:next].blank?  %>
+   <% if !service.checkanswers_page.present? && item[:type] != 'flow.branch' && (item[:next].blank? || item[:next] == service.confirmation_page.uuid) %> 
       <li data-page-type="checkanswers"><a href="#add-page"><%= t('actions.add_check_answers') -%></a></li>
     <% end %>
       


### PR DESCRIPTION
Fixes [ticket](https://trello.com/c/qB3hFBa0/2391-unable-to-add-cya-page-between-last-page-and-confirmation-page)

In the situation where the check your answers page has been deleted, but the confinrmation page remained it was impossible to add the cya page into the flow (without first deleting the confirmation page)

This fix adds the 'Add cya page' link into the connection menu prior to the confirmation page if the cya page is not present.

Before:
<img width="846" alt="image" src="https://user-images.githubusercontent.com/595564/157227761-05c3ca4f-b35c-427b-aafe-087946a6a6da.png">

After:
<img width="1079" alt="image" src="https://user-images.githubusercontent.com/595564/157227659-b0a94b58-27a9-4cbe-b3b5-2d5bd1f93b94.png">
