### PR TITLE
Fix broken (missing condition) FlowConnectorPath

### DIFF
--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -667,15 +667,41 @@ function applyBranchFlowConnectorPaths(view, $overview) {
       else {
         // FORWARD
 
-        if(firstConditionItem && sameRow) {
+        if(firstConditionItem) {
+          if(sameRow) {
           // Create straight path to go from right corner of the branch
           // to the x/y coordinates of the related 'next' destination.
-          new ConnectorPath.ForwardPath({
-            from_x: branchX,
-            from_y: branchY - (rowHeight / 4),
-            to_x: destinationX,
-            to_y: destinationY
-          }, config);
+            new ConnectorPath.ForwardPath({
+              from_x: branchX,
+              from_y: branchY - (rowHeight / 4),
+              to_x: destinationX,
+              to_y: destinationY
+            }, config);
+          }
+          else {
+            // NOT SAME ROW
+
+            if(nextColumn) {
+              new ConnectorPath.ForwardUpForwardPath({
+                from_x: branchX,
+                from_y: branchY - (rowHeight / 4),
+                to_x: destinationX,
+                to_y: destinationY,
+                via_x: conditionX
+              }, config);
+            }
+            else {
+              // NOT NEXT COLUMN
+
+              new ConnectorPath.ForwardUpForwardDownPath({
+                from_x: branchX,
+                from_y: branchY - (rowHeight / 4),
+                to_x: destinationX,
+                to_y: destinationY,
+                via_x: conditionX
+              }, config);
+            }
+          }
         }
         else {
           // NOT FIRST CONDITION ITEM


### PR DESCRIPTION
Conditional logic was missing the following two FlowConnectorPath options for BranchCondition
- ForwardUpForwardPath
- ForwardUpForwardDownPath

Ticket#2551 "Broken arrow" spotted this issue:
**Unfixed**
<img width="1843" alt="Screenshot 2022-05-10 at 19 20 42" src="https://user-images.githubusercontent.com/76942244/167696707-6afdb36a-e094-4a9c-9548-9bee2fee055d.png">

**Fixed**
<img width="1861" alt="Screenshot 2022-05-10 at 19 20 14" src="https://user-images.githubusercontent.com/76942244/167696768-fa8e1111-8c42-406c-ab49-a34841bac2a3.png">

Investigation and fix of the above also revealed this issue:
**Unfixed**
<img width="1876" alt="Screenshot 2022-05-10 at 19 19 15" src="https://user-images.githubusercontent.com/76942244/167696997-6f93ba1f-9eb3-4a9d-abf2-b7267d158fb9.png">

**Fixed**
<img width="1868" alt="Screenshot 2022-05-10 at 19 19 53" src="https://user-images.githubusercontent.com/76942244/167697108-749025d6-2f13-465b-bbd8-f15530a2dbc3.png">

