### PR TITLE
Inject previous UUID into page flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.15.13'
+gem 'metadata_presenter', '2.16.0'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.15.13)
+    metadata_presenter (2.16.0)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -427,7 +427,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.15.13)
+  metadata_presenter (= 2.16.0)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/models/pages_flow.rb
+++ b/app/models/pages_flow.rb
@@ -66,8 +66,10 @@ class PagesFlow
       type: obj.type,
       title: obj.title,
       uuid: obj.uuid,
+      previous_uuid: grid.previous_uuid_for_object(obj.uuid),
+      conditional_uuid: grid.conditional_uuid_for_object(obj.uuid),
       thumbnail: thumbnail_type(obj)
-    }
+    }.compact
   end
 
   def thumbnail_type(obj)

--- a/spec/models/pages_flow_spec.rb
+++ b/spec/models/pages_flow_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe PagesFlow do
               title: 'Full name',
               uuid: '9e1ba77f-f1e5-42f4-b090-437aa9af7f73',
               next: 'adcb61c3-52b1-479b-be51-1bb610876d54',
+              previous_uuid: 'cf6dc32f-502c-4215-8c27-1151a45735bb',
               thumbnail: 'text',
               url: 'name'
             }
@@ -41,6 +42,7 @@ RSpec.describe PagesFlow do
               title: 'Email address',
               uuid: 'adcb61c3-52b1-479b-be51-1bb610876d54',
               next: '4b8c6bf3-878a-4446-9198-48351b3e2185',
+              previous_uuid: '9e1ba77f-f1e5-42f4-b090-437aa9af7f73',
               thumbnail: 'email',
               url: 'email-address'
             }
@@ -51,6 +53,7 @@ RSpec.describe PagesFlow do
               title: 'Parent name',
               uuid: '4b8c6bf3-878a-4446-9198-48351b3e2185',
               next: '54ccc6cd-60c0-4749-947b-a97af1bc0aa2',
+              previous_uuid: 'adcb61c3-52b1-479b-be51-1bb610876d54',
               thumbnail: 'text',
               url: 'parent-name'
             }
@@ -61,6 +64,7 @@ RSpec.describe PagesFlow do
               title: 'Your age',
               uuid: '54ccc6cd-60c0-4749-947b-a97af1bc0aa2',
               next: 'b8335af2-6642-4e2f-8192-0dd12279eec7',
+              previous_uuid: '4b8c6bf3-878a-4446-9198-48351b3e2185',
               thumbnail: 'number',
               url: 'your-age'
             }
@@ -71,6 +75,7 @@ RSpec.describe PagesFlow do
               title: 'Family Hobbies',
               uuid: 'b8335af2-6642-4e2f-8192-0dd12279eec7',
               next: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
+              previous_uuid: '54ccc6cd-60c0-4749-947b-a97af1bc0aa2',
               thumbnail: 'textarea',
               url: 'family-hobbies'
             }
@@ -81,6 +86,7 @@ RSpec.describe PagesFlow do
               title: 'Do you like Star Wars?',
               uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
               next: '7806cd64-0c05-450e-ba6f-2325c8b22d46',
+              previous_uuid: 'b8335af2-6642-4e2f-8192-0dd12279eec7',
               thumbnail: 'radios',
               url: 'do-you-like-star-wars'
             }
@@ -91,6 +97,7 @@ RSpec.describe PagesFlow do
               title: 'What is the day that you like to take holidays?',
               uuid: '7806cd64-0c05-450e-ba6f-2325c8b22d46',
               next: '0c022e95-0748-4dda-8ba5-12fd1d2f596b',
+              previous_uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
               thumbnail: 'date',
               url: 'holiday'
             }
@@ -101,6 +108,7 @@ RSpec.describe PagesFlow do
               title: 'What would you like on your burger?',
               uuid: '0c022e95-0748-4dda-8ba5-12fd1d2f596b',
               next: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
+              previous_uuid: '7806cd64-0c05-450e-ba6f-2325c8b22d46',
               thumbnail: 'checkboxes',
               url: 'burgers'
             }
@@ -111,6 +119,7 @@ RSpec.describe PagesFlow do
               title: 'How well do you know Star Wars?',
               uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
               next: '80420693-d6f2-4fce-a860-777ca774a6f5',
+              previous_uuid: '0c022e95-0748-4dda-8ba5-12fd1d2f596b',
               thumbnail: 'text',
               url: 'star-wars-knowledge'
             }
@@ -121,6 +130,7 @@ RSpec.describe PagesFlow do
               title: 'Tell me how many lights you see',
               uuid: '80420693-d6f2-4fce-a860-777ca774a6f5',
               next: '2ef7d11e-0307-49e9-9fe2-345dc528dd66',
+              previous_uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
               thumbnail: 'content',
               url: 'how-many-lights'
             }
@@ -131,6 +141,7 @@ RSpec.describe PagesFlow do
               title: 'Upload your best dog photo',
               uuid: '2ef7d11e-0307-49e9-9fe2-345dc528dd66',
               next: 'e337070b-f636-49a3-a65c-f506675265f0',
+              previous_uuid: '80420693-d6f2-4fce-a860-777ca774a6f5',
               thumbnail: 'upload',
               url: 'dog-picture'
             }
