### PR TITLE
Component validation menu

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.16.3'
+gem 'metadata_presenter', '2.16.4'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.16.3)
+    metadata_presenter (2.16.4)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -427,7 +427,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.16.3)
+  metadata_presenter (= 2.16.4)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,10 @@
 module ApplicationHelper
   include MetadataPresenter::ApplicationHelper
 
+  def enabled_validations(component)
+    Rails.application.config.enabled_validations & component.supported_validations
+  end
+
   # Used on service flow page
   def flow_thumbnail_link(args)
     link_to edit_page_path(

--- a/app/models/component_validations/base_component_validation.rb
+++ b/app/models/component_validations/base_component_validation.rb
@@ -19,6 +19,10 @@ class BaseComponentValidation
     enabled? && value.present?
   end
 
+  def component
+    @component ||= page.find_component_by_uuid(component_uuid)
+  end
+
   def component_type
     @component_type ||= component.type
   end
@@ -41,10 +45,6 @@ class BaseComponentValidation
 
   def component_validation
     @component_validation ||= component.validation
-  end
-
-  def component
-    @component ||= page.find_component_by_uuid(component_uuid)
   end
 
   def page

--- a/app/validators/base_component_validation_validator.rb
+++ b/app/validators/base_component_validation_validator.rb
@@ -1,10 +1,6 @@
 class BaseComponentValidationValidator < ActiveModel::Validator
-  DEFINITION_BUNDLES = { number: 'validations.number_bundle' }.freeze
-
   def validate(record)
-    bundle = definition_bundle(record.component_type)
-
-    if no_validator_for_component?(bundle, record.validator)
+    if record.component.supported_validations.exclude?(record.validator)
       record.errors.add(
         :validator,
         I18n.t(
@@ -22,22 +18,5 @@ class BaseComponentValidationValidator < ActiveModel::Validator
         )
       )
     end
-  end
-
-  private
-
-  def no_validator_for_component?(bundle, validator)
-    component_validations(bundle).exclude?(validator)
-  end
-
-  def component_validations(bundle)
-    bundle.schema['properties']['validation']['properties'].keys
-  end
-
-  def definition_bundle(component)
-    schema_key = DEFINITION_BUNDLES[component.to_sym]
-    return if schema_key.blank?
-
-    JSON::Validator.schema_for_uri(schema_key)
   end
 end

--- a/app/views/partials/_template_component_question_menu.html.erb
+++ b/app/views/partials/_template_component_question_menu.html.erb
@@ -1,0 +1,21 @@
+<% @page.components.each do |component| %>
+  <script type="text/html"
+          data-component-template="ComponentQuestionMenu_<%= component.type %>"
+          data-component-uuid="<%= component.uuid %>"
+          data-activator-text="<%= t('question.menu.activator') %>">
+    <ul class="govuk-navigation component-activated-menu">
+      <li data-action="required"><span><%= t('question.menu.required')%></span></li>
+      <li data-action="remove"
+          data-api-path="<%= URI.decode_www_form_component(api_service_page_question_destroy_message_path(service.service_id, @page.uuid, component.uuid, method: :delete)) -%>">
+        <span class="destructive"><%= t('question.menu.remove')%></span>
+      </li>
+
+      <% enabled_validations(component).each do |validation| %>
+        <li data-action="<%= validation %>"
+            data-api-path="<%= URI.decode_www_form_component(api_service_page_component_validations_path(service.service_id, @page.uuid, component.uuid, validation)) -%>">
+          <span><%= t("question.menu.#{validation}") %></span>
+        </li>
+      <% end %>
+    </ul>
+  </script>
+<% end %>

--- a/config/initializers/enabled_validations.rb
+++ b/config/initializers/enabled_validations.rb
@@ -1,0 +1,11 @@
+Rails.application.config.enabled_validations = %w(
+  accept
+  date
+  email
+  max_size
+  minimum
+  number
+  required
+  upload
+  virus_scan
+)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,6 +216,7 @@ en:
       activator: 'Properties'
       remove: 'Delete...'
       required: 'Required...'
+      minimum: 'Minimum answer value...'
     dialog:
       heading_remove: Delete the component '#{label}'?
       heading_required: 'Is answering this question required?'


### PR DESCRIPTION
## Create component question menu template

This adds a template for the component question menu. It gets the
supported validations for a given component and then iterates over the
ones that are currently enabled in the Editor to create the links to
configure them.

## Surface component validations from Presenter

The Component model in the presenter now surfaces the supported
validations for a given component.

## Use Presenter 2.16.4
 
