### PR TITLE
Add meta viewport tag to correct responsive view

### DIFF
--- a/app/views/partials/_head_tags.html.erb
+++ b/app/views/partials/_head_tags.html.erb
@@ -1,3 +1,4 @@
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_pack_url('media/images/favicon.ico') %>" type="image/x-icon" />
 <link rel="mask-icon" href="<%= asset_pack_url('media/images/govuk-mask-icon.svg') %>" color="blue">
 <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-180x180.png') %>">


### PR DESCRIPTION
This adds the correct `viewport` meta tag from the design system so that the interface displays correctly on devices.

<img width="942" alt="image" src="https://user-images.githubusercontent.com/595564/162456075-a82f5da8-f47f-4b40-985f-e3f64ee9425d.png">

Before:
<img width="396" alt="image" src="https://user-images.githubusercontent.com/595564/162456286-351fcefe-5497-4f04-b800-0154302f593c.png">

After:
<img width="399" alt="image" src="https://user-images.githubusercontent.com/595564/162456363-5b48262f-2b36-49d8-b3ae-018606e7be6f.png">

There is a corresponding fix for the presenter, which will then require a version bump here too.  this will enable forms to display correctly in the runner too. 


