### PR TITLE
Update acceptance tests to use fixtures

### DIFF
--- a/acceptance/features/add_page_in_the_middle_flow_spec.rb
+++ b/acceptance/features/add_page_in_the_middle_flow_spec.rb
@@ -20,7 +20,7 @@ feature 'Add page in the middle flow' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
   end
 
   scenario 'adding page after first page and before last page' do

--- a/acceptance/features/change_destination_spec.rb
+++ b/acceptance/features/change_destination_spec.rb
@@ -6,8 +6,7 @@ feature 'Deleting page' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
-    given_I_have_a_form_with_pages
+    given_I_have_a_service_fixture(fixture: 'two_branching_points_fixture')
   end
 
   scenario 'change destination to another page' do

--- a/acceptance/features/default_text_spec.rb
+++ b/acceptance/features/default_text_spec.rb
@@ -14,7 +14,7 @@ feature 'Default text' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
   end
 
   scenario 'Text component with default text' do

--- a/acceptance/features/delete_cya_confirmation_pages_spec.rb
+++ b/acceptance/features/delete_cya_confirmation_pages_spec.rb
@@ -9,7 +9,7 @@ feature 'Delete cya confirmation pages' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
   end
 
   scenario 'when deleting CYA page' do

--- a/acceptance/features/deleting_page_spec.rb
+++ b/acceptance/features/deleting_page_spec.rb
@@ -10,7 +10,7 @@ feature 'Deleting page' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'two_branching_points_fixture')
   end
 
   scenario 'when deleting other pages' do
@@ -23,21 +23,18 @@ feature 'Deleting page' do
   end
 
   scenario 'when try to delete a page which has a branching conditional' do
-    given_I_have_a_form_with_pages
     when_I_try_to_delete_a_page_which_has_a_branching_conditional
     sleep 0.5 # Allow time for the page to reload after deleting the page
     then_I_should_see_a_message_that_is_not_possible_to_delete_the_page
   end
 
   scenario 'when try to delete a page which result with a stack branch' do
-    given_I_have_a_form_with_pages
     when_I_try_to_delete_a_page_which_result_in_a_stack_branch
     sleep 0.5 # Allow time for the page to reload after deleting the page
     then_I_should_see_a_message_that_is_not_possible_to_create_stack_branches
   end
 
   scenario 'when deleting a branch destination with a default next' do
-    given_I_have_a_form_with_pages
     and_I_want_to_delete_a_branch_destination_page
     when_I_delete_the_branch_destination_page
     sleep 0.5 # Allow time for the page to reload after deleting the page
@@ -46,7 +43,6 @@ feature 'Deleting page' do
   end
 
   scenario 'when deleting a branch destination with no default next' do
-    given_I_have_a_form_with_pages
     given_I_add_an_exit_page
     and_I_update_the_exit_page_question
     and_I_return_to_flow_page
@@ -57,7 +53,6 @@ feature 'Deleting page' do
   end
 
   scenario 'when deleting a branch' do
-    given_I_have_a_form_with_pages
     and_I_click_to_delete_branching_point_one
     and_I_choose_page_c_to_connect_the_forms
     when_I_delete_the_branching_point
@@ -158,7 +153,7 @@ feature 'Deleting page' do
     when_I_save_my_changes
   end
 
-  def then_I_should_see_the_delete_page_no_default_next_modal  
+  def then_I_should_see_the_delete_page_no_default_next_modal
     expect(page.find('.ui-dialog').text).to include(
       I18n.t(
         'pages.delete_modal.delete_branch_destination_page_no_default_next_message'

--- a/acceptance/features/edit_branch_error_summaries_spec.rb
+++ b/acceptance/features/edit_branch_error_summaries_spec.rb
@@ -8,12 +8,10 @@ feature 'Branching errors' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'no_branches_fixture')
   end
 
   scenario 'when no required fields are filled in' do
-    given_I_add_all_pages_for_a_form_with_branching
-    and_I_return_to_flow_page
     and_I_want_to_add_branching(page_url)
 
     when_I_save_my_changes
@@ -24,8 +22,6 @@ feature 'Branching errors' do
   end
 
   scenario 'when the "Go to" field is not filled in' do
-    given_I_add_all_pages_for_a_form_with_branching
-    and_I_return_to_flow_page
     and_I_want_to_add_branching(page_url)
 
     and_I_select_the_condition_dropdown
@@ -72,8 +68,6 @@ feature 'Branching errors' do
   end
 
   scenario 'when there are two conditional objects to a branching point' do
-    given_I_add_all_pages_for_a_form_with_branching
-    and_I_return_to_flow_page
     and_I_want_to_add_branching(page_url)
 
     and_I_want_to_add_another_conditional

--- a/acceptance/features/edit_branch_page_spec.rb
+++ b/acceptance/features/edit_branch_page_spec.rb
@@ -7,12 +7,10 @@ feature 'New branch page' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'no_branches_fixture')
   end
 
   scenario 'when editing the branch page' do
-    given_I_add_all_pages_for_a_form_with_branching
-    and_I_return_to_flow_page
     and_I_want_to_add_branching(page_url)
 
     then_I_should_see_the_branch_title(index: 0, title: 'Branch 1')
@@ -97,10 +95,10 @@ feature 'New branch page' do
     )
 
     then_I_should_see_the_field_option(
-      'branch[conditionals_attributes][0][expressions_attributes][0][field]', 
+      'branch[conditionals_attributes][0][expressions_attributes][0][field]',
       'Hiking'
     )
-    
+
     and_I_choose_an_option(
       'branch[conditionals_attributes][0][expressions_attributes][0][field]',
       'Sewing'
@@ -108,9 +106,9 @@ feature 'New branch page' do
 
     when_I_save_my_changes
     then_I_should_see_the_previous_page_title('What is your favourite hobby?')
-     
+
     then_I_should_see_the_field_option(
-      'branch[conditionals_attributes][0][expressions_attributes][0][field]', 
+      'branch[conditionals_attributes][0][expressions_attributes][0][field]',
       'Hiking'
     )
 
@@ -118,9 +116,6 @@ feature 'New branch page' do
   end
 
   scenario 'when editing with unconnected pages' do
-    given_I_add_all_pages_for_a_form_with_branching
-    and_I_return_to_flow_page
-
     and_I_want_to_add_branching(page_url)
 
     then_I_should_see_the_branch_title(index: 0, title: 'Branch 1')

--- a/acceptance/features/edit_check_answers_page_spec.rb
+++ b/acceptance/features/edit_check_answers_page_spec.rb
@@ -22,7 +22,7 @@ feature 'Edit check your answers page' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
   end
 
   scenario 'editing page info' do

--- a/acceptance/features/edit_confirmation_page_spec.rb
+++ b/acceptance/features/edit_confirmation_page_spec.rb
@@ -9,7 +9,7 @@ feature 'Edit confirmation pages' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
   end
 
   scenario 'updates all fields' do

--- a/acceptance/features/edit_exit_page_spec.rb
+++ b/acceptance/features/edit_exit_page_spec.rb
@@ -17,7 +17,7 @@ feature 'Edit exit pages' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
     and_I_add_a_content_page('Content Page')
   end
 

--- a/acceptance/features/edit_multiple_questions_page_spec.rb
+++ b/acceptance/features/edit_multiple_questions_page_spec.rb
@@ -4,7 +4,7 @@ feature 'Edit multiple questions page' do
   let(:editor) { EditorApp.new }
   let(:service_name) { generate_service_name }
   let(:url) { 'hakuna-matata' }
-  let(:page_heading) { 'Star wars questions' }
+  let(:page_heading) { 'Hakuna Matata' }
   let(:text_component_question) do
     'C-3P0 is fluent in how many languages?'
   end
@@ -33,76 +33,82 @@ feature 'Edit multiple questions page' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: fixture)
   end
 