@@ -141,6 +152,7 @@ RSpec.describe PagesFlow do
               title: 'Check your answers',
               uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
               next: '778e364b-9a7f-4829-8eb2-510e08f156a3',
+              previous_uuid: '2ef7d11e-0307-49e9-9fe2-345dc528dd66',
               thumbnail: 'checkanswers',
               url: 'check-answers'
             }
@@ -151,6 +163,7 @@ RSpec.describe PagesFlow do
               title: 'Complaint sent',
               uuid: '778e364b-9a7f-4829-8eb2-510e08f156a3',
               next: '',
+              previous_uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
               thumbnail: 'confirmation',
               url: 'confirmation'
             }
@@ -187,6 +200,7 @@ RSpec.describe PagesFlow do
               title: 'Full name',
               uuid: '9e1ba77f-f1e5-42f4-b090-437aa9af7f73',
               next: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
+              previous_uuid: 'cf6dc32f-502c-4215-8c27-1151a45735bb',
               thumbnail: 'text',
               url: 'name'
             }
@@ -197,6 +211,7 @@ RSpec.describe PagesFlow do
               title: 'Do you like Star Wars?',
               uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
               next: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+              previous_uuid: '9e1ba77f-f1e5-42f4-b090-437aa9af7f73',
               thumbnail: 'radios',
               url: 'do-you-like-star-wars'
             }
@@ -206,6 +221,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 1',
               uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+              previous_uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
               thumbnail: 'branch',
               conditionals: [
                 {
@@ -238,6 +254,8 @@ RSpec.describe PagesFlow do
               title: 'How well do you know Star Wars?',
               uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
               next: '0b297048-aa4d-49b6-ac74-18e069118185',
+              previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+              conditional_uuid: 'ecd60ac9-c3ea-47b1-8f79-c4e42df9a9dd',
               thumbnail: 'text',
               url: 'star-wars-knowledge'
             }
@@ -248,6 +266,7 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               uuid: '0b297048-aa4d-49b6-ac74-18e069118185',
               next: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+              previous_uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
               thumbnail: 'radios',
               url: 'favourite-fruit'
             }
@@ -257,6 +276,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 2',
               uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+              previous_uuid: '0b297048-aa4d-49b6-ac74-18e069118185',
               thumbnail: 'branch',
               conditionals: [
                 {
@@ -300,6 +320,8 @@ RSpec.describe PagesFlow do
               title: 'Do you like apple juice?',
               uuid: 'd4342dfd-0d09-4a91-a0ea-d7fd67e706cc',
               next: '05c3306c-0a39-42d2-9e0f-93fd49248f4e',
+              previous_uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+              conditional_uuid: '51b4eda2-a08d-4ab3-a8cb-565091f39424',
               thumbnail: 'radios',
               url: 'apple-juice'
             },
@@ -308,6 +330,8 @@ RSpec.describe PagesFlow do
               title: 'Do you like orange juice?',
               uuid: '91e9f7c6-2f75-4b7d-9eb5-0cf352f7be66',
               next: '05c3306c-0a39-42d2-9e0f-93fd49248f4e',
+              previous_uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+              conditional_uuid: '0a799cea-f5a4-4b89-9ffe-78515b5cb1d7',
               thumbnail: 'radios',
               url: 'orange-juice'
             }
@@ -318,6 +342,7 @@ RSpec.describe PagesFlow do
               title: 'What is your favourite band?',
               uuid: '05c3306c-0a39-42d2-9e0f-93fd49248f4e',
               next: '1d02e508-5953-4eca-af2f-9d67511c8648',
+              previous_uuid: 'd4342dfd-0d09-4a91-a0ea-d7fd67e706cc',
               thumbnail: 'radios',
               url: 'favourite-band'
             }
@@ -327,6 +352,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 3',
               uuid: '1d02e508-5953-4eca-af2f-9d67511c8648',
+              previous_uuid: '05c3306c-0a39-42d2-9e0f-93fd49248f4e',
               thumbnail: 'branch',
               conditionals: [
                 {
@@ -359,6 +385,8 @@ RSpec.describe PagesFlow do
               title: 'Which app do you use to listen music?',
               uuid: '8002df6e-29ab-4cdf-b520-1d7bb931a28f',
               next: 'ef2cafe3-37e2-4533-9b0c-09a970cd38d4',
+              previous_uuid: '1d02e508-5953-4eca-af2f-9d67511c8648',
+              conditional_uuid: '0d3410db-1d05-4a32-bafb-65b52408b89b',
               thumbnail: 'radios',
               url: 'music-app'
             }
@@ -369,6 +397,7 @@ RSpec.describe PagesFlow do
               title: 'What is the best form builder?',
               uuid: 'ef2cafe3-37e2-4533-9b0c-09a970cd38d4',
               next: 'cf8b3e18-dacf-4e91-92e1-018035961003',
+              previous_uuid: '8002df6e-29ab-4cdf-b520-1d7bb931a28f',
               thumbnail: 'radios',
               url: 'best-formbuilder'
             }
@@ -378,6 +407,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 4',
               uuid: 'cf8b3e18-dacf-4e91-92e1-018035961003',
