### PR TITLE
Move flow object API endpoints

### DIFF
--- a/app/controllers/api/move_controller.rb
+++ b/app/controllers/api/move_controller.rb
@@ -1,0 +1,34 @@
+module Api
+  class MoveController < BranchesController
+    def targets
+      @move = Move.new(base_params)
+      render :new, layout: false
+    end
+
+    def change
+      @move = Move.new(base_params.merge(change_params))
+      @move.change
+      redirect_to edit_service_path(service.service_id)
+    end
+
+    private
+
+    def base_params
+      {
+        service: service,
+        grid: grid,
+        previous_flow_uuid: params[:previous_flow_uuid],
+        to_move_uuid: params[:flow_uuid]
+      }
+    end
+
+    def change_params
+      {
+        target_uuid: params[:target_uuid] || params[:move][:target_uuid],
+        previous_flow_uuid: params[:move][:previous_flow_uid],
+        branch_uuid: params[:move][:branch_uuid],
+        conditional_uuid: params[:move][:conditional_uuid]
+      }
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :service
 
+  def grid
+    @grid ||= MetadataPresenter::Grid.new(service)
+  end
+  helper_method :grid
+
   def editable?
     !request.script_name.include?('preview')
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,7 +37,6 @@ module ApplicationHelper
     end
   end
 
-  # START: Remove once new service flow page is finished
   def flow_thumbnail(page)
     type = if page.components.blank?
              page.type.gsub('page.', '')
@@ -46,7 +45,6 @@ module ApplicationHelper
            end
     flow_thumbnail_link(uuid: page.uuid, thumbnail: type, title: page.title)
   end
-  # END: Remove once new service flow page is finished
 
   def flow_title(flow_object)
     flow_object.title || service.find_page_by_uuid(flow_object.uuid).title

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -1,0 +1,82 @@
+class Move
+  include ActiveModel::Model
+  include ApplicationHelper
+  attr_accessor :service, :grid, :previous_flow_uuid, :to_move_uuid, :target_uuid,
+                :conditional_uuid
+
+  def title
+    flow_title(service.flow_object(to_move_uuid))
+  end
+
+  def targets
+    ordered_by_row.each_with_object([]) do |flow_object, ary|
+      next if flow_object.nil? || invalid_target?(flow_object)
+
+      if flow_object.branch?
+        flow_object.conditionals.each.with_index(1) do |conditional, index|
+          ary << branch_target(flow_object, index, conditional)
+        end
+        ary << branch_target(flow_object, flow_object.conditionals.count + 1)
+      else
+        ary << page_target(flow_object)
+      end
+    end
+  end
+
+  private
+
+  def ordered_by_row
+    max_rows.times.each_with_object([]) do |row, ary|
+      ordered_by_column.each do |column|
+        ary << column[row] if column[row].present?
+      end
+    end
+  end
+
+  def branch_target(flow_object, index, conditional = nil)
+    {
+      title: "#{flow_object.title} (Branch #{index})",
+      branch_uuid: flow_object.uuid,
+      conditional_uuid: conditional&.uuid,
+      target_uuid: conditional&.next || flow_object.default_next
+    }.compact
+  end
+
+  def page_target(flow_object)
+    {
+      title: flow_title(flow_object),
+      target_uuid: flow_object.uuid
+    }
+  end
+
+  def invalid_target?(flow_object)
+    to_move_uuid == flow_object.uuid ||
+      invalid_page?(flow_object.uuid) ||
+      flow_object.is_a?(MetadataPresenter::Spacer) ||
+      flow_object.is_a?(MetadataPresenter::Warning)
+  end
+
+  def invalid_page?(uuid)
+    checkanswers_page?(uuid) || confirmation_page?(uuid) || exit_page?(uuid)
+  end
+
+  def checkanswers_page?(uuid)
+    uuid == service.checkanswers_page&.uuid
+  end
+
+  def confirmation_page?(uuid)
+    uuid == service.confirmation_page&.uuid
+  end
+
+  def exit_page?(uuid)
+    service.find_page_by_uuid(uuid)&.type == 'page.exit'
+  end
+
+  def ordered_by_column
+    @ordered_by_column ||= grid.build
+  end
+
+  def max_rows
+    ordered_by_column.map(&:size).max
+  end
+end

