### PR TITLE
Enable deletion of all radio and checkbox items if enough remain

### DIFF
--- a/acceptance/features/edit_single_checkboxes_question_page_spec.rb
+++ b/acceptance/features/edit_single_checkboxes_question_page_spec.rb
@@ -12,10 +12,10 @@ feature 'Edit single radios question page' do
     ['Adobe-wan Kenobi', 'PDFinn']
   end
   let(:options_after_addition) do
-    ['Adobe-wan Kenobi', 'PDFinn', 'Jar Jar Binks']
+    ['Adobe-wan Kenobi', 'Jar Jar Binks']
   end
   let(:options_after_deletion) do
-    ['Adobe-wan Kenobi', 'PDFinn']
+    ['Adobe-wan Kenobi']
   end
   let(:section_heading) { 'I open at the close' }
   let(:default_section_heading) { I18n.t('default_text.section_heading') }
@@ -42,7 +42,7 @@ feature 'Edit single radios question page' do
     when_I_update_the_question_name
     and_I_update_the_options
     and_I_add_an_option('Jar Jar Binks')
-    then_I_should_see_the_options(options_after_addition)
+    then_I_should_see_the_options(initial_options.push('Jar Jar Binks'))
     and_I_return_to_flow_page
     preview_form = then_I_should_see_my_changes_on_preview
     and_I_should_see_the_options_that_I_added(preview_form, options_after_addition)
@@ -52,6 +52,13 @@ feature 'Edit single radios question page' do
     given_I_have_a_single_question_page_with_checkboxes
     when_I_update_the_question_name
     and_I_update_the_options
+    and_I_delete_an_option('PDFinn')
+    and_I_want_to_delete_an_option('Adobe-wan Kenobi')
+    then_I_should_see_the_modal(
+      I18n.t('question_items.delete_modal.can_not_delete_heading'),
+      I18n.t('question_items.min_items_modal.can_not_delete_checkboxes_message')
+    )
+    and_I_close_the_modal(I18n.t('dialogs.button_understood'))
     and_I_add_an_option('Jar Jar Binks')
     then_I_should_see_the_options(options_after_addition)
     and_I_delete_an_option('Jar Jar Binks')
@@ -113,14 +120,21 @@ feature 'Edit single radios question page' do
 
   def and_I_add_an_option(option_label)
     click_button(I18n.t('actions.option_add'))
-    page.find('label', text: I18n.t('default_text.option')).base.send_keys(option_label)
+    page.find('label', text: I18n.t('default_text.option')).set('').base.send_keys(option_label)
     when_I_save_my_changes
   end
 
-  def and_I_delete_an_option(option_label)
+  def and_I_want_to_delete_an_option(option_label)
     when_I_want_to_select_component_properties('label', option_label)
     page.find('span', text: I18n.t('question.menu.remove')).click
-    expect(page).to have_selector('.ui-dialog')
+  end
+
+  def and_I_delete_an_option(option_label)
+    and_I_want_to_delete_an_option(option_label)
+    then_I_should_see_the_modal(
+             I18n.t('dialogs.heading_delete_option', label: option_label),
+             I18n.t('dialogs.message_delete')
+    )
     click_button(I18n.t('dialogs.button_delete_option'))
     expect(page).to_not have_text(option_label)
   end

--- a/acceptance/features/edit_single_radios_question_page_spec.rb
+++ b/acceptance/features/edit_single_radios_question_page_spec.rb
@@ -14,7 +14,7 @@ feature 'Edit single radios question page' do
     ['Adobe-wan Kenobi', 'PDFinn', 'Jar Jar Binks']
   end
   let(:options_after_deletion) do
-    ['Adobe-wan Kenobi', 'PDFinn']
+    ['Adobe-wan Kenobi', 'Jar Jar Binks']
   end
   let(:section_heading) { 'I open at the close' }
   let(:default_section_heading) { I18n.t('default_text.section_heading') }
