### PR TITLE
Fix tab order to save button on question pages

### DIFF
--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -6,6 +6,16 @@
   </div>
 <% end %>
 
+<%= render template: @page.template %>
+<%= render partial: 'partials/add_component_button' %>
+<%= render partial: 'partials/add_content_button' %>
+<%= render partial: 'partials/template_question_menu' %>
+<%= render partial: 'partials/template_content_menu' %>
+<%= render partial: 'partials/template_editable_collection_item_menu' %>
+<%= render partial: 'partials/template_dialog_configuration' %>
+<%= render partial: 'partials/template_content_property_fields' %>
+<%= render partial: 'partials/template_question_property_fields' %>
+
 <%= form_for @page, as: :page, url: page_path(service.service_id, @page.uuid), html: { id: "editContentForm" }, method: :patch do |f| %>
   <% @page.editable_attributes.each do |key, value| %>
     <% if key == :components || key == :extra_components %>
@@ -19,16 +29,6 @@
 
   <%= f.submit t('actions.save'), class: 'govuk-button fb-govuk-button', id: 'fb-editor-save' %>
 <% end %>
-
-<%= render template: @page.template %>
-<%= render partial: 'partials/add_component_button' %>
-<%= render partial: 'partials/add_content_button' %>
-<%= render partial: 'partials/template_question_menu' %>
-<%= render partial: 'partials/template_content_menu' %>
-<%= render partial: 'partials/template_editable_collection_item_menu' %>
-<%= render partial: 'partials/template_dialog_configuration' %>
-<%= render partial: 'partials/template_content_property_fields' %>
-<%= render partial: 'partials/template_question_property_fields' %>
 
 <% # app.page is initialised in partials/properties. %>
 <% # JS object should exist at this point so we're not checking for existence. %>


### PR DESCRIPTION
Simple fix for this was to move the hidden form for saving the metadata to the bottom of the template, meaning the Save button is in the correct place in the default tab order of the document.  The button is already styled to be absolutely positioned where it is. So no further cahnges are required.