### PR TITLE
Fix activated menu voiceover labels

### DIFF
--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -103,7 +103,7 @@ class EditorApp < SitePrism::Page
   def unconnected_flow
     find('#main-content', visible: true)
     flow = detached_flow.map { |element| element.text.gsub("Edit:\n", '').split("\n") }
-    flow.flatten.uniq.reject { |f| f == I18n.t('pages.create') }
+    flow.flatten.uniq.reject { |f| f == I18n.t('pages.create') || f == '+' }
   end
 
   def flow_thumbnail(title)

--- a/app/javascript/src/components/menus/activated_menu.js
+++ b/app/javascript/src/components/menus/activated_menu.js
@@ -18,7 +18,9 @@
  *                       ActivatedMenuActivator.  If none is provided, an element
  *                       will be created and inserted.
  *  - activator_classname (string) class(es) to be added to the created activator
- *  - activator_text (string) accessible label for the created activator element
+ *  - activator_text (string) accessible (visually-hidden) label for the created activator element
+ *  - activator_icon (string) the icon for the activator button, will be hidden
+ *                            from screen-readers
  *  - container_id (string) an HTML id attribute to be applied to the generated
  *                          ActivatedMenuContainer element.  If none is provided 
  *                          a unique id will be generated.
@@ -341,6 +343,7 @@ class ActivatedMenu {
       this.#setMenuOpenPosition();
     }
   }
