### PR TITLE
Surface Move functionality in page menus

### DIFF
--- a/acceptance/features/change_destination_spec.rb
+++ b/acceptance/features/change_destination_spec.rb
@@ -84,6 +84,7 @@ feature 'Deleting page' do
         'Page g',
         'Branching point 2',
         'Question 2 contains Thor',
+        'Otherwise',
         'Page h',
         'Page i',
         'Page j'

--- a/acceptance/features/create_service_spec.rb
+++ b/acceptance/features/create_service_spec.rb
@@ -129,9 +129,4 @@ feature 'Create a service' do
       ]
     )
   end
-
-  def when_I_click_the_three_dots_button_on_the_confirmation_page
-    editor.hover_preview('Application complete')
-    and_I_click_on_the_three_dots
-  end
 end

--- a/acceptance/features/edit_confirmation_page_spec.rb
+++ b/acceptance/features/edit_confirmation_page_spec.rb
@@ -20,7 +20,6 @@ feature 'Edit confirmation pages' do
     when_I_save_my_changes
     and_I_return_to_flow_page
     and_I_click_on_the_confirmation_page_three_dots
-    then_I_should_only_see_three_options_on_page_menu
     and_I_click_edit_page
     then_I_should_see_the_confirmation_heading(confirmation_heading)
     then_I_should_see_the_confirmation_lede(confirmation_lede)

--- a/acceptance/features/edit_exit_page_spec.rb
+++ b/acceptance/features/edit_exit_page_spec.rb
@@ -29,9 +29,6 @@ feature 'Edit exit pages' do
     and_I_change_the_page_lede(exit_lede)
     when_I_save_my_changes
     and_I_return_to_flow_page
-    and_I_click_on_the_exit_page_three_dots
-    then_I_should_only_see_four_options_on_page_menu
-    and_I_return_to_flow_page #reload the page to get rid of the menu blocking link
     and_I_edit_the_page(url: exit_heading)
     then_I_see_the_updated_page_heading(exit_heading)
     then_I_see_the_updated_page_section_heading(exit_section_heading)

--- a/acceptance/features/edit_exit_page_spec.rb
+++ b/acceptance/features/edit_exit_page_spec.rb
@@ -30,7 +30,7 @@ feature 'Edit exit pages' do
     when_I_save_my_changes
     and_I_return_to_flow_page
     and_I_click_on_the_exit_page_three_dots
-    then_I_should_only_see_three_options_on_page_menu
+    then_I_should_only_see_four_options_on_page_menu
     and_I_return_to_flow_page #reload the page to get rid of the menu blocking link
     and_I_edit_the_page(url: exit_heading)
     then_I_see_the_updated_page_heading(exit_heading)

--- a/acceptance/features/move_page_spec.rb
+++ b/acceptance/features/move_page_spec.rb
@@ -1,0 +1,200 @@
+require_relative '../spec_helper'
+
+feature 'Move a page' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:fixture) { 'move_page_fixture' }
+  let(:page_b) { 'Page B' }
+  let(:page_c) { 'Page C' }
+  let(:page_f) { 'Page F' }
+  let(:page_h) { 'Page H' }
+  let(:branching_point_2_branching_1) { 'Branching point 2 (Branch 1)'}
+  let(:original_flow_titles) do
+    [
+      'Service name goes here',
+      'Page B',
+      'Page D',
+      'Branching point 1',
+      'Page D is Item 1',
+      'Otherwise',
+      'Page E',
+      'Page I',
+      'Page F',
+      'Branching point 2',
+      'Page D is Item 1',
+      'Page D is Item 2',
+      'Otherwise',
+      'Page H',
+      'Page K',
+      'Page G',
+      'Page L',
+      'Check your answers',
+      'Complaint sent'
+    ]
+  end
+  let(:page_h_after_page_b_flow) do
+    [
+      'Service name goes here',
+      'Page B',
+      'Page H',
+      'Page D',
+      'Branching point 1',
+      'Page D is Item 1',
+      'Otherwise',
+      'Page E',
+      'Page I',
+      'Page F',
+      'Branching point 2',
+      'Page D is Item 1',
+      'Page D is Item 2',
+      'Otherwise',
+      'Page K',
+      'Page G',
+      'Page L',
+      'Check your answers',
+      'Complaint sent'
+    ]
+  end
+  let(:page_h_after_branching_point_2_branch_1_flow) do
+    # the layout is iterated over vertically by column
+    [
+      'Service name goes here',
+      'Page B',
+      'Page D',
+      'Branching point 1',
+      'Page D is Item 1',
+      'Otherwise',
+      'Page E',
+      'Page I',
+      'Page F',
+      'Branching point 2',
+      'Page D is Item 1',
+      'Page D is Item 2',
+      'Otherwise',
+      'Page H',
+      'Page K',
+      'Page G',
+      'Page L',
+      'Check your answers',
+      'Complaint sent'
+    ]
+  end
+  let(:page_c_in_main_flow) do
+    [
+      'Service name goes here',
+      'Page B',
+      'Page D',
+      'Branching point 1',
+      'Page D is Item 1',
+      'Otherwise',
+      'Page E',
+      'Page I',
+      'Page F',
+      'Branching point 2',
+      'Page D is Item 1',
+      'Page D is Item 2',
+      'Otherwise',
+      'Page C',
+      'Page H',
+      'Page K',
+      'Page G',
+      'Page L',
+      'Check your answers',
+      'Complaint sent'
+    ]
+  end
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service_fixture(name: service_name, fixture: fixture)
+  end
+
+  scenario 'moving pages' do
+    and_I_click_on_the_page_menu(page_h)
+    editor.move_page_link.click
+    then_I_should_see_the_move_target_list(page_h)
+    and_I_select_a_target(page_b)
+    and_I_click_the_move_button
+    then_page_H_should_be_after_page_B
+
+    and_I_click_on_the_page_menu(page_h)
+    editor.move_page_link.click
+    and_I_select_a_target(branching_point_2_branching_1)
+    and_I_click_the_move_button
+    then_page_H_should_be_the_branching_point_2_branch_1_destination
+
+    and_I_click_on_an_unconnected_page_menu(page_c)
+    editor.move_page_link.click
+    and_I_select_a_target(page_f)
+    and_I_click_the_move_button
+    then_page_C_should_be_part_of_the_main_flow
+  end
+
+  scenario 'no default next warning message' do
+    and_I_click_on_the_page_menu('Page G')
+    editor.move_page_link.click
+    then_I_should_see_the_no_default_next_warning
+    and_I_click_understood
+    then_no_pages_should_have_moved
+  end
+
+  scenario 'stacked branching not supported warning message' do
+    and_I_click_on_the_page_menu('Page I')
+    editor.move_page_link.click
+    then_I_should_see_the_stacked_branches_not_supported_warning
+    and_I_click_understood
+    then_no_pages_should_have_moved
+  end
+
+  def and_I_select_a_target(target)
+    find('select#move_target_uuid').select(target)
+  end
+
+  def and_I_click_the_move_button
+    find('button', text: I18n.t('dialogs.move.button')).click
+  end
+
+  def and_I_click_on_an_unconnected_page_menu(flow_title)
+    flow_item = all('.flow-detached-group .flow-item .flow-thumbnail').find do |page_flow|
+      page_flow.text.include?(flow_title)
+    end
+    flow_item.hover
+    editor.three_dots_button.click
+  end
+
+  def then_I_should_see_the_move_target_list(page_title)
+    find('div#move_targets_list', visible: true)
+    expect(editor.text).to include(I18n.t('dialogs.move.label', title: page_title))
+  end
+
+  def then_page_H_should_be_after_page_B
+    expect(editor.main_flow_titles).to eq(page_h_after_page_b_flow)
+  end
+
+  def then_page_H_should_be_the_branching_point_2_branch_1_destination
+    expect(editor.main_flow_titles).to eq(page_h_after_branching_point_2_branch_1_flow)
+  end
+
+  def then_page_C_should_be_part_of_the_main_flow
+    expect(editor.main_flow_titles).to eq(page_c_in_main_flow)
+    expect(editor.unconnected_flow).to be_empty
+  end
+
+  def then_I_should_see_the_no_default_next_warning
+    find('div#branch_destination_no_default_next', visible: true)
+    expect(editor.text).to include(I18n.t('dialogs.move.branch_destination_no_default_next_message'))
+  end
+
+  def then_I_should_see_the_stacked_branches_not_supported_warning
+    find('div#stacked_branches_not_supported', visible: true)
+    expect(editor.text).to include(I18n.t('dialogs.move.stacked_branches_not_supported_message'))
+  end
+
+  def then_no_pages_should_have_moved
+    expect(editor.main_flow_titles).to eq(original_flow_titles)
+  end
+
+  def and_I_click_understood
+    find('button', text: I18n.t('dialogs.button_understood')).click
+  end
+end

