### PR TITLE
use svg for activated menu activator icons

### DIFF
--- a/app/javascript/images/plus-black.svg
+++ b/app/javascript/images/plus-black.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <line x1="10" y1="16" x2="22" y2="16" stroke="#0b0c0c" stroke-width="2.5"/>
+    <line x1="16" y1="22" x2="16" y2="10" stroke="#0b0c0c" stroke-width="2.5"/>
+</svg>

--- a/app/javascript/images/plus-black.svg
+++ b/app/javascript/images/plus-black.svg
@@ -1,4 +1,3 @@
-<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    <line x1="10" y1="16" x2="22" y2="16" stroke="#0b0c0c" stroke-width="2.5"/>
-    <line x1="16" y1="22" x2="16" y2="10" stroke="#0b0c0c" stroke-width="2.5"/>
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M 14.75 22 L 14.75 17.25 L 10 17.25 L 10 14.75 L 14.75 14.75 L 14.75 10 L 17.25 10 L 17.25 14.75 L 22 14.75 L 22 17.25 L 17.25 17.25 L 17.25 22 Z" fill="#0b0c0c"/>
 </svg>

--- a/app/javascript/images/plus-blue.svg
+++ b/app/javascript/images/plus-blue.svg
@@ -1,4 +1,3 @@
-<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    <line x1="10" y1="16" x2="22" y2="16" stroke="#1d70b8" stroke-width="2.5"/>
-    <line x1="16" y1="22" x2="16" y2="10" stroke="#1d70b8" stroke-width="2.5"/>
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M 14.75 22 L 14.75 17.25 L 10 17.25 L 10 14.75 L 14.75 14.75 L 14.75 10 L 17.25 10 L 17.25 14.75 L 22 14.75 L 22 17.25 L 17.25 17.25 L 17.25 22 Z" fill="#1d70b8"/>
 </svg>

--- a/app/javascript/images/plus-blue.svg
+++ b/app/javascript/images/plus-blue.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <line x1="10" y1="16" x2="22" y2="16" stroke="#1d70b8" stroke-width="2.5"/>
+    <line x1="16" y1="22" x2="16" y2="10" stroke="#1d70b8" stroke-width="2.5"/>
+</svg>

--- a/app/javascript/images/plus-white.svg
+++ b/app/javascript/images/plus-white.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <line x1="10" y1="16" x2="22" y2="16" stroke="#ffffff" stroke-width="2.5"/>
+    <line x1="16" y1="22" x2="16" y2="10" stroke="#ffffff" stroke-width="2.5"/>
+</svg>

--- a/app/javascript/images/plus-white.svg
+++ b/app/javascript/images/plus-white.svg
@@ -1,4 +1,3 @@
-<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    <line x1="10" y1="16" x2="22" y2="16" stroke="#ffffff" stroke-width="2.5"/>
-    <line x1="16" y1="22" x2="16" y2="10" stroke="#ffffff" stroke-width="2.5"/>
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M 14.75 22 L 14.75 17.25 L 10 17.25 L 10 14.75 L 14.75 14.75 L 14.75 10 L 17.25 10 L 17.25 14.75 L 22 14.75 L 22 17.25 L 17.25 17.25 L 17.25 22 Z" fill="#ffffff"/>
 </svg>

--- a/app/javascript/images/plus.svg
+++ b/app/javascript/images/plus.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <line x1="9" y1="16" x2="23" y2="16" stroke="currentColor" stroke-width="2"/>
+    <line x1="16" y1="23" x2="16" y2="9" stroke="currentColor" stroke-width="2"/>
+</svg>

--- a/app/javascript/images/three-dots-black.svg
+++ b/app/javascript/images/three-dots-black.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="8" cy="16.5" r="2" fill="#0b0c0c"/>
+    <circle cx="16" cy="16.5" r="2" fill="#0b0c0c"/>
+    <circle cx="24" cy="16.5" r="2" fill="#0b0c0c"/>
+</svg>

--- a/app/javascript/images/three-dots-blue.svg
+++ b/app/javascript/images/three-dots-blue.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="8" cy="16.5" r="2" fill="#1d70b8"/>
+    <circle cx="16" cy="16.5" r="2" fill="#1d70b8"/>
+    <circle cx="24" cy="16.5" r="2" fill="#1d70b8"/>
+</svg>

--- a/app/javascript/images/three-dots-white.svg
+++ b/app/javascript/images/three-dots-white.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="8" cy="16.5" r="2" fill="#ffffff"/>
+    <circle cx="16" cy="16.5" r="2" fill="#ffffff"/>
+    <circle cx="24" cy="16.5" r="2" fill="#ffffff"/>
+</svg>

--- a/app/javascript/images/three-dots.svg
+++ b/app/javascript/images/three-dots.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="8.5" cy="16.5" r="2.5" fill="currentColor"/>
+    <circle cx="16.5" cy="16.5" r="2.5" fill="currentColor"/>
+    <circle cx="24.5" cy="16.5" r="2.5" fill="currentColor"/>
+</svg>

