### PR TITLE
Fix incorrecr branching diamond hover area

### DIFF
--- a/app/views/services/_flow_layout.html.erb
+++ b/app/views/services/_flow_layout.html.erb
@@ -21,8 +21,8 @@
 
     <% if item[:type] == 'flow.branch' %>
       <article class="flow-item flow-branch" aria-label="<%= item[:title] %>" data-fb-id="<%= item[:uuid] %>">
-        <%= image_pack_tag "diamond.svg",  :usemap => "#thumbnail-#{index}" %>
-        <map name="thumbnail-<%= index %>" aria-hidden="true">
+        <%= image_pack_tag "diamond.svg",  :usemap => "#thumbnail-#{item[:uuid]}" %>
+        <map name="thumbnail-<%= item[:uuid] %>" aria-hidden="true">
           <area shape="poly" coords="0,72.5 100,0 200,72.5 100,145" alt="" href="<%= edit_branch_path(service.service_id, item[:uuid]) %>">
         </map>
         <%= flow_text_link(item) %>


### PR DESCRIPTION
This PR resolves [ticket 2430](https://trello.com/c/0H5lcD7M/2430-clicking-a-branching-diamond-goes-to-the-wrong-branching-edit-screen)

Use the flow item UUID instead of the @pages_flow index as the map name attribute.

Using the @pages_flow index meant that all branching diamonds within the same flow route woudl recieve duplicate names which resulted in hovers over later branching diamonds activating the link of the first branching point in the flow.

Using the UUID results in unique IDs for every branching point.