--- a/acceptance/features/page_menu_spec.rb
+++ b/acceptance/features/page_menu_spec.rb
@@ -1,0 +1,79 @@
+require_relative '../spec_helper'
+
+feature 'Page menu items' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:two_menu_items) do
+    [
+      I18n.t('actions.edit_page'),
+      I18n.t('actions.preview_page')
+    ]
+  end
+  let(:three_menu_items) do
+    [
+      I18n.t('actions.edit_page'),
+      I18n.t('actions.preview_page'),
+      I18n.t('actions.delete_page')
+    ]
+  end
+  let(:four_menu_items) do
+    [
+      I18n.t('actions.edit_page'),
+      I18n.t('actions.preview_page'),
+      I18n.t('actions.move_page'),
+      I18n.t('actions.delete_page')
+    ]
+  end
+  let(:branching_menu_items) do
+    [
+      I18n.t('actions.edit_branch'),
+      I18n.t('actions.delete_branch')
+    ]
+  end
+  let(:start_page) { 'Service name goes here' }
+  let(:page_d) { 'Page d' }
+  let(:exit_page) { 'Exit page' }
+  let(:branching_point) { 'Branching point 1' }
+  let(:check_answers) { 'Check your answers' }
+  let(:confirmation) { 'Application complete' }
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service_fixture(name: service_name)
+  end
+
+  scenario 'start page' do
+    and_I_click_on_the_page_menu(start_page)
+    then_I_should_see_the_expected_menu_items(start_page, two_menu_items)
+  end
+
+  scenario 'standard flow page' do
+    and_I_click_on_the_page_menu(page_d)
+    then_I_should_see_the_expected_menu_items(page_d, four_menu_items)
+  end
+
+  scenario 'exit page' do
+    and_I_click_on_the_page_menu(exit_page)
+    then_I_should_see_the_expected_menu_items(exit_page, four_menu_items)
+  end
+
+  scenario 'branching point' do
+    and_I_click_on_the_branching_point_menu(branching_point)
+    then_I_should_see_the_expected_menu_items(branching_point, branching_menu_items)
+  end
+
+  scenario 'check answers page' do
+    and_I_click_on_the_page_menu(check_answers)
+    then_I_should_see_the_expected_menu_items(check_answers, three_menu_items)
+  end
+
+  scenario('confirimation page') do
+    and_I_click_on_the_page_menu(confirmation)
+    then_I_should_see_the_expected_menu_items(confirmation, three_menu_items)
+  end
+
+  def then_I_should_see_the_expected_menu_items(flow_title, expected_menu_items)
+    items = find("ul[data-title='#{flow_title}']").all('[role="menuitem"]').map(&:text)
+    expect(items).to eq(expected_menu_items)
+  end
+end