-  scenario 'adding and updating components' do
-    given_I_have_a_multiple_questions_page
-    and_I_add_the_component(I18n.t('components.list.text'))
-    and_I_add_the_component(I18n.t('components.list.textarea'))
-    and_I_add_the_component(I18n.t('components.list.email'))
-    and_I_add_the_component(I18n.t('components.list.radios'))
-    and_I_add_the_component(I18n.t('components.list.checkboxes'))
-    and_I_update_the_components
-    when_I_save_my_changes
-    and_I_return_to_flow_page
-    preview_form = and_I_preview_the_form
-    then_I_can_answer_the_questions_in_the_page(preview_form)
+  context 'editing multiple questions page' do
+    let(:fixture) { 'multiple_questions_page_fixture' }
+
+    scenario 'adding and updating components' do
+      and_I_edit_the_page(url: page_heading)
+      and_I_add_the_component(I18n.t('components.list.text'))
+      and_I_add_the_component(I18n.t('components.list.textarea'))
+      and_I_add_the_component(I18n.t('components.list.email'))
+      and_I_add_the_component(I18n.t('components.list.radios'))
+      and_I_add_the_component(I18n.t('components.list.checkboxes'))
+      and_I_update_the_components
+      when_I_save_my_changes
+      and_I_return_to_flow_page
+      preview_form = and_I_preview_the_form
+      then_I_can_answer_the_questions_in_the_page(preview_form)
+    end
+
+    scenario 'deleting a text component' do
+      and_I_edit_the_page(url: page_heading)
+      and_I_add_the_component(I18n.t('components.list.text'))
+      and_I_add_the_component(I18n.t('components.list.textarea'))
+      and_I_change_the_text_component(text_component_question)
+      when_I_save_my_changes
+      when_I_want_to_select_component_properties('h2', text_component_question)
+      and_I_want_to_delete_a_component(text_component_question)
+      when_I_save_my_changes
+      and_the_component_is_deleted(text_component_question, remaining: 1)
+    end
+
+    scenario 'deleting an email component' do
+      and_I_edit_the_page(url: page_heading)
+      and_I_add_the_component(I18n.t('components.list.text'))
+      and_I_add_the_component(I18n.t('components.list.textarea'))
+      and_I_add_the_component(I18n.t('components.list.email'))
+      and_I_change_the_email_component(email_component_question)
+      when_I_save_my_changes
+      when_I_want_to_select_component_properties('h2', email_component_question)
+      and_I_want_to_delete_a_component(email_component_question)
+      when_I_save_my_changes
+      and_the_component_is_deleted(email_component_question, remaining: 2)
+    end
+
+    scenario 'deleting content components' do
+      and_I_edit_the_page(url: page_heading)
+      then_I_add_a_content_component(
+        content: content_component
+      )
+      when_I_save_my_changes
+      then_I_should_see_my_content(content_component)
+
+      when_I_want_to_select_component_properties('.output', content_component)
+      and_I_want_to_delete_a_content_component
+      when_I_save_my_changes
+      then_I_should_not_see_my_content(content_component)
+    end
   end
 
-  scenario 'deleting a text component' do
-    given_I_have_a_multiple_questions_page
-    and_I_add_the_component(I18n.t('components.list.text'))
-    and_I_add_the_component(I18n.t('components.list.textarea'))
-    and_I_change_the_text_component(text_component_question)
-    when_I_save_my_changes
-    when_I_want_to_select_component_properties('h2', text_component_question)
-    and_I_want_to_delete_a_component(text_component_question)
-    when_I_save_my_changes
-    and_the_component_is_deleted(text_component_question, remaining: 1)
-  end
+  context 'a form with branches' do
+    let(:fixture) { 'two_branching_points_fixture' }
 
-  scenario 'deleting an email component' do
-    given_I_have_a_multiple_questions_page
-    and_I_add_the_component(I18n.t('components.list.text'))
-    and_I_add_the_component(I18n.t('components.list.textarea'))
-    and_I_add_the_component(I18n.t('components.list.email'))
-    and_I_change_the_email_component(email_component_question)
-    when_I_save_my_changes
-    when_I_want_to_select_component_properties('h2', email_component_question)
-    and_I_want_to_delete_a_component(email_component_question)
-    when_I_save_my_changes
-    and_the_component_is_deleted(email_component_question, remaining: 2)
-  end
+    scenario 'deleting a component not used for branching' do
+      and_I_edit_the_page(url: 'Page g')
+      when_I_want_to_select_component_properties('h2', 'Question 1')
+      and_I_want_to_delete_a_component('Question 1')
+      and_the_component_is_deleted('Question 1', remaining: 1)
+    end
 
-  scenario 'deleting content components' do
-    given_I_have_a_multiple_questions_page
-    then_I_add_a_content_component(
-      content: content_component
-    )
-    when_I_save_my_changes
-    then_I_should_see_my_content(content_component)
-
-    when_I_want_to_select_component_properties('.output', content_component)
-    and_I_want_to_delete_a_content_component
-    when_I_save_my_changes
-    then_I_should_not_see_my_content(content_component)
-  end
-
-  scenario 'deleting a component not used for branching' do
-    given_I_have_a_form_with_pages
-    and_I_edit_the_page(url: 'Page g')
-    when_I_want_to_select_component_properties('h2', 'Question 1')
-    and_I_want_to_delete_a_component('Question 1')
-    and_the_component_is_deleted('Question 1', remaining: 1)
-  end
-
-  scenario 'deleting a component used for branching' do
-    given_I_have_a_form_with_pages
-    and_I_edit_the_page(url: 'Page g')
-    when_I_want_to_select_component_properties('h2', 'Question 2')
-    and_I_want_to_delete_a_branching_component('Question 2')
-    and_the_component_is_not_deleted('Question 2', remaining: 2)
+    scenario 'deleting a component used for branching' do
+      and_I_edit_the_page(url: 'Page g')
+      when_I_want_to_select_component_properties('h2', 'Question 2')
+      and_I_want_to_delete_a_branching_component('Question 2')
+      and_the_component_is_not_deleted('Question 2', remaining: 2)
+    end
   end
 
   def then_I_add_a_content_component(content:)

--- a/acceptance/features/edit_single_checkboxes_question_page_spec.rb
+++ b/acceptance/features/edit_single_checkboxes_question_page_spec.rb
@@ -5,6 +5,7 @@ feature 'Edit single radios question page' do
   let(:editor) { EditorApp.new }
   let(:service_name) { generate_service_name }
   let(:page_url) { 'star-wars-question' }
+  let(:pre_edit_title) { 'Star Wars Question' }
   let(:question) do
     'Which program do Jedi use to open PDF files?'
   end
@@ -22,59 +23,66 @@ feature 'Edit single radios question page' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: fixture)
   end
 
-  scenario 'when editing the checkbox component' do
-    given_I_have_a_single_question_page_with_checkboxes
-    and_I_have_optional_section_heading_text
-    when_I_update_the_question_name
-    and_I_update_the_options
-    when_I_update_the_optional_section_heading
-    when_I_delete_the_optional_section_heading_text
-    and_I_return_to_flow_page
-    preview_form = then_I_should_see_my_changes_on_preview
-    and_I_should_see_the_options_that_I_added(preview_form, initial_options)
+  context 'editing checkbox components' do
+    let(:fixture) { 'checkboxes_page_fixture' }
+
+    scenario 'when editing the checkbox component' do
+      and_I_edit_the_page(url: pre_edit_title)
+      and_I_have_optional_section_heading_text
+      when_I_update_the_question_name
+      and_I_update_the_options
+      when_I_update_the_optional_section_heading
+      when_I_delete_the_optional_section_heading_text
+      and_I_return_to_flow_page
+      preview_form = then_I_should_see_my_changes_on_preview
+      and_I_should_see_the_options_that_I_added(preview_form, initial_options)
+    end
+
+    scenario 'when adding an option to the checkbox component' do
+      and_I_edit_the_page(url: pre_edit_title)
+      when_I_update_the_question_name
+      and_I_update_the_options
+      and_I_add_an_option('Jar Jar Binks')
+      then_I_should_see_the_options(initial_options.push('Jar Jar Binks'))
+      and_I_return_to_flow_page
+      preview_form = then_I_should_see_my_changes_on_preview
+      and_I_should_see_the_options_that_I_added(preview_form, options_after_addition)
+    end
+
+    scenario 'when deleting an option from the checkbox component' do
+      and_I_edit_the_page(url: pre_edit_title)
+      when_I_update_the_question_name
+      and_I_update_the_options
+      and_I_delete_an_option('PDFinn')
+      and_I_want_to_delete_an_option('Adobe-wan Kenobi')
+      then_I_should_see_the_modal(
+        I18n.t('question_items.delete_modal.can_not_delete_heading'),
+        I18n.t('question_items.min_items_modal.can_not_delete_checkboxes_message')
+      )
+      and_I_close_the_modal(I18n.t('dialogs.button_understood'))
+      and_I_add_an_option('Jar Jar Binks')
+      then_I_should_see_the_options(options_after_addition)
+      and_I_delete_an_option('Jar Jar Binks')
+      then_I_should_see_the_options(options_after_deletion)
+      and_I_return_to_flow_page
+      preview_form = then_I_should_see_my_changes_on_preview
+      and_I_should_see_the_options_that_I_added(preview_form, options_after_deletion)
+    end
   end
 
