### PR TITLE
re-order to ensure .ActivatedMenu class is present for ActivatedMenuContainer instantiation

### DIFF
--- a/app/javascript/src/components/menus/activated_menu.js
+++ b/app/javascript/src/components/menus/activated_menu.js
@@ -74,6 +74,8 @@ class ActivatedMenu {
     this.$node = $menu;
     this.#config = config;
     this.#className = "ActivatedMenu";
+
+    this.#addAttributes();
     this.activator = new ActivatedMenuActivator(this, config);
     this.container = new ActivatedMenuContainer(this, config);  
 
@@ -96,7 +98,6 @@ class ActivatedMenu {
       position: null
     }
 
-    this.#addAttributes();
     this.#bindMenuEventHandlers();
     this.#setMenuOpenPosition();
     this.#initializeMenuItems();
@@ -206,7 +207,6 @@ class ActivatedMenu {
   #addAttributes() {
     this.$node.addClass(this.#className);
     this.$node.attr("role", "menu");
-    this.$node.attr("aria-labelledby", this.activator.$node.attr("id"));
   }
 
   #bindMenuEventHandlers() {

--- a/app/javascript/src/components/menus/activated_menu_activator.js
+++ b/app/javascript/src/components/menus/activated_menu_activator.js
@@ -77,6 +77,7 @@ class ActivatedMenuActivator {
     this.$node.attr("id", uniqueString("menuActivator"));
     this.$node.attr("aria-haspopup", "menu");
     this.$node.attr("aria-controls", this.#config.container_id);
+    this.menu.$node.attr("aria-labelledby", this.$node.attr("id"));
   }
 
   #bindEventHandlers() {


### PR DESCRIPTION
Small code fix to correct the fact that the width of Activated Menu Containers was being incorrectly set on the branch edit page due to the .ActivatedMenu class not being present when the ActivatedMenuContainer was created.  This meant the menu was inheriting the width of its parent container and was then being positioned incorrectly.