--- a/app/views/api/move/new.html.erb
+++ b/app/views/api/move/new.html.erb
@@ -1,0 +1,20 @@
+<div class="component-dialog-api-request">
+  <%= form_for @move, url: api_service_flow_move_path(service.service_id, @move.to_move_uuid) do |f| %>
+    <div class="govuk-form-group ">
+      <%= f.hidden_field :previous_flow_uuid, value: @move.previous_flow_uuid %>
+      <%= f.hidden_field :branch_uuid, value: '' %>
+      <%= f.hidden_field :conditional_uuid, value: '' %>
+      <%= f.label :target_uuid, t('dialogs.move.label', title: @move.title), class: "govuk-label govuk-label--m" %>
+      <p> <%= t('dialogs.move.lede') %></p>
+      <div class="govuk-form-group">
+        <select class="govuk-select" name="target_uuid" id="target_uuid">
+          <% @move.targets.each do |target| %>
+            <option value="<%= target[:target_uuid] %>" data-branch-uuid="<%= target[:branch_uuid] %>" data-conditional-uuid="<%= target[:conditional_uuid] %>">
+              <%= target[:title] %>
+            </option>
+          <% end %>
+        </select>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,10 @@ en:
       lede: 'After: "%{title}"'
       go_to: 'Go to: '
       text: 'Any pages that are left without a connection to your form will be moved to the unconnected pages section.'
+    move:
+      label: 'Moving the page "%{title}"'
+      lede: Moving to the page after
+      button: Move
   header:
     service_name: "MoJ Forms"
     home_link_text: "Back to Home"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,8 @@ Rails.application.routes.draw do
     resources :services do
       resources :flow, param: :uuid, only: [] do
         resources :destinations, only: [:new, :create]
