### PR TITLE
Check existence of current_user object

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,10 +53,14 @@ module ApplicationHelper
   end
 
   def moj_forms_team?
+    return if current_user.blank?
+
     Rails.application.config.moj_forms_team.include?(current_user.email)
   end
 
   def moj_forms_dev?
+    return if current_user.blank?
+
     Rails.application.config.moj_forms_devs.include?(current_user.email)
   end
 


### PR DESCRIPTION
The header partial makes use of the helper methods to check whether or
not to show the admin link. If there is no current user then calling
`email` will raise an error.

Add guard clauses to stop that from happening. If there is no
current_user then just return and do not show the admin link.