+              previous_uuid: 'ef2cafe3-37e2-4533-9b0c-09a970cd38d4',
               thumbnail: 'branch',
               conditionals: [
                 {
@@ -410,6 +440,8 @@ RSpec.describe PagesFlow do
               title: 'Which Formbuilder is the best?',
               uuid: 'b5efc09c-ece7-45ae-b0b3-8a7905e25040',
               next: '0c022e95-0748-4dda-8ba5-12fd1d2f596b',
+              previous_uuid: 'cf8b3e18-dacf-4e91-92e1-018035961003',
+              conditional_uuid: '88b97d53-1da7-4464-a0a5-633a9ffd3d3d',
               thumbnail: 'text',
               url: 'which-formbuilder'
             }
@@ -420,6 +452,7 @@ RSpec.describe PagesFlow do
               title: 'What would you like on your burger?',
               uuid: '0c022e95-0748-4dda-8ba5-12fd1d2f596b',
               next: '618b7537-b42b-4551-ae7d-053afa4d9ca9',
+              previous_uuid: 'b5efc09c-ece7-45ae-b0b3-8a7905e25040',
               thumbnail: 'checkboxes',
               url: 'burgers'
             }
@@ -429,6 +462,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 5',
               uuid: '618b7537-b42b-4551-ae7d-053afa4d9ca9',
+              previous_uuid: '0c022e95-0748-4dda-8ba5-12fd1d2f596b',
               thumbnail: 'branch',
               conditionals: [
                 {
@@ -472,6 +506,8 @@ RSpec.describe PagesFlow do
               title: 'Global warming',
               uuid: 'bc666714-c0a2-4674-afe5-faff2e20d847',
               next: 'dc7454f9-4186-48d7-b055-684d57bbcdc7',
+              previous_uuid: '618b7537-b42b-4551-ae7d-053afa4d9ca9',
+              conditional_uuid: '8a0c225f-b078-4728-a181-c3bdd343801c',
               thumbnail: 'content',
               url: 'global-warming'
             },
@@ -480,6 +516,8 @@ RSpec.describe PagesFlow do
               title: 'We love chickens',
               uuid: 'e2887f44-5e8d-4dc0-b1de-496ab6039430',
               next: 'dc7454f9-4186-48d7-b055-684d57bbcdc7',
+              previous_uuid: '618b7537-b42b-4551-ae7d-053afa4d9ca9',
+              conditional_uuid: '7d1b29ac-f310-4246-bab9-957c9b2a20f2',
               thumbnail: 'content',
               url: 'we-love-chickens'
             }
@@ -490,6 +528,7 @@ RSpec.describe PagesFlow do
               title: 'What is the best marvel series?',
               uuid: 'dc7454f9-4186-48d7-b055-684d57bbcdc7',
               next: '84a347fc-8d4b-486a-9996-6a86fa9544c5',
+              previous_uuid: 'bc666714-c0a2-4674-afe5-faff2e20d847',
               thumbnail: 'radios',
               url: 'marvel-series'
             }
@@ -499,6 +538,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 6',
               uuid: '84a347fc-8d4b-486a-9996-6a86fa9544c5',
+              previous_uuid: 'dc7454f9-4186-48d7-b055-684d57bbcdc7',
               thumbnail: 'branch',
               conditionals: [
                 {
@@ -558,6 +598,8 @@ RSpec.describe PagesFlow do
               title: 'Loki',
               uuid: '2cc66e51-2c14-4023-86bf-ded49887cdb2',
               next: '48357db5-7c06-4e85-94b1-5e1c9d8f39eb',
+              previous_uuid: '84a347fc-8d4b-486a-9996-6a86fa9544c5',
+              conditional_uuid: '15e8076f-75ac-4310-89b3-d2b5962babd4',
               thumbnail: 'content',
               url: 'marvel-quotes'
             },
@@ -569,6 +611,8 @@ RSpec.describe PagesFlow do
               title: 'Other quotes',
               uuid: 'f6c51f88-7be8-4cb7-bbfc-6c905727a051',
               next: '48357db5-7c06-4e85-94b1-5e1c9d8f39eb',
+              previous_uuid: '84a347fc-8d4b-486a-9996-6a86fa9544c5',
+              conditional_uuid: '0811ac93-a73e-4a2d-a8f1-68cc8a52ca69',
               thumbnail: 'content',
               url: 'other-quotes'
             }
@@ -579,6 +623,7 @@ RSpec.describe PagesFlow do
               title: 'Select all Arnold Schwarzenegger quotes',
               uuid: '48357db5-7c06-4e85-94b1-5e1c9d8f39eb',
               next: '1079b5b8-abd0-4bf6-aaac-1f01e69e3b39',
+              previous_uuid: '2cc66e51-2c14-4023-86bf-ded49887cdb2',
               thumbnail: 'checkboxes',
               url: 'best-arnold-quote'
             }
@@ -588,6 +633,7 @@ RSpec.describe PagesFlow do
               type: 'flow.branch',
               title: 'Branching point 7',
               uuid: '1079b5b8-abd0-4bf6-aaac-1f01e69e3b39',
