### PR TITLE
Allow for times the confirmation page does not exist

### DIFF
--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -37,7 +37,7 @@
         <li data-page-type="exit"><a href="#add-page"><%= t('actions.add_exit') -%></a></li>
     <% end %>
 
-   <% if !service.checkanswers_page.present? && item[:type] != 'flow.branch' && (item[:next].blank? || item[:next] == service.confirmation_page.uuid) %> 
+   <% if !service.checkanswers_page.present? && item[:type] != 'flow.branch' && (item[:next].blank? || item[:next] == service.confirmation_page&.uuid) %>
       <li data-page-type="checkanswers"><a href="#add-page"><%= t('actions.add_check_answers') -%></a></li>
     <% end %>
 


### PR DESCRIPTION
Sometimes the confirmation page will not exist in a service. Therefore
do not allow the app to error when checking for the UUID of a page that
may or not be there.