@@ -51,9 +51,15 @@ feature 'Edit single radios question page' do
     given_I_have_a_single_question_page_with_radio
     when_I_update_the_question_name
     and_I_update_the_options
+    and_I_want_to_delete_an_option('PDFinn')
+    then_I_should_see_the_modal(
+      I18n.t('question_items.delete_modal.can_not_delete_heading'),
+      I18n.t('question_items.min_items_modal.can_not_delete_radios_message')
+    )
+    and_I_close_the_modal(I18n.t('dialogs.button_understood'))
     and_I_add_an_option('Jar Jar Binks')
     then_I_should_see_the_options(options_after_addition)
-    and_I_delete_an_option('Jar Jar Binks')
+    and_I_delete_an_option('PDFinn')
     then_I_should_see_the_options(options_after_deletion)
     and_I_return_to_flow_page
     preview_form = then_I_should_see_my_changes_on_preview
@@ -102,10 +108,17 @@ feature 'Edit single radios question page' do
     when_I_save_my_changes
   end
 
-  def and_I_delete_an_option(option_label)
+  def and_I_want_to_delete_an_option(option_label)
     when_I_want_to_select_component_properties('label', option_label)
     page.find('span', text: I18n.t('question.menu.remove')).click
-    expect(page).to have_selector('.ui-dialog')
+  end
+
+  def and_I_delete_an_option(option_label)
+    and_I_want_to_delete_an_option(option_label)
+    then_I_should_see_the_modal(
+             I18n.t('dialogs.heading_delete_option', label: option_label),
+             I18n.t('dialogs.message_delete')
+    )
     click_button(I18n.t('dialogs.button_delete_option'))
     expect(page).to_not have_text(option_label)
   end
@@ -134,6 +147,7 @@ feature 'Edit single radios question page' do
       expect(page.text).to include(option)
     end
   end
+
 
   def then_I_should_see_my_changes_on_preview
     preview_form = and_I_preview_the_form

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -76,7 +76,7 @@ class EditorApp < SitePrism::Page
           :xpath,
           "//a[@class='ui-menu-item-wrapper' and contains(.,'Content area')]"
 
-  element :question_three_dots_button, '.ActivatedMenu_Activator'
+  element :question_three_dots_button, '.ActivatedMenu_Activator', visible: true
   element :required_question,
           :xpath,
           "//span[@class='ui-menu-item-wrapper' and contains(.,'Required...')]"

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -409,4 +409,20 @@ module CommonSteps
     find('#main-content', visible: true)
     expect(editor.text).to include(DELETE_WARNING[2])
   end
+
+  def then_I_should_see_the_modal(modal_title, modal_text) 
+    expect(page).to have_selector('.ui-dialog', visible: true)
+    within('.ui-dialog', visible: true) do 
+      expect(page).to have_content modal_title
+      expect(page).to have_content modal_text
+    end
+  end
+
+  def and_I_close_the_modal(button_text=nil)
+    if button_text
+      click_button(button_text); 
+    else
+      click_button('.ui-dialog-titlebar-close')
+    end
+  end
 end

