### PR TITLE
Copy changes to Publish authentication modal

### DIFF
--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -15,8 +15,8 @@ feature 'Publishing' do
   let(:username_and_password_errors) do
     # the use of '‘' is correct
     [
-      "Your answer for ‘Create a username’ is too short (6 characters at least)",
-      "Your answer for ‘Create a password’ is too short (6 characters at least)",
+      I18n.t('activemodel.errors.models.publish_service_creation.username_too_short'),
+      I18n.t('activemodel.errors.models.publish_service_creation.password_too_short'),
     ]
   end
 

--- a/app/services/publish_service_creation.rb
+++ b/app/services/publish_service_creation.rb
@@ -12,14 +12,28 @@ class PublishServiceCreation
                 :publish_service_id
 
   validates :service_id, :version_id, :user_id, presence: true
-  validates :username,
-            :password,
-            presence: true,
-            if: :require_authentication?
-  validates :username, :password,
-            length: { minimum: 6, maximum: 50 },
-            if: :require_authentication?,
-            allow_blank: true
+  with_options if: :require_authentication? do |record|
+    record.validates :username, presence: { message: I18n.t(
+      'activemodel.errors.models.publish_service_creation.blank_username'
+    ) }
+    record.validates :username, allow_blank: true, length: {
+      minimum: 6,
+      maximum: 50,
+      message: I18n.t(
+        'activemodel.errors.models.publish_service_creation.username_too_short'
+      )
+    }
+    record.validates :password, presence: { message: I18n.t(
+      'activemodel.errors.models.publish_service_creation.blank_password'
+    ) }
+    record.validates :password, allow_blank: true, length: {
+      minimum: 6,
+      maximum: 50,
+      message: I18n.t(
+        'activemodel.errors.models.publish_service_creation.password_too_short'
+      )
+    }
+  end
 
   def save
     return false if invalid?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -309,6 +309,11 @@ en:
         default_next: Otherwise
     errors:
       models:
+        publish_service_creation:
+          blank_username: 'Enter a username'
+          blank_password: 'Enter a password'
+          username_too_short: 'Username must be at least 6 characters'
+          password_too_short: 'Password must be at least 6 characters'
         page_creation:
           taken: "You already have a page with that name"
           reserved: "That name is used for something else"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -298,8 +298,8 @@ en:
       publish_service_creation:
         allow_anonymous: 'Allow anyone with the link to view'
         require_authentication: 'Set a username and password'
-        test_title: 'Publishing to Test site'
-        live_title: 'Publishing to Live site'
+        test_title: 'Publish to Test site'
+        live_title: 'Publish to Live site'
         description: 'You need to set a username and password for your form, which you can share with trusted contacts'
         username: 'Create a username'
         username_hint: 'Your username must be at least 6 characters long'


### PR DESCRIPTION
[Trello](https://trello.com/c/k5EntNtE/2501-threat-form-published-to-test-is-missing-basic-auth-m)

- Changes to the title of the modals
- Changes to error messages

These are custom validations as we are unable to use the built in validations without having to manipulate
the `${attribute}`. Since the `${attribute}` passed is the label, any changes to the label could potentially break the error messages.

### Before
<img width="868" alt="Screenshot 2022-05-10 at 18 28 13" src="https://user-images.githubusercontent.com/29227502/167687984-92c674f9-9754-4352-b854-503eb7d7dcca.png">

### After
<img width="848" alt="Screenshot 2022-05-10 at 18 27 39" src="https://user-images.githubusercontent.com/29227502/167687995-7b93b5d1-85cb-4336-a644-4ca402a38760.png">