--- a/app/javascript/styles/_component_activated_menu.scss
+++ b/app/javascript/styles/_component_activated_menu.scss
@@ -21,21 +21,28 @@
 .ActivatedMenuActivator {
   @include icon_button;
 
-  &:after {
-    content: "...";
+  &::after {
+    content: url('../images/three-dots-blue.svg');
     display: block;
+    position: absolute;
     font-weight: bold;
-    letter-spacing: 2px;
-    left: 1px;
-    position: relative;
+    top: -1px;
+    left: 0;
+    right: 0;
+    bottom: 0; 
     text-indent: 0;
-    top: -27px;
+  }
+
+  &:hover::after {
+    content: url('../images/three-dots-white.svg');
+  }
+
+  &:focus::after {
+    content: url('../images/three-dots-black.svg');
   }
 }
 
 .ActivatedMenu {
-
-
   a, span {
     @include button_type_link;
     border: none;

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -645,7 +645,6 @@ html {
 .ConnectionMenuActivator {
   display: inline-block;
   left: calc(100% + 10px);
-  // opacity: 0;
   overflow: hidden;
   position: absolute;
   top: 46px;
@@ -657,6 +656,7 @@ html {
   
   &::after {
     content: url('../images/plus-blue.svg');
+    top: 0;
   }
   &:hover::after {
     content: url('../images/plus-white.svg');

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -655,10 +655,14 @@ html {
     top: -17px;
   }
   
-  &:after {
-    content: "\271A";
-    top: -22px;
-    font-weight: normal;
+  &::after {
+    content: url('../images/plus-blue.svg');
+  }
+  &:hover::after {
+    content: url('../images/plus-white.svg');
+  }
+  &:focus::after {
+    content:url('../images/plus-black.svg')
   }
 }
 

--- a/app/javascript/styles/_mixins.scss
+++ b/app/javascript/styles/_mixins.scss
@@ -85,16 +85,18 @@
   text-indent: -10000px;
   width: 35px;
 
+  &:hover {
+    border-color: $govuk-link-colour;
+    outline: none;
+  }
+
   &:focus {
     @include focus;
     border-color: $govuk-focus-colour;
     outline: none;
   }
 
-  &:hover {
-    border-color: $govuk-link-colour;
-    outline: none;
-  }
+
 
   &.destructive:focus,
   &.destructive:hover {

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -8,6 +8,11 @@ environment.plugins.prepend('Provide',
   })
 );
 
+// resolve-url-loader must be used before sass-loader
+environment.loaders.get('sass').use.splice(-1, 0, {
+  loader: 'resolve-url-loader'
+});
+
 const aliasConfig = { 'jquery': 'jquery/src/jquery', 'jquery-ui': 'jquery-ui-dist/jquery-ui.js' };
 environment.config.set('resolve.alias', aliasConfig);
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "govuk-frontend": "^3.14.0",
     "jquery": "^3.6.0",
     "jquery-ui-dist": "^1.13.1",
+    "resolve-url-loader": "^5.0.0",
     "showdown": "^2.0.3",
     "tabbable": "^5.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,6 +1253,14 @@ acorn@^8.5.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
+adjust-sourcemap-loader@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/adjust-sourcemap-loader/-/adjust-sourcemap-loader-4.0.0.tgz#fc4a0fd080f7d10471f30a7320f25560ade28c99"
+  integrity sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==
+  dependencies:
+    loader-utils "^2.0.0"
+    regex-parser "^2.2.11"
+
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -4230,6 +4238,11 @@ nanoid@3.3.1:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
   integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
 
+nanoid@^3.3.1:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -5302,6 +5315,15 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
+postcss@^8.2.14:
+  version "8.4.12"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.12.tgz#1e7de78733b28970fa4743f7da6f3763648b1905"
+  integrity sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==
+  dependencies:
+    nanoid "^3.3.1"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -5504,6 +5526,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regex-parser@^2.2.11:
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.11.tgz#3b37ec9049e19479806e878cabe7c1ca83ccfe58"
+  integrity sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==
+
 regexpu-core@^4.7.1:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.8.0.tgz#e5605ba361b67b1718478501327502f4479a98f0"
@@ -5577,6 +5604,17 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve-url-loader@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz#ee3142fb1f1e0d9db9524d539cfa166e9314f795"
+  integrity sha512-uZtduh8/8srhBoMx//5bwqjQ+rfYOUq8zC9NrMUGtjBiGTtFJM42s58/36+hTqeqINcnYe08Nj3LkK9lW4N8Xg==
+  dependencies:
+    adjust-sourcemap-loader "^4.0.0"
+    convert-source-map "^1.7.0"
+    loader-utils "^2.0.0"
+    postcss "^8.2.14"
+    source-map "0.6.1"
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -5865,7 +5903,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-"source-map-js@>=0.6.2 <2.0.0":
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
@@ -5894,15 +5932,15 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
   integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
 
+source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
-
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 source-map@~0.7.2:
   version "0.7.3"


### PR DESCRIPTION
Third time lucky 🤞

Approach to manu activator labels that does not rely on either css generated 'text' content - which could be read out by screen reader (or potentially announced as 'unpronouncable'!) and also do not place any presentational code in the JS component.

Use SVGs as the generated content - From what I've read these will not be announced by screen readers as they are not 'text' content.  This is allowable under WCAG as this comes under 'decorative' content, and we are providing an accessible label that is announced.

The only slightly sad thing in here is that due to the way CSS genrated content is treated we can't use currentColor in the SVG to pick up on the color changes on interaction, so we've had to rely on 3 SVGs for each one.

![image](https://user-images.githubusercontent.com/595564/164663286-f6daae15-241a-49f3-b5c1-cb6c50302a51.png)