+
 
   /*
    * Removes any position values that have occurred as a result of

--- a/app/javascript/src/components/menus/activated_menu_activator.js
+++ b/app/javascript/src/components/menus/activated_menu_activator.js
@@ -35,9 +35,13 @@ class ActivatedMenuActivator {
     this.#config = config;
     this.#className = "ActivatedMenuActivator";
     this.menu = menu;
+    
+    if(!this.#config.hasOwnProperty('activator_icon')) {
+      this.#config['activator_icon'] = '...';//'...';
+    }
+    
     this.$node = this.#insertNode($node);
     this.$node.data("instance", this);
-    
     this.#addAttributes();
     this.#bindEventHandlers();
   }
@@ -64,10 +68,12 @@ class ActivatedMenuActivator {
   #createNode() {
       const $node = $(
         createElement("button", 
-                      this.#config.activator_text, 
+                      undefined, 
                       this.#config.activator_classname
         )
       );
+      $node.append('<span class="ActivatedMenuActivator__icon" aria-hidden="true">'+this.#config.activator_icon+'</span>');
+      $node.append('<span class="govuk-visually-hidden">'+this.#config.activator_text+'</span>');
       return $node;
   }
 

--- a/app/javascript/src/components/menus/connection_menu.js
+++ b/app/javascript/src/components/menus/connection_menu.js
@@ -11,7 +11,8 @@ class ConnectionMenu extends ActivatedMenu {
     super($node, mergeObjects({
       activator_classname: $node.data("activator-classname"),
       container_id: $node.data("activated-menu-container-id"),
-      activator_text: $node.data("activator-text")
+      activator_text: $node.data("activator-text"),
+      activator_icon: $node.data("activator-icon")
     }, config));
 
     // Register event handler for selection of menu item.

--- a/app/javascript/styles/_component_activated_menu.scss
+++ b/app/javascript/styles/_component_activated_menu.scss
@@ -20,21 +20,21 @@
 
 .ActivatedMenuActivator {
   @include icon_button;
+  text-indent: 0;
 
-  &:after {
-    content: "...";
-    display: block;
+  &__icon {
+    position: relative;
+    display:inline-block;
+    top: -5px;
+    left: 1px;
+    width: 100%;
+    text-align: center;
     font-weight: bold;
     letter-spacing: 2px;
-    left: 1px;
-    position: relative;
-    text-indent: 0;
-    top: -27px;
   }
 }
 
 .ActivatedMenu {
-
 
   a, span {
     @include button_type_link;

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -642,6 +642,35 @@ html {
   opacity: 1;
 }
 
+.flow-condition {
+  @include list_reset;
+  margin: 0 100px 0 0;
+  padding: 0 25px;
+  text-align: center;
+  width: 300px;
+  
+  .flow-expressions {
+    a, span {
+      @include govuk-font($size: 16);
+
+      color: $govuk-secondary-text-colour;
+      display: inline;
+      position: static;
+      width: auto;
+    }
+
+   .operator {
+      color: $govuk-secondary-text-colour;
+      font-weight: bold;
+    }
+
+    .condition-operator {
+      text-transform: uppercase;
+      font-weight: bold;
+    } 
+  }
+}
+
 .ConnectionMenuActivator {
   display: inline-block;
   left: calc(100% + 10px);
@@ -654,39 +683,10 @@ html {
     left: calc(100% - 24px);
     top: -17px;
   }
-  
-  &:after {
-    content: "\271A";
-    top: -22px;
-    font-weight: normal;
+
+  .ActivatedMenuActivator__icon {
+    top: 0;
   }
-}
-
-.flow-condition {
-  @include list_reset;
-  margin: 0 100px 0 0;
-  padding: 0 25px;
-  text-align: center;
-  width: 300px;
-
-  a, span {
-    @include govuk-font($size: 16);
-
-    color: $govuk-secondary-text-colour;
-    display: inline;
-    position: static;
-    width: auto;
-  }
-
- .operator {
-    color: $govuk-secondary-text-colour;
-    font-weight: bold;
-  }
-
-  .condition-operator {
-    text-transform: uppercase;
-    font-weight: bold;
-  } 
 }
 
 .flow-conditions {

--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -1,4 +1,5 @@
 <ul class="govuk-navigation component-activated-menu"
+    data-activator-icon="+"
     data-activator-text="<%= t('pages.create') %>"
     data-activator-classname="<%= item[:type] == 'flow.branch' ? 'branch-' : '' -%>connection-menu-activator"
     data-component="ConnectionMenu"

--- a/test/component_activated_content_menu_test.js
+++ b/test/component_activated_content_menu_test.js
@@ -320,7 +320,7 @@ describe("ContentMenu", function() {
       expect(content.menu.config).to.exist;
       expect(content.menu.config.activator_text).to.exist;
       expect(content.menu.config.activator_text).to.equal(ACTIVATOR_TEXT);
-      expect(content.menu.activator.$node.text()).to.equal(ACTIVATOR_TEXT);
+      expect(content.menu.activator.$node.children().last().text()).to.equal(ACTIVATOR_TEXT);
     });
 
     it("should apply config.activator_classname to any created activator", function() {

--- a/test/component_activated_menu_test.js
+++ b/test/component_activated_menu_test.js
@@ -13,12 +13,13 @@ describe("ActivatedMenu", function() {
   const TEST_SELECTION_ELEMENT_ID = "component-activated-menu-test-selection-event-element";
   const TEST_SELECTION_EVENT_NAME = "ActivatedMenuTestSelectionEventName";
   var menu;
+  var $ul;
 
   before(function() {
     // jQuery is present in document because the
     // components use it so we can use it here.
 
-    var $ul = $(`<ul>
+    $ul = $(`<ul>
                    <li>
                      <span>Item 1a</span>
                      <ul>
@@ -274,6 +275,7 @@ describe("ActivatedMenu", function() {
   describe("ActivatedMenuActivator (created)", function() {
     const ACTIVATOR_CLASSNAME = "activated-menu-created-activator-classname";
     const ACTIVATOR_TEXT = "activated menu text here";
+    const ACTIVATOR_ICON = "...";
     var menu_creating_activator;
 
     before(function() {
@@ -314,7 +316,24 @@ describe("ActivatedMenu", function() {
       expect(menu_creating_activator.config.activator_text).to.exist;
       expect(typeof menu_creating_activator.config.activator_text).to.equal("string");
       expect(menu_creating_activator.config.activator_text).to.equal(ACTIVATOR_TEXT);
-      expect(menu_creating_activator.activator.$node.text()).to.equal(ACTIVATOR_TEXT);
+      expect(menu_creating_activator.activator.$node.children().last().text()).to.equal(ACTIVATOR_TEXT);
+    });
+
+    it("should use default icon when none passed in", function() {
+      expect(menu_creating_activator.config.activator_icon).to.exist;
+      expect(menu_creating_activator.config.activator_icon).to.equal(ACTIVATOR_ICON);
+      expect(menu_creating_activator.activator.$node.children().first().text()).to.equal(ACTIVATOR_ICON);
+    });
+    it("should use custom icon when passed in", function() {
+      var menu_creating_activator = new ActivatedMenu ($ul, {
+        activator_classname: ACTIVATOR_CLASSNAME,
+        activator_text: ACTIVATOR_TEXT,
+        activator_icon: "+",
+      });
+      expect(menu_creating_activator.config.activator_icon).to.exist;
+      expect(menu_creating_activator.config.activator_icon).to.equal('+');
+      expect(menu_creating_activator.activator.$node.children().first().text()).to.equal('+');
+
     });
 
     it("should apply config.activator_classname to any created activator", function() {

--- a/test/component_activated_question_menu_test.js
+++ b/test/component_activated_question_menu_test.js
@@ -316,7 +316,7 @@ describe("QuestionMenu", function() {
       expect(menu.config).to.exist;
       expect(menu.config.activator_text).to.exist;
       expect(menu.config.activator_text).to.equal(ACTIVATOR_TEXT);
-      expect(menu.activator.$node.text()).to.equal(ACTIVATOR_TEXT);
+      expect(menu.activator.$node.children().last().text()).to.equal(ACTIVATOR_TEXT);
     });
 
     it("should apply config.activator_classname to any created activator", function() {


### PR DESCRIPTION
This is an update / improvement on the previous version of this fix.

The prior attempt at this fix went for the 'easy' option of simply replacing the '+' icon on the connection menu with a UTF-8 symbol that didn't get read out by a screenreader.  However the result was tbh a bit ugly.

So this PR does it properly!

We switch from using a `::after` with generated content, to using a `span` with `aria-hidden="true"` along with wrapping the main label text in a span that is visually hidden.

This is a more robust solution (i.e. it is more guaranteed to work across other screenreading software than just MacOS voiceover) and it also means we can continue with the same visual appearance as before.

Previous Fix:
![image](https://user-images.githubusercontent.com/595564/164468871-1e5c3b0d-c0e3-4e35-85b9-28087451d77e.png)

New Approach:
![image](https://user-images.githubusercontent.com/595564/164468924-3123a8f1-cd59-4df1-886a-b3c4206a35d4.png)

