### PR TITLE
Update metadata when moving a flow object

### DIFF
--- a/app/controllers/api/move_controller.rb
+++ b/app/controllers/api/move_controller.rb
@@ -24,9 +24,8 @@ module Api
 
     def change_params
       {
-        target_uuid: params[:target_uuid] || params[:move][:target_uuid],
-        previous_flow_uuid: params[:move][:previous_flow_uid],
-        branch_uuid: params[:move][:branch_uuid],
+        previous_flow_uuid: params[:move][:previous_flow_uuid],
+        target_uuid: params[:target_uuid],
         conditional_uuid: params[:move][:conditional_uuid]
       }
     end

--- a/app/controllers/api/move_controller.rb
+++ b/app/controllers/api/move_controller.rb
@@ -23,11 +23,11 @@ module Api
     end
 
     def change_params
-      {
-        previous_flow_uuid: params[:move][:previous_flow_uuid],
-        target_uuid: params[:target_uuid],
-        conditional_uuid: params[:move][:conditional_uuid]
-      }
+      params.require(:move).permit(
+        :previous_flow_uuid,
+        :target_uuid,
+        :conditional_uuid
+      )
     end
   end
 end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -36,9 +36,8 @@ class Move
   def branch_target(flow_object, index, conditional = nil)
     {
       title: "#{flow_object.title} (Branch #{index})",
-      branch_uuid: flow_object.uuid,
-      conditional_uuid: conditional&.uuid,
-      target_uuid: conditional&.next || flow_object.default_next
+      target_uuid: flow_object.uuid,
+      conditional_uuid: conditional&.uuid
     }.compact
   end
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -1,8 +1,11 @@
 class Move
   include ActiveModel::Model
   include ApplicationHelper
+  include MetadataVersion
   attr_accessor :service, :grid, :previous_flow_uuid, :to_move_uuid, :target_uuid,
                 :conditional_uuid
+
+  alias_method :change, :create_version
 
   def title
     flow_title(service.flow_object(to_move_uuid))
@@ -21,6 +24,13 @@ class Move
         ary << page_target(flow_object)
       end
     end
+  end
+
+  def metadata
+    update_previous_flow_object if previous_flow_uuid.present?
+
+    service.flow_object(target_uuid).branch? ? update_branch : update_page
+    service.metadata.to_h.deep_stringify_keys
   end
 
   private
@@ -77,5 +87,46 @@ class Move
 
   def max_rows
     ordered_by_column.map(&:size).max
+  end
+
+  def update_previous_flow_object
+    to_move_default_next = service.flow[to_move_uuid]['next']['default']
+
+    if service.flow_object(previous_flow_uuid).branch? && conditional_uuid.present?
+      service.flow[previous_flow_uuid]['next']['conditionals'].each do |conditional|
+        if conditional['_uuid'] == conditional_uuid
+          conditional['next'] = to_move_default_next
+        end
+      end
+    else
+      update_default_next(previous_flow_uuid, to_move_default_next)
+    end
+  end
+
+  def update_page
+    set_target_uuid_as_to_move_default_next
+    update_default_next(target_uuid, to_move_uuid)
+  end
+
+  def update_branch
+    if conditional_uuid.present?
+      service.flow[target_uuid]['next']['conditionals'].each do |conditional|
+        if conditional['_uuid'] == conditional_uuid
+          update_default_next(to_move_uuid, conditional['next'])
+          conditional['next'] = to_move_uuid
+        end
+      end
+    else
+      set_target_uuid_as_to_move_default_next
+      update_default_next(target_uuid, to_move_uuid)
+    end
+  end
+
+  def set_target_uuid_as_to_move_default_next
+    update_default_next(to_move_uuid, service.flow[target_uuid]['next']['default'])
+  end
+
+  def update_default_next(to_update_uuid, new_default_next)
+    service.flow[to_update_uuid]['next']['default'] = new_default_next
   end
 end

