### PR TITLE
Deny access to forms for unauthorised users

### DIFF
--- a/acceptance/features/admin_spec.rb
+++ b/acceptance/features/admin_spec.rb
@@ -25,7 +25,7 @@ feature 'Visiting admin pages' do
     then_I_should_not_see_the_admin_link
     admin_pages.each do |path|
       given_I_visit_an_admin_page(path)
-      then_I_should_be_redirected_to_the_services_page
+      then_I_should_be_redirected_to_the_unauthorised_page
     end
   end
 
@@ -39,8 +39,14 @@ feature 'Visiting admin pages' do
     expect(page.text).to include(I18n.t('home.show.sign_in'))
   end
 
+  def then_I_should_be_redirected_to_the_unauthorised_page
+    expect(page.current_path).to eq('/unauthorised')
+    expect(page.text).to include(I18n.t('auth.unauthorised.heading'))
+    expect(page.text).to include(I18n.t('auth.unauthorised.body'))
+  end
+
   def then_I_should_not_see_the_admin_link
-    expect(page.text).not_to include(I18n.t('home.show.admin'))
+    expect(page.text).not_to include(I18n.t('partials.header.admin'))
   end
 
   def then_I_should_be_redirected_to_the_services_page

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -171,7 +171,7 @@ module CommonSteps
 
   def and_I_return_to_flow_page
     editor.pages_link.click
-    sleep 0.5 
+    sleep 0.5
     page.find('#main-content', visible: true)
   end
 
@@ -421,9 +421,9 @@ module CommonSteps
     expect(editor.text).to include(DELETE_WARNING[2])
   end
 
-  def then_I_should_see_the_modal(modal_title, modal_text) 
+  def then_I_should_see_the_modal(modal_title, modal_text)
     expect(page).to have_selector('.ui-dialog', visible: true)
-    within('.ui-dialog', visible: true) do 
+    within('.ui-dialog', visible: true) do
       expect(page).to have_content modal_title
       expect(page).to have_content modal_text
     end
@@ -431,7 +431,7 @@ module CommonSteps
 
   def and_I_close_the_modal(button_text=nil)
     if button_text
-      click_button(button_text); 
+      click_button(button_text);
     else
       click_button('.ui-dialog-titlebar-close')
     end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -18,7 +18,7 @@ module Admin
     before_action :authenticate_admin
 
     def authenticate_admin
-      redirect_to login_path unless moj_forms_dev? || moj_forms_team?
+      redirect_to unauthorised_path unless moj_forms_dev? || moj_forms_team?
     end
 
     def published(environment)

--- a/app/controllers/api/branches_controller.rb
+++ b/app/controllers/api/branches_controller.rb
@@ -1,5 +1,6 @@
 class Api::BranchesController < BranchesController
   before_action :assign_branch, only: %i[new_conditional]
+  skip_before_action :authorised_access
 
   def new_conditional
     render layout: false

--- a/app/controllers/api/move_controller.rb
+++ b/app/controllers/api/move_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class MoveController < BranchesController
+  class MoveController < ApiController
     def targets
       @move = Move.new(base_params)
       render :new, layout: false

--- a/app/controllers/permissions_controller.rb
+++ b/app/controllers/permissions_controller.rb
@@ -1,3 +1,7 @@
 class PermissionsController < ApplicationController
+  include ApplicationHelper
+  include AuthorisationHelper
+
   before_action :require_user!
+  before_action :authorised_access
 end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,5 +1,6 @@
 class ServicesController < PermissionsController
   layout 'form', only: :edit
+  skip_before_action :authorised_access, only: %i[index create]
 
   def index
     @service_creation = ServiceCreation.new

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -14,4 +14,6 @@ class UserSessionsController < ApplicationController
   def signup_error
     @error_type = params[:error_type]
   end
+
+  def unauthorised; end
 end

