### PR TITLE
Re-enable branch question condition if blank

### DIFF
--- a/app/javascript/src/component_branch.js
+++ b/app/javascript/src/component_branch.js
@@ -268,6 +268,7 @@ class BranchQuestion {
            this.enable(); 
            break;
       default:
+           this.enable(); 
            // Just trigger an event
            $(document).trigger(EVENT_QUESTION_CHANGE, this.condition.branch);
     }


### PR DESCRIPTION
Samll fix for this [ticket](https://trello.com/c/5UhTfICc/2388-saving-a-branching-point-with-select-a-question-isnt-always-prevented-and-breaks)

Re-enables the if question select if the user resets it to '--- Select Question ---' to allow for further selection.

This change also seems to resolve all validation/styling issues mentioned on the ticket too.