-  scenario 'when adding an option to the checkbox component' do
-    given_I_have_a_single_question_page_with_checkboxes
-    when_I_update_the_question_name
-    and_I_update_the_options
-    and_I_add_an_option('Jar Jar Binks')
-    then_I_should_see_the_options(initial_options.push('Jar Jar Binks'))
-    and_I_return_to_flow_page
-    preview_form = then_I_should_see_my_changes_on_preview
-    and_I_should_see_the_options_that_I_added(preview_form, options_after_addition)
-  end
+  context 'editing options with branching form' do
+    let(:fixture) { 'two_branching_points_fixture' }
 
-  scenario 'when deleting an option from the checkbox component' do
-    given_I_have_a_single_question_page_with_checkboxes
-    when_I_update_the_question_name
-    and_I_update_the_options
-    and_I_delete_an_option('PDFinn')
-    and_I_want_to_delete_an_option('Adobe-wan Kenobi')
-    then_I_should_see_the_modal(
-      I18n.t('question_items.delete_modal.can_not_delete_heading'),
-      I18n.t('question_items.min_items_modal.can_not_delete_checkboxes_message')
-    )
-    and_I_close_the_modal(I18n.t('dialogs.button_understood'))
-    and_I_add_an_option('Jar Jar Binks')
-    then_I_should_see_the_options(options_after_addition)
-    and_I_delete_an_option('Jar Jar Binks')
-    then_I_should_see_the_options(options_after_deletion)
-    and_I_return_to_flow_page
-    preview_form = then_I_should_see_my_changes_on_preview
-    and_I_should_see_the_options_that_I_added(preview_form, options_after_deletion)
-  end
-
-  scenario 'when deleting an option used for branching' do
-    given_I_have_a_form_with_pages
-    and_I_edit_the_page(url: 'Page b')
-    when_I_want_to_select_component_properties('label', 'Hulk')
-    page.find('span', text: I18n.t('question.menu.remove')).click
-    expect(page).to have_selector('.ui-dialog')
-    expect(page.text).to include(I18n.t('question_items.delete_modal.can_not_delete_heading')) 
+    scenario 'when deleting an option used for branching' do
+      and_I_edit_the_page(url: 'Page b')
+      when_I_want_to_select_component_properties('label', 'Hulk')
+      page.find('span', text: I18n.t('question.menu.remove')).click
+      expect(page).to have_selector('.ui-dialog')
+      expect(page.text).to include(I18n.t('question_items.delete_modal.can_not_delete_heading'))
+    end
   end
 
   def given_I_have_a_single_question_page_with_checkboxes
@@ -99,7 +107,7 @@ feature 'Edit single radios question page' do
     and_I_edit_the_question
     when_I_save_my_changes
   end
-  
+
   def and_I_edit_the_question
     editor.question_heading.first.set(question)
   end

--- a/acceptance/features/edit_single_question_page_spec.rb
+++ b/acceptance/features/edit_single_question_page_spec.rb
@@ -15,7 +15,7 @@ feature 'Edit single question page' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
   end
 
   scenario 'when editing text component' do

--- a/acceptance/features/edit_single_radios_question_page_spec.rb
+++ b/acceptance/features/edit_single_radios_question_page_spec.rb
@@ -4,6 +4,7 @@ feature 'Edit single radios question page' do
   let(:editor) { EditorApp.new }
   let(:service_name) { generate_service_name }
   let(:page_url) { 'star-wars-question' }
+  let(:pre_edit_title) { 'Star Wars Question' }
   let(:question) do
     'Which program do Jedi use to open PDF files?'
   end
@@ -21,11 +22,11 @@ feature 'Edit single radios question page' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'radios_page_fixture')
   end
 
   scenario 'when editing the radio component' do
-    given_I_have_a_single_question_page_with_radio
+    and_I_edit_the_page(url: pre_edit_title)
     and_I_have_optional_section_heading_text
     when_I_update_the_question_name
     and_I_update_the_options
@@ -37,7 +38,7 @@ feature 'Edit single radios question page' do
   end
 
   scenario 'when adding an option to the radio component' do
-    given_I_have_a_single_question_page_with_radio
+    and_I_edit_the_page(url: pre_edit_title)
     when_I_update_the_question_name
     and_I_update_the_options
     and_I_add_an_option('Jar Jar Binks')
@@ -48,7 +49,7 @@ feature 'Edit single radios question page' do
   end
 
   scenario 'when deleting an option from the radio component' do
-    given_I_have_a_single_question_page_with_radio
+    and_I_edit_the_page(url: pre_edit_title)
     when_I_update_the_question_name
     and_I_update_the_options
     and_I_want_to_delete_an_option('Adobe-wan Kenobi')
@@ -83,7 +84,7 @@ feature 'Edit single radios question page' do
     and_I_edit_the_question
     when_I_save_my_changes
   end
-  
+
   def and_I_edit_the_question
     editor.question_heading.first.set(question)
   end

--- a/acceptance/features/editing_standalone_page_spec.rb
+++ b/acceptance/features/editing_standalone_page_spec.rb
@@ -7,7 +7,7 @@ feature 'Edit standalone pages' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
   end
 
   scenario 'editing footer standalone pages' do

--- a/acceptance/features/mark_questions_as_optional_spec.rb
+++ b/acceptance/features/mark_questions_as_optional_spec.rb
@@ -6,7 +6,7 @@ feature 'Mark question as optional' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
   end
 
   scenario 'change required fields to optional' do

--- a/acceptance/features/new_branch_page_spec.rb
+++ b/acceptance/features/new_branch_page_spec.rb
@@ -7,12 +7,10 @@ feature 'New branch page' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'no_branches_fixture')
   end
 
   scenario 'when all required fields are filled in' do
-    given_I_add_all_pages_for_a_form_with_branching
-    and_I_return_to_flow_page
     and_I_want_to_add_branching(page_url)
 
     then_I_should_be_on_the_correct_branch_page('new')

--- a/acceptance/features/preview_a_page_spec.rb
+++ b/acceptance/features/preview_a_page_spec.rb
@@ -8,7 +8,7 @@ feature 'Preview page' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
   end
 
   scenario 'preview start page' do

--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -24,11 +24,10 @@ feature 'Preview form' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'preview_form_fixture')
   end
 
   scenario 'preview the whole form' do
-    given_I_add_all_pages_for_a_form
     preview_form = when_I_preview_the_form
     then_I_can_navigate_until_the_end_of_the_form(preview_form)
   end
@@ -46,61 +45,6 @@ feature 'Preview form' do
       page.find_link('Cookies').click
       expect(page.find('h1').text).to eq('Cookies')
     end
-  end
-
-  def given_I_add_all_pages_for_a_form
-    given_I_add_a_single_question_page_with_text
-    and_I_add_a_page_url('name')
-    when_I_add_the_page
-    when_I_update_the_question_name('Full name')
-    and_I_return_to_flow_page
-
-    given_I_add_a_multiple_question_page
-    and_I_add_a_page_url('multi')
-    when_I_add_the_page
-    and_I_change_the_page_heading(multiple_page_heading)
-    and_I_add_the_component(I18n.t('components.list.text'))
-    and_I_change_the_text_component(text_component_question)
-    when_I_update_the_question_name('Multiple Question page')
-    and_I_add_a_multiple_page_content_component(content: content_component)
-    and_I_add_the_component(I18n.t('components.list.textarea'))
-    and_I_change_the_textarea_component(textarea_component_question, component: 2)
-    when_I_save_my_changes
-    and_I_return_to_flow_page
-
-    given_I_add_a_content_page
-    and_I_add_a_page_url('content-page')
-    when_I_add_the_page
-    and_I_change_the_page_heading(content_page_heading)
-    when_I_save_my_changes
-    and_I_return_to_flow_page
-
-    given_I_add_a_single_question_page_with_date
-    and_I_add_a_page_url('date-of-birth')
-    when_I_add_the_page
-    when_I_update_the_question_name('Date of birth')
-    and_I_return_to_flow_page
-
-    given_I_add_a_single_question_page_with_checkboxes
-    and_I_add_a_page_url('favourite-fruit')
-    when_I_add_the_page
-    when_I_update_the_question_name('What is your favourite fruit?')
-    and_I_edit_the_option_items
-    and_I_make_the_question_optional
-    and_I_return_to_flow_page
-
-    given_I_add_a_single_question_page_with_upload
-    and_I_add_a_page_url('file-upload')
-    when_I_add_the_page
-    when_I_update_the_question_name('Upload your file')
-    and_I_make_the_question_optional
-    and_I_return_to_flow_page
-
-    given_I_add_a_single_question_page_with_email
-    and_I_add_a_page_url('email')
-    when_I_add_the_page
-    when_I_update_the_question_name('Email address')
-    and_I_return_to_flow_page
   end
 
   def and_I_add_a_multiple_page_content_component(content:)