--- a/acceptance/fixtures/move_page_fixture.json
+++ b/acceptance/fixtures/move_page_fixture.json
@@ -1,0 +1,575 @@
+{
+  "_id": "service.base",
+  "flow": {
+    "09e91fd9-7a46-4840-adbc-244d545cfef7": {
+      "next": {
+        "default": "520fde26-8124-4c67-a550-cd38d2ef304d",
+        "conditionals": [
+          {
+            "next": "37a94466-97fa-427f-88b2-09b369435d0d",
+            "_type": "if",
+            "_uuid": "2d87a4bf-d532-48f5-956c-31ba5d046f63",
+            "expressions": [
+              {
+                "page": "65a2e01a-57dc-4702-8e41-ed8f9921ac7d",
+                "field": "c5571937-9388-4411-b5fa-34ddf9bc4ca0",
+                "operator": "is",
+                "component": "ac41be35-914e-4b22-8683-f5477716b7d4"
+              }
+            ]
+          }
+        ]
+      },
+      "_type": "flow.branch",
+      "title": "Branching point 1"
+    },
+    "13ecf9bd-5064-4cad-baf8-3dfa091928cb": {
+      "next": {
+        "default": "7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c"
+      },
+      "_type": "flow.page"
+    },
+    "2c7deb33-19eb-4569-86d6-462e3d828d87": {
+      "next": {
+        "default": "e337070b-f636-49a3-a65c-f506675265f0"
+      },
+      "_type": "flow.page"
+    },
+    "37a94466-97fa-427f-88b2-09b369435d0d": {
+      "next": {
+        "default": "13ecf9bd-5064-4cad-baf8-3dfa091928cb"
+      },
+      "_type": "flow.page"
+    },
+    "3a584d15-6805-4a21-bc05-b61c3be47857": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "520fde26-8124-4c67-a550-cd38d2ef304d": {
+      "next": {
+        "default": "ffadeb22-063b-4e4f-9502-bd753c706b1d"
+      },
+      "_type": "flow.page"
+    },
+    "65a2e01a-57dc-4702-8e41-ed8f9921ac7d": {
+      "next": {
+        "default": "09e91fd9-7a46-4840-adbc-244d545cfef7"
+      },
+      "_type": "flow.page"
+    },
+    "68fbb180-9a2a-48f6-9da6-545e28b8d35a": {
+      "next": {
+        "default": "65a2e01a-57dc-4702-8e41-ed8f9921ac7d"
+      },
+      "_type": "flow.page"
+    },
+    "778e364b-9a7f-4829-8eb2-510e08f156a3": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c": {
+      "next": {
+        "default": "e337070b-f636-49a3-a65c-f506675265f0"
+      },
+      "_type": "flow.page"
+    },
+    "be130ac1-f33d-4845-807d-89b23b90d205": {
+      "next": {
+        "default": "2c7deb33-19eb-4569-86d6-462e3d828d87"
+      },
+      "_type": "flow.page"
+    },
+    "cf6dc32f-502c-4215-8c27-1151a45735bb": {
+      "next": {
+        "default": "68fbb180-9a2a-48f6-9da6-545e28b8d35a"
+      },
+      "_type": "flow.page"
+    },
+    "e337070b-f636-49a3-a65c-f506675265f0": {
+      "next": {
+        "default": "778e364b-9a7f-4829-8eb2-510e08f156a3"
+      },
+      "_type": "flow.page"
+    },
+    "e8708909-922e-4eaf-87a5-096f7a713fcb": {
+      "next": {
+        "default": "65a2e01a-57dc-4702-8e41-ed8f9921ac7d"
+      },
+      "_type": "flow.page"
+    },
+    "ffadeb22-063b-4e4f-9502-bd753c706b1d": {
+      "next": {
+        "default": "3a584d15-6805-4a21-bc05-b61c3be47857",
+        "conditionals": [
+          {
+            "next": "13ecf9bd-5064-4cad-baf8-3dfa091928cb",
+            "_type": "if",
+            "_uuid": "daccbe9d-f0dc-41eb-8182-c542bfaa015c",
+            "expressions": [
+              {
+                "page": "65a2e01a-57dc-4702-8e41-ed8f9921ac7d",
+                "field": "c5571937-9388-4411-b5fa-34ddf9bc4ca0",
+                "operator": "is",
+                "component": "ac41be35-914e-4b22-8683-f5477716b7d4"
+              }
+            ]
+          },
+          {
+            "next": "be130ac1-f33d-4845-807d-89b23b90d205",
+            "_type": "if",
+            "_uuid": "b4eaf825-a523-4372-a15b-072b016b0ead",
+            "expressions": [
+              {
+                "page": "65a2e01a-57dc-4702-8e41-ed8f9921ac7d",
+                "field": "67160ff1-6f7c-43a8-8bf6-49b3d5f450f6",
+                "operator": "is",
+                "component": "ac41be35-914e-4b22-8683-f5477716b7d4"
+              }
+            ]
+          }
+        ]
+      },
+      "_type": "flow.branch",
+      "title": "Branching point 2"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Start page body",
+      "_type": "page.start",
+      "_uuid": "cf6dc32f-502c-4215-8c27-1151a45735bb",
+      "heading": "Service name goes here",
+      "before_you_start": "Start page before you start"
+    },
+    {
+      "_id": "page.b",
+      "url": "page-b",
+      "body": "Page B body",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "68fbb180-9a2a-48f6-9da6-545e28b8d35a",
+      "heading": "Page B",
+      "components": [
+        {
+          "_id": "page-b_text_1",
+          "hint": "",
+          "name": "page-b_text_1",
+          "_type": "text",
+          "_uuid": "509f0dc1-3066-4af3-8bd7-9aef99fdf22e",
+          "label": "Page B",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "max_length": 20,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.c",
+      "url": "page-c",
+      "body": "Page C body",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "e8708909-922e-4eaf-87a5-096f7a713fcb",
+      "heading": "Page C",
+      "components": [
+        {
+          "_id": "page-c_text_1",
+          "hint": "",
+          "name": "page-c_text_1",
+          "_type": "text",
+          "_uuid": "fda1e5a1-ed5f-49c9-a943-dc930a520984",
+          "label": "Page C",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "max_length": 20,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.d",
+      "url": "page-d",
+      "body": "Page D body",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "65a2e01a-57dc-4702-8e41-ed8f9921ac7d",
+      "heading": "Page D",
+      "components": [
+        {
+          "_id": "page-d_radios_1",
+          "hint": "",
+          "name": "page-d_radios_1",
+          "_type": "radios",
+          "_uuid": "ac41be35-914e-4b22-8683-f5477716b7d4",
+          "items": [
+            {
+              "_id": "page-d_radios_1_item_1",
+              "hint": "",
+              "name": "page-d_radios_1",
+              "_type": "radio",
+              "_uuid": "c5571937-9388-4411-b5fa-34ddf9bc4ca0",
+              "label": "Item 1",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Item 1",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-d_radios_1_item_2",
+              "hint": "",
+              "name": "page-d_radios_1",
+              "_type": "radio",
+              "_uuid": "67160ff1-6f7c-43a8-8bf6-49b3d5f450f6",
+              "label": "Item 2",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Item 2",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-d_radios_1_item_3",
+              "hint": "",
+              "name": "page-d_radios_1",
+              "_type": "radio",
+              "_uuid": "ea223fa3-06d0-4111-a7e9-c6b9012d7928",
+              "label": "Item 3",
+              "value": "value-3",
+              "errors": {
+              },
+              "legend": "Item 3",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page D",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.e",
+      "url": "page-e",
+      "body": "Page E body",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "37a94466-97fa-427f-88b2-09b369435d0d",
+      "heading": "Page E",
+      "components": [
+        {
+          "_id": "page-e_text_1",
+          "hint": "",
+          "name": "page-e_text_1",
+          "_type": "text",
+          "_uuid": "d4295f66-7882-4673-bf0e-c9c9b627cb10",
+          "label": "Page E",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "max_length": 20,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.f",
+      "url": "page-f",
+      "body": "Page F body",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "13ecf9bd-5064-4cad-baf8-3dfa091928cb",
+      "heading": "Page F",
+      "components": [
+        {
+          "_id": "page-f_text_1",
+          "hint": "",
+          "name": "page-f_text_1",
+          "_type": "text",
+          "_uuid": "f837fabd-044a-441c-b204-fcec79648b41",
+          "label": "Page F",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "max_length": 20,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.g",
+      "url": "page-g",
+      "lede": "lede",
+      "_type": "page.exit",
+      "_uuid": "3a584d15-6805-4a21-bc05-b61c3be47857",
+      "heading": "Page G",
+      "components": [
+        {
+          "_id": "exit_content_1",
+          "name": "exit_content_1",
+          "_type": "content",
+          "_uuid": "9774d986-135a-4b7f-924d-7527b790e1a0",
+          "content": "This is an exit page"
+        }
+      ],
+      "section_heading": "Section heading"
+    },
+    {
+      "_id": "page.h",
+      "url": "page-h",
+      "body": "Page H body",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c",
+      "heading": "Page H",
+      "components": [
+        {
+          "_id": "page-h_text_1",
+          "hint": "",
+          "name": "page-h_text_1",
+          "_type": "text",
+          "_uuid": "8fabefd3-2d18-44ac-873b-f8095643da65",
+          "label": "Page H",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "max_length": 20,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.i",
+      "url": "page-i",
+      "body": "Page I body",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "520fde26-8124-4c67-a550-cd38d2ef304d",
+      "heading": "Page I",
+      "components": [
+        {
+          "_id": "page-i_text_1",
+          "hint": "",
+          "name": "page-i_text_1",
+          "_type": "text",
+          "_uuid": "ebd99204-0f15-4e6e-a937-c6da30b140f8",
+          "label": "Page I",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "max_length": 20,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.k",
+      "url": "page-k",
+      "body": "Page K body",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "be130ac1-f33d-4845-807d-89b23b90d205",
+      "heading": "Page K",
+      "components": [
+        {
+          "_id": "page-k_text_1",
+          "hint": "",
+          "name": "page-k_text_1",
+          "_type": "text",
+          "_uuid": "ebd99204-0f15-4e6e-a937-c6da30b140f8",
+          "label": "Page K",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "max_length": 20,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.l",
+      "url": "page-l",
+      "body": "Page L body",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "2c7deb33-19eb-4569-86d6-462e3d828d87",
+      "heading": "Page L",
+      "components": [
+        {
+          "_id": "page-l_text_1",
+          "hint": "",
+          "name": "page-l_text_1",
+          "_type": "text",
+          "_uuid": "ae38d9b2-e0d9-4f5c-8e38-c8c96b66cad9",
+          "label": "Page L",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "max_length": 20,
+            "min_length": 2
+          }
+        }
+      ]
+    },
+    {
+      "_id": "page.check-answers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "e337070b-f636-49a3-a65c-f506675265f0",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+        {
+          "_id": "check-answers_content_2",
+          "name": "check-answers_content_2",
+          "_type": "content",
+          "_uuid": "b065ff4f-90c5-4ba2-b4ac-c984a9dd2470",
+          "content": "Take the cannoli.",
+          "collection": "components"
+        }
+      ],
+      "send_heading": "Now send your application",
+      "add_component": "content",
+      "extra_components": [
+        {
+          "_id": "check-answers_content_1",
+          "name": "check-answers_content_1",
+          "_type": "content",
+          "_uuid": "3e6ef27e-91a6-402f-8291-b7ce669e824e",
+          "content": "Check yourself before you wreck yourself.",
+          "collection": "extra_components"
+        }
+      ],
+      "add_extra_component": "content"
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "confirmation",
+      "body": "Some day I will be the most powerful Jedi ever!",
+      "lede": "",
+      "_type": "page.confirmation",
+      "_uuid": "778e364b-9a7f-4829-8eb2-510e08f156a3",
+      "heading": "Complaint sent",
+      "components": [
+
+      ]
+    }
+  ],
+  "locale": "en",
+  "created_at": "",
+  "created_by": "",
+  "service_id": "",
+  "version_id": "",
+  "service_name": "",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "Cookies body",
+      "_type": "page.standalone",
+      "_uuid": "fd52e7c0-03f7-4001-ae7e-f2e4142b0ccc",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "Privacy body",
+      "_type": "page.standalone",
+      "_uuid": "4b86fe8c-7723-4cce-9378-7b2510279e04",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "Accessibility body",
+      "_type": "page.standalone",
+      "_uuid": "c439c7fd-f411-4e11-8598-4023934bac93",
+      "heading": "Accessibility statement",
+      "components": [
+
+      ]
+    }
+  ]
+}

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -96,20 +96,31 @@ class EditorApp < SitePrism::Page
   element :three_dots_button, '.flow-menu-activator'
   element :preview_page_link, :link, I18n.t('actions.preview_page')
   element :add_page_here_link, :link, I18n.t('actions.add_page')
+  element :move_page_link, :link, I18n.t('actions.move_page')
   element :delete_page_link, :link, I18n.t('actions.delete_page')
   element :delete_page_modal_button, :link, I18n.t('dialogs.button_delete'), visible: true
   element :branching_link, :link, I18n.t('actions.add_branch')
 
+  def main_flow_titles
+    flow_titles(main_flow)
+  end
+
   def unconnected_flow
+    flow_titles(detached_flow)
+  end
+
+  def flow_titles(flow_items)
     find('#main-content', visible: true)
-    flow = detached_flow.map { |element| element.text.gsub("Edit:\n", '').split("\n") }
-    flow.flatten.uniq.reject { |f| f == I18n.t('pages.create') }
+    flow = flow_items.map { |element| element.text.gsub("Edit:\n", '').split("\n").uniq }
+    flow.flatten.reject do |title|
+      title == I18n.t('pages.create') || title == I18n.t('pages.actions')
+    end
   end
 
   def flow_thumbnail(title)
     preview_page_images.find { |p| p.text.include?(title) }
   end
-  
+
   def flow_article(title)
     flow_items.find { |p| p.text.include?(title) }
   end
@@ -196,6 +207,7 @@ class EditorApp < SitePrism::Page
   element :change_destination_link, :link, I18n.t('actions.change_destination')
   element :change_next_page_button, :button, I18n.t('dialogs.destination.button_change')
 
+  elements :main_flow, '#flow-overview .flow-item'
   elements :detached_flow, '.flow-detached-group .flow-item'
 
   def edit_service_link(service_name)

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -348,13 +348,11 @@ module CommonSteps
   end
 
   def and_I_click_on_the_page_menu(flow_title)
-    editor.service_name.click
     editor.flow_thumbnail(flow_title).hover
     and_I_click_on_the_three_dots
   end
 
   def and_I_click_on_the_branching_point_menu(branch_title)
-    editor.service_name.click
     editor.hover_branch(branch_title)
     and_I_click_on_the_three_dots
   end

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -47,6 +47,10 @@ module CommonSteps
   end
   alias_method :when_I_try_to_create_a_service_with_the_same_name, :given_I_have_a_service
 
+  def given_I_have_a_service_fixture(name: generate_service_name, fixture: nil)
+    visit admin_test_service_path(name, fixture)
+  end
+
   def given_I_have_another_service
     given_I_have_a_service(another_service_name)
   end
@@ -343,6 +347,18 @@ module CommonSteps
     editor.three_dots_button.click
   end
 
+  def and_I_click_on_the_page_menu(flow_title)
+    editor.service_name.click
+    editor.flow_thumbnail(flow_title).hover
+    and_I_click_on_the_three_dots
+  end
+
+  def and_I_click_on_the_branching_point_menu(branch_title)
+    editor.service_name.click
+    editor.hover_branch(branch_title)
+    and_I_click_on_the_three_dots
+  end
+
   def and_I_click_on_the_connection_menu
     find('#main-content', visible: true)
     editor.all('.connection-menu-activator').last.click
@@ -352,25 +368,6 @@ module CommonSteps
     within('.ui-dialog') do
       editor.delete_page_modal_button.click
     end
-  end
-
-  def then_I_should_only_see_three_options_on_page_menu
-    options = all('[role="menuitem"]').map(&:text)
-    expect(options).to eq([
-      I18n.t('actions.edit_page'),
-      I18n.t('actions.preview_page'),
-      I18n.t('actions.delete_page')
-    ])
-  end
-
-  def then_I_should_only_see_four_options_on_page_menu
-    options = all('[role="menuitem"]').map(&:text)
-    expect(options).to eq([
-      I18n.t('actions.edit_page'),
-      I18n.t('actions.preview_page'),
-      I18n.t('actions.move_page'),
-      I18n.t('actions.delete_page')
-    ])
   end
 
   def then_I_should_not_be_able_to_add_page(page_title, page_link)
@@ -396,15 +393,13 @@ module CommonSteps
   end
 
   def and_I_delete_cya_page
-    editor.flow_thumbnail('Check your answers').hover
-    and_I_click_on_the_three_dots
+    and_I_click_on_the_page_menu('Check your answers')
     editor.delete_page_link.click
     and_I_click_delete
   end
 
   def when_I_delete_confirmation_page
-    editor.flow_thumbnail('Application complete').hover
-    and_I_click_on_the_three_dots
+    and_I_click_on_the_page_menu('Application complete')
     editor.delete_page_link.click
     and_I_click_delete
   end

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -363,6 +363,16 @@ module CommonSteps
     ])
   end
 
+  def then_I_should_only_see_four_options_on_page_menu
+    options = all('[role="menuitem"]').map(&:text)
+    expect(options).to eq([
+      I18n.t('actions.edit_page'),
+      I18n.t('actions.preview_page'),
+      I18n.t('actions.move_page'),
+      I18n.t('actions.delete_page')
+    ])
+  end
+
   def then_I_should_not_be_able_to_add_page(page_title, page_link)
     find('#main-content', visible: true)
     editor.connection_menu(page_title).click

--- a/app/controllers/api/move_controller.rb
+++ b/app/controllers/api/move_controller.rb
@@ -18,6 +18,7 @@ module Api
         service: service,
         grid: grid,
         previous_flow_uuid: params[:previous_flow_uuid],
+        previous_conditional_uuid: params[:previous_conditional_uuid],
         to_move_uuid: params[:flow_uuid]
       }
     end
@@ -25,8 +26,9 @@ module Api
     def change_params
       params.require(:move).permit(
         :previous_flow_uuid,
+        :previous_conditional_uuid,
         :target_uuid,
-        :conditional_uuid
+        :target_conditional_uuid
       )
     end
   end

--- a/app/controllers/api/move_controller.rb
+++ b/app/controllers/api/move_controller.rb
@@ -2,7 +2,7 @@ module Api
   class MoveController < ApiController
     def targets
       @move = Move.new(base_params)
-      render :new, layout: false
+      render @move, layout: false
     end
 
     def change

--- a/app/javascript/src/components/menus/page_menu.js
+++ b/app/javascript/src/components/menus/page_menu.js
@@ -49,6 +49,10 @@ class PageMenu extends ActivatedMenu {
            this.deleteItemApi(item);
            break;
 
+      case "move-api":
+           this.moveItemApi(item);
+           break;
+
       default: this.link(item);
     }
   }
@@ -117,5 +121,22 @@ class PageMenu extends ActivatedMenu {
       }
     });
   }
+
+  moveItemApi(element) {
+    var $link = element.find("> a");
+    new DialogApiRequest($link.attr("href"), {
+      activator: $link,
+      closeOnClickSelector: ".govuk-button",
+      build: function(dialog) {
+        dialog.$node.find("#move_target_uuid").on("change", function(e) {
+          // Get the selected option and then update the hidden conditional
+          // uuid field
+          var selectedOption = $(this).find("option").eq(this.selectedIndex)
+          var conditionalUuid = selectedOption.data("conditional-uuid")
+          dialog.$node.find("#move_conditional_uuid").val(conditionalUuid)
+        });
+      }
+    });
+  }
 }
-module.exports = PageMenu; 
+module.exports = PageMenu;

--- a/app/javascript/src/components/menus/page_menu.js
+++ b/app/javascript/src/components/menus/page_menu.js
@@ -133,7 +133,7 @@ class PageMenu extends ActivatedMenu {
           // uuid field
           var selectedOption = $(this).find("option").eq(this.selectedIndex)
           var conditionalUuid = selectedOption.data("conditional-uuid")
-          dialog.$node.find("#move_conditional_uuid").val(conditionalUuid)
+          dialog.$node.find("#move_target_conditional_uuid").val(conditionalUuid)
         });
       }
     });

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -80,14 +80,26 @@ class Move
     {
       title: "#{flow_object.title} (Branch #{index})",
       target_uuid: flow_object.uuid,
-      conditional_uuid: conditional&.uuid
+      conditional_uuid: conditional&.uuid,
+      selected: conditional_next?(conditional) || branch_default_next?(flow_object)
     }.compact