+        get '/move/:previous_flow_uuid', to: 'move#targets', as: :move
+        post :move, to: 'move#change'
       end
 
       resources :pages, only: [:show] do

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -1,0 +1,138 @@
+RSpec.describe Move do
+  subject(:move) do
+    described_class.new(
+      service: service,
+      grid: grid,
+      previous_flow_uuid: previous_flow_uuid,
+      to_move_uuid: to_move_uuid,
+      target_uuid: target_uuid,
+      conditional_uuid: conditional_uuid
+    )
+  end
+  let(:latest_metadata) { metadata_fixture(:branching_11) }
+  let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+  let(:grid) { MetadataPresenter::Grid.new(service) }
+  let(:previous_flow_uuid) { nil }
+  let(:to_move_uuid) { nil }
+  let(:target_uuid) { nil }
+  let(:conditional_uuid) { nil }
+
+  describe '#targets' do
+    let(:to_move_uuid) { '2ffc17b7-b14a-417f-baff-07adebd4f259' } # Page B
+    let(:targets) { move.targets }
+    let(:target_uuids) { targets.map { |t| t[:target_uuid] } }
+    let(:target_titles) { targets.map { |t| t[:title] } }
+    let(:unconnected_uuids) { service.flow.keys - grid.flow_uuids }
+    let(:expected_target_titles) do
+      [
+        'Service name goes here',
+        'Page A',
+        'Branching point 1 (Branch 1)',
+        'Branching point 1 (Branch 2)',
+        'Branching point 1 (Branch 3)',
+        'Page C',
+        'Page D',
+        'Page E',
+        'Page F',
+        'Branching point 4 (Branch 1)',
+        'Branching point 4 (Branch 2)',
+        'Branching point 4 (Branch 3)',
+        'Branching point 4 (Branch 4)',
+        'Branching point 4 (Branch 5)',
+        'Page G',
+        'Page H',
+        'Page I',
+        'Page J',
+        'Branching point 2 (Branch 1)',
+        'Branching point 2 (Branch 2)',
+        'Branching point 2 (Branch 3)',
+        'Page K',
+        'Page L',
+        'Page M',
+        'Page N',
+        'Page O',
+        'Branching point 3 (Branch 1)',
+        'Branching point 3 (Branch 2)',
+        'Page P'
+      ]
+    end
+
+    it 'lists the targets in order of rows with branch destinations listed together' do
+      expect(target_titles).to eq(expected_target_titles)
+    end
+
+    it 'does not include the object being moved' do
+      expect(target_uuids).not_to include(to_move_uuid)
+    end
+
+    it 'sets the correct uuid for an object' do
+      expect(targets.first[:target_uuid]).to eq(service.start_page.uuid)
+    end
+
+    it 'does not include any branch objects' do
+      expect(target_uuids).not_to include(*service.branches.map(&:uuid))
+    end
+
+    it 'does not include any unconnected pages' do
+      expect(target_uuids).not_to include(*unconnected_uuids)
+    end
+
+    context 'page targets' do
+      let(:page_targets) { targets.reject { |t| t[:branch_uuid].present? } }
+      let(:target_uuids) { page_targets.map { |t| t[:target_uuid] } }
+
+      it 'does not show the checkanswers page' do
+        expect(target_uuids).not_to include(service.checkanswers_page.uuid)
+      end
+
+      it 'does not show the confirmation page' do
+        expect(target_uuids).not_to include(service.confirmation_page.uuid)
+      end
+
+      context 'exit pages' do
+        let(:latest_metadata) { metadata_fixture(:exit_only_service) }
+        let(:exit_page_uuid) do
+          service.pages.find { |p| p.type == 'page.exit' }.uuid
+        end
+
+        it 'does not show any exit pages' do
+          expect(target_uuids).not_to include(exit_page_uuid)
+        end
+      end
+    end
+
+    context 'branch targets' do
+      let(:branch_targets) { targets.select { |t| t[:branch_uuid].present? } }
+      let(:target_uuids) { branch_targets.map { |t| t[:target_uuid] } }
+      let(:branch) { service.flow_object('f55d002d-b2c1-4dcc-87b7-0da7cbc5c87c') } # branching point 1
+      let(:conditional) { branch.conditionals[1] }
+
+      it 'sets the branch uuid' do
+        expect(branch_targets[1][:branch_uuid]).to eq(branch.uuid)
+      end
+
+      it 'sets the conditional uuid' do
+        expect(branch_targets[1][:conditional_uuid]).to eq(conditional.uuid)
+      end
+
+      it 'allows checkanswers page if they are a branch destination' do
+        expect(target_uuids).to include(service.checkanswers_page.uuid)
+      end
+
+      it 'does not show the confirmation page' do
+        expect(target_uuids).not_to include(service.confirmation_page.uuid)
+      end
+
+      context 'exit page' do
+        let(:latest_metadata) { metadata_fixture(:branching_7) }
+        let(:exit_page_uuid) do
+          service.pages.find { |p| p.type == 'page.exit' }.uuid
+        end
+
+        it 'allows exit pages if they are a branch destination' do
+          expect(target_uuids).to include(exit_page_uuid)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/move_spec.rb
+++ b/spec/requests/api/move_spec.rb
@@ -1,0 +1,113 @@
+RSpec.describe 'Move spec', type: :request do
+  describe 'GET /api/services/:service_id/flow/:flow_uuid/move' do
+    let(:request) do
+      get "/api/services/#{service.service_id}/flow/#{flow_uuid}/move/#{previous_flow_uuid}"
+    end
+    let(:service) { MetadataPresenter::Service.new(metadata) }
+    let(:metadata) { metadata_fixture(:branching_11) }
+    let(:flow_uuid) { '2ffc17b7-b14a-417f-baff-07adebd4f259' } # Page B
+    let(:previous_flow_uuid) { '1d60bef0-100a-4f3b-9e6f-1711e8adda7e' } # Page A
+
+    context 'when moving a page' do
+      let(:invalid_targets) do
+        [
+          'Check your answers',
+          'Confirmation'
+        ]
+      end
+      let(:unconnected_targets) do
+        [
+          'Page Q',
+          'Page R',
+          'Page S'
+        ]
+      end
+      let(:expected_targets) do
+        [
+          'Service name goes here',
+          'Page A',
+          'Branching point 1 (Branch 1)',
+          'Branching point 1 (Branch 2)',
+          'Branching point 1 (Branch 3)',
+          'Page C',
+          'Page D',
+          'Page E',
+          'Page F',
+          'Branching point 4 (Branch 1)',
+          'Branching point 4 (Branch 2)',
+          'Branching point 4 (Branch 3)',
+          'Branching point 4 (Branch 4)',
+          'Branching point 4 (Branch 5)',
+          'Page G',
+          'Page H',
+          'Page I',
+          'Page J',
+          'Branching point 2 (Branch 1)',
+          'Branching point 2 (Branch 2)',
+          'Branching point 2 (Branch 3)',
+          'Page K',
+          'Page L',
+          'Page M',
+          'Page N',
+          'Page O',
+          'Branching point 3 (Branch 1)',
+          'Branching point 3 (Branch 2)',
+          'Page P'
+        ]
+      end
+      let(:expected_branch_and_conditionals) do
+        [
+          'data-branch-uuid="f55d002d-b2c1-4dcc-87b7-0da7cbc5c87c" data-conditional-uuid="9149bc4c-9773-454f-b9b6-5524b91102ca"',
+          'data-branch-uuid="f55d002d-b2c1-4dcc-87b7-0da7cbc5c87c" data-conditional-uuid="6c4dd853-671d-4f62-845e-6471bd102e36"',
+          'data-branch-uuid="f55d002d-b2c1-4dcc-87b7-0da7cbc5c87c" data-conditional-uuid=""',
+          'data-branch-uuid="7fe9a893-384c-4e8a-bb94-b1ec4f6a24d1" data-conditional-uuid="db2676e0-3cef-4943-af00-3ddbece930d2"',
+          'data-branch-uuid="7fe9a893-384c-4e8a-bb94-b1ec4f6a24d1" data-conditional-uuid="0b99ff9b-e9db-47ff-acf9-c15b00113a13"',
+          'data-branch-uuid="7fe9a893-384c-4e8a-bb94-b1ec4f6a24d1" data-conditional-uuid="e3f94a86-a371-47fb-b866-1909b055316d"',
+          'data-branch-uuid="7fe9a893-384c-4e8a-bb94-b1ec4f6a24d1" data-conditional-uuid="7c013bb4-abc7-4270-a0c2-fd70715839b6"',
+          'data-branch-uuid="7fe9a893-384c-4e8a-bb94-b1ec4f6a24d1" data-conditional-uuid=""',
+          'data-branch-uuid="a02f7073-ba5a-459d-b6b9-abe548c933a6" data-conditional-uuid="0bdc8fde-be62-4945-8496-854e867a665d"',
+          'data-branch-uuid="a02f7073-ba5a-459d-b6b9-abe548c933a6" data-conditional-uuid="4ad9f7e9-5444-41d8-b7f8-17d2108ed27a"',
+          'data-branch-uuid="a02f7073-ba5a-459d-b6b9-abe548c933a6" data-conditional-uuid=""',
+          'data-branch-uuid="4cad5db1-bf68-4f7f-baf6-b2d48b342705" data-conditional-uuid="7b69e2fb-a18b-405e-b47e-75970e6f5e4b"',
+          'data-branch-uuid="4cad5db1-bf68-4f7f-baf6-b2d48b342705" data-conditional-uuid=""'
+        ]
+      end
+
+      before do
+        allow_any_instance_of(
+          Api::MoveController
+        ).to receive(:require_user!).and_return(true)
+
+        allow_any_instance_of(
+          Api::MoveController
+        ).to receive(:service).and_return(service)
+
+        request
+      end
+
+      it 'returns the list of possible targets' do
+        expected_targets.each do |title|
+          expect(response.body).to include(title)
+        end
+      end
+
+      it 'returns the correct branch and conditional uuids for branch targets' do
+        expected_branch_and_conditionals.each do |branch_and_conditional|
+          expect(response.body).to include(branch_and_conditional)
+        end
+      end
+
+      it 'does not include any unconnected targets' do
+        unconnected_targets.each do |title|
+          expect(response.body).not_to include(title)
+        end
+      end
+
+      it 'does not include the checkanswers, confirmation page or the page being moved' do
+        invalid_targets.each do |title|
+          expect(response.body).not_to include(title)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add the GET endpoint for the moving object functionality.
Currently the Move model will return a list of valid page and branch targets
that a flow object can be moved after, or replace in the case of a
branch target.

The POST endpoint is not used at this moment.