### PR TITLE
Fix connection menu voiceover labels

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -656,8 +656,9 @@ html {
   }
   
   &:after {
-    content: "\FF0B";
+    content: "\271A";
     top: -22px;
+    font-weight: normal;
   }
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -656,7 +656,7 @@ html {
   }
   
   &:after {
-    content: '+';
+    content: "\FF0B";
     top: -22px;
   }
 }


### PR DESCRIPTION
Changes the symbol used for the conection menu from a `+` to a different unicode plus sign in order for it not to be read out bby a screenreader.