--- a/app/javascript/src/component_editable_collection_item_menu.js
+++ b/app/javascript/src/component_editable_collection_item_menu.js
@@ -48,51 +48,17 @@ class EditableCollectionItemMenu extends ActivatedMenu {
   }
 
   selection(event, item) {
-    var action = item.data("action");
+    let action = item.data("action");
     this.selectedItem = item;
 
     event.preventDefault();
     switch(action) {
       case "remove":
-           this.remove(item);
-           break;
-    }
-  }
-
-  remove(menuItem) {
-    var path = menuItem.data('api-path');
-    var collectionItem = this.collectionItem
-
-    var questionUuid =  collectionItem.component.data._uuid;
-    var optionUuid =  collectionItem.data._uuid; 
-
-    var url = utilities.stringInject(path, { 
-      'question_uuid': questionUuid, 
-      'option_uuid': optionUuid ?? 'new', 
-    });
-
-    if( !optionUuid ) {
-      url = url + '&label=' + encodeURIComponent( collectionItem.$node.find('label').text() );
-    }
-
-    if( collectionItem.component.canHaveItemsRemoved() ) {
-      new DialogApiRequest(url, {
-        activator: menuItem,
-        closeOnClickSelector: ".govuk-button",
-        build: function(dialog) {
-          dialog.$node.find("[data-method=delete]").on("click", function(e) {
-            e.preventDefault();
-            collectionItem.component.removeItem(collectionItem)
-          })
-        }
-      });
-    } else {
-      console.log(this._config.view.dialog);
-      this._config.view.dialog.open({
-        heading: 'This option cannot be removed',
-        content: 'Radio questions require a minimum of 2 answers.',
-        ok: 'Understood'
-      });
+        $(document).trigger("EditableCollectionItemMenuSelectionRemove", { 
+          selectedItem: item,
+          collectionItem: this.collectionItem
+        });
+        break;
     }
   }
 }

--- a/app/javascript/src/component_editable_collection_item_menu.js
+++ b/app/javascript/src/component_editable_collection_item_menu.js
@@ -20,6 +20,7 @@ const utilities = require('./utilities');
 const mergeObjects = utilities.mergeObjects;
 const ActivatedMenu = require('./component_activated_menu');
 const DialogApiRequest = require('./component_dialog_api_request');
+const Dialog = require('./component_dialog');
 
 
 class EditableCollectionItemMenu extends ActivatedMenu {
@@ -58,8 +59,8 @@ class EditableCollectionItemMenu extends ActivatedMenu {
     }
   }
 
