### PR TITLE
Progressively enhance branching diamond with clip-path for nicer focu…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,6 +25,18 @@ module ApplicationHelper
     end
   end
 
+  def flow_branch_link(item)
+    link_to edit_branch_path(service.service_id, item[:uuid]), class: 'govuk-link' do
+      concat(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 125" tabindex="-1" focusable="false">
+          <polygon fill="" points="1,62.5 100,1 199,62.5 100,124" stroke="" stroke-width="2"/>
+          </svg>'.html_safe
+      )
+      concat tag.span("#{t('actions.edit')}: ", class: 'govuk-visually-hidden')
+      concat tag.span(item[:title], class: 'text')
+    end
+  end
+
   def strip_url(url)
     url.to_s.chomp('/').reverse.chomp('/').reverse.strip.downcase
   end

--- a/app/javascript/images/diamond.svg
+++ b/app/javascript/images/diamond.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 125" usemap="#workmap">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 125">
   <polygon fill="none" points="1,62.5 100,1 199,62.5 100,124" stroke="#1d70b8" stroke-width="2"></polygon>
 </svg>

--- a/app/javascript/styles/_component_activated_menu.scss
+++ b/app/javascript/styles/_component_activated_menu.scss
@@ -21,6 +21,10 @@
 .ActivatedMenuActivator {
   @include icon_button;
 
+  &:focus {
+    border-color: govuk-colour('black');
+  }
+
   &::after {
     content: url('../images/three-dots-blue.svg');
     display: block;

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -605,20 +605,7 @@ html {
   height: 125px;
   width: 200px;
 
-  & > a {
-    box-sizing: border-box;
-    color: govuk-colour("black");
-	  display: inline-block;
-    margin-top: 30px;
-    padding: 0 40px;
-    position: relative;
-    text-align: center;
-    text-decoration: none;
-    width: inherit;
-  }
-
   img {
-    background-color: govuk-colour("white");
     height: 125px;
     left: 0;
     position: absolute;
@@ -626,6 +613,69 @@ html {
     width: inherit;
   }
 
+  & > a {
+    box-sizing: border-box;
+    color: govuk-colour("black");
+    display: block;
+    position: absolute;
+    top: 30px;
+    left: 48px;
+    right:48px;
+    bottom: 30px;
+    text-align: center;
+    text-decoration: none;
+  }
+  
+  // without clip-path support we use the imagemap, so hide the svg element
+  & svg {
+    display: none;
+  }
+
+  @supports(clip-path: polygon(0% 50%, 50% 0%, 100% 50%, 50% 100%)) {
+    // if the browser supports clip-path we don't need the imagemap
+    & img,
+    & map {
+      display: none;
+    }
+    
+    // make the link fill the whole area and clip it
+    & > a {
+     clip-path: polygon(0% 50%, 50% 0%, 100% 50%, 50% 100%);
+     top: 0;
+     left: 0;
+     right:0;
+     bottom: 0;
+     padding: 30px 48px; // keep text area same as without clip-path
+    }
+    
+    // show the svg and make it fill the container
+    & svg {
+      display: block;
+      position: absolute;
+      height: 125px;
+      width: 200px;
+      z-index: -1; // ensure it remains 'under' the link
+      top: 0;
+      left: 0;
+    }
+    
+    svg polygon {
+      fill: #fff;
+      stroke: $govuk-link-colour;
+    }
+
+    & > a:focus {
+      // we're filling the svg on focus, so we don't need the box shadow as it
+      // makes the element break out of the diamond
+      box-shadow: none;
+    }
+
+    & > a:focus svg polygon  {
+      fill: govuk-colour('yellow');
+      stroke: govuk-colour('black');
+    }
+  }
+  
   .FlowItemMenuActivator {
     bottom: 10px;
     left: 82px;

--- a/app/views/services/_flow_layout.html.erb
+++ b/app/views/services/_flow_layout.html.erb
@@ -25,7 +25,8 @@
         <map name="thumbnail-<%= item[:uuid] %>" aria-hidden="true">
           <area shape="poly" coords="0,72.5 100,0 200,72.5 100,145" alt="<%= item[:title]-%>" role="presentation" href="<%= edit_branch_path(service.service_id, item[:uuid]) %>" tabindex="-1">
         </map>
-        <%= flow_text_link(item) %>
+        <%= flow_branch_link(item) %>
+        <%= render partial: 'services/flow_branch_menu', locals: { item: item } %>
         <ul class="flow-conditions">
           <% item[:conditionals].each_with_index do |condition, index| %>
             <li class="flow-condition" data-from="<%= "#{item[:uuid]}-#{index}" %>" data-next="<%= condition[:next] %>">
@@ -51,7 +52,6 @@
             </li>
           <% end %>
         </ul>
-        <%= render partial: 'services/flow_branch_menu', locals: { item: item } %>
       </article>
     <% else %>
 


### PR DESCRIPTION
This PR makes the focus state for the branching diamonds much nicer in browsers that support the `clip-path' property.

With clip-path:
![image](https://user-images.githubusercontent.com/595564/166684975-c679c46f-2dde-4e44-94ae-f9e7e5b8386c.png)

Without clip-path (fallback):
![image](https://user-images.githubusercontent.com/595564/166684907-89e2cc88-3eef-4136-bc44-eab8b5d0f4b5.png)

While the picture at [caniuse](https://caniuse.com/?search=clip-path) doesn't look great, that is mostly due to browsers only supporting part of a fairly large spec for clip-path.  In reality every browser that isn't red on caniuse supports what we're using it for (everything except IE)

![image](https://user-images.githubusercontent.com/595564/166685488-2b40fec8-b544-496c-bc49-4ba6c2462935.png)


By wrapping all of the new rules in `@supports` we can provide the old `imagemap` functionality to IE and then in browsers that support it we hide the imagemap and rely on `clip-path` to provide the diamond shaped link area and styling an inline svg to control the colors on focus.