+              previous_uuid: '48357db5-7c06-4e85-94b1-5e1c9d8f39eb',
               thumbnail: 'branch',
               conditionals: [
                 {
@@ -652,6 +698,8 @@ RSpec.describe PagesFlow do
               title: 'You are right',
               uuid: '56e80942-d0a4-405a-85cd-bd1b100013d6',
               next: 'e337070b-f636-49a3-a65c-f506675265f0',
+              previous_uuid: '1079b5b8-abd0-4bf6-aaac-1f01e69e3b39',
+              conditional_uuid: '5ce78103-3935-4c57-9278-79bf2b8b93b1',
               thumbnail: 'content',
               url: 'arnold-right-answers'
             },
@@ -660,6 +708,8 @@ RSpec.describe PagesFlow do
               title: 'You are wrong', # wrong answers, GOTG quotes
               uuid: '6324cca4-7770-4765-89b9-1cdc41f49c8b',
               next: 'e337070b-f636-49a3-a65c-f506675265f0',
+              previous_uuid: '1079b5b8-abd0-4bf6-aaac-1f01e69e3b39',
+              conditional_uuid: 'd45c65c7-a9b4-4128-8562-89bd4f0167ec',
               thumbnail: 'content',
               url: 'arnold-wrong-answers'
             },
@@ -671,6 +721,7 @@ RSpec.describe PagesFlow do
               title: 'You are wrong', # incomplete answers, Otherwise
               uuid: '941137d7-a1da-43fd-994a-98a4f9ea6d46',
               next: 'e337070b-f636-49a3-a65c-f506675265f0',
+              previous_uuid: '1079b5b8-abd0-4bf6-aaac-1f01e69e3b39',
               thumbnail: 'content',
               url: 'arnold-incomplete-answers'
             }
@@ -681,6 +732,7 @@ RSpec.describe PagesFlow do
               title: 'Check your answers',
               uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
               next: '778e364b-9a7f-4829-8eb2-510e08f156a3',
+              previous_uuid: '56e80942-d0a4-405a-85cd-bd1b100013d6',
               thumbnail: 'checkanswers',
               url: 'check-answers'
             }
@@ -691,6 +743,7 @@ RSpec.describe PagesFlow do
               title: 'Complaint sent',
               uuid: '778e364b-9a7f-4829-8eb2-510e08f156a3',
               next: '',
+              previous_uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
               thumbnail: 'confirmation',
               url: 'confirmation'
             }
@@ -728,6 +781,7 @@ RSpec.describe PagesFlow do
                 title: 'Page B',
                 uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
                 next: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                previous_uuid: 'cf6dc32f-502c-4215-8c27-1151a45735bb',
                 thumbnail: 'radios',
                 url: 'page-b'
               }
@@ -737,6 +791,7 @@ RSpec.describe PagesFlow do
                 type: 'flow.branch',
                 title: 'Branching point 1',
                 uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                previous_uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
                 thumbnail: 'branch',
                 conditionals: [
                   {
@@ -780,6 +835,8 @@ RSpec.describe PagesFlow do
                 title: 'Page C',
                 uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 next: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                conditional_uuid: 'b753b3f0-188e-4435-a84d-894557ba2007',
                 thumbnail: 'text',
                 url: 'page-c'
               },
@@ -788,6 +845,8 @@ RSpec.describe PagesFlow do
                 title: 'Page G',
                 uuid: '3a584d15-6805-4a21-bc05-b61c3be47857',
                 next: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                conditional_uuid: '2622668f-7ad2-4130-9d4f-274ff540b7e8',
                 thumbnail: 'text',
                 url: 'page-g'
               },
@@ -796,6 +855,7 @@ RSpec.describe PagesFlow do
                 title: 'Page J',
                 uuid: 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992',
                 next: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
                 thumbnail: 'radios',
                 url: 'page-j'
               }
@@ -806,6 +866,7 @@ RSpec.describe PagesFlow do
                 title: 'Page D',
                 uuid: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 next: '37a94466-97fa-427f-88b2-09b369435d0d',
+                previous_uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 thumbnail: 'text',
                 url: 'page-d'
               },
@@ -814,6 +875,7 @@ RSpec.describe PagesFlow do
                 title: 'Page H',
                 uuid: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
                 next: '520fde26-8124-4c67-a550-cd38d2ef304d',
+                previous_uuid: '3a584d15-6805-4a21-bc05-b61c3be47857',
                 thumbnail: 'text',
                 url: 'page-h'
               },
@@ -821,6 +883,7 @@ RSpec.describe PagesFlow do
                 type: 'flow.branch',
                 title: 'Branching point 2',
                 uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+                previous_uuid: 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992',
                 thumbnail: 'branch',
                 conditionals: [
                   {
@@ -853,6 +916,7 @@ RSpec.describe PagesFlow do
                 title: 'Page E',
                 uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 next: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
+                previous_uuid: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 thumbnail: 'text',
                 url: 'page-e'
               },
@@ -861,6 +925,7 @@ RSpec.describe PagesFlow do
                 title: 'Page I',
                 uuid: '520fde26-8124-4c67-a550-cd38d2ef304d',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
                 thumbnail: 'text',
                 url: 'page-i'
               },
@@ -869,6 +934,8 @@ RSpec.describe PagesFlow do
                 title: 'Page K',
                 uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 next: '2c7deb33-19eb-4569-86d6-462e3d828d87',