--- a/app/views/api/move/new.html.erb
+++ b/app/views/api/move/new.html.erb
@@ -2,14 +2,13 @@
   <%= form_for @move, url: api_service_flow_move_path(service.service_id, @move.to_move_uuid) do |f| %>
     <div class="govuk-form-group ">
       <%= f.hidden_field :previous_flow_uuid, value: @move.previous_flow_uuid %>
-      <%= f.hidden_field :branch_uuid, value: '' %>
       <%= f.hidden_field :conditional_uuid, value: '' %>
       <%= f.label :target_uuid, t('dialogs.move.label', title: @move.title), class: "govuk-label govuk-label--m" %>
       <p> <%= t('dialogs.move.lede') %></p>
       <div class="govuk-form-group">
         <select class="govuk-select" name="target_uuid" id="target_uuid">
           <% @move.targets.each do |target| %>
-            <option value="<%= target[:target_uuid] %>" data-branch-uuid="<%= target[:branch_uuid] %>" data-conditional-uuid="<%= target[:conditional_uuid] %>">
+            <option value="<%= target[:target_uuid] %>" data-conditional-uuid="<%= target[:conditional_uuid] %>">
               <%= target[:title] %>
             </option>
           <% end %>

--- a/app/views/api/move/new.html.erb
+++ b/app/views/api/move/new.html.erb
@@ -6,7 +6,7 @@
       <%= f.label :target_uuid, t('dialogs.move.label', title: @move.title), class: "govuk-label govuk-label--m" %>
       <p> <%= t('dialogs.move.lede') %></p>
       <div class="govuk-form-group">
-        <select class="govuk-select" name="target_uuid" id="target_uuid">
+        <select class="govuk-select" name="move[target_uuid]" id="move[target_uuid]">
           <% @move.targets.each do |target| %>
             <option value="<%= target[:target_uuid] %>" data-conditional-uuid="<%= target[:conditional_uuid] %>">
               <%= target[:title] %>
@@ -15,5 +15,8 @@
         </select>
       </div>
     </div>
+    <button class="govuk-button fb-govuk-button">
+      <%= t('dialogs.move.button') %>
+    </button>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
     resources :services do
       resources :flow, param: :uuid, only: [] do
         resources :destinations, only: [:new, :create]
-        get '/move/:previous_flow_uuid', to: 'move#targets', as: :move
+        get '/move/(:previous_flow_uuid)', to: 'move#targets', as: :move
         post :move, to: 'move#change'
       end
 

--- a/spec/requests/api/move_spec.rb
+++ b/spec/requests/api/move_spec.rb
@@ -1,5 +1,44 @@
+RSpec.describe 'Move GET routes', type: :routing do
+  context 'when previous_flow_uuid is present' do
+    let(:request) do
+      get '/api/services/some-service-id/flow/some-flow-uuid/move/some-previous-flow-uuid'
+    end
+    let(:expected_route) do
+      {
+        controller: 'api/move',
+        action: 'targets',
+        service_id: 'some-service-id',
+        flow_uuid: 'some-flow-uuid',
+        previous_flow_uuid: 'some-previous-flow-uuid'
+      }
+    end
+
+    it 'correctly routes the request' do
+      expect(request).to route_to(expected_route)
+    end
+  end
+
+  context 'when previous_flow_uuid is not present' do
+    let(:request) do
+      get '/api/services/some-service-id/flow/some-flow-uuid/move'
+    end
+    let(:expected_route) do
+      {
+        controller: 'api/move',
+        action: 'targets',
+        service_id: 'some-service-id',
+        flow_uuid: 'some-flow-uuid'
+      }
+    end
+
+    it 'correctly routes the request' do
+      expect(request).to route_to(expected_route)
+    end
+  end
+end
+
 RSpec.describe 'Move spec', type: :request do
-  describe 'GET /api/services/:service_id/flow/:flow_uuid/move' do
+  describe 'GET /api/services/:service_id/flow/:flow_uuid/move/(:previous_flow_uuid)' do
     let(:request) do
       get "/api/services/#{service.service_id}/flow/#{flow_uuid}/move/#{previous_flow_uuid}"
     end