--- a/app/helpers/authorisation_helper.rb
+++ b/app/helpers/authorisation_helper.rb
@@ -1,0 +1,19 @@
+module AuthorisationHelper
+  def authorised_access
+    return if moj_forms_team? || moj_forms_dev?
+
+    unless current_user.id == service.created_by
+      redirect_to redirect_unauthorised_path
+    end
+  end
+
+  def redirect_unauthorised_path
+    return unauthorised_path unless preview?
+
+    "#{request.base_url}/unauthorised"
+  end
+
+  def preview?
+    URI(request.original_url).path.split('/').last == 'preview'
+  end
+end

--- a/app/validators/metadata_url_validator.rb
+++ b/app/validators/metadata_url_validator.rb
@@ -9,6 +9,7 @@ class MetadataUrlValidator < ActiveModel::EachValidator
     metrics
     ping
     reserved
+    unauthorised
   ].freeze
 
   def validate_each(record, attribute, value)

--- a/app/views/partials/_template_editable_collection_item_menu.html.erb
+++ b/app/views/partials/_template_editable_collection_item_menu.html.erb
@@ -4,7 +4,7 @@
   <ul class="govuk-navigation component-activated-menu">
     <%#= we unescape the route helper in order to keep the url placeholders intact for JS to replace them -%>
     <li data-action="remove"
-        data-api-path="<%= URI.unescape( api_service_page_question_question_option_destroy_message_path(service.service_id,@page.uuid,'#{question_uuid}', '#{option_uuid}', method: :delete) ) -%>">
+        data-api-path="<%= URI.decode_www_form_component(api_service_page_question_question_option_destroy_message_path(service.service_id,@page.uuid,'#{question_uuid}', '#{option_uuid}', method: :delete) ) -%>">
       <span class="destructive"><%= t('question.menu.remove')%></span>
     </li>
   </ul>

--- a/app/views/user_sessions/unauthorised.html.erb
+++ b/app/views/user_sessions/unauthorised.html.erb
@@ -1,0 +1,11 @@
+<div class="fb-main-grid-wrapper" data-block-id="unauthorised-access" data-block-type="page" data-block-pagetype="unauthorised-access">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl" data-block-id="unauthorised-access-heading" data-block-property="heading">
+        <%= t('auth.unauthorised.heading') %>
+      </h1>
+
+      <p><%= t('auth.unauthorised.body') %></p>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
 
   partials:
     header:
+      admin: Admin
       forms: Your forms
       sign_out: Sign out %{user_name}
       user_guide: "User guide"
@@ -77,7 +78,6 @@ en:
       lede: Prototype, test and publish online forms quickly and easily
       body: 'To find out more about MoJ Forms, email us at <a href="mailto:moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a>, or <a href="https://app.slack.com/client/T02DYEB3A/CE26QEL1Z">ask us a question on Slack</a>.'
       callout: You will need a @digital.justice.gov.uk or @justice.gov.uk email address to use MoJ Forms.
-      admin: Admin
       sign_in: Sign in
   auth:
     existing_user:
@@ -88,6 +88,9 @@ en:
     signup_not_allowed:
       heading: 'Unable to sign in'
       body: 'You cannot sign in with that email address'
+    unauthorised:
+      heading: You don't have access to that page
+      body: Contact the form owner or the MoJ Forms team for help.
   actions:
     edit: 'Edit'
     save: 'Save'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,11 +21,12 @@ Rails.application.routes.draw do
   get '/metrics', to: 'metrics#show'
 
   # Auth0 routes
-  get "/auth/auth0/callback" => "auth0#callback", as: 'auth0_callback'
-  get "/auth/failure" => "auth0#failure"
+  get "/auth/auth0/callback", to: "auth0#callback", as: 'auth0_callback'
+  get "/auth/failure", to: "auth0#failure"
 
-  get '/signup_not_allowed' => 'user_sessions#signup_not_allowed', as: 'signup_not_allowed'
-  get '/signup_error/:error_type' => 'user_sessions#signup_error', as: 'signup_error'
+  get '/signup_not_allowed', to: 'user_sessions#signup_not_allowed', as: 'signup_not_allowed'
+  get '/signup_error/:error_type', to: 'user_sessions#signup_error', as: 'signup_error'
+  get '/unauthorised', to: 'user_sessions#unauthorised'
   resource :user_session, only: [:destroy]
 
   if Rails.env.development?

