### PR TITLE
Bump presenter 2.16.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.16.1'
+gem 'metadata_presenter', '2.16.2'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.16.1)
+    metadata_presenter (2.16.2)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -427,7 +427,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.16.1)
+  metadata_presenter (= 2.16.2)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
[Trello](https://trello.com/c/c4I4IvM3/2410-sometime-the-flow-view-shows-confirmation-before-cya-and-other-bugs)
Relates to: https://github.com/ministryofjustice/fb-metadata-presenter/pull/217

Version 2.16.2 of the presenter changes the way the confirmation page is placed on the grid by ensuring it is placed after the CYA page.