### PR TITLE
Fix indexing of component, operator and field

### DIFF
--- a/acceptance/features/edit_branch_page_spec.rb
+++ b/acceptance/features/edit_branch_page_spec.rb
@@ -44,7 +44,47 @@ feature 'New branch page' do
     when_I_save_my_changes
     then_I_should_be_on_the_correct_branch_page('edit')
 
-    then_I_can_add_and_delete_conditionals_and_expressions
+    then_I_can_add_conditionals_and_expressions
+
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][2][component]',
+      'What is your favourite hobby?'
+    )
+
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][2][operator]',
+      'is not'
+    )
+
+    and_I_choose_an_option(
+      'branch[conditionals_attributes][0][expressions_attributes][2][field]',
+      'Sewing'
+    )
+
+    when_I_save_my_changes
+    then_I_should_not_see_an_error_summary
+
+    then_I_should_see_the_field_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][operator]',
+      'is'
+    )
+
+    then_I_should_see_the_field_option(
+      'branch[conditionals_attributes][0][expressions_attributes][0][field]',
+      'Hiking'
+    )
+
+    then_I_should_see_the_field_option(
+      'branch[conditionals_attributes][0][expressions_attributes][1][operator]',
+      'is not'
+    )
+
+    then_I_should_see_the_field_option(
+      'branch[conditionals_attributes][0][expressions_attributes][1][field]',
+      'Sewing'
+    )
+
+    then_I_can_delete_conditionals_and_expressions
 
     and_I_choose_an_option(
       'branch[conditionals_attributes][0][expressions_attributes][0][operator]',
@@ -113,7 +153,8 @@ feature 'New branch page' do
     when_I_save_my_changes
     then_I_should_be_on_the_correct_branch_page('edit')
 
-    then_I_can_add_and_delete_conditionals_and_expressions
+    then_I_can_add_conditionals_and_expressions
+    then_I_can_delete_conditionals_and_expressions
 
     when_I_save_my_changes
     then_I_should_see_the_previous_page_title('What is your favourite hobby?')

--- a/acceptance/features/new_branch_page_spec.rb
+++ b/acceptance/features/new_branch_page_spec.rb
@@ -77,7 +77,8 @@ feature 'New branch page' do
       'Which flavours of ice cream have you eaten?'
     )
 
-    then_I_can_add_and_delete_conditionals_and_expressions
+    then_I_can_add_conditionals_and_expressions
+    then_I_can_delete_conditionals_and_expressions
 
     when_I_save_my_changes
     then_I_should_be_on_the_correct_branch_page('edit')

--- a/acceptance/support/branching_steps.rb
+++ b/acceptance/support/branching_steps.rb
@@ -28,12 +28,14 @@ module BranchingSteps
     and_I_return_to_flow_page
   end
 
-  def then_I_can_add_and_delete_conditionals_and_expressions
+  def then_I_can_add_conditionals_and_expressions
     and_I_add_another_condition
     then_I_should_see_the_operator(I18n.t('branches.expression.and'))
     then_I_should_see_another_question_list
     then_I_should_see_the_delete_condition_button
+  end
 
+  def then_I_can_delete_conditionals_and_expressions
     and_I_delete_the_condition
     then_I_should_not_see_the_operator(I18n.t('branches.expression.and'))
     then_I_should_not_see_text(I18n.t('branches.condition_remove'))
@@ -293,5 +295,10 @@ module BranchingSteps
 
     editor.save_button.click
     and_I_return_to_flow_page
+  end
+
+  # Error summary #
+  def then_I_should_not_see_an_error_summary
+    expect(page).not_to have_selector('.govuk-error-summary')
   end
 end

--- a/app/javascript/src/controller_branches.js
+++ b/app/javascript/src/controller_branches.js
@@ -269,16 +269,14 @@ function createBranchConditionTemplate($node) {
     // Now take a copy of the HTML.
     html = $condition.get(0).outerHTML;
   }
-
   // html is a string, either empty or populated, so we should be safe from here.
   html = html.replace(
-          /branch_conditionals_attributes_0_expressions_attributes_0_component/mig,
-          "branch_conditionals_attributes_#{branch_index}_expressions_attributes_#{condition_index}_component");
+          /branch_conditionals_attributes_0_expressions_attributes_0_(component|operator|field)/mig,
+          "branch_conditionals_attributes_#{branch_index}_expressions_attributes_#{condition_index}_$1");
   html = html.replace(
-          /branch\[conditionals_attributes\]\[0\]\[expressions_attributes\]\[0\]\[component\]/mig,
-          "branch[conditionals_attributes][#{branch_index}][expressions_attributes][#{condition_index}][component]");
+          /branch\[conditionals_attributes\]\[0\]\[expressions_attributes\]\[0\]\[(component|operator|field)\]/mig,
+          "branch[conditionals_attributes][#{branch_index}][expressions_attributes][#{condition_index}][$1]");
   return html;
 }
-
 
 module.exports = BranchesController;

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -158,34 +158,34 @@ RSpec.describe Expression do
   end
 
   describe '#name_attr' do
-    let(:expected_name) do
-      'branch[conditionals_attributes][1][expressions_attributes][0][answer]'
-    end
+    let(:attributes) { %w[answer component operator field] }
 
-    it 'constucts the correct name attribute' do
-      expect(
-        expression.name_attr(
-          conditional_index: 1,
-          expression_index: 0,
-          attribute: 'answer'
-        )
-      ).to eq(expected_name)
+    it 'constructs the correct name attribute' do
+      attributes.each do |attribute|
+        expect(
+          expression.name_attr(
+            conditional_index: 1,
+            expression_index: 0,
+            attribute: attribute
+          )
+        ).to eq("branch[conditionals_attributes][1][expressions_attributes][0][#{attribute}]")
+      end
     end
   end
 
   describe '#id_attr' do
-    let(:expected_id) do
-      'branch_conditionals_attributes_0_expressions_attributes_1_operator'
-    end
+    let(:attributes) { %w[component operator field] }
 
     it 'constructs the correct id attribute' do
-      expect(
-        expression.id_attr(
-          conditional_index: 0,
-          expression_index: 1,
-          attribute: 'operator'
-        )
-      ).to eq(expected_id)
+      attributes.each do |attribute|
+        expect(
+          expression.id_attr(
+            conditional_index: 0,
+            expression_index: 1,
+            attribute: attribute
+          )
+        ).to eq("branch_conditionals_attributes_0_expressions_attributes_1_#{attribute}")
+      end
     end
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/Ajo83X4k/2409-unspecified-error-when-triing-to-have-an-and-condition-with-two-options-of-the-same-checkbox-as-contain)
When a user clicks 'Add condition' on a branching point, the name and id attributes should change.
Currently, only the `component` indices are being correctly indexed, the `operator` and `field` indices were not changed, as a result an error was thrown. This PR fixes this issue.

### Before
![old](https://user-images.githubusercontent.com/29227502/157863505-e5d04eb4-9cff-4132-88f4-8216d17a9ac9.png)

### After
![Screenshot 2022-03-11 at 12 02 23](https://user-images.githubusercontent.com/29227502/157863527-ac5f5d28-50a3-46b8-bb98-9a21f67b3831.png)