+                previous_uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+                conditional_uuid: 'f51a3793-53dc-4537-b84b-399a59c103f4',
                 thumbnail: 'text',
                 url: 'page-k'
               },
@@ -877,6 +944,7 @@ RSpec.describe PagesFlow do
                 title: 'Page M',
                 uuid: 'd80a2225-63c3-4944-873f-504b61311a15',
                 next: '393645a4-f037-4e75-8359-51f9b0e360fb',
+                previous_uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
                 thumbnail: 'text',
                 url: 'page-m'
               }
@@ -887,6 +955,7 @@ RSpec.describe PagesFlow do
                 title: 'Page F',
                 uuid: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 thumbnail: 'text',
                 url: 'page-f'
               },
@@ -898,6 +967,7 @@ RSpec.describe PagesFlow do
                 title: 'Page L',
                 uuid: '2c7deb33-19eb-4569-86d6-462e3d828d87',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 thumbnail: 'text',
                 url: 'page-l'
               },
@@ -906,6 +976,7 @@ RSpec.describe PagesFlow do
                 title: 'Page N',
                 uuid: '393645a4-f037-4e75-8359-51f9b0e360fb',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: 'd80a2225-63c3-4944-873f-504b61311a15',
                 thumbnail: 'text',
                 url: 'page-n'
               }
@@ -916,6 +987,7 @@ RSpec.describe PagesFlow do
                 title: 'Check your answers',
                 uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
                 next: '778e364b-9a7f-4829-8eb2-510e08f156a3',
+                previous_uuid: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
                 thumbnail: 'checkanswers',
                 url: 'check-answers'
               }
@@ -926,6 +998,7 @@ RSpec.describe PagesFlow do
                 title: 'Complaint sent',
                 uuid: '778e364b-9a7f-4829-8eb2-510e08f156a3',
                 next: '',
+                previous_uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
                 thumbnail: 'confirmation',
                 url: 'confirmation'
               }
@@ -958,6 +1031,7 @@ RSpec.describe PagesFlow do
                 title: 'Page B',
                 uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
                 next: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                previous_uuid: 'cf6dc32f-502c-4215-8c27-1151a45735bb',
                 thumbnail: 'radios',
                 url: 'page-b'
               }
@@ -967,6 +1041,7 @@ RSpec.describe PagesFlow do
                 type: 'flow.branch',
                 title: 'Branching point 1',
                 uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                previous_uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
                 thumbnail: 'branch',
                 conditionals: [
                   {
@@ -1010,6 +1085,8 @@ RSpec.describe PagesFlow do
                 title: 'Page C',
                 uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 next: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                conditional_uuid: '39bab61b-93d5-486c-8e02-cea0aeb48215',
                 thumbnail: 'text',
                 url: 'page-c'
               },
@@ -1018,6 +1095,8 @@ RSpec.describe PagesFlow do
                 title: 'Page G',
                 uuid: '3a584d15-6805-4a21-bc05-b61c3be47857',
                 next: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                conditional_uuid: '96810acb-b5e6-45c1-bacb-6b7a10c0d3a0',
                 thumbnail: 'text',
                 url: 'page-g'
               },
@@ -1026,6 +1105,7 @@ RSpec.describe PagesFlow do
                 title: 'Page K',
                 uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 next: '2c7deb33-19eb-4569-86d6-462e3d828d87',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
                 thumbnail: 'text',
                 url: 'page-k'
               }
@@ -1036,6 +1116,7 @@ RSpec.describe PagesFlow do
                 title: 'Page D',
                 uuid: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 next: '37a94466-97fa-427f-88b2-09b369435d0d',
+                previous_uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 thumbnail: 'text',
                 url: 'page-d'
               },
@@ -1044,6 +1125,7 @@ RSpec.describe PagesFlow do
                 title: 'Page H',
                 uuid: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
                 next: '520fde26-8124-4c67-a550-cd38d2ef304d',
+                previous_uuid: '3a584d15-6805-4a21-bc05-b61c3be47857',
                 thumbnail: 'text',
                 url: 'page-h'
               },
@@ -1052,6 +1134,7 @@ RSpec.describe PagesFlow do
                 title: 'Page L',
                 uuid: '2c7deb33-19eb-4569-86d6-462e3d828d87',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 thumbnail: 'text',
                 url: 'page-l'
               }
@@ -1062,6 +1145,7 @@ RSpec.describe PagesFlow do
                 title: 'Page E',
                 uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 next: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
+                previous_uuid: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 thumbnail: 'text',
                 url: 'page-e'
               },
@@ -1070,6 +1154,7 @@ RSpec.describe PagesFlow do
                 title: 'Page I',
                 uuid: '520fde26-8124-4c67-a550-cd38d2ef304d',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
                 thumbnail: 'text',
                 url: 'page-i'
               }
@@ -1080,6 +1165,7 @@ RSpec.describe PagesFlow do
                 title: 'Page F',
                 uuid: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 thumbnail: 'text',
                 url: 'page-f'
               }
@@ -1090,6 +1176,7 @@ RSpec.describe PagesFlow do
                 title: 'Check your answers',
                 uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
                 next: '778e364b-9a7f-4829-8eb2-510e08f156a3',
