### PR TITLE
Generate acceptance tests from fixture

### DIFF
--- a/acceptance/fixtures/acceptance_test_fixture.json
+++ b/acceptance/fixtures/acceptance_test_fixture.json
@@ -1,0 +1,847 @@
+{
+  "_id": "service.base",
+  "flow": {
+    "00553892-5ff8-499b-a6cd-c16cc217f5ac": {
+      "next": {
+        "default": "c4466cbf-2018-486d-ab74-89d84c70c3e5"
+      },
+      "_type": "flow.page"
+    },
+    "206384ec-9641-404e-8e3c-d86645e229a4": {
+      "next": {
+        "default": "6781549e-107a-4c45-971b-ed22f52db271"
+      },
+      "_type": "flow.page"
+    },
+    "2ee0ff62-dd81-4508-a26c-e1d95445bafe": {
+      "next": {
+        "default": "6fa93bac-4b8a-4fa4-9e49-4876b0387e84"
+      },
+      "_type": "flow.page"
+    },
+    "3bd6dd9b-f7f5-4a4c-9cf0-183215dbe242": {
+      "next": {
+        "default": "99a530a5-5b65-46c5-88f4-307992d405b2"
+      },
+      "_type": "flow.page"
+    },
+    "6781549e-107a-4c45-971b-ed22f52db271": {
+      "next": {
+        "default": "86487d7c-3774-4913-828f-8921fbdc9bad"
+      },
+      "_type": "flow.page"
+    },
+    "6fa93bac-4b8a-4fa4-9e49-4876b0387e84": {
+      "next": {
+        "default": "8f5480e1-85f2-4add-a354-1daf638cfe97",
+        "conditionals": [
+          {
+            "next": "206384ec-9641-404e-8e3c-d86645e229a4",
+            "_type": "if",
+            "_uuid": "b3ca3d11-10d1-4b82-bdfd-4f7c1a25f53d",
+            "expressions": [
+              {
+                "page": "2ee0ff62-dd81-4508-a26c-e1d95445bafe",
+                "field": "06126fa7-4792-4032-aee2-702548214753",
+                "operator": "contains",
+                "component": "293a4034-5fb8-4852-81f2-9d76a8b966ec"
+              }
+            ]
+          },
+          {
+            "next": "86487d7c-3774-4913-828f-8921fbdc9bad",
+            "_type": "if",
+            "_uuid": "37ee67df-6fc0-4067-8df0-3f83343a6bc4",
+            "expressions": [
+              {
+                "page": "2ee0ff62-dd81-4508-a26c-e1d95445bafe",
+                "field": "d8137590-f105-4d86-9287-96ab2c24f071",
+                "operator": "contains",
+                "component": "293a4034-5fb8-4852-81f2-9d76a8b966ec"
+              }
+            ]
+          }
+        ]
+      },
+      "_type": "flow.branch",
+      "title": "Branching point 1"
+    },
+    "7a6438d3-abff-4b9a-9c97-8d04ee21f317": {
+      "next": {
+        "default": "99a530a5-5b65-46c5-88f4-307992d405b2",
+        "conditionals": [
+          {
+            "next": "3bd6dd9b-f7f5-4a4c-9cf0-183215dbe242",
+            "_type": "if",
+            "_uuid": "bca38bd9-79af-4ec2-87b0-b16283ad2942",
+            "expressions": [
+              {
+                "page": "877a54d4-74ae-4ca2-9868-917d652eeba8",
+                "field": "aa6f4189-558c-4eb3-a6c7-6900d4f2d5d3",
+                "operator": "contains",
+                "component": "5a636193-cf7b-41c7-bf71-b53ad9b236b0"
+              }
+            ]
+          }
+        ]
+      },
+      "_type": "flow.branch",
+      "title": "Branching point 2"
+    },
+    "86487d7c-3774-4913-828f-8921fbdc9bad": {
+      "next": {
+        "default": "fc5ec678-6ce8-4409-bfb6-8e1c4a81f524"
+      },
+      "_type": "flow.page"
+    },
+    "877a54d4-74ae-4ca2-9868-917d652eeba8": {
+      "next": {
+        "default": "7a6438d3-abff-4b9a-9c97-8d04ee21f317"
+      },
+      "_type": "flow.page"
+    },
+    "8f5480e1-85f2-4add-a354-1daf638cfe97": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "99a530a5-5b65-46c5-88f4-307992d405b2": {
+      "next": {
+        "default": "c6a89b77-abe9-4c10-a512-73d9dde0acea"
+      },
+      "_type": "flow.page"
+    },
+    "c4466cbf-2018-486d-ab74-89d84c70c3e5": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "c6a89b77-abe9-4c10-a512-73d9dde0acea": {
+      "next": {
+        "default": "00553892-5ff8-499b-a6cd-c16cc217f5ac"
+      },
+      "_type": "flow.page"
+    },
+    "fc5ec678-6ce8-4409-bfb6-8e1c4a81f524": {
+      "next": {
+        "default": "877a54d4-74ae-4ca2-9868-917d652eeba8"
+      },
+      "_type": "flow.page"
+    },
+    "ff0c64b9-8e84-41bd-9d56-a9e6da9580c8": {
+      "next": {
+        "default": "2ee0ff62-dd81-4508-a26c-e1d95445bafe"
+      },
+      "_type": "flow.page"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "_type": "page.start",
+      "_uuid": "ff0c64b9-8e84-41bd-9d56-a9e6da9580c8",
+      "heading": "Service name goes here",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
+    },
+    {
+      "_id": "page.page-b",
+      "url": "page-b",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "2ee0ff62-dd81-4508-a26c-e1d95445bafe",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-b_checkboxes_1",
+          "hint": "",
+          "name": "page-b_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "293a4034-5fb8-4852-81f2-9d76a8b966ec",
+          "items": [
+            {
+              "_id": "page-b_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-b_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "06126fa7-4792-4032-aee2-702548214753",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-b_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-b_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "d8137590-f105-4d86-9287-96ab2c24f071",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page b",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-c",
+      "url": "page-c",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "206384ec-9641-404e-8e3c-d86645e229a4",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-c_checkboxes_1",
+          "hint": "",
+          "name": "page-c_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "d362c7ee-ceed-49ac-a992-a9900de03c38",
+          "items": [
+            {
+              "_id": "page-c_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-c_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "846d2104-062b-489f-9292-36d9b5dcd0ba",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-c_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-c_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "97722c43-3e78-450a-a246-573748ed6f4a",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page c",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-d",
+      "url": "page-d",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "6781549e-107a-4c45-971b-ed22f52db271",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-d_checkboxes_1",
+          "hint": "",
+          "name": "page-d_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "822f2aaa-b45f-4211-bf75-0f85eebb4223",
+          "items": [
+            {
+              "_id": "page-d_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-d_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "3927f9b2-c1d7-4392-960d-4d687dda32ef",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-d_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-d_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "6e2bcd0b-0187-4a07-8a67-8b9935bf031a",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page d",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-e",
+      "url": "page-e",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "86487d7c-3774-4913-828f-8921fbdc9bad",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-e_checkboxes_1",
+          "hint": "",
+          "name": "page-e_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "104e682a-7942-45d4-974b-7f3dd0e7fc2a",
+          "items": [
+            {
+              "_id": "page-e_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-e_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "1884eef9-238b-4fba-94ce-8c4138abeb16",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-e_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-e_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "ed9701c8-f624-45d0-9706-63c30984f399",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page e",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-f",
+      "url": "page-f",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "fc5ec678-6ce8-4409-bfb6-8e1c4a81f524",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-f_checkboxes_1",
+          "hint": "",
+          "name": "page-f_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "2c98ef94-e684-4714-9969-aba826032c52",
+          "items": [
+            {
+              "_id": "page-f_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-f_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "f3b2124d-70e4-4818-97a1-f278a58c3aa6",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-f_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-f_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "4a2be7dd-f31d-4ac2-90a0-ee16003510b3",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page f",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-g",
+      "url": "page-g",
+      "_type": "page.multiplequestions",
+      "_uuid": "877a54d4-74ae-4ca2-9868-917d652eeba8",
+      "heading": "Page g",
+      "components": [
+        {
+          "_id": "page-g_radios_1",
+          "hint": "",
+          "name": "page-g_radios_1",
+          "_type": "radios",
+          "_uuid": "67e1a7ea-1b84-4eb8-8f2d-d71239508dc6",
+          "items": [
+            {
+              "_id": "page-g_radios_1_item_1",
+              "hint": "",
+              "name": "page-g_radios_1",
+              "_type": "radio",
+              "_uuid": "07a0e716-ba36-4f09-b203-91eb48d7135b",
+              "label": "Thanos",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-g_radios_1_item_2",
+              "hint": "",
+              "name": "page-g_radios_1",
+              "_type": "radio",
+              "_uuid": "7963d15b-30ac-4a5c-b892-3c359e4d6f08",
+              "label": "Option",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Question 1",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "_id": "page-g_checkboxes_1",
+          "hint": "",
+          "name": "page-g_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "5a636193-cf7b-41c7-bf71-b53ad9b236b0",
+          "items": [
+            {
+              "_id": "page-g_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-g_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "aa6f4189-558c-4eb3-a6c7-6900d4f2d5d3",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-g_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-g_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "b395f101-5ff3-442c-b88c-092cdde84a91",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Question 2",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "add_component": "checkboxes",
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-h",
+      "url": "page-h",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "3bd6dd9b-f7f5-4a4c-9cf0-183215dbe242",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-h_checkboxes_1",
+          "hint": "",
+          "name": "page-h_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "e6888c5b-ec41-4871-a970-be0c413ff114",
+          "items": [
+            {
+              "_id": "page-h_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-h_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "fcaaa013-0fcc-4eb0-8db4-5b9f2374e40e",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-h_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-h_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "6195eb5f-28b8-46c8-aeac-b911505d9b42",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page h",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-i",
+      "url": "page-i",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "99a530a5-5b65-46c5-88f4-307992d405b2",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-i_checkboxes_1",
+          "hint": "",
+          "name": "page-i_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "7e370dde-327f-4ea6-87cd-66e46c9bcb87",
+          "items": [
+            {
+              "_id": "page-i_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-i_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "4c30ee08-d481-40c5-b4ee-7bca24c50270",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-i_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-i_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "26834c7b-799b-47af-b5a6-9de9b8263aa4",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page i",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-j",
+      "url": "page-j",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "c6a89b77-abe9-4c10-a512-73d9dde0acea",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-j_checkboxes_1",
+          "hint": "",
+          "name": "page-j_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "297dc736-983a-437d-9456-a93cdc4185ac",
+          "items": [
+            {
+              "_id": "page-j_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-j_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "04c9fb69-4322-41f6-afe3-d11faa69f25a",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-j_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-j_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "991d7798-24d1-4a7f-8b81-ed09623f714a",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page j",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.checkanswers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "00553892-5ff8-499b-a6cd-c16cc217f5ac",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+
+      ],
+      "send_heading": "Now send your application",
+      "extra_components": [
+
+      ]
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "form-sent",
+      "_type": "page.confirmation",
+      "_uuid": "c4466cbf-2018-486d-ab74-89d84c70c3e5",
+      "heading": "Application complete",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.exit-page",
+      "url": "exit-page",
+      "lede": "",
+      "_type": "page.exit",
+      "_uuid": "8f5480e1-85f2-4add-a354-1daf638cfe97",
+      "heading": "Exit page",
+      "components": [
+
+      ],
+      "section_heading": ""
+    }
+  ],
+  "locale": "en",
+  "created_at": "",
+  "created_by": "",
+  "service_id": "",
+  "version_id": "",
+  "service_name": "",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "/cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "/privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "/accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "Cookies body",
+      "_type": "page.standalone",
+      "_uuid": "8b569379-3b00-477c-9bd8-a3db37b3fdea",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "Privacy body",
+      "_type": "page.standalone",
+      "_uuid": "0ede84eb-a732-48c2-a881-42a916f47468",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "Accessibility body",
+      "_type": "page.standalone",
+      "_uuid": "a3cc747e-be3b-4a2e-94ad-c64b612481f7",
+      "heading": "Accessibility statement",
+      "components": [
+
+      ]
+    }
+  ]
+}

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -32,7 +32,7 @@ module CommonSteps
         "document.getElementById('btn-login').click()"
       )
     else
-      editor.sign_in_email_field.set('form-builder-developers@digital.justice.gov.uk')
+      editor.sign_in_email_field.set('fb-acceptance-tests@digital.justice.gov.uk')
       editor.sign_in_submit.click
     end
 

--- a/app/controllers/admin/test_services_controller.rb
+++ b/app/controllers/admin/test_services_controller.rb
@@ -1,0 +1,77 @@
+module Admin
+  class TestServicesController < Admin::ApplicationController
+    before_action :authenticate_test_user!
+    before_action :deny_live_environment!
+    skip_before_action :authenticate_admin
+
+    ACCEPTANCE_TEST_FIXTURE = 'acceptance_test_fixture'.freeze
+
+    def create
+      service_creation = ServiceCreation.new(
+        service_name: test_service_name,
+        current_user: current_user
+      )
+
+      if service_creation.create
+        test_service_version = AdminMetadataVersion.new(
+          service: OpenStruct.new(service_id: service_creation.service_id),
+          metadata: fixture_metadata.merge(test_service_attributes(service_creation))
+        ).create_version
+
+        if test_service_version
+          redirect_to edit_service_path(service_creation.service_id)
+        else
+          render json: {
+            message: "Failed to create test service version -> #{test_service_name}"
+          }, status: :bad_request
+        end
+      else
+        render json: {
+          message: "Failed to create test service -> #{test_service_name}"
+        }, status: :bad_request
+      end
+    end
+
+    def authenticate_test_user!
+      unless current_user.email == 'fb-acceptance-tests@digital.justice.gov.uk'
+        render json: { message: 'Unauthorised' }, status: :unauthorized
+      end
+    end
+
+    def deny_live_environment!
+      if ENV['PLATFORM_ENV'] == 'live'
+        render json: { message: 'Unauthorised' }, status: :unauthorized
+      end
+    end
+
+    def fixture_metadata
+      JSON.parse(
+        File.read(
+          Rails.root.join(
+            'acceptance',
+            'fixtures',
+            "#{fixture_name}.json"
+          )
+        )
+      )
+    end
+
+    def fixture_name
+      return ACCEPTANCE_TEST_FIXTURE if params[:fixture].blank?
+
+      params[:fixture]
+    end
+
+    def test_service_attributes(service_creation)
+      {
+        'service_name' => service_creation.service_name,
+        'service_id' => service_creation.service_id,
+        'created_by' => current_user.id
+      }
+    end
+
+    def test_service_name
+      @test_service_name ||= params.require(:test_service_name)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     end
     resources :users
     resources :publish_services
+    get '/test-service/:test_service_name/(:fixture)', to: 'test_services#create', as: :test_service
 
     root to: "overviews#index"
   end

--- a/spec/requests/admin/test_service_spec.rb
+++ b/spec/requests/admin/test_service_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe 'GET create test service', type: :request do
+  context 'when authorised user' do
+    let(:request) { get "/admin/test-service/#{service_name}" }
+    let(:service_name) { SecureRandom.uuid }
+    let(:authorised_user) do
+      double(id: SecureRandom.uuid, email: 'fb-acceptance-tests@digital.justice.gov.uk')
+    end
+
+    before do
+      allow_any_instance_of(
+        Admin::TestServicesController
+      ).to receive(:require_user!).and_return(true)
+      allow_any_instance_of(
+        Admin::TestServicesController
+      ).to receive(:authenticate_test_user!).and_return(true)
+      allow_any_instance_of(Admin::TestServicesController).to receive(:current_user).and_return(authorised_user)
+      allow(ENV).to receive(:[])
+    end
+
+    context 'when live environment' do
+      before do
+        allow(ENV).to receive(:[]).with('PLATFORM_ENV').and_return('live')
+        request
+      end
+
+      it 'does not allow access' do
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+
+  context 'when unauthorised user' do
+    let(:request) { get "/admin/test-service/#{service_name}" }
+    let(:service_name) { SecureRandom.uuid }
+    let(:unauthorised_user) do
+      double(id: SecureRandom.uuid, email: 'steven.grant@khonshu.com')
+    end
+
+    before do
+      allow_any_instance_of(
+        Admin::TestServicesController
+      ).to receive(:require_user!).and_return(true)
+      allow_any_instance_of(Admin::TestServicesController).to receive(:current_user).and_return(unauthorised_user)
+      request
+    end
+
+    it 'does not allow access' do
+      expect(response.status).to eq(401)
+    end
+  end
+end


### PR DESCRIPTION
This adds an admin endpoint accessible only by the acceptance tests user
which will take a fixture and directly create a service version via the
API instead of stepping through the creation process in the UI.