--- a/spec/requests/api/move_spec.rb
+++ b/spec/requests/api/move_spec.rb
@@ -96,19 +96,19 @@ RSpec.describe 'Move spec', type: :request do
       end
       let(:expected_branch_and_conditionals) do
         [
-          'data-branch-uuid="f55d002d-b2c1-4dcc-87b7-0da7cbc5c87c" data-conditional-uuid="9149bc4c-9773-454f-b9b6-5524b91102ca"',
-          'data-branch-uuid="f55d002d-b2c1-4dcc-87b7-0da7cbc5c87c" data-conditional-uuid="6c4dd853-671d-4f62-845e-6471bd102e36"',
-          'data-branch-uuid="f55d002d-b2c1-4dcc-87b7-0da7cbc5c87c" data-conditional-uuid=""',
-          'data-branch-uuid="7fe9a893-384c-4e8a-bb94-b1ec4f6a24d1" data-conditional-uuid="db2676e0-3cef-4943-af00-3ddbece930d2"',
-          'data-branch-uuid="7fe9a893-384c-4e8a-bb94-b1ec4f6a24d1" data-conditional-uuid="0b99ff9b-e9db-47ff-acf9-c15b00113a13"',
-          'data-branch-uuid="7fe9a893-384c-4e8a-bb94-b1ec4f6a24d1" data-conditional-uuid="e3f94a86-a371-47fb-b866-1909b055316d"',
-          'data-branch-uuid="7fe9a893-384c-4e8a-bb94-b1ec4f6a24d1" data-conditional-uuid="7c013bb4-abc7-4270-a0c2-fd70715839b6"',
-          'data-branch-uuid="7fe9a893-384c-4e8a-bb94-b1ec4f6a24d1" data-conditional-uuid=""',
-          'data-branch-uuid="a02f7073-ba5a-459d-b6b9-abe548c933a6" data-conditional-uuid="0bdc8fde-be62-4945-8496-854e867a665d"',
-          'data-branch-uuid="a02f7073-ba5a-459d-b6b9-abe548c933a6" data-conditional-uuid="4ad9f7e9-5444-41d8-b7f8-17d2108ed27a"',
-          'data-branch-uuid="a02f7073-ba5a-459d-b6b9-abe548c933a6" data-conditional-uuid=""',
-          'data-branch-uuid="4cad5db1-bf68-4f7f-baf6-b2d48b342705" data-conditional-uuid="7b69e2fb-a18b-405e-b47e-75970e6f5e4b"',
-          'data-branch-uuid="4cad5db1-bf68-4f7f-baf6-b2d48b342705" data-conditional-uuid=""'
+          'data-conditional-uuid="9149bc4c-9773-454f-b9b6-5524b91102ca"',
+          'data-conditional-uuid="6c4dd853-671d-4f62-845e-6471bd102e36"',
+          'data-conditional-uuid=""',
+          'data-conditional-uuid="db2676e0-3cef-4943-af00-3ddbece930d2"',
+          'data-conditional-uuid="0b99ff9b-e9db-47ff-acf9-c15b00113a13"',
+          'data-conditional-uuid="e3f94a86-a371-47fb-b866-1909b055316d"',
+          'data-conditional-uuid="7c013bb4-abc7-4270-a0c2-fd70715839b6"',
+          'data-conditional-uuid=""',
+          'data-conditional-uuid="0bdc8fde-be62-4945-8496-854e867a665d"',
+          'data-conditional-uuid="4ad9f7e9-5444-41d8-b7f8-17d2108ed27a"',
+          'data-conditional-uuid=""',
+          'data-conditional-uuid="7b69e2fb-a18b-405e-b47e-75970e6f5e4b"',
+          'data-conditional-uuid=""'
         ]
       end
 


### PR DESCRIPTION
Update the metadata to represent where a user wants to move an object to
in the flow.

If there is a previous flow uuid present then that previous objects
default next needs to be updated to point to what the object being moved
used to point to.

target_uuid represents the page that an object should be moved after or
the branch uuid for which the object being moved needs to replace either
one of the conditional destinations or the branch default next.