+                previous_uuid: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
                 thumbnail: 'checkanswers',
                 url: 'check-answers'
               }
@@ -1100,6 +1187,7 @@ RSpec.describe PagesFlow do
                 title: 'Complaint sent',
                 uuid: '778e364b-9a7f-4829-8eb2-510e08f156a3',
                 next: '',
+                previous_uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
                 thumbnail: 'confirmation',
                 url: 'confirmation'
               }
@@ -1132,6 +1220,7 @@ RSpec.describe PagesFlow do
                 title: 'Page B',
                 uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
                 next: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
+                previous_uuid: 'cf6dc32f-502c-4215-8c27-1151a45735bb',
                 thumbnail: 'text',
                 url: 'page-b'
               }
@@ -1142,6 +1231,7 @@ RSpec.describe PagesFlow do
                 title: 'Page C',
                 uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 next: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
+                previous_uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
                 thumbnail: 'text',
                 url: 'page-c'
               }
@@ -1152,6 +1242,7 @@ RSpec.describe PagesFlow do
                 title: 'Page D',
                 uuid: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 next: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                previous_uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 thumbnail: 'radios',
                 url: 'page-d'
               }
@@ -1161,6 +1252,7 @@ RSpec.describe PagesFlow do
                 type: 'flow.branch',
                 title: 'Branching point 1',
                 uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                previous_uuid: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 thumbnail: 'branch',
                 conditionals: [
                   {
@@ -1193,6 +1285,8 @@ RSpec.describe PagesFlow do
                 title: 'Page E',
                 uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 next: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                conditional_uuid: '457ca1ed-b188-4980-bf9b-01f8dde5ffe9',
                 thumbnail: 'text',
                 url: 'page-e'
               },
@@ -1201,6 +1295,7 @@ RSpec.describe PagesFlow do
                 title: 'Page I',
                 uuid: '520fde26-8124-4c67-a550-cd38d2ef304d',
                 next: 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
                 thumbnail: 'text',
                 url: 'page-i'
               }
@@ -1211,6 +1306,7 @@ RSpec.describe PagesFlow do
                 title: 'Page F',
                 uuid: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
                 next: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
+                previous_uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 thumbnail: 'text',
                 url: 'page-f'
               },
@@ -1219,6 +1315,7 @@ RSpec.describe PagesFlow do
                 title: 'Page J',
                 uuid: 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992',
                 next: 'be130ac1-f33d-4845-807d-89b23b90d205',
+                previous_uuid: '520fde26-8124-4c67-a550-cd38d2ef304d',
                 thumbnail: 'radios',
                 url: 'page-j'
               }
@@ -1229,6 +1326,7 @@ RSpec.describe PagesFlow do
                 title: 'Page H',
                 uuid: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
                 thumbnail: 'text',
                 url: 'page-h'
               },
@@ -1237,6 +1335,7 @@ RSpec.describe PagesFlow do
                 title: 'Page K',
                 uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 next: '2c7deb33-19eb-4569-86d6-462e3d828d87',
+                previous_uuid: 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992',
                 thumbnail: 'text',
                 url: 'page-k'
               }
@@ -1250,6 +1349,7 @@ RSpec.describe PagesFlow do
                 title: 'Page L',
                 uuid: '2c7deb33-19eb-4569-86d6-462e3d828d87',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 thumbnail: 'text',
                 url: 'page-l'
               }
@@ -1260,6 +1360,7 @@ RSpec.describe PagesFlow do
                 title: 'Check your answers',
                 uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
                 next: '778e364b-9a7f-4829-8eb2-510e08f156a3',
+                previous_uuid: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
                 thumbnail: 'checkanswers',
                 url: 'check-answers'
               }
@@ -1270,6 +1371,7 @@ RSpec.describe PagesFlow do
                 title: 'Complaint sent',
                 uuid: '778e364b-9a7f-4829-8eb2-510e08f156a3',
                 next: '',
+                previous_uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
                 thumbnail: 'confirmation',
                 url: 'confirmation'
               }
@@ -1302,6 +1404,7 @@ RSpec.describe PagesFlow do
                 title: 'Page B',
                 uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
                 next: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                previous_uuid: 'cf6dc32f-502c-4215-8c27-1151a45735bb',
                 thumbnail: 'radios',
                 url: 'page-b'
               }
@@ -1311,6 +1414,7 @@ RSpec.describe PagesFlow do
                 type: 'flow.branch',
                 title: 'Branching point 1',
                 uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                previous_uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
                 thumbnail: 'branch',
                 conditionals: [
                   {
@@ -1354,6 +1458,8 @@ RSpec.describe PagesFlow do
                 title: 'Page C',
                 uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 next: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                conditional_uuid: '91965137-99bd-4bcf-b9c3-61afaa7fc5c0',
                 thumbnail: 'text',
                 url: 'page-c'
               },
@@ -1362,6 +1468,8 @@ RSpec.describe PagesFlow do
                 title: 'Page G',
                 uuid: '3a584d15-6805-4a21-bc05-b61c3be47857',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                conditional_uuid: '10396fae-c28c-445c-a633-14d6439271a8',
                 thumbnail: 'text',
                 url: 'page-g'
               },