+  end
+
+  def conditional_next?(conditional)
+    return if conditional.blank?
+
+    conditional.next == to_move_uuid
+  end
+
+  def branch_default_next?(flow_object)
+    flow_object.uuid == previous_flow_uuid && flow_object.default_next == to_move_uuid
   end
 
   def page_target(flow_object)
     {
       title: flow_title(flow_object),
-      target_uuid: flow_object.uuid
+      target_uuid: flow_object.uuid,
+      selected: flow_object.uuid == previous_flow_uuid
     }
   end
 

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -182,7 +182,10 @@ class Move
   end
 
   def update_default_next(to_update_uuid, new_default_next)
-    return if exit_page?(to_update_uuid)
+    # Exit pages have no default next.
+    # If the new_default_next is the same as the to_update_uuid then the resulting
+    # move would mean the page would be pointing to itself.
+    return if exit_page?(to_update_uuid) || to_update_uuid == new_default_next
 
     service.flow[to_update_uuid]['next']['default'] = new_default_next
   end

--- a/app/models/pages_flow.rb
+++ b/app/models/pages_flow.rb
@@ -67,7 +67,7 @@ class PagesFlow
       title: obj.title,
       uuid: obj.uuid,
       previous_uuid: grid.previous_uuid_for_object(obj.uuid),
-      conditional_uuid: grid.conditional_uuid_for_object(obj.uuid),
+      previous_conditional_uuid: grid.conditional_uuid_for_object(obj.uuid),
       thumbnail: thumbnail_type(obj)
     }.compact
   end

--- a/app/views/api/move/_branch_destination_no_default_next.html.erb
+++ b/app/views/api/move/_branch_destination_no_default_next.html.erb
@@ -1,0 +1,14 @@
+<div class="component component-dialog component-dialog-api-request"
+     data-component="DialogApiRequest">
+
+  <h3 data-node="heading" class="govuk-label govuk-label--m">
+    <%= t('dialogs.move.you_cannot_move_this_page') %>
+  </h3>
+  <p data-node="content">
+    <%= t('dialogs.move.branch_destination_no_default_next_message') %>
+  </p>
+
+  <div class="ui-dialog-buttonset">
+    <button class="govuk-button ui-button"><%= t('dialogs.button_understood') %></button>
+  </div>
+</div>

--- a/app/views/api/move/_branch_destination_no_default_next.html.erb
+++ b/app/views/api/move/_branch_destination_no_default_next.html.erb
@@ -1,5 +1,5 @@
 <div class="component component-dialog component-dialog-api-request"
-     data-component="DialogApiRequest">
+     data-component="DialogApiRequest" id="branch_destination_no_default_next">
 
   <h3 data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.move.you_cannot_move_this_page') %>

--- a/app/views/api/move/_new.html.erb
+++ b/app/views/api/move/_new.html.erb
@@ -8,7 +8,11 @@
       <div class="govuk-form-group">
         <select class="govuk-select" name="move[target_uuid]" id="move_target_uuid">
           <% @move.targets.each do |target| %>
-            <option value="<%= target[:target_uuid] %>" data-conditional-uuid="<%= target[:conditional_uuid] %>">
+            <% if target[:selected] %>
+              <option value="<%= target[:target_uuid] %>" data-conditional-uuid="<%= target[:conditional_uuid] %>" selected="selected">
+            <% else %>
+              <option value="<%= target[:target_uuid] %>" data-conditional-uuid="<%= target[:conditional_uuid] %>">
+            <% end %>
               <%= target[:title] %>
             </option>
           <% end %>

--- a/app/views/api/move/_new.html.erb
+++ b/app/views/api/move/_new.html.erb
@@ -1,4 +1,4 @@
-<div class="component-dialog-api-request">
+<div class="component-dialog-api-request" id="move_targets_list">
   <%= form_for @move, url: api_service_flow_move_path(service.service_id, @move.to_move_uuid) do |f| %>
     <div class="govuk-form-group ">
       <%= f.hidden_field :previous_flow_uuid, value: @move.previous_flow_uuid %>

--- a/app/views/api/move/_new.html.erb
+++ b/app/views/api/move/_new.html.erb
@@ -2,7 +2,8 @@
   <%= form_for @move, url: api_service_flow_move_path(service.service_id, @move.to_move_uuid) do |f| %>
     <div class="govuk-form-group ">
       <%= f.hidden_field :previous_flow_uuid, value: @move.previous_flow_uuid %>
-      <%= f.hidden_field :conditional_uuid, value: '' %>
+      <%= f.hidden_field :previous_conditional_uuid, value: @move.previous_conditional_uuid %>
+      <%= f.hidden_field :target_conditional_uuid, value: '' %>
       <%= f.label :target_uuid, t('dialogs.move.label', title: @move.title), class: "govuk-label govuk-label--m" %>
       <p> <%= t('dialogs.move.lede') %></p>
       <div class="govuk-form-group">

--- a/app/views/api/move/_new.html.erb
+++ b/app/views/api/move/_new.html.erb
@@ -20,7 +20,7 @@
       <%= t('dialogs.move.button') %>
     </button>
 
-    <button class="govuk-button govuk-button--secondary ui-button" type="button" >
+    <button class="govuk-button govuk-button--secondary" type="button" >
       <%= t('dialogs.button_cancel') %>
     </button>
   <% end %>

