### PR TITLE
add aria for menu items to communicate state

### DIFF
--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -79,7 +79,7 @@ class EditorApp < SitePrism::Page
   element :question_three_dots_button, '.ActivatedMenuActivator', visible: true
   element :required_question,
           :xpath,
-          "//*[@role='menuitem' and contains(.,'Required...')]"
+          "//*[@role='menuitemcheckbox' and contains(.,'Required...')]"
 
   elements :add_page_submit_button, :button, I18n.t('pages.create')
   elements :form_pages, '#flow-overview .flow-item'

--- a/app/javascript/src/components/menus/activated_menu_item.js
+++ b/app/javascript/src/components/menus/activated_menu_item.js
@@ -44,9 +44,9 @@ class ActivatedMenuItem {
 
     if(!role) {
       $(item).attr("role", "menuitem");
-      $(item).attr("tabindex", "-1");
-      $(item).attr("id", uniqueString("menuItem"));
     }
+    $(item).attr("tabindex", "-1");
+    $(item).attr("id", uniqueString("menuItem"));
 
     if(this.hasSubmenu()) {
       $(item).attr("aria-haspopup", "menu");

--- a/app/javascript/src/components/menus/question_menu.js
+++ b/app/javascript/src/components/menus/question_menu.js
@@ -78,10 +78,10 @@ class QuestionMenu extends ActivatedMenu {
    **/
   setRequiredViewState() {
     if(this.question.data.validation.required) {
-      $("[data-action=required]").addClass("on");
+      this.$node.find("[data-action=required] > :first-child").attr("aria-checked", "true");
     }
     else {
-      $("[data-action=required]").removeClass("on");
+      this.$node.find("[data-action=required] > :first-child").attr("aria-checked", "false");
     }
   }
 }

--- a/app/javascript/styles/_component_activated_menu.scss
+++ b/app/javascript/styles/_component_activated_menu.scss
@@ -84,6 +84,18 @@
         vertical-align: middle;
       }
     }
+
+    &[aria-checked="true"] {
+      &:after {
+        content: "\2713";
+        font-size: 16px;
+        height: 100%;
+        position: absolute;
+        right: 10px;
+        top: 12px;
+        vertical-align: middle;
+      }
+    }
   }
 
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -885,37 +885,6 @@ html {
 }
 
 
-/* Question Menu
- * ------------- */
-.QuestionMenu {
-  [data-action="required"].on {
-    position: relative;
-
-    span {
-      &:after {
-        border-color: $govuk-link-colour;
-        border-style: solid;
-        border-width: 0 2px 3px 0;
-        bottom: 13px;
-        content: "";
-        display: block;
-        height: 17px;
-        position: absolute;
-        right: 17px;
-        transform: rotate(45deg);
-        width: 6px;
-      }
-
-      &:hover {
-        &:after {
-          border-color: govuk-colour("white");
-        }
-      }
-    }
-  }
-}
-
-
 /* govuk-navigation does not appear to exist
  * so adding something simple here.
  * ----------------------------------------- */

--- a/app/views/partials/_template_component_question_menu.html.erb
+++ b/app/views/partials/_template_component_question_menu.html.erb
@@ -1,10 +1,10 @@
 <% @page.components.each do |component| %>
   <script type="text/html"
-          data-component-template="ComponentQuestionMenu_<%= component.type %>"
+          data-component-template="QuestionMenu_<%= component.uuid %>"
           data-component-uuid="<%= component.uuid %>"
           data-activator-text="<%= t('question.menu.activator') %>">
     <ul class="govuk-navigation component-activated-menu">
-      <li data-action="required"><span><%= t('question.menu.required')%></span></li>
+      <li data-action="required"><span role="menuitemcheckbox" aria-checked="<%= component.validation['required'] -%>"><%= t('question.menu.required')%></span></li>
       <li data-action="remove"
           data-api-path="<%= URI.decode_www_form_component(api_service_page_question_destroy_message_path(service.service_id, @page.uuid, component.uuid, method: :delete)) -%>">
         <span class="destructive"><%= t('question.menu.remove')%></span>
@@ -13,9 +13,9 @@
       <% enabled_validations(component).each do |validation| %>
         <li data-action="<%= validation %>"
             data-api-path="<%= URI.decode_www_form_component(api_service_page_component_validations_path(service.service_id, @page.uuid, component.uuid, validation)) -%>">
-          <span><%= t("question.menu.#{validation}") %></span>
+          <span role="menuitemcheckbox" aria-checked="<%= component.validation[validation] -%>"><%= t("question.menu.#{validation}") %></span>
         </li>
       <% end %>
     </ul>
-  </script>
+  </script> 
 <% end %>

--- a/app/views/partials/_template_question_menu.html.erb
+++ b/app/views/partials/_template_question_menu.html.erb
@@ -3,7 +3,7 @@
         data-component-template="QuestionMenu"
         data-activator-text="<%= t('question.menu.activator') %>">
   <ul class="govuk-navigation component-activated-menu">
-    <li data-action="required"><span><%= t('question.menu.required')%></span></li>
+    <li data-action="required"><span role="menuitemcheckbox"><%= t('question.menu.required')%></span></li>
     <li data-action="remove"
         data-api-path="<%= api_service_page_question_destroy_message_path(service.service_id,@page.uuid,'question_uuid', method: :delete) -%>">
       <span class="destructive"><%= t('question.menu.remove')%></span>

--- a/test/component_activated_question_menu_test.js
+++ b/test/component_activated_question_menu_test.js
@@ -231,24 +231,24 @@ describe("QuestionMenu", function() {
   });
 
   describe("setRequiredViewState()", function() {
-    it("should add class 'on' to required item when required is true", function() {
+    it("should add aria-checked to required item when required is true", function() {
       var $target = menu.$node.find("li[data-action=required]");
-      expect($target.hasClass("on")).to.be.false;
+      expect($target.children().first().attr("aria-checked")).to.equal("false");
 
       menu.question.data.validation.required = true;
       menu.setRequiredViewState()
-      expect($target.hasClass("on")).to.be.true;
+      expect($target.children().first().attr("aria-checked")).to.equal("true");
     });
 
     it("should remove class 'on' for required item when required is false", function() {
       var $target = menu.$node.find("li[data-action=required]");
 
-      $target.addClass("on");
-      expect($target.hasClass("on")).to.be.true;
+      $target.children().first().attr("aria-checked", "true");
+      expect($target.children().first().attr("aria-checked")).to.equal("true");
 
       menu.question.data.validation.required = false;
       menu.setRequiredViewState()
-      expect($target.hasClass("on")).to.be.false;
+      expect($target.children().first().attr("aria-checked")).to.equal("false");
     });
   });
 


### PR DESCRIPTION
PR to add aria role and checked state to Question Menu items.

We give them a role of `menuitemcheckbox` and set `aria-checked` to `true` or `false`.  This allows the items to be announced with their checked status.  

Also update the displayed graphic for the checkmark from a 'border' based drawing to a UTF-8 glyph (approved by Fabien).

Before:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/595564/167480171-82255afc-337d-46c2-b4fb-f8b2cc2e37d5.png">

After:
<img width="452" alt="image" src="https://user-images.githubusercontent.com/595564/167480226-aa4396ba-ca9b-42a9-8b44-42e0c2c029a1.png">


N.B `template_component_question_menu.html.erb` is a new file for the validations work and will in due course replace `template_question_menu.html.erb` - left both in this PR to keep it focused on just the accessibility change.