@@ -1370,6 +1478,7 @@ RSpec.describe PagesFlow do
                 title: 'Page J',
                 uuid: 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992',
                 next: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
                 thumbnail: 'radios',
                 url: 'page-j'
               }
@@ -1380,6 +1489,7 @@ RSpec.describe PagesFlow do
                 title: 'Page D',
                 uuid: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 next: '37a94466-97fa-427f-88b2-09b369435d0d',
+                previous_uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 thumbnail: 'text',
                 url: 'page-d'
               },
@@ -1390,6 +1500,7 @@ RSpec.describe PagesFlow do
                 type: 'flow.branch',
                 title: 'Branching point 2',
                 uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+                previous_uuid: 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992',
                 thumbnail: 'branch',
                 conditionals: [
                   {
@@ -1422,6 +1533,7 @@ RSpec.describe PagesFlow do
                 title: 'Page E',
                 uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 next: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
+                previous_uuid: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 thumbnail: 'text',
                 url: 'page-e'
               },
@@ -1433,6 +1545,8 @@ RSpec.describe PagesFlow do
                 title: 'Page K',
                 uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 next: '2c7deb33-19eb-4569-86d6-462e3d828d87',
+                previous_uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+                conditional_uuid: 'a2312258-bcbe-48b0-b30c-37d51caaf756',
                 thumbnail: 'text',
                 url: 'page-k'
               },
@@ -1441,6 +1555,7 @@ RSpec.describe PagesFlow do
                 title: 'Page M',
                 uuid: 'd80a2225-63c3-4944-873f-504b61311a15',
                 next: '393645a4-f037-4e75-8359-51f9b0e360fb',
+                previous_uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
                 thumbnail: 'text',
                 url: 'page-m'
               }
@@ -1451,6 +1566,7 @@ RSpec.describe PagesFlow do
                 title: 'Page F',
                 uuid: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 thumbnail: 'text',
                 url: 'page-f'
               },
@@ -1462,6 +1578,7 @@ RSpec.describe PagesFlow do
                 title: 'Page L',
                 uuid: '2c7deb33-19eb-4569-86d6-462e3d828d87',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 thumbnail: 'text',
                 url: 'page-l'
               },
@@ -1470,6 +1587,7 @@ RSpec.describe PagesFlow do
                 title: 'Page N',
                 uuid: '393645a4-f037-4e75-8359-51f9b0e360fb',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: 'd80a2225-63c3-4944-873f-504b61311a15',
                 thumbnail: 'text',
                 url: 'page-n'
               }
@@ -1480,6 +1598,7 @@ RSpec.describe PagesFlow do
                 title: 'Check your answers',
                 uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
                 next: '778e364b-9a7f-4829-8eb2-510e08f156a3',
+                previous_uuid: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
                 thumbnail: 'checkanswers',
                 url: 'check-answers'
               }
@@ -1490,6 +1609,7 @@ RSpec.describe PagesFlow do
                 title: 'Complaint sent',
                 uuid: '778e364b-9a7f-4829-8eb2-510e08f156a3',
                 next: '',
+                previous_uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
                 thumbnail: 'confirmation',
                 url: 'confirmation'
               }
@@ -1522,6 +1642,7 @@ RSpec.describe PagesFlow do
                 title: 'Page B',
                 uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
                 next: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
+                previous_uuid: 'cf6dc32f-502c-4215-8c27-1151a45735bb',
                 thumbnail: 'text',
                 url: 'page-b'
               }
@@ -1532,6 +1653,7 @@ RSpec.describe PagesFlow do
                 title: 'Page C',
                 uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 next: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
+                previous_uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
                 thumbnail: 'text',
                 url: 'page-c'
               }
@@ -1542,6 +1664,7 @@ RSpec.describe PagesFlow do
                 title: 'Page D',
                 uuid: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 next: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                previous_uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 thumbnail: 'radios',
                 url: 'page-d'
               }
@@ -1551,6 +1674,7 @@ RSpec.describe PagesFlow do
                 type: 'flow.branch',
                 title: 'Branching point 1',
                 uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                previous_uuid: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 thumbnail: 'branch',
                 conditionals: [
                   {
@@ -1583,6 +1707,8 @@ RSpec.describe PagesFlow do
                 title: 'Page E',
                 uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                conditional_uuid: 'b65ad907-d415-4139-8955-9e9a3d119b50',
                 thumbnail: 'text',
                 url: 'page-e'
               },
@@ -1591,6 +1717,7 @@ RSpec.describe PagesFlow do
                 title: 'Page I',
                 uuid: '520fde26-8124-4c67-a550-cd38d2ef304d',
                 next: 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
                 thumbnail: 'text',
                 url: 'page-i'
               }
@@ -1604,6 +1731,7 @@ RSpec.describe PagesFlow do
                 title: 'Page J',
                 uuid: 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992',
                 next: 'be130ac1-f33d-4845-807d-89b23b90d205',
+                previous_uuid: '520fde26-8124-4c67-a550-cd38d2ef304d',
                 thumbnail: 'radios',
                 url: 'page-j'
               }
@@ -1617,6 +1745,7 @@ RSpec.describe PagesFlow do
                 title: 'Page K',
                 uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 next: '2c7deb33-19eb-4569-86d6-462e3d828d87',