--- a/app/views/api/move/_stacked_branches_not_supported.html.erb
+++ b/app/views/api/move/_stacked_branches_not_supported.html.erb
@@ -1,0 +1,14 @@
+<div class="component component-dialog component-dialog-api-request"
+     data-component="DialogApiRequest">
+
+  <h3 data-node="heading" class="govuk-label govuk-label--m">
+    <%= t('dialogs.move.you_cannot_move_this_page') %>
+  </h3>
+  <p data-node="content">
+    <%= t('dialogs.move.stacked_branches_not_supported_message') %>
+  </p>
+
+  <div class="ui-dialog-buttonset">
+    <button class="govuk-button ui-button"><%= t('dialogs.button_understood') %></button>
+  </div>
+</div>

--- a/app/views/api/move/_stacked_branches_not_supported.html.erb
+++ b/app/views/api/move/_stacked_branches_not_supported.html.erb
@@ -1,5 +1,5 @@
 <div class="component component-dialog component-dialog-api-request"
-     data-component="DialogApiRequest">
+     data-component="DialogApiRequest" id="stacked_branches_not_supported">
 
   <h3 data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.move.you_cannot_move_this_page') %>

--- a/app/views/api/move/new.html.erb
+++ b/app/views/api/move/new.html.erb
@@ -6,7 +6,7 @@
       <%= f.label :target_uuid, t('dialogs.move.label', title: @move.title), class: "govuk-label govuk-label--m" %>
       <p> <%= t('dialogs.move.lede') %></p>
       <div class="govuk-form-group">
-        <select class="govuk-select" name="move[target_uuid]" id="move[target_uuid]">
+        <select class="govuk-select" name="move[target_uuid]" id="move_target_uuid">
           <% @move.targets.each do |target| %>
             <option value="<%= target[:target_uuid] %>" data-conditional-uuid="<%= target[:conditional_uuid] %>">
               <%= target[:title] %>
@@ -15,8 +15,13 @@
         </select>
       </div>
     </div>
+
     <button class="govuk-button fb-govuk-button">
       <%= t('dialogs.move.button') %>
