### PR TITLE
Fix brief flash of unstyled content issue

### DIFF
--- a/app/javascript/src/controller_default.js
+++ b/app/javascript/src/controller_default.js
@@ -21,6 +21,7 @@ const Dialog = require('./component_dialog');
 const DialogConfirmation = require('./component_dialog_confirmation');
 const Expander = require('./component_expander');
 const post = require('./utilities').post;
+const JS_ENHANCEMENT_DONE = "jsdone";
 
 
 class DefaultController {
@@ -64,6 +65,19 @@ class DefaultController {
     $node.on("keydown", function() {
       view.$lastPoint = $node;
     });
+  }
+
+  /* General actions to happen when called by a view that is ready.
+   * e.g. Implemented initially for the brief flash of content fix
+   *      first required on ServicesController and then shared with
+   *      the PublishController.
+   *
+   * Using this shares code and gives a place for other such actions
+   * to happen, if/when they may be discovered.
+   **/
+  ready() {
+    // Reverse the Brief flash of content white screen blocker (see CSS).
+    $("#main-content").addClass(JS_ENHANCEMENT_DONE);
   }
 }
 

--- a/app/javascript/src/controller_publish.js
+++ b/app/javascript/src/controller_publish.js
@@ -40,17 +40,17 @@ class PublishController extends DefaultController {
  **/
 PublishController.index = function() {
   var view = this;
-  setupPublishForms.call(this);
+  setupPublishForms.call(view);
 
   // When to show 15 minute message.
-  if(this.publishFormTest.firstTimePublish() || this.publishFormProd.firstTimePublish()) {
-    this.dialog.content = {
+  if(view.publishFormTest.firstTimePublish() || view.publishFormProd.firstTimePublish()) {
+    view.dialog.content = {
       ok: view.text.dialogs.button_publish,
       heading: view.text.dialogs.heading_publish,
       content: view.text.dialogs.message_publish
     };
 
-    this.dialog.open();
+    view.dialog.open();
   }
 }
 
@@ -58,7 +58,9 @@ PublishController.index = function() {
 /* Set up for the Create action
  **/
 PublishController.create = function() {
-  setupPublishForms.call(this);
+  var view = this;
+  setupPublishForms.call(view);
+  view.ready();
 }
 
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -32,7 +32,6 @@ const SELECTOR_FLOW_CONDITION = ".flow-condition";
 const SELECTOR_FLOW_ITEM = ".flow-item";
 const SELECTOR_FLOW_LINE_PATH = ".FlowConnectorPath path:first-child";
 const SELECTOR_FLOW_DETACHED_GROUP = ".flow-detached-group";
-const JS_ENHANCEMENT_DONE = "jsdone";
 
 
 class ServicesController extends DefaultController {
@@ -72,9 +71,7 @@ ServicesController.edit = function() {
   }
 
   addServicesContentScrollContainer(view);
-
-  // Reverse the Brief flash of content quickfix.
-  $("#main-content").addClass(JS_ENHANCEMENT_DONE);
+  view.ready();
 }
 
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -17,6 +17,24 @@ html {
   position: relative;
 }
 
+.publish-create,
+.services-edit {
+  main {
+    // Brief flash of content not ready for display.
+    // This can be reversed when slow or view reliant JS has
+    // finished running. We're using the controller name + action
+    // so we can use it only where actually needed. Find the
+    // corresponding JS to turn it off in DefaultController.ready()
+    // method, that is called in related controller+action code, at
+    // the appropriate point to turn off/reverse the white screen.
+    visibility: hidden;
+
+    &.jsdone {
+      visibility: visible;
+    }
+  }
+}
+
 .sr-only {
   height: 1px;
   left: -10000px;
@@ -486,7 +504,6 @@ html {
 
 /* NEW FORM FLOW CSS
  * ------------------------ */
-
 .services-edit {
   h1 {
     clear: both;
@@ -494,20 +511,6 @@ html {
 
     @include govuk-media-query($from: tablet) {
       clear: none;
-    }
-  }
-
-  main {
-    // Quickfix for Brief flash of content not ready for display.
-    // This can be reversed when slow or view reliant JS has
-    // finished running. We're using the controller name + action
-    // so we can use it only where actually needed. Find the
-    // corresponding JS controller+action function to see where it
-    // is turned off/reversed.
-    visibility: hidden;
-
-    &.jsdone {
-      visibility: visible;
     }
   }
 


### PR DESCRIPTION
Prevent this (no JS dialog implemented yet) view from flashing...
<img width="1133" alt="Screenshot 2022-04-28 at 14 52 00" src="https://user-images.githubusercontent.com/76942244/165767976-e5f44cb9-f92a-4757-b619-26bf6e44d3b9.png">

...before this one (with JS dialog) is ready.
<img width="1105" alt="Screenshot 2022-04-28 at 14 52 12" src="https://user-images.githubusercontent.com/76942244/165768056-e5add2cb-826b-4feb-9faa-e993e7ce63e3.png">