+                previous_uuid: 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992',
                 thumbnail: 'text',
                 url: 'page-k'
               }
@@ -1630,6 +1759,7 @@ RSpec.describe PagesFlow do
                 title: 'Page L',
                 uuid: '2c7deb33-19eb-4569-86d6-462e3d828d87',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 thumbnail: 'text',
                 url: 'page-l'
               }
@@ -1640,6 +1770,7 @@ RSpec.describe PagesFlow do
                 title: 'Check your answers',
                 uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
                 next: '778e364b-9a7f-4829-8eb2-510e08f156a3',
+                previous_uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 thumbnail: 'checkanswers',
                 url: 'check-answers'
               }
@@ -1650,6 +1781,7 @@ RSpec.describe PagesFlow do
                 title: 'Complaint sent',
                 uuid: '778e364b-9a7f-4829-8eb2-510e08f156a3',
                 next: '',
+                previous_uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
                 thumbnail: 'confirmation',
                 url: 'confirmation'
               }
@@ -1682,6 +1814,7 @@ RSpec.describe PagesFlow do
                 title: 'Page B',
                 uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
                 next: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
+                previous_uuid: 'cf6dc32f-502c-4215-8c27-1151a45735bb',
                 thumbnail: 'text',
                 url: 'page-b'
               }
@@ -1692,6 +1825,7 @@ RSpec.describe PagesFlow do
                 title: 'Page C',
                 uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 next: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
+                previous_uuid: '68fbb180-9a2a-48f6-9da6-545e28b8d35a',
                 thumbnail: 'text',
                 url: 'page-c'
               }
@@ -1702,6 +1836,7 @@ RSpec.describe PagesFlow do
                 title: 'Page D',
                 uuid: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 next: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                previous_uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 thumbnail: 'radios',
                 url: 'page-d'
               }
@@ -1711,6 +1846,7 @@ RSpec.describe PagesFlow do
                 type: 'flow.branch',
                 title: 'Branching point 1',
                 uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                previous_uuid: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 thumbnail: 'branch',
                 conditionals: [
                   {
@@ -1743,6 +1879,8 @@ RSpec.describe PagesFlow do
                 title: 'Page E',
                 uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 next: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
+                conditional_uuid: '2d87a4bf-d532-48f5-956c-31ba5d046f63',
                 thumbnail: 'text',
                 url: 'page-e'
               },
@@ -1751,6 +1889,7 @@ RSpec.describe PagesFlow do
                 title: 'Page I',
                 uuid: '520fde26-8124-4c67-a550-cd38d2ef304d',
                 next: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+                previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
                 thumbnail: 'text',
                 url: 'page-i'
               }
@@ -1761,6 +1900,7 @@ RSpec.describe PagesFlow do
                 title: 'Page F',
                 uuid: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
                 next: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
+                previous_uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 thumbnail: 'text',
                 url: 'page-f'
               },
@@ -1768,6 +1908,7 @@ RSpec.describe PagesFlow do
                 type: 'flow.branch',
                 title: 'Branching point 2',
                 uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+                previous_uuid: '520fde26-8124-4c67-a550-cd38d2ef304d',
                 thumbnail: 'branch',
                 conditionals: [
                   {
@@ -1811,6 +1952,7 @@ RSpec.describe PagesFlow do
                 title: 'Page H',
                 uuid: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
                 thumbnail: 'text',
                 url: 'page-h'
               },
@@ -1822,6 +1964,8 @@ RSpec.describe PagesFlow do
                 title: 'Page K',
                 uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 next: '2c7deb33-19eb-4569-86d6-462e3d828d87',
+                previous_uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
+                conditional_uuid: 'b4eaf825-a523-4372-a15b-072b016b0ead',
                 thumbnail: 'text',
                 url: 'page-k'
               },
@@ -1830,6 +1974,7 @@ RSpec.describe PagesFlow do
                 title: 'Page G',
                 uuid: '3a584d15-6805-4a21-bc05-b61c3be47857',
                 next: '',
+                previous_uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
                 thumbnail: 'exit',
                 url: 'page-g'
               }
@@ -1846,6 +1991,7 @@ RSpec.describe PagesFlow do
                 title: 'Page L',
                 uuid: '2c7deb33-19eb-4569-86d6-462e3d828d87',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
+                previous_uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 thumbnail: 'text',
                 url: 'page-l'
               }
@@ -1856,6 +2002,7 @@ RSpec.describe PagesFlow do
                 title: 'Check your answers',
                 uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
                 next: '778e364b-9a7f-4829-8eb2-510e08f156a3',
+                previous_uuid: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
                 thumbnail: 'checkanswers',
                 url: 'check-answers'
               }
@@ -1866,6 +2013,7 @@ RSpec.describe PagesFlow do
                 title: 'Complaint sent',
                 uuid: '778e364b-9a7f-4829-8eb2-510e08f156a3',
                 next: '',
+                previous_uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
                 thumbnail: 'confirmation',
                 url: 'confirmation'
               }


### PR DESCRIPTION
In order to have the necessary information for the move functionality we
need to inject the previous UUID into the page flow. If the page in
question is also a branch destination then we also inject the
conditional UUID.