-  remove(item) {
-    var path = item.data('api-path');
+  remove(menuItem) {
+    var path = menuItem.data('api-path');
     var collectionItem = this.collectionItem
 
     var questionUuid =  collectionItem.component.data._uuid;
@@ -73,19 +74,26 @@ class EditableCollectionItemMenu extends ActivatedMenu {
     if( !optionUuid ) {
       url = url + '&label=' + encodeURIComponent( collectionItem.$node.find('label').text() );
     }
-  
-    console.log(url);
 
-    new DialogApiRequest(url, {
-      activator: item,
-      closeOnClickSelector: ".govuk-button",
-      build: function(dialog) {
-        dialog.$node.find("[data-method=delete]").on("click", function(e) {
-          e.preventDefault();
-          collectionItem.component.removeItem(collectionItem)
-        })
-      }
-    })
+    if( collectionItem.component.canHaveItemsRemoved() ) {
+      new DialogApiRequest(url, {
+        activator: menuItem,
+        closeOnClickSelector: ".govuk-button",
+        build: function(dialog) {
+          dialog.$node.find("[data-method=delete]").on("click", function(e) {
+            e.preventDefault();
+            collectionItem.component.removeItem(collectionItem)
+          })
+        }
+      });
+    } else {
+      console.log(this._config.view.dialog);
+      this._config.view.dialog.open({
+        heading: 'This option cannot be removed',
+        content: 'Radio questions require a minimum of 2 answers.',
+        ok: 'Understood'
+      });
+    }
   }
 }
 

--- a/app/javascript/src/component_editable_collection_item_menu.js
+++ b/app/javascript/src/component_editable_collection_item_menu.js
@@ -19,8 +19,6 @@
 const utilities = require('./utilities');
 const mergeObjects = utilities.mergeObjects;
 const ActivatedMenu = require('./component_activated_menu');
-const DialogApiRequest = require('./component_dialog_api_request');
-const Dialog = require('./component_dialog');
 
 
 class EditableCollectionItemMenu extends ActivatedMenu {

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -384,6 +384,7 @@ function enhanceQuestions(view) {
   view.$editable.filter("[data-fb-content-type=checkboxes]").each(function(i, node) {
     var question = new CheckboxesQuestion($(this), {
       form: view.dataController.$form,
+      view: view,
       text: {
         edit: view.text.actions.edit,
         itemAdd: view.text.option_add,
@@ -415,6 +416,7 @@ function enhanceQuestions(view) {
   view.$editable.filter("[data-fb-content-type=radios]").each(function(i, node) {
     var question = new RadiosQuestion($(this), {
       form: view.dataController.$form,
+      view: view,
       text: {
         edit: view.text.actions.edit,
         itemAdd: view.text.option_add,

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -539,10 +539,11 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
     this.items = [];
     this._preservedItemCount = (this.type == "radios" ? 2 : 1); // Either minimum 2 radios or 1 checkbox.
     
-    EditableCollectionFieldComponent.createCollectionItemTemplate.call(this, config);
-    EditableCollectionFieldComponent.createEditableCollectionItems.call(this, config);
+    this.#createCollectionItemTemplate(config);
+    this.#createEditableCollectionItems(config);
 
     new EditableCollectionItemInjector(this, config);
+
     $node.addClass("EditableCollectionFieldComponent");
   }
 
@@ -563,6 +564,93 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
     }
   }
 
+ /*
+ * Create an item template which can be cloned in component.addItem()
+ * config (Object) key/value pairs for extra information.
+ *
+ * Note: Initial index elements of Array/Collection is called directly
+ * without any checking for existence. This is because they should always
+ * exist and, if they do not, we want the script to throw an error
+ * because it would alert us to something very wrong.
+ **/
+  #createCollectionItemTemplate(config) {
+    var $clone = this.$node.find(config.selectorCollectionItem).eq(0).clone();
+    var data = mergeObjects({}, config.data, ["items", "_uuid"]); // pt.1 Copy without items and component uuid.
+    var itemConfig = mergeObjects({}, config, ["data"]); // pt.2 Copy without data.
+    itemConfig.data = mergeObjects(data, config.data.items[0], "_uuid"); // Bug fix response to JS reference handling.
+
+    // Filters could be changing the blah_1 values to blah_0, depending on filters in play.
+    itemConfig.data = this.#applyFilters(config.filters, 0, itemConfig.data);
+
+    // In case we need some custom actions on element.
+    safelyActivateFunction(config.onCollectionItemClone, $clone);
+
+    $clone.data("config", itemConfig);
+
+    // Note: If we need to strip out some attributes or alter the template
+    //       in some way, do that here.
+
+    this.$itemTemplate = $clone;
+  }
+
+   /*
+   * Find radio or checkbox items and enhance with editable functionality.
+   * Creates the initialising values for this.items
+   * config (Object) key/value pairs for extra information.
+   **/
+    #createEditableCollectionItems(config) {
+    var component = this;
+    component.$node.find(config.selectorCollectionItem).each(function(i) {
+      // WARNING! DO NOT MOVE data or itemConfig OUTSIDE OF THIS LOOP
+      // Due to JS reference handling of objects we need to make sure data and itemConfig are
+      // inside the loop to instantiate two completely different variables. JS will not pass
+      // by value so the alternative is creating EditableCollectionItems that share these objects.
+      var data = mergeObjects({}, config.data, ["items", "_uuid"]); // pt.1 Copy without items and component uuid.
+      var itemConfig = mergeObjects({ preserveItem: (i < component._preservedItemCount) }, config, ["data"]); // pt.2 Without data
+      itemConfig.data = mergeObjects(data, config.data.items[i]); // Bug fix response to JS reference handling.
+
+      // Only wrap in EditableComponentCollectionItem functionality if doesn't look like it has it.
+      if(this.className.indexOf("EditableComponentCollectionItem") < 0) {
+        var item = new EditableComponentCollectionItem(component, $(this), itemConfig);
+        item.menu = createEditableCollectionItemMenu(component, component._config);
+        component.items.push(item);
+      }
+    });
+  }
+
+  /*
+   * Run through the collection items to make sure data is sync'd when we've
+   * either added a new item or removed one (e.g. makes sure to avoid clash
+   * of data _id values.
+   **/
+  #updateItems() {
+    var filters = this._config.filters;
+    for(var i=0; i < this.items.length; ++i) {
+      this.items[i].data = this.#applyFilters(filters, i+1, this.items[i].data);
+    }
+  }
+
+
+  /*
+   * Applies config.filters to the data passed in, with an index number, since this should
+   * be called within a loop of the items. It has been expracted out to counter complications
+   * running into closure issues due to manipulating data within a loop.
+   * @unique (Integer|String) Should be current loop number, or at least something unique.
+   * @data   (Object) Collection item data.
+   **/
+  #applyFilters(filters, unique, data) {
+    var filtered_data = {};
+    for(var prop in data) {
+      if(filters && filters.hasOwnProperty(prop)) {
+        filtered_data[prop] = filters[prop].call(data[prop], unique);
+      }
+      else {
+        filtered_data[prop] = data[prop];
+      }
+    }
+    return filtered_data;
+  }
+
   canHaveItemsRemoved() {
     return this.items.length > this._preservedItemCount;
   }
@@ -576,7 +664,7 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
     var item = new EditableComponentCollectionItem(this, $clone, this.$itemTemplate.data("config"));
     item.menu = createEditableCollectionItemMenu(this, this._config);
     this.items.push(item);
-    EditableCollectionFieldComponent.updateItems.call(this);
+    this.#updateItems();
 
     safelyActivateFunction(this._config.onItemAdd, $clone);
     this.emitSaveRequired();
@@ -588,7 +676,7 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
     safelyActivateFunction(this._config.onItemRemove, item);
     this.items.splice(index, 1);
     item.$node.remove();
-    EditableCollectionFieldComponent.updateItems.call(this);
+    this.#updateItems();
     this.emitSaveRequired();
   }
 
@@ -601,92 +689,11 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
   }
 }
 
-/* Private function
- * Create an item template which can be cloned in component.addItem()
- * config (Object) key/value pairs for extra information.
- *
- * Note: Initial index elements of Array/Collection is called directly
- * without any checking for existence. This is because they should always
- * exist and, if they do not, we want the script to throw an error
- * because it would alert us to something very wrong.
- **/
-EditableCollectionFieldComponent.createCollectionItemTemplate = function(config) {
-  var $clone = this.$node.find(config.selectorCollectionItem).eq(0).clone();
-  var data = mergeObjects({}, config.data, ["items", "_uuid"]); // pt.1 Copy without items and component uuid.
-  var itemConfig = mergeObjects({}, config, ["data"]); // pt.2 Copy without data.
-  itemConfig.data = mergeObjects(data, config.data.items[0], "_uuid"); // Bug fix response to JS reference handling.
-
-  // Filters could be changing the blah_1 values to blah_0, depending on filters in play.
-  itemConfig.data = EditableCollectionFieldComponent.applyFilters(config.filters, 0, itemConfig.data);
-
-  // In case we need some custom actions on element.
-  safelyActivateFunction(config.onCollectionItemClone, $clone);
-
-  $clone.data("config", itemConfig);
-
-  // Note: If we need to strip out some attributes or alter the template
-  //       in some way, do that here.
-
-  this.$itemTemplate = $clone;
-}
-
-/* Private function
- * Find radio or checkbox items and enhance with editable functionality.
- * Creates the initialising values for this.items
- * config (Object) key/value pairs for extra information.
- **/
-EditableCollectionFieldComponent.createEditableCollectionItems = function(config) {
-  var component = this;
-  component.$node.find(config.selectorCollectionItem).each(function(i) {
-    // WARNING! DO NOT MOVE data or itemConfig OUTSIDE OF THIS LOOP
-    // Due to JS reference handling of objects we need to make sure data and itemConfig are
-    // inside the loop to instantiate two completely different variables. JS will not pass
-    // by value so the alternative is creating EditableCollectionItems that share these objects.
-    var data = mergeObjects({}, config.data, ["items", "_uuid"]); // pt.1 Copy without items and component uuid.
-    var itemConfig = mergeObjects({ preserveItem: (i < component._preservedItemCount) }, config, ["data"]); // pt.2 Without data
-    itemConfig.data = mergeObjects(data, config.data.items[i]); // Bug fix response to JS reference handling.
-
-    // Only wrap in EditableComponentCollectionItem functionality if doesn't look like it has it.
-    if(this.className.indexOf("EditableComponentCollectionItem") < 0) {
-      var item = new EditableComponentCollectionItem(component, $(this), itemConfig);
-      item.menu = createEditableCollectionItemMenu(component, component._config);
-      component.items.push(item);
-    }
-  });
-}
-
-/* Private function
- * Run through the collection items to make sure data is sync'd when we've
- * either added a new item or removed one (e.g. makes sure to avoid clash
- * of data _id values.
- **/
-EditableCollectionFieldComponent.updateItems = function() {
-  var filters = this._config.filters;
-  for(var i=0; i < this.items.length; ++i) {
-    this.items[i].data = EditableCollectionFieldComponent.applyFilters(filters, i+1, this.items[i].data);
-  }
-}
 
 
-/* Private function
- * Applies config.filters to the data passed in, with an index number, since this should
- * be called within a loop of the items. It has been expracted out to counter complications
- * running into closure issues due to manipulating data within a loop.
- * @unique (Integer|String) Should be current loop number, or at least something unique.
- * @data   (Object) Collection item data.
- **/
-EditableCollectionFieldComponent.applyFilters = function(filters, unique, data) {
-  var filtered_data = {};
-  for(var prop in data) {
-    if(filters && filters.hasOwnProperty(prop)) {
-      filtered_data[prop] = filters[prop].call(data[prop], unique);
-    }
-    else {
-      filtered_data[prop] = data[prop];
-    }
-  }
-  return filtered_data;
-}
+
+
+
 
 /* Editable Component Collection Item:
  * Used for things like Radio Options/Checkboxes that have a label and hint element

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -612,7 +612,6 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
       // Only wrap in EditableComponentCollectionItem functionality if doesn't look like it has it.
       if(this.className.indexOf("EditableComponentCollectionItem") < 0) {
         var item = new EditableComponentCollectionItem(component, $(this), itemConfig);
-        item.menu = createEditableCollectionItemMenu(component, component._config);
         component.items.push(item);
       }
     });
@@ -662,7 +661,6 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
     var $clone = this.$itemTemplate.clone();
     $lastItem.after($clone);
     var item = new EditableComponentCollectionItem(this, $clone, this.$itemTemplate.data("config"));
-    item.menu = createEditableCollectionItemMenu(this, this._config);
     this.items.push(item);
     this.#updateItems();
 

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -49,16 +49,20 @@
         button_delete_page: "<%= t('dialogs.button_delete_page') %>",
         button_ok: "<%= t('dialogs.button_ok') %>",
         button_publish: "<%= t('publish.dialog.alert_button') %>",
+        button_understood: "<%= t('dialogs.button_understood') -%>",
         heading: "<%= t('dialogs.heading') %>",
         heading_delete: '<%= t('dialogs.heading_delete').html_safe %>',
         heading_delete_condition: "<%= t('dialogs.heading_delete_condtition').html_safe %>",
         heading_delete_branch: "<%= t('dialogs.heading_delete_branch').html_safe %>",
         heading_delete_option: '<%= t('dialogs.heading_delete_option').html_safe %>',
+        heading_can_not_delete_option: "<%= t('question_items.delete_modal.can_not_delete_heading').html_safe -%>",
         heading_publish: "<%= t('publish.dialog.alert_heading') %>",
         message: "<%= t('dialogs.message') %>",
         message_delete: "<%= t('dialogs.message_delete') %>",
         message_delete_branch: "<%= t('dialogs.message_delete_branch') %>",
-        message_publish: "<%= t('publish.dialog.alert_text').html_safe %>"
+        message_publish: "<%= t('publish.dialog.alert_text').html_safe %>",
+        message_delete_radio_min: "<%= t('question_items.min_items_modal.can_not_delete_radios_message').html_safe -%>",
+        message_delete_checkbox_min: "<%= t('question_items.min_items_modal.can_not_delete_checkboxes_message').html_safe -%>"
       },
       actions: {
         edit: "<%= t('actions.edit') %>",

--- a/app/views/partials/_template_dialog.html.erb
+++ b/app/views/partials/_template_dialog.html.erb
@@ -5,7 +5,11 @@
         data-text-ok="<%= t('dialogs.button_ok') %>">
 
   <div class="component component-dialog" id="dialog">
-    <h3 data-node="heading" class="govuk-label govuk-label--m"><%= t('dialogs.heading') %></h3>
-    <p data-node="content"><%= t('dialogs.message') %></p>
+    <h3 data-node="heading" class="govuk-label govuk-label--m">
+      <%= t('dialogs.heading') %>
+    </h3>
+    <p data-node="content">
+      <%= t('dialogs.message') %>
+    </p>
   </div>
 </script>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,6 +140,9 @@ en:
     delete_modal:
       can_not_delete_heading: 'You cannot delete this option yet'
       can_not_delete_message: 'You cannot delete this option because it is used in a branching condition. Update the branching point first, then try again.'
+    min_items_modal:
+      can_not_delete_radios_message: 'Radios questions require a minimum of 2 answers'
+      can_not_delete_checkboxes_message: 'Checkboxes questions require a minimum of 1 answer'
   pages:
     flow:
       heading: 'Pages flow'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,8 +141,8 @@ en:
       can_not_delete_heading: 'You cannot delete this option yet'
       can_not_delete_message: 'You cannot delete this option because it is used in a branching condition. Update the branching point first, then try again.'
     min_items_modal:
-      can_not_delete_radios_message: 'Radios questions require a minimum of 2 answers'
-      can_not_delete_checkboxes_message: 'Checkboxes questions require a minimum of 1 answer'
+      can_not_delete_radios_message: 'Radio buttons require a minimum of 2 options'
+      can_not_delete_checkboxes_message: 'Checkboxes require a minimum of 1 option'
   pages:
     flow:
       heading: 'Pages flow'


### PR DESCRIPTION
Resolves [#2403](https://trello.com/c/EMiIHIsM/2403-support-deleting-the-first-checkbox-option-in-question-when-there-are-at-least-2) and [#2404](https://trello.com/c/c8nTnAdX/2404-support-deleting-the-first-radio-option-in-question-when-there-are-at-least-3)

This change allows for deleting any radio or checkbox option, as long as there are at least 2 radios remaining or 1 checkbox remaining.

To be consistent with other behaviour, we now show the eitable item menu activator, and delete menu item for all items.  If there are not enough items remaining then the use will be shown a modal explaining why they cannot delete the option.

**Before:**
![image](https://user-images.githubusercontent.com/595564/159022539-baf2e7e7-d3de-45b9-b76c-7658a0c366de.png)
No activator or menu for the first 2 radios

**After:**
![image](https://user-images.githubusercontent.com/595564/159022661-c1ba6e9f-6514-4c0c-8e6a-f1ef313eb50e.png)
Menu activator and manu available for all options

![image](https://user-images.githubusercontent.com/595564/159022777-1de8fce1-421e-4eff-85dc-6f46a01d1aac.png)
When attempting a deletion that would result in too few options remaining a modal is shown.

![image](https://user-images.githubusercontent.com/595564/159023026-815409e8-b34d-4661-8066-6e1a64f32f97.png)
Having added a third option the first option can now be deleted.