--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -11,7 +11,7 @@ feature 'Branching errors' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service
+    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
   end
 
   scenario 'when visiting the publishing page with submitting pages present' do

--- a/acceptance/fixtures/checkboxes_page_fixture.json
+++ b/acceptance/fixtures/checkboxes_page_fixture.json
@@ -1,0 +1,180 @@
+{
+  "_id": "service.base",
+  "flow": {
+    "349c97e1-40a7-4be4-a90d-1edd1273f53b": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "6bf197b1-32c4-4e4c-88a0-5f99ce8755f9": {
+      "next": {
+        "default": "349c97e1-40a7-4be4-a90d-1edd1273f53b"
+      },
+      "_type": "flow.page"
+    },
+    "aeb6d3d7-c796-4355-b3e2-67c57bab78f9": {
+      "next": {
+        "default": "bb048201-29e6-4145-b1b5-bad32e329276"
+      },
+      "_type": "flow.page"
+    },
+    "bb048201-29e6-4145-b1b5-bad32e329276": {
+      "next": {
+        "default": "6bf197b1-32c4-4e4c-88a0-5f99ce8755f9"
+      },
+      "_type": "flow.page"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "_type": "page.start",
+      "_uuid": "aeb6d3d7-c796-4355-b3e2-67c57bab78f9",
+      "heading": "Service name goes here",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
+    },
+    {
+      "_id": "page.star-wars-question",
+      "url": "star-wars-question",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "bb048201-29e6-4145-b1b5-bad32e329276",
+      "heading": "",
+      "components": [
+        {
+          "_id": "star-wars-question_checkboxes_1",
+          "hint": "",
+          "name": "star-wars-question_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "dbe8b8ef-2c96-455c-9889-8c223d9898df",
+          "items": [
+            {
+              "_id": "star-wars-question_checkboxes_1_item_1",
+              "hint": "",
+              "_type": "checkbox",
+              "_uuid": "063727cb-0b61-4516-90ad-37ec64560b74",
+              "label": "Option",
+              "value": "value-1"
+            },
+            {
+              "_id": "star-wars-question_checkboxes_1_item_2",
+              "hint": "",
+              "_type": "checkbox",
+              "_uuid": "0905ed25-656b-4d61-ba96-b68010091180",
+              "label": "Option",
+              "value": "value-2"
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Star Wars Question",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.checkanswers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "6bf197b1-32c4-4e4c-88a0-5f99ce8755f9",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+
+      ],
+      "send_heading": "Now send your application",
+      "extra_components": [
+
+      ]
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "form-sent",
+      "_type": "page.confirmation",
+      "_uuid": "349c97e1-40a7-4be4-a90d-1edd1273f53b",
+      "heading": "Application complete",
+      "components": [
+
+      ]
+    }
+  ],
+  "locale": "en",
+  "created_at": "2022-04-25T13:09:03Z",
+  "created_by": "47a4e5d7-92ad-464c-b01a-e3bd0a1ee454",
+  "service_id": "ca7b2d85-a2c7-4cec-a528-a51b2531fb14",
+  "version_id": "b4089161-9ff8-401f-b8cc-3ba658c19b35",
+  "service_name": "Acceptance-test-Stormtrooper-FN-d9738695-33e1-484c-9af9-5476db0aea73",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "/cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "/privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "/accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "Cookies body",
+      "_type": "page.standalone",
+      "_uuid": "8974e6b9-b53e-452d-b4d4-2b5bbfb9f383",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "Privacy body",
+      "_type": "page.standalone",
+      "_uuid": "950f83e2-fec9-4251-ad29-1220e68250d1",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "Acessibility body",
+      "_type": "page.standalone",
+      "_uuid": "2d5fca2b-b790-488b-b34d-6366cfd1aebc",
+      "heading": "Accessibility statement",
+      "components": [
+
+      ]
+    }
+  ]
+}

--- a/acceptance/fixtures/default_new_service_fixture.json
+++ b/acceptance/fixtures/default_new_service_fixture.json
@@ -1,0 +1,131 @@
+{
+  "_id": "service.base",
+  "flow": {
+    "349c97e1-40a7-4be4-a90d-1edd1273f53b": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "6bf197b1-32c4-4e4c-88a0-5f99ce8755f9": {
+      "next": {
+        "default": "349c97e1-40a7-4be4-a90d-1edd1273f53b"
+      },
+      "_type": "flow.page"
+    },
+    "aeb6d3d7-c796-4355-b3e2-67c57bab78f9": {
+      "next": {
+        "default": "6bf197b1-32c4-4e4c-88a0-5f99ce8755f9"
+      },
+      "_type": "flow.page"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "_type": "page.start",
+      "_uuid": "aeb6d3d7-c796-4355-b3e2-67c57bab78f9",
+      "heading": "Service name goes here",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
+    },
+    {
+      "_id": "page.checkanswers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "6bf197b1-32c4-4e4c-88a0-5f99ce8755f9",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+
+      ],
+      "send_heading": "Now send your application",
+      "extra_components": [
+
+      ]
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "form-sent",
+      "_type": "page.confirmation",
+      "_uuid": "349c97e1-40a7-4be4-a90d-1edd1273f53b",
+      "heading": "Application complete",
+      "components": [
+
+      ]
+    }
+  ],
+  "locale": "en",
+  "created_by": "",
+  "service_name": "",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "/cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "/privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "/accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "Cookies body",
+      "_type": "page.standalone",
+      "_uuid": "8974e6b9-b53e-452d-b4d4-2b5bbfb9f383",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "Privacy body",
+      "_type": "page.standalone",
+      "_uuid": "950f83e2-fec9-4251-ad29-1220e68250d1",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "Acessibility body",
+      "_type": "page.standalone",
+      "_uuid": "2d5fca2b-b790-488b-b34d-6366cfd1aebc",
+      "heading": "Accessibility statement",
+      "components": [
+
+      ]
+    }
+  ],
+  "service_id": "",
+  "created_at": "",
+  "version_id": ""
+}

--- a/acceptance/fixtures/multiple_questions_page_fixture.json
+++ b/acceptance/fixtures/multiple_questions_page_fixture.json
@@ -1,0 +1,148 @@
+{
+  "_id": "service.base",
+  "flow": {
+    "6f442b2c-da71-4731-a569-2178223b17de": {
+      "next": {
+        "default": "e97612ff-d05a-45e0-9860-54bb0db79878"
+      },
+      "_type": "flow.page"
+    },
+    "74ed8ba0-48c4-45bf-9690-0d49a03774a3": {
+      "next": {
+        "default": "6f442b2c-da71-4731-a569-2178223b17de"
+      },
+      "_type": "flow.page"
+    },
+    "e97612ff-d05a-45e0-9860-54bb0db79878": {
+      "next": {
+        "default": "f4545064-4278-4533-a282-e153c25f89f5"
+      },
+      "_type": "flow.page"
+    },
+    "f4545064-4278-4533-a282-e153c25f89f5": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "_type": "page.start",
+      "_uuid": "74ed8ba0-48c4-45bf-9690-0d49a03774a3",
+      "heading": "Service name goes here",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
+    },
+    {
+      "_id": "page.hakuna-matata",
+      "url": "hakuna-matata",
+      "_type": "page.multiplequestions",
+      "_uuid": "6f442b2c-da71-4731-a569-2178223b17de",
+      "heading": "Hakuna Matata",
+      "components": [
+
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.checkanswers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "e97612ff-d05a-45e0-9860-54bb0db79878",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+
+      ],
+      "send_heading": "Now send your application",
+      "extra_components": [
+
+      ]
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "form-sent",
+      "_type": "page.confirmation",
+      "_uuid": "f4545064-4278-4533-a282-e153c25f89f5",
+      "heading": "Application complete",
+      "components": [
+
+      ]
+    }
+  ],
+  "locale": "en",
+  "created_at": "",
+  "created_by": "",
+  "service_id": "",
+  "version_id": "",
+  "service_name": "",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "/cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "/privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "/accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "Cookies body",
+      "_type": "page.standalone",
+      "_uuid": "a0b4fe7e-2d34-4d31-97ee-2faf753309df",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "Privacy body",
+      "_type": "page.standalone",
+      "_uuid": "0ed96d27-6cd5-4181-98b6-1cdf5fc60236",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "Accessibility body",
+      "_type": "page.standalone",
+      "_uuid": "d568386d-4842-4497-85e4-560b378e2fb2",
+      "heading": "Accessibility statement",
+      "components": [
+
+      ]
+    }
+  ]
+}