--- a/spec/requests/admin/admin_authorisation_spec.rb
+++ b/spec/requests/admin/admin_authorisation_spec.rb
@@ -1,0 +1,98 @@
+RSpec.describe 'Admin authorisation spec', type: :request do
+  let(:service) { MetadataPresenter::Service.new(metadata_fixture(:branching)) }
+  let(:current_user) { double(id: SecureRandom.uuid, email: 'ellen.ripley@nostromo.eg') }
+
+  before do
+    allow_any_instance_of(Admin::ApplicationController).to receive(:require_user!).and_return(true)
+    allow_any_instance_of(
+      Admin::ApplicationController
+    ).to receive(:current_user).and_return(current_user)
+  end
+
+  shared_examples 'an authorisation action' do
+    context 'when admin user' do
+      before do
+        allow_any_instance_of(
+          Admin::ApplicationController
+        ).to receive(:moj_forms_dev?).and_return(true)
+      end
+
+      it 'allows access' do
+        request
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'when not admin user' do
+      it 'does not allow access' do
+        expect(request).to redirect_to(unauthorised_path)
+      end
+    end
+  end
+
+  context 'when admin dashboard root' do
+    it_behaves_like 'an authorisation action' do
+      let(:request) { get admin_root_path }
+    end
+  end
+
+  context 'when overviews page' do
+    it_behaves_like 'an authorisation action' do
+      let(:request) { get '/admin/overviews' }
+    end
+  end
+
+  context 'when legacy service name page' do
+    it_behaves_like 'an authorisation action' do
+      let(:request) { get '/admin/legacy_service_names' }
+    end
+  end
+
+  context 'when uptime checks page' do
+    it_behaves_like 'an authorisation action' do
+      let(:request) { get '/admin/uptime_checks' }
+
+      before do
+        allow_any_instance_of(
+          Admin::UptimeChecksController
+        ).to receive(:services_without_uptime_checks).and_return([])
+        allow_any_instance_of(
+          Admin::UptimeChecksController
+        ).to receive(:with_uptime_checks).and_return([])
+        allow_any_instance_of(
+          Admin::UptimeChecksController
+        ).to receive(:non_editor_service_checks).and_return([])
+      end
+    end
+  end
+
+  context 'when services page' do
+    it_behaves_like 'an authorisation action' do
+      let(:request) { get '/admin/services' }
+      let(:all_services) do
+        {
+          services: [],
+          total_count: 0,
+          page: 1,
+          per_page: 10
+        }
+      end
+
+      before do
+        allow(MetadataApiClient::Service).to receive(:all_services).and_return(all_services)
+      end
+    end
+  end
+
+  context 'when users page' do
+    it_behaves_like 'an authorisation action' do
+      let(:request) { get '/admin/users' }
+    end
+  end
+
+  context 'when publish services page' do
+    it_behaves_like 'an authorisation action' do
+      let(:request) { get '/admin/publish_services' }
+    end
+  end
+end

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -1,0 +1,100 @@
+RSpec.describe 'Authorisation spec', type: :request do
+  let(:service) { MetadataPresenter::Service.new(metadata_fixture(:branching)) }
+  let(:current_user) { double(id: SecureRandom.uuid, email: 'steven.grant@khonshu.eg') }
+  let(:expected_unauthorised_path) { unauthorised_path }
+
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:require_user!).and_return(true)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
+    allow_any_instance_of(ApplicationController).to receive(:service).and_return(service)
+  end
+
+  context 'all services page' do
+    let(:request) { get '/services' }
+
+    before do
+      allow_any_instance_of(ServicesController).to receive(:services).and_return([])
+      request
+    end
+
+    it 'does not call authorised_access' do
+      expect_any_instance_of(ServicesController).not_to receive(:authorised_access)
+    end
+
+    it 'responds successfully' do
+      expect(response.status).to be(200)
+    end
+  end
+
+  shared_examples 'an authorisation action' do
+    context 'when admin user' do
+      before do
+        allow_any_instance_of(PermissionsController).to receive(:moj_forms_team?).and_return(true)
+      end
+
+      it 'allows access' do
+        request
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'when service creator' do
+      before do
+        allow(service).to receive(:created_by).and_return(current_user.id)
+      end
+
+      it 'allows access' do
+        request
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context 'when not the service creator or admin user' do
+      it 'does not allow access' do
+        expect(request).to redirect_to(expected_unauthorised_path)
+      end
+    end
+  end
+
+  context 'editing a service' do
+    it_behaves_like 'an authorisation action' do
+      let(:request) { get "/services/#{service.service_id}/edit" }
+    end
+  end
+
+  context 'editing a page' do
+    it_behaves_like 'an authorisation action' do
+      let(:request) do
+        get "/services/#{service.service_id}/pages/#{service.start_page.uuid}/edit"
+      end
+    end
+  end
+
+  context 'editing a branch' do
+    it_behaves_like 'an authorisation action' do
+      let(:branch) { service.branches.first }
+      let(:request) do
+        get "/services/#{service.service_id}/branches/#{branch.uuid}/edit"
+      end
+    end
+  end
+
+  context 'visiting the publishing page' do
+    it_behaves_like 'an authorisation action' do
+      let(:request) { get "/services/#{service.service_id}/publish" }
+    end
+  end
+
+  context 'visiting the settings page' do
+    it_behaves_like 'an authorisation action' do
+      let(:request) { get "/services/#{service.service_id}/settings" }
+    end
+  end
+
+  context 'previewing a form' do
+    it_behaves_like 'an authorisation action' do
+      let(:request) { get "/services/#{service.service_id}/preview" }
+      let(:expected_unauthorised_path) { 'http://www.example.com/unauthorised' }
+    end
+  end
+end

