### PR TITLE
location of instance property has moved on expander

### DIFF
--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -198,7 +198,7 @@ function layoutFormFlowOverview(view) {
 **/
 function layoutDetachedItemsOveriew(view) {
   var $container = view.$flowDetached;
-  var expander = $container.data("instance"); // Element is set as an Expander Component.
+  var expander = $container.find('.Expander').data("instance"); // Element is set as an Expander Component.
 
   // Make sure it's open on page load
   expander.open();


### PR DESCRIPTION
Quick fix to recitify the fact that the expander component $node is now different and the services edit controller was looking at the wrong element for the `instance` property.