--- a/acceptance/fixtures/no_branches_fixture.json
+++ b/acceptance/fixtures/no_branches_fixture.json
@@ -1,0 +1,327 @@
+{
+  "_id": "service.base",
+  "flow": {
+    "2786aa9d-c171-487e-9a73-b3a1b4850bbf": {
+      "next": {
+        "default": "d1670c23-f84c-4cbd-b5fb-a3a9bbbae89f"
+      },
+      "_type": "flow.page"
+    },
+    "295b5b20-3cd2-431f-9d59-bedf4a1f9a03": {
+      "next": {
+        "default": "ad3e07f7-98d1-46e7-8286-d4f33bf43f33"
+      },
+      "_type": "flow.page"
+    },
+    "4964090f-1c1f-43e5-8cc8-e40eef2a6c56": {
+      "next": {
+        "default": "295b5b20-3cd2-431f-9d59-bedf4a1f9a03"
+      },
+      "_type": "flow.page"
+    },
+    "9b0f43c5-3fc2-446d-99e1-83a51f942a77": {
+      "next": {
+        "default": "f8477c4c-2163-4cec-804c-96410ca8847d"
+      },
+      "_type": "flow.page"
+    },
+    "ad3e07f7-98d1-46e7-8286-d4f33bf43f33": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "d1670c23-f84c-4cbd-b5fb-a3a9bbbae89f": {
+      "next": {
+        "default": "4964090f-1c1f-43e5-8cc8-e40eef2a6c56"
+      },
+      "_type": "flow.page"
+    },
+    "f8477c4c-2163-4cec-804c-96410ca8847d": {
+      "next": {
+        "default": "2786aa9d-c171-487e-9a73-b3a1b4850bbf"
+      },
+      "_type": "flow.page"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "_type": "page.start",
+      "_uuid": "9b0f43c5-3fc2-446d-99e1-83a51f942a77",
+      "heading": "Service name goes here",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
+    },
+    {
+      "_id": "page.favourite-hobby",
+      "url": "favourite-hobby",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "f8477c4c-2163-4cec-804c-96410ca8847d",
+      "heading": "",
+      "components": [
+        {
+          "_id": "favourite-hobby_radios_1",
+          "hint": "",
+          "name": "favourite-hobby_radios_1",
+          "_type": "radios",
+          "_uuid": "ccc99e9c-ad9f-4727-a1aa-cf774b71ad1c",
+          "items": [
+            {
+              "_id": "favourite-hobby_radios_1_item_1",
+              "hint": "",
+              "name": "favourite-hobby_radios_1",
+              "_type": "radio",
+              "_uuid": "69f6fd64-608f-4502-8b7e-879afeda762c",
+              "label": "Hiking",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "favourite-hobby_radios_1_item_2",
+              "hint": "",
+              "name": "favourite-hobby_radios_1",
+              "_type": "radio",
+              "_uuid": "3c72168e-6e61-41f1-9c63-c15e22a15a08",
+              "label": "Sewing",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "What is your favourite hobby?",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.ice-cream",
+      "url": "ice-cream",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "2786aa9d-c171-487e-9a73-b3a1b4850bbf",
+      "heading": "",
+      "components": [
+        {
+          "_id": "ice-cream_checkboxes_1",
+          "hint": "",
+          "name": "ice-cream_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "e587d254-c787-4550-8a11-2a74a7f8a258",
+          "items": [
+            {
+              "_id": "ice-cream_checkboxes_1_item_1",
+              "hint": "",
+              "name": "ice-cream_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "7bbe7e60-49ff-4329-bbf6-e5a8793a9621",
+              "label": "Hokey Pokey",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "ice-cream_checkboxes_1_item_2",
+              "hint": "",
+              "name": "ice-cream_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "1d64c6a4-3cd9-419c-b4d2-01c41f6ba4b8",
+              "label": "Chocolate",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Which flavours of ice cream have you eaten?",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.hiking",
+      "url": "hiking",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "d1670c23-f84c-4cbd-b5fb-a3a9bbbae89f",
+      "heading": "",
+      "components": [
+        {
+          "_id": "hiking_text_1",
+          "hint": "",
+          "name": "hiking_text_1",
+          "_type": "text",
+          "_uuid": "f79b477d-377e-4759-acd0-34c0197a0320",
+          "label": "Favourite hiking destination",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.sewing",
+      "url": "sewing",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "4964090f-1c1f-43e5-8cc8-e40eef2a6c56",
+      "heading": "",
+      "components": [
+        {
+          "_id": "sewing_text_1",
+          "hint": "",
+          "name": "sewing_text_1",
+          "_type": "text",
+          "_uuid": "c4856d81-f229-4d78-884a-70f440992c9a",
+          "label": "Favourite sewing project",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.checkanswers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "295b5b20-3cd2-431f-9d59-bedf4a1f9a03",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+
+      ],
+      "send_heading": "Now send your application",
+      "extra_components": [
+
+      ]
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "form-sent",
+      "_type": "page.confirmation",
+      "_uuid": "ad3e07f7-98d1-46e7-8286-d4f33bf43f33",
+      "heading": "Application complete",
+      "components": [
+
+      ]
+    }
+  ],
+  "locale": "en",
+  "created_at": "",
+  "created_by": "",
+  "service_id": "",
+  "version_id": "",
+  "service_name": "",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "/cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "/privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "/accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "Cookies body",
+      "_type": "page.standalone",
+      "_uuid": "64914834-9898-458b-ad60-49b36cbc02dc",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "Privacy body",
+      "_type": "page.standalone",
+      "_uuid": "af6c8197-b1b4-4b19-89a9-5934dc75cbbe",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "Accessibility body",
+      "_type": "page.standalone",
+      "_uuid": "c1a0f3ac-0041-4617-aa88-a3411907752c",
+      "heading": "Accessibility statement",
+      "components": [
+
+      ]
+    }
+  ]
+}

--- a/acceptance/fixtures/preview_form_fixture.json
+++ b/acceptance/fixtures/preview_form_fixture.json
@@ -1,0 +1,417 @@
+{
+  "_id": "service.base",
+  "flow": {
+    "1fca2fa7-2a2b-413b-bc72-f3d4ec1c6acb": {
+      "next": {
+        "default": "32b2cf60-340d-4d70-9274-a9fe02175f4d"
+      },
+      "_type": "flow.page"
+    },
+    "2321bae5-233d-4379-9e8c-734307333342": {
+      "next": {
+        "default": "a913ee92-2c0f-4df2-b84e-63ba76651c57"
+      },
+      "_type": "flow.page"
+    },
+    "32b2cf60-340d-4d70-9274-a9fe02175f4d": {
+      "next": {
+        "default": "e22bde01-0d6e-4cef-86eb-1b0062e38277"
+      },
+      "_type": "flow.page"
+    },
+    "349c97e1-40a7-4be4-a90d-1edd1273f53b": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "6bf197b1-32c4-4e4c-88a0-5f99ce8755f9": {
+      "next": {
+        "default": "349c97e1-40a7-4be4-a90d-1edd1273f53b"
+      },
+      "_type": "flow.page"
+    },
+    "a913ee92-2c0f-4df2-b84e-63ba76651c57": {
+      "next": {
+        "default": "ce8fcba6-25e8-4731-a99e-994f8a10081f"
+      },
+      "_type": "flow.page"
+    },
+    "aeb6d3d7-c796-4355-b3e2-67c57bab78f9": {
+      "next": {
+        "default": "c2a2dac3-f05e-405f-ac4b-93bced45583a"
+      },
+      "_type": "flow.page"
+    },
+    "c2a2dac3-f05e-405f-ac4b-93bced45583a": {
+      "next": {
+        "default": "2321bae5-233d-4379-9e8c-734307333342"
+      },
+      "_type": "flow.page"
+    },
+    "ce8fcba6-25e8-4731-a99e-994f8a10081f": {
+      "next": {
+        "default": "1fca2fa7-2a2b-413b-bc72-f3d4ec1c6acb"
+      },
+      "_type": "flow.page"
+    },
+    "e22bde01-0d6e-4cef-86eb-1b0062e38277": {
+      "next": {
+        "default": "6bf197b1-32c4-4e4c-88a0-5f99ce8755f9"
+      },
+      "_type": "flow.page"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "_type": "page.start",
+      "_uuid": "aeb6d3d7-c796-4355-b3e2-67c57bab78f9",
+      "heading": "Service name goes here",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
+    },
+    {
+      "_id": "page.name",
+      "url": "name",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "c2a2dac3-f05e-405f-ac4b-93bced45583a",
+      "heading": "",
+      "components": [
+        {
+          "_id": "name_text_1",
+          "hint": "",
+          "name": "name_text_1",
+          "_type": "text",
+          "_uuid": "6cc74d7e-2f5c-4d14-9bff-800f867a2723",
+          "label": "Full name",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.multi",
+      "url": "multi",
+      "_type": "page.multiplequestions",
+      "_uuid": "2321bae5-233d-4379-9e8c-734307333342",
+      "heading": "Multiple Question page",
+      "components": [
+        {
+          "_id": "multi_text_1",
+          "hint": "",
+          "name": "multi_text_1",
+          "_type": "text",
+          "_uuid": "44fc7a83-5523-4fc1-a70f-d1f81d235047",
+          "label": "What is the name of the Gungan who became a taxi driver?",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "_id": "multi_content_1",
+          "name": "multi_content_1",
+          "_type": "content",
+          "_uuid": "8841f9a3-c5d8-40b5-86d1-9708b59f347d",
+          "content": "I am a doctor not a doorstop\n\n",
+          "collection": "components"
+        },
+        {
+          "_id": "multi_textarea_1",
+          "hint": "",
+          "name": "multi_textarea_1",
+          "rows": 5,
+          "_type": "textarea",
+          "_uuid": "5c2a106a-e694-4dae-a5d0-693f6f456847",
+          "label": "What droid always takes the long way around?",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "add_component": "textarea",
+      "section_heading": ""
+    },
+    {
+      "_id": "page.content-page",
+      "url": "content-page",
+      "body": "",
+      "lede": "",
+      "_type": "page.content",
+      "_uuid": "a913ee92-2c0f-4df2-b84e-63ba76651c57",
+      "heading": "There is no bathroom",
+      "components": [
+
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.date-of-birth",
+      "url": "date-of-birth",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "ce8fcba6-25e8-4731-a99e-994f8a10081f",
+      "heading": "",
+      "components": [
+        {
+          "_id": "date-of-birth_date_1",
+          "hint": "",
+          "name": "date-of-birth_date_1",
+          "_type": "date",
+          "_uuid": "d5a4ad35-761e-426e-8d02-0d757f3e2e1d",
+          "errors": {
+          },
+          "legend": "Date of birth",
+          "date_type": "day-month-year",
+          "collection": "components",
+          "validation": {
+            "date": true,
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.favourite-fruit",
+      "url": "favourite-fruit",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "1fca2fa7-2a2b-413b-bc72-f3d4ec1c6acb",
+      "heading": "",
+      "components": [
+        {
+          "_id": "favourite-fruit_checkboxes_1",
+          "hint": "",
+          "name": "favourite-fruit_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "0d148e7c-09a0-465b-9c72-0b21073f286c",
+          "items": [
+            {
+              "_id": "favourite-fruit_checkboxes_1_item_1",
+              "hint": "",
+              "name": "favourite-fruit_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "4f622add-8144-431e-bd0d-6dbdea4aac07",
+              "label": "Apples",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "favourite-fruit_checkboxes_1_item_2",
+              "hint": "",
+              "name": "favourite-fruit_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "8a2e350c-ca87-45a7-812a-19f51df1a56e",
+              "label": "Oranges",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "What is your favourite fruit? (Optional)",
+          "collection": "components",
+          "validation": {
+            "required": false
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.file-upload",
+      "url": "file-upload",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "32b2cf60-340d-4d70-9274-a9fe02175f4d",
+      "heading": "",
+      "components": [
+        {
+          "_id": "file-upload_upload_1",
+          "hint": "[Optional hint text]",
+          "name": "file-upload_upload_1",
+          "_type": "upload",
+          "_uuid": "1ada6580-9ee5-4d58-9d86-f5cdb913743e",
+          "label": "Upload your file (Optional)",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "accept": [
+              "text/csv",
+              "text/plain",
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+              "application/msword",
+              "application/vnd.oasis.opendocument.spreadsheet",
+              "application/vnd.oasis.opendocument.text",
+              "application/pdf",
+              "application/rtf",
+              "image/jpeg",
+              "image/png",
+              "application/vnd.ms-excel"
+            ],
+            "max_size": "7340032",
+            "required": false,
+            "virus_scan": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.email",
+      "url": "email",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "e22bde01-0d6e-4cef-86eb-1b0062e38277",
+      "heading": "",
+      "components": [
+        {
+          "_id": "email_email_1",
+          "hint": "",
+          "name": "email_email_1",
+          "_type": "email",
+          "_uuid": "b250e4f3-02b7-43ba-8e65-2064e8b841cd",
+          "label": "Email address",
+          "errors": {
+          },
+          "collection": "components",
+          "validation": {
+            "email": true,
+            "required": true,
+            "max_length": 256
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.checkanswers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "6bf197b1-32c4-4e4c-88a0-5f99ce8755f9",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+
+      ],
+      "send_heading": "Now send your application",
+      "extra_components": [
+
+      ]
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "form-sent",
+      "_type": "page.confirmation",
+      "_uuid": "349c97e1-40a7-4be4-a90d-1edd1273f53b",
+      "heading": "Application complete",
+      "components": [
+
+      ]
+    }
+  ],
+  "locale": "en",
+  "created_at": "2022-04-25T13:51:25Z",
+  "created_by": "47a4e5d7-92ad-464c-b01a-e3bd0a1ee454",
+  "service_id": "21152909-fbfc-4e1a-96da-ab8f7f2e808a",
+  "version_id": "f13687bf-1296-4b99-a34d-b2c375f848fb",
+  "service_name": "Acceptance-test-Stormtrooper-FN-3003aab9-9c86-494d-934a-64226eee2af1",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "/cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "/privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "/accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "Cookies body",
+      "_type": "page.standalone",
+      "_uuid": "8974e6b9-b53e-452d-b4d4-2b5bbfb9f383",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "Privacy body",
+      "_type": "page.standalone",
+      "_uuid": "950f83e2-fec9-4251-ad29-1220e68250d1",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "Acessibility body",
+      "_type": "page.standalone",
+      "_uuid": "2d5fca2b-b790-488b-b34d-6366cfd1aebc",
+      "heading": "Accessibility statement",
+      "components": [
+
+      ]
+    }
+  ]
+}

--- a/acceptance/fixtures/radios_page_fixture.json
+++ b/acceptance/fixtures/radios_page_fixture.json
@@ -1,0 +1,180 @@
+{
+  "_id": "service.base",
+  "flow": {
+    "349c97e1-40a7-4be4-a90d-1edd1273f53b": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "6bf197b1-32c4-4e4c-88a0-5f99ce8755f9": {
+      "next": {
+        "default": "349c97e1-40a7-4be4-a90d-1edd1273f53b"
+      },
+      "_type": "flow.page"
+    },
+    "8e508063-671e-4f87-804c-70eff4c40b72": {
+      "next": {
+        "default": "6bf197b1-32c4-4e4c-88a0-5f99ce8755f9"
+      },
+      "_type": "flow.page"
+    },
+    "aeb6d3d7-c796-4355-b3e2-67c57bab78f9": {
+      "next": {
+        "default": "8e508063-671e-4f87-804c-70eff4c40b72"
+      },
+      "_type": "flow.page"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "_type": "page.start",
+      "_uuid": "aeb6d3d7-c796-4355-b3e2-67c57bab78f9",
+      "heading": "Service name goes here",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
+    },
+    {
+      "_id": "page.star-wars-question",
+      "url": "star-wars-question",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "8e508063-671e-4f87-804c-70eff4c40b72",
+      "heading": "",
+      "components": [
+        {
+          "_id": "star-wars-question_radios_1",
+          "hint": "",
+          "name": "star-wars-question_radios_1",
+          "_type": "radios",
+          "_uuid": "ccade4c5-73d3-4d90-bde6-29d8e63ef61d",
+          "items": [
+            {
+              "_id": "star-wars-question_radios_1_item_1",
+              "hint": "",
+              "_type": "radio",
+              "_uuid": "8717fa10-e234-4e21-a25f-abd30e86eef8",
+              "label": "Option",
+              "value": "value-1"
+            },
+            {
+              "_id": "star-wars-question_radios_1_item_2",
+              "hint": "",
+              "_type": "radio",
+              "_uuid": "2994727a-e34b-4327-bcf9-120d33430349",
+              "label": "Option",
+              "value": "value-2"
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Star Wars Question",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.checkanswers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "6bf197b1-32c4-4e4c-88a0-5f99ce8755f9",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+
+      ],
+      "send_heading": "Now send your application",
+      "extra_components": [
+
+      ]
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "form-sent",
+      "_type": "page.confirmation",
+      "_uuid": "349c97e1-40a7-4be4-a90d-1edd1273f53b",
+      "heading": "Application complete",
+      "components": [
+
+      ]
+    }
+  ],
+  "locale": "en",
+  "created_at": "2022-04-25T13:44:30Z",
+  "created_by": "47a4e5d7-92ad-464c-b01a-e3bd0a1ee454",
+  "service_id": "6a61ef72-c86c-4767-8bd9-8bc67a5b251e",
+  "version_id": "2cd3a5b1-e595-4057-a8a0-a73e73c579b0",
+  "service_name": "Acceptance-test-Stormtrooper-FN-1b437d11-ddaf-426d-879d-627449b6aa3c",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "/cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "/privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "/accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "Cookies body",
+      "_type": "page.standalone",
+      "_uuid": "8974e6b9-b53e-452d-b4d4-2b5bbfb9f383",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "Privacy body",
+      "_type": "page.standalone",
+      "_uuid": "950f83e2-fec9-4251-ad29-1220e68250d1",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "Acessibility body",
+      "_type": "page.standalone",
+      "_uuid": "2d5fca2b-b790-488b-b34d-6366cfd1aebc",
+      "heading": "Accessibility statement",
+      "components": [
+
+      ]
+    }
+  ]
+}

--- a/acceptance/fixtures/two_branching_points_fixture.json
+++ b/acceptance/fixtures/two_branching_points_fixture.json
@@ -1,0 +1,829 @@
+{
+  "_id": "service.base",
+  "flow": {
+    "0af66d05-25ab-40fa-8e21-4bbcc1437ee7": {
+      "next": {
+        "default": "f565e703-1301-4cc0-b110-85cb04577b3f"
+      },
+      "_type": "flow.page"
+    },
+    "179eef69-a9a3-41de-9619-86035a02b898": {
+      "next": {
+        "default": "a5c6ac7e-413e-491e-aa85-aef65e0ad05b"
+      },
+      "_type": "flow.page"
+    },
+    "1a11a560-b803-45a3-af04-ac1e6e01fe22": {
+      "next": {
+        "default": "0af66d05-25ab-40fa-8e21-4bbcc1437ee7",
+        "conditionals": [
+          {
+            "next": "84515c81-5819-44bd-a533-bb36a75e1652",
+            "_type": "if",
+            "_uuid": "0b1bab50-8a34-4e71-9011-a1ff40f6bed3",
+            "expressions": [
+              {
+                "page": "58df5afb-a118-4e19-be7f-f826f975ea85",
+                "field": "d4c5e6fa-8c08-4270-a125-3d2453b1a589",
+                "operator": "contains",
+                "component": "b9169fcf-f5dd-44e7-a8a4-e007616cd406"
+              }
+            ]
+          },
+          {
+            "next": "b2049bca-ac2e-476c-9e74-198e0452123e",
+            "_type": "if",
+            "_uuid": "f3e05087-c8f2-4fe1-9d81-2137252981e1",
+            "expressions": [
+              {
+                "page": "58df5afb-a118-4e19-be7f-f826f975ea85",
+                "field": "843d6bd5-a67d-41e5-9390-20817e21eae8",
+                "operator": "contains",
+                "component": "b9169fcf-f5dd-44e7-a8a4-e007616cd406"
+              }
+            ]
+          }
+        ]
+      },
+      "_type": "flow.branch",
+      "title": "Branching point 1"
+    },
+    "3616ac86-ab5b-413f-a81c-56e978ddb729": {
+      "next": {
+        "default": "b2049bca-ac2e-476c-9e74-198e0452123e"
+      },
+      "_type": "flow.page"
+    },
+    "4c6c06a0-fdef-4057-b8b1-09714774fa65": {
+      "next": {
+        "default": "179eef69-a9a3-41de-9619-86035a02b898"
+      },
+      "_type": "flow.page"
+    },
+    "58df5afb-a118-4e19-be7f-f826f975ea85": {
+      "next": {
+        "default": "1a11a560-b803-45a3-af04-ac1e6e01fe22"
+      },
+      "_type": "flow.page"
+    },
+    "7328667a-e564-48c8-b68e-cea91bb65907": {
+      "next": {
+        "default": "58df5afb-a118-4e19-be7f-f826f975ea85"
+      },
+      "_type": "flow.page"
+    },
+    "84515c81-5819-44bd-a533-bb36a75e1652": {
+      "next": {
+        "default": "3616ac86-ab5b-413f-a81c-56e978ddb729"
+      },
+      "_type": "flow.page"
+    },
+    "8de72c8f-486f-4c05-922f-dffdbf870809": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "a5c6ac7e-413e-491e-aa85-aef65e0ad05b": {
+      "next": {
+        "default": "c1655a71-f7f0-41a3-905f-21c992b79e88"
+      },
+      "_type": "flow.page"
+    },
+    "b2049bca-ac2e-476c-9e74-198e0452123e": {
+      "next": {
+        "default": "bdb5c793-1f1e-4f7b-af2f-fd305f8c4bc2"
+      },
+      "_type": "flow.page"
+    },
+    "bdb5c793-1f1e-4f7b-af2f-fd305f8c4bc2": {
+      "next": {
+        "default": "0af66d05-25ab-40fa-8e21-4bbcc1437ee7"
+      },
+      "_type": "flow.page"
+    },
+    "c1655a71-f7f0-41a3-905f-21c992b79e88": {
+      "next": {
+        "default": "8de72c8f-486f-4c05-922f-dffdbf870809"
+      },
+      "_type": "flow.page"
+    },
+    "f565e703-1301-4cc0-b110-85cb04577b3f": {
+      "next": {
+        "default": "179eef69-a9a3-41de-9619-86035a02b898",
+        "conditionals": [
+          {
+            "next": "4c6c06a0-fdef-4057-b8b1-09714774fa65",
+            "_type": "if",
+            "_uuid": "c0bc36c8-c9ad-4aa9-98fb-34fa81c63621",
+            "expressions": [
+              {
+                "page": "0af66d05-25ab-40fa-8e21-4bbcc1437ee7",
+                "field": "ffe04cde-aba8-4f10-8338-8b4f4f612551",
+                "operator": "contains",
+                "component": "8b4de621-d197-4cdb-be03-484270d8405a"
+              }
+            ]
+          }
+        ]
+      },
+      "_type": "flow.branch",
+      "title": "Branching point 2"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "_type": "page.start",
+      "_uuid": "7328667a-e564-48c8-b68e-cea91bb65907",
+      "heading": "Service name goes here",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
+    },
+    {
+      "_id": "page.page-b",
+      "url": "page-b",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "58df5afb-a118-4e19-be7f-f826f975ea85",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-b_checkboxes_1",
+          "hint": "",
+          "name": "page-b_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "b9169fcf-f5dd-44e7-a8a4-e007616cd406",
+          "items": [
+            {
+              "_id": "page-b_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-b_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "d4c5e6fa-8c08-4270-a125-3d2453b1a589",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-b_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-b_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "843d6bd5-a67d-41e5-9390-20817e21eae8",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page b",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-c",
+      "url": "page-c",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "84515c81-5819-44bd-a533-bb36a75e1652",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-c_checkboxes_1",
+          "hint": "",
+          "name": "page-c_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "3af46a4f-5e8f-4787-a5ec-70a40e7f9171",
+          "items": [
+            {
+              "_id": "page-c_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-c_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "57cf8edc-0115-4d5d-b29a-7702c97e4c50",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-c_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-c_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "afcb4d3c-36c6-4f96-945d-4ced2fcb50b4",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page c",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-d",
+      "url": "page-d",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "3616ac86-ab5b-413f-a81c-56e978ddb729",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-d_checkboxes_1",
+          "hint": "",
+          "name": "page-d_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "8d9d0ecd-a444-4d4a-9de4-2587f02319c8",
+          "items": [
+            {
+              "_id": "page-d_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-d_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "9cc7b43c-f3f2-403a-a9e3-f67e81b667e6",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-d_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-d_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "7f4c47a1-a354-4ef6-ad87-55879dff6c8d",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page d",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-e",
+      "url": "page-e",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "b2049bca-ac2e-476c-9e74-198e0452123e",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-e_checkboxes_1",
+          "hint": "",
+          "name": "page-e_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "c27cdcc0-6898-42e9-8692-f7af5bc6466c",
+          "items": [
+            {
+              "_id": "page-e_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-e_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "25003b38-80cb-40ac-b571-5eedda67f3f5",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-e_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-e_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "f57b0fe4-53b8-4867-bd83-b07bdae5d7f8",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page e",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-f",
+      "url": "page-f",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "bdb5c793-1f1e-4f7b-af2f-fd305f8c4bc2",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-f_checkboxes_1",
+          "hint": "",
+          "name": "page-f_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "e2b36f1c-e832-45c6-9c7a-71a09c4ca097",
+          "items": [
+            {
+              "_id": "page-f_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-f_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "f9e4f679-d4d7-4937-b168-b335c7bd3a72",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-f_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-f_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "d633f335-5b39-4299-863c-770590c14cdc",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page f",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-g",
+      "url": "page-g",
+      "_type": "page.multiplequestions",
+      "_uuid": "0af66d05-25ab-40fa-8e21-4bbcc1437ee7",
+      "heading": "Page g",
+      "components": [
+        {
+          "_id": "page-g_radios_1",
+          "hint": "",
+          "name": "page-g_radios_1",
+          "_type": "radios",
+          "_uuid": "4a5243aa-afeb-4036-ba25-12f1233dd919",
+          "items": [
+            {
+              "_id": "page-g_radios_1_item_1",
+              "hint": "",
+              "name": "page-g_radios_1",
+              "_type": "radio",
+              "_uuid": "0bb67705-2fef-482b-8855-3b3cd988760b",
+              "label": "Thanos",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-g_radios_1_item_2",
+              "hint": "",
+              "name": "page-g_radios_1",
+              "_type": "radio",
+              "_uuid": "9bd86339-fe39-441f-9c23-84e4e2a43b7d",
+              "label": "Option",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Question 1",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        },
+        {
+          "_id": "page-g_checkboxes_1",
+          "hint": "",
+          "name": "page-g_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "8b4de621-d197-4cdb-be03-484270d8405a",
+          "items": [
+            {
+              "_id": "page-g_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-g_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "ffe04cde-aba8-4f10-8338-8b4f4f612551",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-g_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-g_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "70cd0db4-bdfa-45bb-a2cf-5a192d64265d",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Question 2",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "add_component": "checkboxes",
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-h",
+      "url": "page-h",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "4c6c06a0-fdef-4057-b8b1-09714774fa65",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-h_checkboxes_1",
+          "hint": "",
+          "name": "page-h_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "efc40cf1-780c-4101-8f5d-c0b49e9ded40",
+          "items": [
+            {
+              "_id": "page-h_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-h_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "f5c3f059-9aff-463f-9617-543a765b4b30",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-h_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-h_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "1f5a2193-fc55-46c9-98a6-ae25c5e647cf",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page h",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-i",
+      "url": "page-i",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "179eef69-a9a3-41de-9619-86035a02b898",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-i_checkboxes_1",
+          "hint": "",
+          "name": "page-i_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "970df721-8699-41b4-8089-6df6c20bb85b",
+          "items": [
+            {
+              "_id": "page-i_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-i_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "fa62a9d4-9124-4191-84b4-d5c610d6221a",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-i_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-i_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "523cda64-9f3d-40a3-a85c-c2b3890450b3",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page i",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.page-j",
+      "url": "page-j",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "a5c6ac7e-413e-491e-aa85-aef65e0ad05b",
+      "heading": "",
+      "components": [
+        {
+          "_id": "page-j_checkboxes_1",
+          "hint": "",
+          "name": "page-j_checkboxes_1",
+          "_type": "checkboxes",
+          "_uuid": "b185d5a8-3db0-4ad3-89cd-91a97e9332f3",
+          "items": [
+            {
+              "_id": "page-j_checkboxes_1_item_1",
+              "hint": "",
+              "name": "page-j_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "5533d9e7-e2de-43ab-9c4a-14d8056c119b",
+              "label": "Thor",
+              "value": "value-1",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            },
+            {
+              "_id": "page-j_checkboxes_1_item_2",
+              "hint": "",
+              "name": "page-j_checkboxes_1",
+              "_type": "checkbox",
+              "_uuid": "1b65e0a1-05de-4d27-bbf1-b06cc8519aa7",
+              "label": "Hulk",
+              "value": "value-2",
+              "errors": {
+              },
+              "legend": "Question",
+              "collection": "components",
+              "validation": {
+                "required": true
+              }
+            }
+          ],
+          "errors": {
+          },
+          "legend": "Page j",
+          "collection": "components",
+          "validation": {
+            "required": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.checkanswers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "c1655a71-f7f0-41a3-905f-21c992b79e88",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+
+      ],
+      "send_heading": "Now send your application",
+      "extra_components": [
+
+      ]
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "form-sent",
+      "_type": "page.confirmation",
+      "_uuid": "8de72c8f-486f-4c05-922f-dffdbf870809",
+      "heading": "Application complete",
+      "components": [
+
+      ]
+    }
+  ],
+  "locale": "en",
+  "created_at": "",
+  "created_by": "",
+  "service_id": "",
+  "version_id": "",
+  "service_name": "",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "/cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "/privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "/accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "Cookies body",
+      "_type": "page.standalone",
+      "_uuid": "881fdf28-9a45-4a12-b1e9-a6f468c1be9b",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "Privacy body",
+      "_type": "page.standalone",
+      "_uuid": "eddbf1a2-7ab4-4985-a92e-874479a73b4d",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "Accessibility body",
+      "_type": "page.standalone",
+      "_uuid": "1fda4d88-704b-4550-bbf1-ea60d5fed4e9",
+      "heading": "Accessibility statement",
+      "components": [
+
+      ]
+    }
+  ]
+}

--- a/acceptance/support/branching_steps.rb
+++ b/acceptance/support/branching_steps.rb
@@ -208,20 +208,6 @@ module BranchingSteps
     expect(editor).to have_text(page_title)
   end
 
-  def given_I_have_a_form_with_pages
-    given_I_have_a_page('page-b')
-    given_I_have_a_page('page-c')
-    given_I_have_a_page('page-d')
-    given_I_have_a_page('page-e')
-    given_I_have_a_page('page-f')
-    given_I_have_a_multiquestion_page('page-g')
-    given_I_have_a_page('page-h')
-    given_I_have_a_page('page-i')
-    given_I_have_a_page('page-j')
-    given_I_have_a_branching_point_one
-    given_I_have_a_branching_point_two
-  end
-
   def given_I_have_a_page(url)
     given_I_add_a_single_question_page_with_checkboxes
     and_I_add_a_page_url(url)


### PR DESCRIPTION
This updates many of the editing of pages and components acceptance
tests to use fixtures instead of constantly recreating services before
each scenario by interacting with the UI.

We still keep some of the tests which do it that way, but it is
unecessary for all of them.