--- a/spec/requests/preview_spec.rb
+++ b/spec/requests/preview_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe 'GET /services/:service_id/preview' do
   let(:request) { get "/services/#{service.service_id}/preview" }
-  context 'when not authenticated' do
+  let(:current_user) { double(id: service.created_by, email: 'peter.quill@milano.com') }
+
+  context 'when user is not signed in' do
     before { request }
 
     it 'redirects to root path' do
@@ -8,7 +10,7 @@ RSpec.describe 'GET /services/:service_id/preview' do
     end
   end
 
-  context 'when authenticated' do
+  context 'when user is signed in' do
     before do
       allow_any_instance_of(
         PermissionsController
@@ -16,9 +18,7 @@ RSpec.describe 'GET /services/:service_id/preview' do
       expect_any_instance_of(
         ApplicationController
       ).to receive(:service).at_least(:once).and_return(service)
-      allow_any_instance_of(
-        ApplicationController
-      ).to receive(:current_user).and_return(double(id: '1'))
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
       request
     end
 

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe 'Settings' do
   let(:current_user) do
     double(id: SecureRandom.uuid)
   end
+  let(:current_user) { double(id: service.created_by, email: 'bishop@sulaco.com') }
+
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
+  end
 
   describe 'POST /services/:id/settings/form_information' do
     before do


### PR DESCRIPTION
Currently the Editor has two types of users:

- Form creators
- Admin users

These are the only users that should be able to access forms, pages,
branches and to be able to preview forms.

In addition admin users are the only ones that should have access to the
admin dashboard, but should retain access to the other parts of the
Editor no matter who created the form.

We skip checking for specific user authorisation on the all forms page
as there are no specific services involved.

The API endpoints need a bit more work. Some of the API Controllers
inherit from the main apps BranchesController as it is used to setup
some branch parameters. This does mean that the authorisation behaviour
is a little different. For the main app we want to show an unauthorised
page. However for the API endpoints we would want to respond with a
standard unauthorised status.

For this particular PR the endpoints are already requiring that a user
is logged in. Only the Move endpoint affects any metadata and this will
we addressed in another PR.

For the remainder of the API endpoints we will revisit the authorisation
in a different PR as it will be a fairly large restructuring.

<img width="893" alt="Screenshot 2022-04-21 at 10 48 53" src="https://user-images.githubusercontent.com/3466862/164429110-f893f6db-29b6-46fe-8a85-b58916bf0441.png">

