### PR TITLE
Remove Add exit page from start page connection menu

### DIFF
--- a/acceptance/features/create_service_spec.rb
+++ b/acceptance/features/create_service_spec.rb
@@ -9,6 +9,7 @@ feature 'Create a service' do
   let(:checkanswers_title) { 'Check your answers' }
   let(:confirmation_link_text) { I18n.t('actions.add_confirmation')  }
   let(:confirmation_title) { 'Application complete' }
+  let(:exit_link_text) { I18n.t('actions.add_exit')  }
   let(:exit_url) { 'exit' }
   let(:form_urls) do
     # page url links have the word "Edit" as a visually hidden span element
@@ -51,6 +52,7 @@ feature 'Create a service' do
     then_I_should_see_the_page_flow_in_order(order: form_urls)
     then_I_should_not_be_able_to_add_page(start_page_title, checkanswers_link_text)
     then_I_should_not_be_able_to_add_page(start_page_title, confirmation_link_text)
+    then_I_should_not_be_able_to_add_page(start_page_title, exit_link_text)
   end
 
   scenario 'validates uniqueness of the service name' do
@@ -65,6 +67,7 @@ feature 'Create a service' do
     then_I_should_see_default_service_pages
     then_I_should_not_be_able_to_add_page(start_page_title, checkanswers_link_text)
     then_I_should_not_be_able_to_add_page(start_page_title, confirmation_link_text)
+    and_I_add_a_content_page('Content Page')
     given_I_add_an_exit_page
     and_I_return_to_flow_page
     then_some_pages_should_be_unconnected

--- a/acceptance/features/edit_exit_page_spec.rb
+++ b/acceptance/features/edit_exit_page_spec.rb
@@ -18,6 +18,7 @@ feature 'Edit exit pages' do
   background do
     given_I_am_logged_in
     given_I_have_a_service
+    and_I_add_a_content_page('Content Page')
   end
 
   scenario 'updates all fields' do
@@ -30,6 +31,7 @@ feature 'Edit exit pages' do
     and_I_return_to_flow_page
     and_I_click_on_the_exit_page_three_dots
     then_I_should_only_see_three_options_on_page_menu
+    and_I_return_to_flow_page #reload the page to get rid of the menu blocking link
     and_I_edit_the_page(url: exit_heading)
     then_I_see_the_updated_page_heading(exit_heading)
     then_I_see_the_updated_page_section_heading(exit_section_heading)
@@ -102,7 +104,8 @@ feature 'Edit exit pages' do
   def then_I_should_stop_until_the_exit_page(preview_form)
     within_window(preview_form) do
       page.click_button 'Start now'
-
+      expect(page).to have_content(I18n.t('actions.continue'))
+      page.click_button I18n.t('actions.continue')
       expect(page.current_path).to include('/preview/exit')
       expect(page.all('button').to_a).to eq([])
     end

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -156,6 +156,15 @@ module CommonSteps
     editor.edit_service_link(service_name).click
   end
 
+  def and_I_add_a_content_page(page_title)
+    given_I_add_a_content_page
+    and_I_add_a_page_url(page_title)
+    when_I_add_the_page
+    and_I_change_the_page_heading(page_title)
+    when_I_save_my_changes
+    and_I_return_to_flow_page
+  end
+
   def and_I_edit_the_page(url:)
     page.find('.govuk-link', text: url).click
   end

--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -32,11 +32,13 @@
       <li data-page-type="multiplequestions"><a href="#add-page"><%= t('actions.add_multi_question') -%></a></li>
 
       <li data-page-type="content"><a href="#add-page"><%= t('actions.add_content') -%></a></li>
-
-      <li data-page-type="exit"><a href="#add-page"><%= t('actions.add_exit') -%></a></li>
+      
+      <% unless item[:type] == 'page.start' %>
+        <li data-page-type="exit"><a href="#add-page"><%= t('actions.add_exit') -%></a></li>
+      <% end %>
     <% end %>
 
-   <% if !service.checkanswers_page.present? && item[:type] != 'flow.branch' && (item[:next].blank? || item[:next] == service.confirmation_page&.uuid) %>
+    <% if !service.checkanswers_page.present? && item[:type] != 'flow.branch' && (item[:next].blank? || item[:next] == service.confirmation_page&.uuid) %>
       <li data-page-type="checkanswers"><a href="#add-page"><%= t('actions.add_check_answers') -%></a></li>
     <% end %>
 
@@ -58,13 +60,13 @@
       <% unless item[:type] == 'page.start' %>
         <li data-action="link">
           <%= link_to t('services.branch'),
-          new_branches_path(service.service_id, item[:uuid]) %>
+            new_branches_path(service.service_id, item[:uuid]) %>
         </li>
       <% end %>
 
       <li data-action="destination">
         <%= link_to t('actions.change_destination'),
-        new_api_service_flow_destination_path(service.service_id, item[:uuid]) %>
+          new_api_service_flow_destination_path(service.service_id, item[:uuid]) %>
       </li>
     <% end %>
 </ul>


### PR DESCRIPTION
Resolves [ticket #2428](https://trello.com/c/UUJPyxMM/2428-remove-add-exit-page-from-start-page-connection-menu) 

Removes the menuitem 'Add exit page' from the connection menu after the startpage.  

**Before:**
![image](https://user-images.githubusercontent.com/595564/159470026-beb88320-5f2a-40b6-a747-ffc75eb12644.png)

**After:**
![image](https://user-images.githubusercontent.com/595564/159470079-c7427544-d806-48bb-80da-07d5f5ad9f00.png)

Also removes the connection menu branching flag related code as it is no longer needed ([ticket #2407](https://trello.com/c/KSPPNDkC/2407-branching-flag-clean-up-in-the-code-base))