+    </button>
+
+    <button class="govuk-button govuk-button--secondary ui-button" type="button" >
+      <%= t('dialogs.button_cancel') %>
     </button>
   <% end %>
 </div>

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -49,6 +49,7 @@
       question_optional_flag: "<%= t('question.optional_flag') %>",
       dialogs: {
         button_change_destination: "<%= t('dialogs.destination.button_change') %>",
+        button_move: "<%= t('dialogs.move.button') %>",
         button_cancel: "<%= t('dialogs.button_cancel') %>",
         button_delete: "<%= t('dialogs.button_delete') %>",
         button_delete_condition: "<%= t('dialogs.button_delete_condition') %>",

--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -32,7 +32,7 @@
       <li data-page-type="multiplequestions"><span><%= t('actions.add_multi_question') -%></span></li>
 
       <li data-page-type="content"><span><%= t('actions.add_content') -%></span></li>
-      
+
       <% unless item[:type] == 'page.start' %>
         <li data-page-type="exit"><span><%= t('actions.add_exit') -%></span></li>
       <% end %>

--- a/app/views/services/_flow_page_menu.html.erb
+++ b/app/views/services/_flow_page_menu.html.erb
@@ -16,6 +16,13 @@
     </li>
   <% end %>
 
+  <% unless (item[:type] =~ /page.(start|checkanswers|confirmation)/) %>
+    <li data-action="move-api">
+      <%= link_to t('actions.move_page'),
+        api_service_flow_move_path(service.service_id, item[:uuid], item[:previous_uuid].to_s) %>
+    </li>
+  <% end %>
+
   <% unless item[:type] == 'page.start' %>
     <li data-action="delete-api">
       <%= link_to t('actions.delete_page'),

--- a/app/views/services/_flow_page_menu.html.erb
+++ b/app/views/services/_flow_page_menu.html.erb
@@ -19,7 +19,12 @@
   <% unless (item[:type] =~ /page.(start|checkanswers|confirmation)/) %>
     <li data-action="move-api">
       <%= link_to t('actions.move_page'),
-        api_service_flow_move_path(service.service_id, item[:uuid], item[:previous_uuid].to_s) %>
+        api_service_flow_move_path(
+          service.service_id,
+          item[:uuid],
+          item[:previous_uuid].to_s,
+          item[:previous_conditional_uuid].to_s
+        ) %>
     </li>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,8 +57,8 @@ en:
       go_to: 'Go to: '
       text: 'Any pages that are left without a connection to your form will be moved to the unconnected pages section.'
     move:
-      label: 'Moving the page "%{title}"'
-      lede: Moving to the page after
+      label: 'Move the page "%{title}"'
+      lede: 'Move to after:'
       button: Move
       you_cannot_move_this_page: 'You cannot move this page yet'
       stacked_branches_not_supported_message: 'Moving this page would result in 2 branching points in a row, which is not currently possible. Try combining your branching rules into 1 branching point.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,6 +109,7 @@ en:
     option_add: 'Add option'
     option_remove: 'Delete...'
     change_destination: 'Change next page...'
+    move_page: 'Move page...'
     add_single_question: 'Add single question page'
     add_multi_question: 'Add multiple question page'
     add_content: 'Add content page'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,7 @@ en:
       button: Move
       you_cannot_move_this_page: 'You cannot move this page yet'
       stacked_branches_not_supported_message: 'Moving this page would result in 2 branching points in a row, which is not currently possible. Try combining your branching rules into 1 branching point.'
+      branch_destination_no_default_next_message: 'You cannot leave a branch without any pages. Either edit the branching point or add another page to the branch first.'
   header:
     service_name: "MoJ Forms"
     home_link_text: "Back to Home"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,8 @@ en:
       label: 'Moving the page "%{title}"'
       lede: Moving to the page after
       button: Move
+      you_cannot_move_this_page: 'You cannot move this page yet'
+      stacked_branches_not_supported_message: 'Moving this page would result in 2 branching points in a row, which is not currently possible. Try combining your branching rules into 1 branching point.'
   header:
     service_name: "MoJ Forms"
     home_link_text: "Back to Home"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,7 @@ Rails.application.routes.draw do
     resources :services do
       resources :flow, param: :uuid, only: [] do
         resources :destinations, only: [:new, :create]
-        get '/move/(:previous_flow_uuid)', to: 'move#targets', as: :move
+        get '/move/(:previous_flow_uuid)/(:previous_conditional_uuid)', to: 'move#targets', as: :move
         post :move, to: 'move#change'
       end
 

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Move do
       end
     end
 
-    context 'when moving a page would not cause stocked branches' do
+    context 'when moving a page would not cause stacked branches' do
       let(:to_move_uuid) { 'cf6dc32f-502c-4215-8c27-1151a45735bb' } # Page B
       let(:previous_flow_uuid) { service.start_page.uuid }
       let(:expected_partial_path) { 'new' }
@@ -148,7 +148,7 @@ RSpec.describe Move do
         expect(previous_flow_target[:selected]).to be_truthy
       end
 
-      it 'sets the selected property to false when ' do
+      it 'sets the selected property to false when previous page has not been matched' do
         other_targets.each do |target|
           expect(target[:selected]).to be_falsey
         end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -318,6 +318,19 @@ RSpec.describe Move do
           end
         end
       end
+
+      context 'when moving a page would result in it pointing to itself' do
+        let(:latest_metadata) { metadata_fixture(:branching_11) }
+        let(:metadata_flow) { move.metadata['flow'] }
+        let(:to_move_uuid) { 'e31718ad-0ba7-4b45-81aa-d3081f423022' } # Page D
+        let(:previous_flow_uuid) { '66c9e581-942e-4a9e-93ec-343208a2f510' } # Page C
+        let(:target_uuid) { 'f55d002d-b2c1-4dcc-87b7-0da7cbc5c87c' } # Branching Point 1
+        let(:page_e) { '007f4f35-8236-40cc-866c-cc2c27c33949' }
+
+        it 'does not update the default next of the page being moved' do
+          expect(metadata_flow[to_move_uuid]['next']['default']).to eq(page_e)
+        end
+      end
     end
   end
 end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -17,6 +17,54 @@ RSpec.describe Move do
   let(:target_uuid) { nil }
   let(:conditional_uuid) { nil }
 
+  describe '#to_partial_path' do
+    let(:latest_metadata) { metadata_fixture(:branching_2) }
+
+    context 'when moving the page would cause branches to stack' do
+      let(:to_move_uuid) { 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992' } # Page J
+      let(:previous_flow_uuid) { '09e91fd9-7a46-4840-adbc-244d545cfef7' } # Branching Point 1
+      let(:expected_partial_path) { 'stacked_branches_not_supported' }
+
+      it 'returns the stacked branches not supported partial' do
+        expect(move.to_partial_path).to eq(expected_partial_path)
+      end
+    end
+
+    context 'when moving a page would not cause stocked branches' do
+      let(:to_move_uuid) { 'cf6dc32f-502c-4215-8c27-1151a45735bb' } # Page B
+      let(:previous_flow_uuid) { service.start_page.uuid }
+      let(:expected_partial_path) { 'new' }
+
+      it 'returns the default new partial' do
+        expect(move.to_partial_path).to eq(expected_partial_path)
+      end
+    end
+
+    context 'when there is no previous object uuid' do
+      let(:to_move_uuid) { 'cf6dc32f-502c-4215-8c27-1151a45735bb' } # Page B
+      let(:expected_partial_path) { 'new' }
+
+      it 'returns the default new partial' do
+        expect(move.to_partial_path).to eq(expected_partial_path)
+      end
+    end
+
+    context 'when the object to move default next is empty' do
+      let(:latest_metadata) do
+        meta = metadata_fixture(:branching_2)
+        meta['flow'][to_move_uuid]['next']['default'] = ''
+        meta
+      end
+      let(:to_move_uuid) { 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992' } # Page J
+      let(:previous_flow_uuid) { '09e91fd9-7a46-4840-adbc-244d545cfef7' } # Branching Point 1
+      let(:expected_partial_path) { 'new' }
+
+      it 'returns the default new partial' do
+        expect(move.to_partial_path).to eq(expected_partial_path)
+      end
+    end
+  end
+
   describe '#targets' do
     let(:to_move_uuid) { '2ffc17b7-b14a-417f-baff-07adebd4f259' } # Page B
     let(:targets) { move.targets }

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Move do
 
   describe '#targets' do
     let(:to_move_uuid) { '2ffc17b7-b14a-417f-baff-07adebd4f259' } # Page B
+    let(:previous_flow_uuid) { '1d60bef0-100a-4f3b-9e6f-1711e8adda7e' } # Page A
     let(:targets) { move.targets }
     let(:target_uuids) { targets.map { |t| t[:target_uuid] } }
     let(:target_titles) { targets.map { |t| t[:title] } }
@@ -119,6 +120,25 @@ RSpec.describe Move do
 
     it 'does not include any unconnected pages' do
       expect(target_uuids).not_to include(*unconnected_uuids)
+    end
+
+    context 'selected property' do
+      let(:previous_flow_target) do
+        targets.find { |t| t[:target_uuid] == previous_flow_uuid }
+      end
+      let(:other_targets) do
+        targets.reject { |t| t[:target_uuid] == previous_flow_uuid }
+      end
+
+      it 'sets the selected property when previous page matches to true' do
+        expect(previous_flow_target[:selected]).to be_truthy
+      end
+
+      it 'sets the selected property to false when ' do
+        other_targets.each do |target|
+          expect(target[:selected]).to be_falsey
+        end
+      end
     end
 
     context 'page targets' do

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -4,18 +4,20 @@ RSpec.describe Move do
       service: service,
       grid: grid,
       previous_flow_uuid: previous_flow_uuid,
+      previous_conditional_uuid: previous_conditional_uuid,
       to_move_uuid: to_move_uuid,
       target_uuid: target_uuid,
-      conditional_uuid: conditional_uuid
+      target_conditional_uuid: target_conditional_uuid
     )
   end
   let(:latest_metadata) { metadata_fixture(:branching_11) }
   let(:service) { MetadataPresenter::Service.new(latest_metadata) }
   let(:grid) { MetadataPresenter::Grid.new(service) }
   let(:previous_flow_uuid) { nil }
+  let(:previous_conditional_uuid) { nil }
   let(:to_move_uuid) { nil }
   let(:target_uuid) { nil }
-  let(:conditional_uuid) { nil }
+  let(:target_conditional_uuid) { nil }
 
   describe '#to_partial_path' do
     let(:latest_metadata) { metadata_fixture(:branching_2) }
@@ -215,21 +217,21 @@ RSpec.describe Move do
         end
 
         context 'previous flow uuid id a branch' do
-          context 'when conditional uuid is present' do
+          context 'when previous conditional uuid is present' do
             let(:previous_flow_uuid) { 'f55d002d-b2c1-4dcc-87b7-0da7cbc5c87c' } # Branching Point 1
             let(:to_move_uuid) { '66c9e581-942e-4a9e-93ec-343208a2f510' } # Page C
-            let(:conditional_uuid) { '9149bc4c-9773-454f-b9b6-5524b91102ca' }
+            let(:previous_conditional_uuid) { '9149bc4c-9773-454f-b9b6-5524b91102ca' }
             let(:expected_default_next) { 'e31718ad-0ba7-4b45-81aa-d3081f423022' } # Page D
 
             it 'updates the conditional next to the to_move objects original default next' do
               conditional = metadata_flow[previous_flow_uuid]['next']['conditionals'].find do |c|
-                c['_uuid'] == conditional_uuid
+                c['_uuid'] == previous_conditional_uuid
               end
               expect(conditional['next']).to eq(expected_default_next)
             end
           end
 
-          context 'when conditional uuid is not present' do
+          context 'when previous conditional uuid is not present' do
             let(:latest_metadata) { metadata_fixture(:branching_10) }
             let(:previous_flow_uuid) { 'f55d002d-b2c1-4dcc-87b7-0da7cbc5c87c' } # Branching Point 1
             let(:to_move_uuid) { 'ad011e6b-5926-42f8-8b7c-668558850c52' } # Page N
@@ -265,12 +267,12 @@ RSpec.describe Move do
         let(:target_uuid) { 'a02f7073-ba5a-459d-b6b9-abe548c933a6' } # Branching Point 2
 
         context 'conditional destination' do
-          let(:conditional_uuid) { '4ad9f7e9-5444-41d8-b7f8-17d2108ed27a' }
+          let(:target_conditional_uuid) { '4ad9f7e9-5444-41d8-b7f8-17d2108ed27a' }
           let(:checkanswers) { 'da2576f9-7ddd-4316-b24b-103708139214' }
 
           it 'updates the branch condtional next to the to_move_uuid' do
             conditional = metadata_flow[target_uuid]['next']['conditionals'].find do |c|
-              c['_uuid'] == conditional_uuid
+              c['_uuid'] == target_conditional_uuid
             end
             expect(conditional['next']).to eq(to_move_uuid)
           end

--- a/spec/models/move_spec.rb
+++ b/spec/models/move_spec.rb
@@ -51,14 +51,26 @@ RSpec.describe Move do
       end
     end
 
+    context 'move a branch destination that has no default next' do
+      let(:latest_metadata) { metadata_fixture(:branching_7) }
+      let(:metadata_flow) { move.metadata['flow'] }
+      let(:to_move_uuid) { '3a584d15-6805-4a21-bc05-b61c3be47857' } # Page G
+      let(:previous_flow_uuid) { 'ffadeb22-063b-4e4f-9502-bd753c706b1d' } # Branching Point 2
+      let(:expected_partial_path) { 'branch_destination_no_default_next' }
+
+      it 'returns the branch destination no default next partial' do
+        expect(move.to_partial_path).to eq(expected_partial_path)
+      end
+    end
+
     context 'when the object to move default next is empty' do
       let(:latest_metadata) do
         meta = metadata_fixture(:branching_2)
         meta['flow'][to_move_uuid]['next']['default'] = ''
         meta
       end
-      let(:to_move_uuid) { 'f475d6fd-0ea4-45d5-985e-e1a7c7a5b992' } # Page J
-      let(:previous_flow_uuid) { '09e91fd9-7a46-4840-adbc-244d545cfef7' } # Branching Point 1
+      let(:to_move_uuid) { '65a2e01a-57dc-4702-8e41-ed8f9921ac7d' } # Page D
+      let(:previous_flow_uuid) { 'fda1e5a1-ed5f-49c9-a943-dc930a520984' } # Page C
       let(:expected_partial_path) { 'new' }
 
       it 'returns the default new partial' do
@@ -241,6 +253,18 @@ RSpec.describe Move do
               expect(metadata_flow[previous_flow_uuid]['next']['default']).to eq(expected_default_next)
             end
           end
+        end
+      end
+
+      context 'moving an exit page' do
+        let(:latest_metadata) { metadata_fixture(:branching_7) }
+        let(:metadata_flow) { move.metadata['flow'] }
+        let(:to_move_uuid) { '3a584d15-6805-4a21-bc05-b61c3be47857' } # Page G
+        let(:previous_flow_uuid) { 'ffadeb22-063b-4e4f-9502-bd753c706b1d' } # Branching Point 2
+        let(:target_uuid) { '13ecf9bd-5064-4cad-baf8-3dfa091928cb' } # Page F
+
+        it 'does not update the exit pages default next' do
+          expect(metadata_flow[to_move_uuid]['next']['default']).to be_empty
         end
       end
     end

--- a/spec/models/pages_flow_spec.rb
+++ b/spec/models/pages_flow_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe PagesFlow do
               uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
               next: '0b297048-aa4d-49b6-ac74-18e069118185',
               previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
-              conditional_uuid: 'ecd60ac9-c3ea-47b1-8f79-c4e42df9a9dd',
+              previous_conditional_uuid: 'ecd60ac9-c3ea-47b1-8f79-c4e42df9a9dd',
               thumbnail: 'text',
               url: 'star-wars-knowledge'
             }
@@ -321,7 +321,7 @@ RSpec.describe PagesFlow do
               uuid: 'd4342dfd-0d09-4a91-a0ea-d7fd67e706cc',
               next: '05c3306c-0a39-42d2-9e0f-93fd49248f4e',
               previous_uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
-              conditional_uuid: '51b4eda2-a08d-4ab3-a8cb-565091f39424',
+              previous_conditional_uuid: '51b4eda2-a08d-4ab3-a8cb-565091f39424',
               thumbnail: 'radios',
               url: 'apple-juice'
             },
@@ -331,7 +331,7 @@ RSpec.describe PagesFlow do
               uuid: '91e9f7c6-2f75-4b7d-9eb5-0cf352f7be66',
               next: '05c3306c-0a39-42d2-9e0f-93fd49248f4e',
               previous_uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
-              conditional_uuid: '0a799cea-f5a4-4b89-9ffe-78515b5cb1d7',
+              previous_conditional_uuid: '0a799cea-f5a4-4b89-9ffe-78515b5cb1d7',
               thumbnail: 'radios',
               url: 'orange-juice'
             }
