### PR TITLE
Remove unnecessary form-group class from move template

### DIFF
--- a/app/views/api/move/_new.html.erb
+++ b/app/views/api/move/_new.html.erb
@@ -1,24 +1,23 @@
 <div class="component-dialog-api-request" id="move_targets_list">
   <%= form_for @move, url: api_service_flow_move_path(service.service_id, @move.to_move_uuid) do |f| %>
+    <%= f.hidden_field :previous_flow_uuid, value: @move.previous_flow_uuid %>
+    <%= f.hidden_field :previous_conditional_uuid, value: @move.previous_conditional_uuid %>
+    <%= f.hidden_field :target_conditional_uuid, value: '' %>
+
     <div class="govuk-form-group ">
-      <%= f.hidden_field :previous_flow_uuid, value: @move.previous_flow_uuid %>
-      <%= f.hidden_field :previous_conditional_uuid, value: @move.previous_conditional_uuid %>
-      <%= f.hidden_field :target_conditional_uuid, value: '' %>
       <%= f.label :target_uuid, t('dialogs.move.label', title: @move.title), class: "govuk-label govuk-label--m" %>
-      <p> <%= t('dialogs.move.lede') %></p>
-      <div class="govuk-form-group">
-        <select class="govuk-select" name="move[target_uuid]" id="move_target_uuid">
-          <% @move.targets.each do |target| %>
-            <% if target[:selected] %>
-              <option value="<%= target[:target_uuid] %>" data-conditional-uuid="<%= target[:conditional_uuid] %>" selected="selected">
-            <% else %>
-              <option value="<%= target[:target_uuid] %>" data-conditional-uuid="<%= target[:conditional_uuid] %>">
-            <% end %>
-              <%= target[:title] %>
-            </option>
+      <p><%= t('dialogs.move.content') %></p>
+      <select class="govuk-select" name="move[target_uuid]" id="move_target_uuid">
+        <% @move.targets.each do |target| %>
+          <% if target[:selected] %>
+            <option value="<%= target[:target_uuid] %>" data-conditional-uuid="<%= target[:conditional_uuid] %>" selected="selected">
+          <% else %>
+            <option value="<%= target[:target_uuid] %>" data-conditional-uuid="<%= target[:conditional_uuid] %>">
           <% end %>
-        </select>
-      </div>
+            <%= target[:title] %>
+          </option>
+        <% end %>
+      </select>
     </div>
 
     <button class="govuk-button fb-govuk-button">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,7 +58,7 @@ en:
       text: 'Any pages that are left without a connection to your form will be moved to the unconnected pages section.'
     move:
       label: 'Move the page "%{title}"'
-      lede: 'Move to after:'
+      content: 'Move to after:'
       button: Move
       you_cannot_move_this_page: 'You cannot move this page yet'
       stacked_branches_not_supported_message: 'Moving this page would result in 2 branching points in a row, which is not currently possible. Try combining your branching rules into 1 branching point.'


### PR DESCRIPTION
There were one too many divs with govuk-form-group as a class in the
move template