@@ -386,7 +386,7 @@ RSpec.describe PagesFlow do
               uuid: '8002df6e-29ab-4cdf-b520-1d7bb931a28f',
               next: 'ef2cafe3-37e2-4533-9b0c-09a970cd38d4',
               previous_uuid: '1d02e508-5953-4eca-af2f-9d67511c8648',
-              conditional_uuid: '0d3410db-1d05-4a32-bafb-65b52408b89b',
+              previous_conditional_uuid: '0d3410db-1d05-4a32-bafb-65b52408b89b',
               thumbnail: 'radios',
               url: 'music-app'
             }
@@ -441,7 +441,7 @@ RSpec.describe PagesFlow do
               uuid: 'b5efc09c-ece7-45ae-b0b3-8a7905e25040',
               next: '0c022e95-0748-4dda-8ba5-12fd1d2f596b',
               previous_uuid: 'cf8b3e18-dacf-4e91-92e1-018035961003',
-              conditional_uuid: '88b97d53-1da7-4464-a0a5-633a9ffd3d3d',
+              previous_conditional_uuid: '88b97d53-1da7-4464-a0a5-633a9ffd3d3d',
               thumbnail: 'text',
               url: 'which-formbuilder'
             }
@@ -507,7 +507,7 @@ RSpec.describe PagesFlow do
               uuid: 'bc666714-c0a2-4674-afe5-faff2e20d847',
               next: 'dc7454f9-4186-48d7-b055-684d57bbcdc7',
               previous_uuid: '618b7537-b42b-4551-ae7d-053afa4d9ca9',
-              conditional_uuid: '8a0c225f-b078-4728-a181-c3bdd343801c',
+              previous_conditional_uuid: '8a0c225f-b078-4728-a181-c3bdd343801c',
               thumbnail: 'content',
               url: 'global-warming'
             },
@@ -517,7 +517,7 @@ RSpec.describe PagesFlow do
               uuid: 'e2887f44-5e8d-4dc0-b1de-496ab6039430',
               next: 'dc7454f9-4186-48d7-b055-684d57bbcdc7',
               previous_uuid: '618b7537-b42b-4551-ae7d-053afa4d9ca9',
-              conditional_uuid: '7d1b29ac-f310-4246-bab9-957c9b2a20f2',
+              previous_conditional_uuid: '7d1b29ac-f310-4246-bab9-957c9b2a20f2',
               thumbnail: 'content',
               url: 'we-love-chickens'
             }
@@ -599,7 +599,7 @@ RSpec.describe PagesFlow do
               uuid: '2cc66e51-2c14-4023-86bf-ded49887cdb2',
               next: '48357db5-7c06-4e85-94b1-5e1c9d8f39eb',
               previous_uuid: '84a347fc-8d4b-486a-9996-6a86fa9544c5',
-              conditional_uuid: '15e8076f-75ac-4310-89b3-d2b5962babd4',
+              previous_conditional_uuid: '15e8076f-75ac-4310-89b3-d2b5962babd4',
               thumbnail: 'content',
               url: 'marvel-quotes'
             },
@@ -612,7 +612,7 @@ RSpec.describe PagesFlow do
               uuid: 'f6c51f88-7be8-4cb7-bbfc-6c905727a051',
               next: '48357db5-7c06-4e85-94b1-5e1c9d8f39eb',
               previous_uuid: '84a347fc-8d4b-486a-9996-6a86fa9544c5',
-              conditional_uuid: '0811ac93-a73e-4a2d-a8f1-68cc8a52ca69',
+              previous_conditional_uuid: '0811ac93-a73e-4a2d-a8f1-68cc8a52ca69',
               thumbnail: 'content',
               url: 'other-quotes'
             }
@@ -699,7 +699,7 @@ RSpec.describe PagesFlow do
               uuid: '56e80942-d0a4-405a-85cd-bd1b100013d6',
               next: 'e337070b-f636-49a3-a65c-f506675265f0',
               previous_uuid: '1079b5b8-abd0-4bf6-aaac-1f01e69e3b39',
-              conditional_uuid: '5ce78103-3935-4c57-9278-79bf2b8b93b1',
+              previous_conditional_uuid: '5ce78103-3935-4c57-9278-79bf2b8b93b1',
               thumbnail: 'content',
               url: 'arnold-right-answers'
             },
@@ -709,7 +709,7 @@ RSpec.describe PagesFlow do
               uuid: '6324cca4-7770-4765-89b9-1cdc41f49c8b',
               next: 'e337070b-f636-49a3-a65c-f506675265f0',
               previous_uuid: '1079b5b8-abd0-4bf6-aaac-1f01e69e3b39',
-              conditional_uuid: 'd45c65c7-a9b4-4128-8562-89bd4f0167ec',
+              previous_conditional_uuid: 'd45c65c7-a9b4-4128-8562-89bd4f0167ec',
               thumbnail: 'content',
               url: 'arnold-wrong-answers'
             },
@@ -836,7 +836,7 @@ RSpec.describe PagesFlow do
                 uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 next: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
-                conditional_uuid: 'b753b3f0-188e-4435-a84d-894557ba2007',
+                previous_conditional_uuid: 'b753b3f0-188e-4435-a84d-894557ba2007',
                 thumbnail: 'text',
                 url: 'page-c'
               },
@@ -846,7 +846,7 @@ RSpec.describe PagesFlow do
                 uuid: '3a584d15-6805-4a21-bc05-b61c3be47857',
                 next: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
                 previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
-                conditional_uuid: '2622668f-7ad2-4130-9d4f-274ff540b7e8',
+                previous_conditional_uuid: '2622668f-7ad2-4130-9d4f-274ff540b7e8',
                 thumbnail: 'text',
                 url: 'page-g'
               },
@@ -935,7 +935,7 @@ RSpec.describe PagesFlow do
                 uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 next: '2c7deb33-19eb-4569-86d6-462e3d828d87',
                 previous_uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
-                conditional_uuid: 'f51a3793-53dc-4537-b84b-399a59c103f4',
+                previous_conditional_uuid: 'f51a3793-53dc-4537-b84b-399a59c103f4',
                 thumbnail: 'text',
                 url: 'page-k'
               },
@@ -1086,7 +1086,7 @@ RSpec.describe PagesFlow do
                 uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 next: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
-                conditional_uuid: '39bab61b-93d5-486c-8e02-cea0aeb48215',
+                previous_conditional_uuid: '39bab61b-93d5-486c-8e02-cea0aeb48215',
                 thumbnail: 'text',
                 url: 'page-c'
               },
@@ -1096,7 +1096,7 @@ RSpec.describe PagesFlow do
                 uuid: '3a584d15-6805-4a21-bc05-b61c3be47857',
                 next: '7a561e9f-f4f8-4d2e-a01e-4097fc3ccf1c',
                 previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
-                conditional_uuid: '96810acb-b5e6-45c1-bacb-6b7a10c0d3a0',
+                previous_conditional_uuid: '96810acb-b5e6-45c1-bacb-6b7a10c0d3a0',
                 thumbnail: 'text',
                 url: 'page-g'
               },
@@ -1286,7 +1286,7 @@ RSpec.describe PagesFlow do
                 uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 next: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
                 previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
-                conditional_uuid: '457ca1ed-b188-4980-bf9b-01f8dde5ffe9',
+                previous_conditional_uuid: '457ca1ed-b188-4980-bf9b-01f8dde5ffe9',
                 thumbnail: 'text',
                 url: 'page-e'
               },
@@ -1459,7 +1459,7 @@ RSpec.describe PagesFlow do
                 uuid: 'e8708909-922e-4eaf-87a5-096f7a713fcb',
                 next: '65a2e01a-57dc-4702-8e41-ed8f9921ac7d',
                 previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
-                conditional_uuid: '91965137-99bd-4bcf-b9c3-61afaa7fc5c0',
+                previous_conditional_uuid: '91965137-99bd-4bcf-b9c3-61afaa7fc5c0',
                 thumbnail: 'text',
                 url: 'page-c'
               },
@@ -1469,7 +1469,7 @@ RSpec.describe PagesFlow do
                 uuid: '3a584d15-6805-4a21-bc05-b61c3be47857',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
                 previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
-                conditional_uuid: '10396fae-c28c-445c-a633-14d6439271a8',
+                previous_conditional_uuid: '10396fae-c28c-445c-a633-14d6439271a8',
                 thumbnail: 'text',
                 url: 'page-g'
               },
@@ -1546,7 +1546,7 @@ RSpec.describe PagesFlow do
                 uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 next: '2c7deb33-19eb-4569-86d6-462e3d828d87',
                 previous_uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
-                conditional_uuid: 'a2312258-bcbe-48b0-b30c-37d51caaf756',
+                previous_conditional_uuid: 'a2312258-bcbe-48b0-b30c-37d51caaf756',
                 thumbnail: 'text',
                 url: 'page-k'
               },
@@ -1708,7 +1708,7 @@ RSpec.describe PagesFlow do
                 uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 next: 'e337070b-f636-49a3-a65c-f506675265f0',
                 previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
-                conditional_uuid: 'b65ad907-d415-4139-8955-9e9a3d119b50',
+                previous_conditional_uuid: 'b65ad907-d415-4139-8955-9e9a3d119b50',
                 thumbnail: 'text',
                 url: 'page-e'
               },
@@ -1880,7 +1880,7 @@ RSpec.describe PagesFlow do
                 uuid: '37a94466-97fa-427f-88b2-09b369435d0d',
                 next: '13ecf9bd-5064-4cad-baf8-3dfa091928cb',
                 previous_uuid: '09e91fd9-7a46-4840-adbc-244d545cfef7',
-                conditional_uuid: '2d87a4bf-d532-48f5-956c-31ba5d046f63',
+                previous_conditional_uuid: '2d87a4bf-d532-48f5-956c-31ba5d046f63',
                 thumbnail: 'text',
                 url: 'page-e'
               },
@@ -1965,7 +1965,7 @@ RSpec.describe PagesFlow do
                 uuid: 'be130ac1-f33d-4845-807d-89b23b90d205',
                 next: '2c7deb33-19eb-4569-86d6-462e3d828d87',
                 previous_uuid: 'ffadeb22-063b-4e4f-9502-bd753c706b1d',
-                conditional_uuid: 'b4eaf825-a523-4372-a15b-072b016b0ead',
+                previous_conditional_uuid: 'b4eaf825-a523-4372-a15b-072b016b0ead',
                 thumbnail: 'text',
                 url: 'page-k'
               },

--- a/spec/requests/api/move_spec.rb
+++ b/spec/requests/api/move_spec.rb
@@ -111,6 +111,9 @@ RSpec.describe 'Move spec', type: :request do
           'data-conditional-uuid=""'
         ]
       end
+      let(:selected_target) do
+        '<option value="1d60bef0-100a-4f3b-9e6f-1711e8adda7e" data-conditional-uuid="" selected="selected">'
+      end
 
       before do
         allow_any_instance_of(
@@ -146,6 +149,10 @@ RSpec.describe 'Move spec', type: :request do
         invalid_targets.each do |title|
           expect(response.body).not_to include(title)
         end
+      end
+
+      it 'sets the selected attribute for the previous target' do
+        expect(response.body).to include(selected_target)
       end
     end
   end

--- a/spec/requests/api/move_spec.rb
+++ b/spec/requests/api/move_spec.rb
@@ -1,20 +1,41 @@
 RSpec.describe 'Move GET routes', type: :routing do
   context 'when previous_flow_uuid is present' do
-    let(:request) do
-      get '/api/services/some-service-id/flow/some-flow-uuid/move/some-previous-flow-uuid'
-    end
-    let(:expected_route) do
+    let(:service_id) { 'some-service-id' }
+    let(:flow_uuid) { 'some-flow-uuid' }
+    let(:previous_flow_uuid) { 'some-previous-flow-uuid' }
+    let(:move_route) do
       {
         controller: 'api/move',
         action: 'targets',
-        service_id: 'some-service-id',
-        flow_uuid: 'some-flow-uuid',
-        previous_flow_uuid: 'some-previous-flow-uuid'
+        service_id: service_id,
+        flow_uuid: flow_uuid,
+        previous_flow_uuid: previous_flow_uuid
       }
     end
 
-    it 'correctly routes the request' do
-      expect(request).to route_to(expected_route)
+    context 'when previous conditional uuid is not present' do
+      let(:request) do
+        get "/api/services/#{service_id}/flow/#{flow_uuid}/move/#{previous_flow_uuid}"
+      end
+      let(:expected_route) { move_route }
+
+      it 'correctly routes the request' do
+        expect(request).to route_to(expected_route)
+      end
+    end
+
+    context 'when previous conditional uuid is present' do
+      let(:request) do
+        get "/api/services/#{service_id}/flow/#{flow_uuid}/move/#{previous_flow_uuid}/#{previous_conditional_uuid}"
+      end
+      let(:previous_conditional_uuid) { 'some-previous-conditional-uuid' }
+      let(:expected_route) do
+        move_route.merge(previous_conditional_uuid: previous_conditional_uuid)
+      end
+
+      it 'correctly routes the request' do
+        expect(request).to route_to(expected_route)
+      end
     end
   end
 
@@ -38,16 +59,28 @@ RSpec.describe 'Move GET routes', type: :routing do
 end
 
 RSpec.describe 'Move spec', type: :request do
-  describe 'GET /api/services/:service_id/flow/:flow_uuid/move/(:previous_flow_uuid)' do
-    let(:request) do
-      get "/api/services/#{service.service_id}/flow/#{flow_uuid}/move/#{previous_flow_uuid}"
-    end
+  describe 'GET /api/services/:service_id/flow/:flow_uuid/move/(:previous_flow_uuid)/(:previous_conditional_uuid' do
     let(:service) { MetadataPresenter::Service.new(metadata) }
     let(:metadata) { metadata_fixture(:branching_11) }
     let(:flow_uuid) { '2ffc17b7-b14a-417f-baff-07adebd4f259' } # Page B
     let(:previous_flow_uuid) { '1d60bef0-100a-4f3b-9e6f-1711e8adda7e' } # Page A
 
-    context 'when moving a page' do
+    before do
+      allow_any_instance_of(
+        Api::MoveController
+      ).to receive(:require_user!).and_return(true)
+
+      allow_any_instance_of(
+        Api::MoveController
+      ).to receive(:service).and_return(service)
+
+      request
+    end
+
+    context 'when previous conditional uuid is not present' do
+      let(:request) do
+        get "/api/services/#{service.service_id}/flow/#{flow_uuid}/move/#{previous_flow_uuid}"
+      end
       let(:invalid_targets) do
         [
           'Check your answers',
@@ -114,17 +147,8 @@ RSpec.describe 'Move spec', type: :request do
       let(:selected_target) do
         '<option value="1d60bef0-100a-4f3b-9e6f-1711e8adda7e" data-conditional-uuid="" selected="selected">'
       end
-
-      before do
-        allow_any_instance_of(
-          Api::MoveController
-        ).to receive(:require_user!).and_return(true)
-
-        allow_any_instance_of(
-          Api::MoveController
-        ).to receive(:service).and_return(service)
-
-        request
+      let(:previous_uuid_field) do
+        '<input value="1d60bef0-100a-4f3b-9e6f-1711e8adda7e" autocomplete="off" type="hidden" name="move[previous_flow_uuid]" id="move_previous_flow_uuid" />'
       end
 
       it 'returns the list of possible targets' do
@@ -154,6 +178,33 @@ RSpec.describe 'Move spec', type: :request do
       it 'sets the selected attribute for the previous target' do
         expect(response.body).to include(selected_target)
       end
+
+      it 'sets the hidden field for the previous uuid' do
+        expect(response.body).to include(previous_uuid_field)
+      end
+    end
+
+    context 'when previous conditional uuid is present' do
+      let(:request) do
+        get "/api/services/#{service.service_id}/flow/#{flow_uuid}/move/#{previous_flow_uuid}/#{previous_conditional_uuid}"
+      end
+      let(:flow_uuid) { '1314e473-9096-4434-8526-03a7b4b7b132' } # Page K
+      let(:previous_flow_uuid) { 'a02f7073-ba5a-459d-b6b9-abe548c933a6' } # Branching Point 2
+      let(:previous_conditional_uuid) { '0bdc8fde-be62-4945-8496-854e867a665d' }
+      let(:selected_target) do
+        '<option value="a02f7073-ba5a-459d-b6b9-abe548c933a6" data-conditional-uuid="0bdc8fde-be62-4945-8496-854e867a665d" selected="selected">'
+      end
+      let(:previous_conditional_uuid_field) do
+        '<input value="0bdc8fde-be62-4945-8496-854e867a665d" autocomplete="off" type="hidden" name="move[previous_conditional_uuid]" id="move_previous_conditional_uuid" />'
+      end
+
+      it 'sets the selected attribute for the previous target' do
+        expect(response.body).to include(selected_target)
+      end
+
+      it 'sets the previous conditional uuid hidden field' do
+        expect(response.body).to include(previous_conditional_uuid_field)
+      end
     end
   end
 
@@ -170,7 +221,7 @@ RSpec.describe 'Move spec', type: :request do
         move: {
           previous_flow_uuid: '1d60bef0-100a-4f3b-9e6f-1711e8adda7e', # Page A
           target_uuid: '007f4f35-8236-40cc-866c-cc2c27c33949', # Page E
-          conditional_uuid: ''
+          target_conditional_uuid: ''
         }
       }
     end


### PR DESCRIPTION
## Do not allow stacked branches

<img width="578" alt="Screenshot 2022-04-12 at 14 15 31" src="https://user-images.githubusercontent.com/3466862/162976792-91b5c874-47af-4f2f-9107-58a0db9a32ac.png">


If the previous object and the default next of the object being moved
are branches then we should show the user a useful message that prevents
them from moving that object.

## Do not allow moving a page is a branch destination and there is no default next

<img width="690" alt="Screenshot 2022-04-14 at 17 50 10" src="https://user-images.githubusercontent.com/3466862/163716658-d102e09f-d68e-4a08-b2b8-aa642559c10e.png">

If the page being moved is a branch destination and has no default next, like exit pages, then we cannot allow these to be moved until the branch has been updated.

## Show Move Page link in page menu

<img width="402" alt="Screenshot 2022-04-12 at 14 43 25" src="https://user-images.githubusercontent.com/3466862/162976325-bff11edf-0e20-4228-b510-594940e80862.png">

Except for start page, check answers page and confirmation page.

## Preselect the to move objects previous uuid

Preselect the object the previous uuid for the object that is being
moved in the targets list presented in the move modal.

For a branch destination it will select the numbered branch from the
list. e.g Branching Point 1 (Branch 2)

## Differentiate between previous and target conditional UUIDs

When moving a page we need to be able to differentiate between the
previous conditional uuid, if the page being moved was a branch
destination, and the target conditional uuid if the page being moved is
going to replace a branch destination.