### PR TITLE
Testable validation modals

### DIFF
--- a/app/controllers/api/component_validations_controller.rb
+++ b/app/controllers/api/component_validations_controller.rb
@@ -10,7 +10,7 @@ module Api
       if @component_validation.valid?
         render json: @component_validation.to_metadata, status: :accepted
       else
-        render @component_validation, layout: false
+        render @component_validation, layout: false, status: :unprocessable_entity
       end
     end
 

--- a/app/javascript/src/component_dialog_api_request.js
+++ b/app/javascript/src/component_dialog_api_request.js
@@ -86,6 +86,7 @@ class DialogApiRequest {
     this.#state = "closed";
 
     jxhr.done(function() {
+      console.log('jxhr.done');
       if(conf.closeOnClickSelector) {
         let $buttons = $(conf.closeOnClickSelector, dialog.$node);
         $buttons.eq(0).focus();
@@ -123,6 +124,7 @@ class DialogApiRequest {
           ]
         );
       }
+      utilities.safelyActivateFunction(dialog.#config.done, dialog);
     });
   }
 

--- a/app/javascript/src/component_dialog_validation.js
+++ b/app/javascript/src/component_dialog_validation.js
@@ -1,0 +1,133 @@
+const utilities = require('./utilities');
+const DialogApiRequest = require('./component_dialog_api_request');
+
+
+class DialogValidation {
+  #config;
+  #state;
+
+  constructor(url, config) {
+    var dialog = this;
+    var conf = utilities.mergeObjects({
+      closeOnClickSelector: 'button[type="button"]',
+      submitOnClickSelector: 'button[type="submit"]',
+    }, config);
+
+    this.$node = $(); // Should be overwritten on successful GET
+    this.$container = $(); // Should be overwritten on successful GET
+    this.#config = conf;
+    this.#state = "closed";
+
+    var jxhr = $.get(url, function(response) {
+      dialog.$node = $(response);
+
+      // Allow a passed function to run against the created $node (response HTML) before creating a dialog effect
+      utilities.safelyActivateFunction(dialog.#config.build, dialog);
+
+      dialog.$node.data("instance", dialog);
+      dialog.$node.dialog({
+        classes: conf.classes,
+        closeOnEscape: true,
+        height: "auto",
+        modal: true,
+        resizable: false,
+        open: function() { dialog.#state = "open"; },
+        close: function() { dialog.#state = "closed"; }
+      });
+
+      // Now jQueryUI dialog is in place let's initialise container and put class on it.
+      dialog.$container = dialog.$node.parents(".ui-dialog");
+      dialog.$container.addClass("DialogApiRequest");
+    });
+
+
+    jxhr.done(() => {
+      utilities.safelyActivateFunction(dialog.#config.done, dialog);
+      this.enhance(); 
+    });
+  }
+
+  get state() {
+    return this.#state;
+  }
+
+  enhance() {
+    var dialog = this;
+    this.#setupCloseButtons();
+    this.#setupSubmitButton();
+    
+    let $revealingCheckboxes = $('input[type="checkbox"][aria-controls]');
+    $revealingCheckboxes.each(function() {
+      var id = $(this).attr('aria-controls');
+      var checked = $(this).prop('checked');
+      var $content = dialog.$node.find('#'+id);
+
+      if(checked) {
+        $content.removeClass('govuk-checkboxes__conditional--hidden');
+        $(this).attr('aria-expanded', true);
+      } else {
+        $content.addClass('govuk-checkboxes__conditional--hidden');
+        $(this).attr('aria-expanded', false);
+      }
+
+      $(this).on('change', function() {
+        var checked = $(this).prop('checked');
+        if(checked) {
+          $content.removeClass('govuk-checkboxes__conditional--hidden');
+          $(this).attr('aria-expanded', true);
+        } else {
+          $content.addClass('govuk-checkboxes__conditional--hidden');
+          $(this).attr('aria-expanded', false);
+        }
+      })
+    })
+  }
+
+  open() {
+    var $node = this.$node;
+    this.$node.dialog("open");
+    window.setTimeout(function() {
+      // Not great but works.
+      // We want the focus put inside dialog as all functionality to trap tabbing is there already.
+      // Because we sometimes open dialogs from other components, those other components may (like
+      // menus) shift focus from the opening dialog. We need this delay to allow those other events
+      // to play out before we try to set focus in the dialog. Delay time is arbitrary but we
+      // obviously want it as low as possible to avoid user annoyance. Increase only if have to.
+      $node.parent().find("input, button").not(".ui-dialog-titlebar-close").eq(0).focus();
+    }, 100);
+  }
+
+  close() {
+    // Attempt to refocus on original activator
+    if(this.#config.activator) {
+      this.#config.activator.focus();
+    }
+    this.$node.dialog("close");
+  }
+
+  #setupCloseButtons() {
+    var dialog = this;
+    if(this.#config.closeOnClickSelector) {
+      let $buttons = $(this.#config.closeOnClickSelector, this.$node);
+      $buttons.eq(0).focus();
+      $buttons.on("click", function() {
+        dialog.close();
+      });
+    } 
+  }
+
+  #setupSubmitButton() {
+    var dialog = this;
+    if(this.#config.submitOnClickSelector) {
+      let $buttons = $(this.#config.submitOnClickSelector, this.$node);
+      $buttons.on("click", function(e) {
+        e.preventDefault();
+        utilities.safelyActivateFunction(dialog.#config.submit, dialog );
+      });
+    }
+  }
+
+}
+
+
+module.exports = DialogValidation;

--- a/app/javascript/src/component_dialog_validation.js
+++ b/app/javascript/src/component_dialog_validation.js
@@ -40,7 +40,7 @@ class DialogValidation {
 
       // Now jQueryUI dialog is in place let's initialise container and put class on it.
       dialog.$container = dialog.$node.parents(".ui-dialog");
-      dialog.$container.addClass("DialogApiRequest");
+      dialog.$container.addClass("DialogValidation");
     });
 
 
@@ -105,16 +105,20 @@ class DialogValidation {
     }
   }
 
+  /* 
+  * simply a function alias for better readability / nicer api 
+  * expected to eb called if the dialog html is changed dynamically\
+  * will re-enhance the html to add the required functionality 
+  * */
   refresh() {
+    this.#enhance();
+  }
+
+  #enhance() {
     var dialog = this;
     this.#setupCloseButtons();
     this.#setupSubmitButton();
     utilities.safelyActivateFunction(dialog.#config.onRefresh, dialog);
-  }
-
-  /* simply a function alias for better readability on first load */
-  #enhance() {
-    this.refresh();
   }
 
   /* add event listeners to configured close buttons */

--- a/app/javascript/src/components/menus/activated_menu.js
+++ b/app/javascript/src/components/menus/activated_menu.js
@@ -173,10 +173,19 @@ class ActivatedMenu {
     if( index < 0 ) {
       index = $items.length - 1;
     }
-    this.currentFocusIndex = index;
     var $item = $($items[index]).find('> :first-child');
-    $item.focus();
-    this.$node.attr('aria-activedescendant', $item.attr('id'));
+    if($item.parent().is('[aria-disabled]')) {
+      // if item is disabled, skip it
+      if( index > this.currentFocusIndex) {
+        this.focus(index+1);  
+      } else {
+        this.focus(index-1);  
+      }
+    } else {
+      this.currentFocusIndex = index;
+      $item.focus();
+      this.$node.attr('aria-activedescendant', $item.attr('id'));
+    }
   }
 
   focusNext(){

--- a/app/javascript/src/components/menus/question_menu.js
+++ b/app/javascript/src/components/menus/question_menu.js
@@ -40,7 +40,7 @@ class QuestionMenu extends ActivatedMenu {
 
     this.container.$node.addClass("QuestionMenu");
     this.question = config.question;
-    this.setRequiredViewState();
+    this.setValidationStates();
   }
 
   selection(event, item) {
@@ -55,6 +55,9 @@ class QuestionMenu extends ActivatedMenu {
       case "required":
           this.required();
           break;
+      case "validation":
+        this.validation(item);
+        break;
       case "close":
         this.close();
         break;
@@ -69,6 +72,11 @@ class QuestionMenu extends ActivatedMenu {
     $(document).trigger("QuestionMenuSelectionRequired", this.question);
   }
 
+  validation(menuItem) {
+    var validation = menuItem.data("validation");
+    $(document).trigger("QuestionMenuSelectionValidation", { question: this.question, validation: validation });
+  }
+
   close() {
     super.close(); 
     this.activator.$node.removeClass("active");
@@ -76,13 +84,26 @@ class QuestionMenu extends ActivatedMenu {
 
   /* Change required option state for view purpose
    **/
-  setRequiredViewState() {
-    if(this.question.data.validation.required) {
-      this.$node.find("[data-action=required] > :first-child").attr("aria-checked", "true");
-    }
-    else {
-      this.$node.find("[data-action=required] > :first-child").attr("aria-checked", "false");
-    }
+  // setRequiredViewState() {
+  //   if(this.question.data.validation.required) {
+  //     this.$node.find("[data-action=required] > :first-child").attr("aria-checked", "true");
+  //   }
+  //   else {
+  //     this.$node.find("[data-action=required] > :first-child").attr("aria-checked", "false");
+  //   }
+  // }
+  
+  setValidationStates() {
+    var validationData = this.question.data.validation;
+    this.$node.find("[data-validation]").each(function() {
+      var validationType = $(this).data('validation');
+      if( validationData[validationType] ) {
+        $(this).find('> :first-child').attr('aria-checked', 'true');
+      } else {
+        $(this).find('> :first-child').attr('aria-checked', 'false');
+      }
+    });
   }
+
 }
 module.exports = QuestionMenu; 

--- a/app/javascript/src/components/menus/question_menu.js
+++ b/app/javascript/src/components/menus/question_menu.js
@@ -40,7 +40,7 @@ class QuestionMenu extends ActivatedMenu {
 
     this.container.$node.addClass("QuestionMenu");
     this.question = config.question;
-    this.setValidationStates();
+    this.setEnabledValidations();
   }
 
   selection(event, item) {
@@ -82,18 +82,7 @@ class QuestionMenu extends ActivatedMenu {
     this.activator.$node.removeClass("active");
   }
 
-  /* Change required option state for view purpose
-   **/
-  // setRequiredViewState() {
-  //   if(this.question.data.validation.required) {
-  //     this.$node.find("[data-action=required] > :first-child").attr("aria-checked", "true");
-  //   }
-  //   else {
-  //     this.$node.find("[data-action=required] > :first-child").attr("aria-checked", "false");
-  //   }
-  // }
-  
-  setValidationStates() {
+  setEnabledValidations() {
     var validationData = this.question.data.validation;
     this.$node.find("[data-validation]").each(function() {
       var validationType = $(this).data('validation');

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -19,7 +19,6 @@
 const  { 
   updateHiddenInputOnForm,
   stringInject,
-  post
 }  = require('./utilities');
 const ActivatedMenu = require('./components/menus/activated_menu');
 const editable_components = require('./editable_components');
@@ -269,7 +268,6 @@ function addQuestionMenuListeners(view) {
 
   view.$document.on("QuestionMenuSelectionValidation", function(event, details) {
     const {question, validation} = details;
-    var questionUuid = question.data._uuid;
     var apiUrl = question.menu.selectedItem.data('apiPath');
     
     new DialogValidation(apiUrl, {
@@ -298,26 +296,27 @@ function addQuestionMenuListeners(view) {
       onRefresh: function(dialog) {
         var $revealingCheckboxes = dialog.$node.find('input[type="checkbox"][aria-controls]');
         $revealingCheckboxes.each(function() {
-          var id = $(this).attr('aria-controls');
-          var checked = $(this).prop('checked');
+          var checkbox = $(this);
+          var id = checkbox.attr('aria-controls');
+          var checked = checkbox.prop('checked');
           var $content = dialog.$node.find('#'+id);
 
           if(checked) {
             $content.removeClass('govuk-checkboxes__conditional--hidden');
-            $(this).attr('aria-expanded', true);
+            checkbox.attr('aria-expanded', true);
           } else {
             $content.addClass('govuk-checkboxes__conditional--hidden');
-            $(this).attr('aria-expanded', false);
+            checkbox.attr('aria-expanded', false);
           }
 
-          $(this).on('change', function() {
-            var checked = $(this).prop('checked');
+          checkbox.on('change', function() {
+            var checked = checkbox.prop('checked');
             if(checked) {
               $content.removeClass('govuk-checkboxes__conditional--hidden');
-              $(this).attr('aria-expanded', true);
+              checkbox.attr('aria-expanded', true);
             } else {
               $content.addClass('govuk-checkboxes__conditional--hidden');
-              $(this).attr('aria-expanded', false);
+              checkbox.attr('aria-expanded', false);
             }
           });
         }); 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -294,6 +294,7 @@ function addQuestionMenuListeners(view) {
           $valueField.val('');
         }
       },
+
       submit: function(dialog) {
         var $form = dialog.$node.find('form');
           $.ajax({ 

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -65,8 +65,24 @@ class Question {
       this.data.validation[arr[i].name] = (arr[i].value == "true" ? true : false);
     }
 
-    this.menu.setRequiredViewState();
+    this.menu.setValidationStates();
     this.setRequiredFlag();
+  }
+
+  get validation() {
+    return this.data.validation;
+  }
+
+  set validation(data) {
+    Object.keys(data).forEach( (validationType) => {
+        if(data[validationType] == '') {
+          delete this.data.validation[validationType];
+        } else {
+          this.data.validation[validationType] = data[validationType];
+        }
+    });
+    this.menu.setValidationStates();
+    this.editable.emitSaveRequired();
   }
 
 
@@ -111,7 +127,7 @@ class Question {
  **/
 function createQuestionMenu() {
   var question = this;
-  var template = $("[data-component-template=QuestionMenu]");
+  var template = $("[data-component-template=QuestionMenu_"+question.data._uuid+"]");
   var $ul = $(template.html());
 
   // Need to make sure $ul is added to body before we try to create a QuestionMenu out of it.

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -69,10 +69,6 @@ class Question {
     this.setRequiredFlag();
   }
 
-  get validation() {
-    return this.data.validation;
-  }
-
   set validation(data) {
     Object.keys(data).forEach( (validationType) => {
         if(data[validationType] == '') {

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -65,7 +65,7 @@ class Question {
       this.data.validation[arr[i].name] = (arr[i].value == "true" ? true : false);
     }
 
-    this.menu.setValidationStates();
+    this.menu.setEnabledValidations();
     this.setRequiredFlag();
   }
 
@@ -81,7 +81,7 @@ class Question {
           this.data.validation[validationType] = data[validationType];
         }
     });
-    this.menu.setValidationStates();
+    this.menu.setEnabledValidations();
     this.editable.emitSaveRequired();
   }
 

--- a/app/models/component_validations/base_component_validation.rb
+++ b/app/models/component_validations/base_component_validation.rb
@@ -57,7 +57,7 @@ class BaseComponentValidation
   def to_json(*_args); end
 
   private
-  
+
   def previously_enabled?
     component_validation.key?(validator)
   end

--- a/app/models/component_validations/base_component_validation.rb
+++ b/app/models/component_validations/base_component_validation.rb
@@ -57,9 +57,9 @@ class BaseComponentValidation
   def to_json(*_args); end
 
   private
-
+  
   def previously_enabled?
-    component_validation.key(validator)
+    component_validation.key?(validator)
   end
 
   def component_validation

--- a/app/models/component_validations/minimum_validation.rb
+++ b/app/models/component_validations/minimum_validation.rb
@@ -16,10 +16,10 @@ class MinimumValidation < BaseComponentValidation
   end
 
   def to_metadata
-    return { DEFAULT_METADATA_KEY => '' } if status.blank? 
+    return { DEFAULT_METADATA_KEY => '' } if status.blank?
 
     meta = default_metadata(DEFAULT_METADATA_KEY)
-    meta[DEFAULT_METADATA_KEY] = value  
+    meta[DEFAULT_METADATA_KEY] = value
     meta
   end
 end

--- a/app/models/component_validations/minimum_validation.rb
+++ b/app/models/component_validations/minimum_validation.rb
@@ -16,8 +16,10 @@ class MinimumValidation < BaseComponentValidation
   end
 
   def to_metadata
+    return { DEFAULT_METADATA_KEY => '' } if status.blank? 
+
     meta = default_metadata(DEFAULT_METADATA_KEY)
-    meta[DEFAULT_METADATA_KEY] = value
+    meta[DEFAULT_METADATA_KEY] = value  
     meta
   end
 end

--- a/app/views/api/component_validations/_minimum_validation.html.erb
+++ b/app/views/api/component_validations/_minimum_validation.html.erb
@@ -1,1 +1,12 @@
-<input class="govuk-input govuk-!-width-one-third" id="component_validation_minimum" name="component_validation[value]" type="" spellcheck="false" autocomplete="" value="<%= @component_validation.main_value %>">
+<label class="govuk-label govuk-label--m govuk-visually-hidden" for="component_validation_value">Minimum number</label>
+<input class="govuk-input govuk-input--width-5 <%= @component_validation.errors.present? ? 'govuk-input--error' : '' %>"
+       id="component_validation_value"
+       name="component_validation[value]"
+       required
+       pattern="[0-9]*" 
+       inputmode="numeric"
+       spellcheck="false"
+       autocomplete=""
+       aria-describedby="<%= @component_validation.errors.present? ? 'component_validation_value_error' : '' %>"
+       <%=   @component_validation.errors.present? ? 'aria-invalid=true' : '' %>
+       value="<%= @component_validation.main_value %>">

--- a/app/views/api/component_validations/_new.html.erb
+++ b/app/views/api/component_validations/_new.html.erb
@@ -7,7 +7,8 @@
       <%= f.label :component_validation, @component_validation.label, class: "govuk-label govuk-label--m" %>
       <div class="govuk-checkboxes" data-module="govuk-checkboxes">
         <div class="govuk-checkboxes__item">
-          <input class="govuk-checkboxes__input" id="component_validation_status" name="component_validation[status]" type="checkbox" value="enabled" data-aria-controls="conditional_component_validation" <%= @component_validation.enabled? ? 'checked' : '' %>>
+          <input type="hidden" name="component_validation[status]" value="" />
+          <input class="govuk-checkboxes__input" id="component_validation_status" name="component_validation[status]" type="checkbox" value="enabled" aria-controls="conditional_component_validation" <%= @component_validation.enabled? ? 'checked' : '' %>>
           <label class="govuk-label govuk-checkboxes__label" for="component_validation_status">
             <%= @component_validation.status_label %>
           </label>
@@ -15,16 +16,17 @@
 
         <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="conditional_component_validation">
           <div class="govuk-form-group <%= @component_validation.errors.present? ? 'govuk-form-group--error' : '' %>">
-          <% @component_validation.errors.each do |error|  %>
-            <span class="govuk-error-message"><%= error.message %></span>
-          <% end %>
+            <% @component_validation.errors.each do |error|  %>
+              <span class="govuk-error-message"><%= error.message %></span>
+            <% end %>
 
-          <%= render @component_validation.component_partial %>
+            <%= render @component_validation.component_partial %>
+          </div>
         </div>
       </div>
     </div>
 
-    <button class="govuk-button fb-govuk-button">
+    <button class="govuk-button fb-govuk-button" type="submit">
       <%= t('dialogs.component_validations.button') %>
     </button>
 

--- a/app/views/api/component_validations/_new.html.erb
+++ b/app/views/api/component_validations/_new.html.erb
@@ -2,28 +2,32 @@
   <%= form_for @component_validation,
       url: api_service_page_component_validations_path(
            service.service_id, @component_validation.page_uuid, @component_validation.component_uuid, @component_validation.validator
-           ) do |f| %>
-    <div class="govuk-form-group">
-      <%= f.label :component_validation, @component_validation.label, class: "govuk-label govuk-label--m" %>
-      <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-        <div class="govuk-checkboxes__item">
-          <input type="hidden" name="component_validation[status]" value="" />
-          <input class="govuk-checkboxes__input" id="component_validation_status" name="component_validation[status]" type="checkbox" value="enabled" aria-controls="conditional_component_validation" <%= @component_validation.enabled? ? 'checked' : '' %>>
-          <label class="govuk-label govuk-checkboxes__label" for="component_validation_status">
-            <%= @component_validation.status_label %>
-          </label>
-        </div>
+      ), 
+      html: { novalidate: true } do |f| %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <%= @component_validation.label -%>
+          </legend>
+          <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="component_validation_status" name="component_validation[status]" type="checkbox" value="enabled" aria-controls="conditional_component_validation" <%= @component_validation.enabled? ? 'checked' : '' %>>
+              <label class="govuk-label govuk-checkboxes__label" for="component_validation_status">
+                <%= @component_validation.status_label %>
+              </label>
+            </div>
 
-        <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="conditional_component_validation">
-          <div class="govuk-form-group <%= @component_validation.errors.present? ? 'govuk-form-group--error' : '' %>">
-            <% @component_validation.errors.each do |error|  %>
-              <span class="govuk-error-message"><%= error.message %></span>
-            <% end %>
+            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="conditional_component_validation">
+              <div class="govuk-form-group <%= @component_validation.errors.present? ? 'govuk-form-group--error' : '' %>">
+                <% @component_validation.errors.each do |error|  %>
+                  <span class="govuk-error-message" id="component_validation_value_error"><%= error.message %></span>
+                <% end %>
 
-            <%= render @component_validation.component_partial %>
+                <%= render @component_validation.component_partial %>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
+        </fieldset>
     </div>
 
     <button class="govuk-button fb-govuk-button" type="submit">

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -9,7 +9,7 @@
 <%= render template: @page.template %>
 <%= render partial: 'partials/add_component_button' %>
 <%= render partial: 'partials/add_content_button' %>
-<%= render partial: 'partials/template_question_menu' %>
+<%= render partial: 'partials/template_component_question_menu' %>
 <%= render partial: 'partials/template_content_menu' %>
 <%= render partial: 'partials/template_editable_collection_item_menu' %>
 <%= render partial: 'partials/template_dialog_configuration' %>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -1,3 +1,4 @@
+<script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 <header class="govuk-header govuk-header__container" role="banner" data-module="govuk-header">
   <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 

--- a/app/views/partials/_template_component_question_menu.html.erb
+++ b/app/views/partials/_template_component_question_menu.html.erb
@@ -5,16 +5,20 @@
           data-activator-text="<%= t('question.menu.activator') %>">
     <ul class="govuk-navigation component-activated-menu">
       <li data-action="required" data-validation="required"><span role="menuitemcheckbox" aria-checked="<%= component.validation ? component.validation['required'] : 'false' -%>"><%= t('question.menu.required')%></span></li>
-      <li data-action="remove"
-          data-api-path="<%= URI.decode_www_form_component(api_service_page_question_destroy_message_path(service.service_id, @page.uuid, component.uuid, method: :delete)) -%>">
-        <span class="destructive"><%= t('question.menu.remove')%></span>
-      </li>
+
 
       <% enabled_validations(component).each do |validation| %>
         <li data-action="validation"
             data-validation="<%= validation %>"
             data-api-path="<%= URI.decode_www_form_component(api_service_page_component_validations_path(service.service_id, @page.uuid, component.uuid, validation)) -%>">
           <span role="menuitemcheckbox" aria-checked="<%= component.validation[validation] ? 'true' : 'false' -%>"><%= t("question.menu.#{validation}") %></span>
+        </li>
+      <% end %>
+
+      <% unless @page.type == 'page.singlequestion' %>
+         <li data-action="remove"
+            data-api-path="<%= URI.decode_www_form_component(api_service_page_question_destroy_message_path(service.service_id, @page.uuid, component.uuid, method: :delete)) -%>">
+          <span class="destructive"><%= t('question.menu.remove')%></span>
         </li>
       <% end %>
     </ul>

--- a/app/views/partials/_template_component_question_menu.html.erb
+++ b/app/views/partials/_template_component_question_menu.html.erb
@@ -4,16 +4,17 @@
           data-component-uuid="<%= component.uuid %>"
           data-activator-text="<%= t('question.menu.activator') %>">
     <ul class="govuk-navigation component-activated-menu">
-      <li data-action="required"><span role="menuitemcheckbox" aria-checked="<%= component.validation['required'] -%>"><%= t('question.menu.required')%></span></li>
+      <li data-action="required" data-validation="required"><span role="menuitemcheckbox" aria-checked="<%= component.validation['required'] -%>"><%= t('question.menu.required')%></span></li>
       <li data-action="remove"
           data-api-path="<%= URI.decode_www_form_component(api_service_page_question_destroy_message_path(service.service_id, @page.uuid, component.uuid, method: :delete)) -%>">
         <span class="destructive"><%= t('question.menu.remove')%></span>
       </li>
 
       <% enabled_validations(component).each do |validation| %>
-        <li data-action="<%= validation %>"
+        <li data-action="validation"
+            data-validation="<%= validation %>"
             data-api-path="<%= URI.decode_www_form_component(api_service_page_component_validations_path(service.service_id, @page.uuid, component.uuid, validation)) -%>">
-          <span role="menuitemcheckbox" aria-checked="<%= component.validation[validation] -%>"><%= t("question.menu.#{validation}") %></span>
+          <span role="menuitemcheckbox" aria-checked="<%= component.validation[validation] ? 'true' : 'false' -%>"><%= t("question.menu.#{validation}") %></span>
         </li>
       <% end %>
     </ul>

--- a/app/views/partials/_template_component_question_menu.html.erb
+++ b/app/views/partials/_template_component_question_menu.html.erb
@@ -1,10 +1,10 @@
-<% @page.components.each do |component| %>
+<% @page.components&.each do |component| %>
   <script type="text/html"
           data-component-template="QuestionMenu_<%= component.uuid %>"
           data-component-uuid="<%= component.uuid %>"
           data-activator-text="<%= t('question.menu.activator') %>">
     <ul class="govuk-navigation component-activated-menu">
-      <li data-action="required" data-validation="required"><span role="menuitemcheckbox" aria-checked="<%= component.validation['required'] -%>"><%= t('question.menu.required')%></span></li>
+      <li data-action="required" data-validation="required"><span role="menuitemcheckbox" aria-checked="<%= component.validation ? component.validation['required'] : 'false' -%>"><%= t('question.menu.required')%></span></li>
       <li data-action="remove"
           data-api-path="<%= URI.decode_www_form_component(api_service_page_question_destroy_message_path(service.service_id, @page.uuid, component.uuid, method: :delete)) -%>">
         <span class="destructive"><%= t('question.menu.remove')%></span>

--- a/config/initializers/enabled_validations.rb
+++ b/config/initializers/enabled_validations.rb
@@ -3,7 +3,6 @@ Rails.application.config.enabled_validations = %w(
   date
   email
   max_size
-  minimum
   number
   required
   upload

--- a/test/component_activated_question_menu_test.js
+++ b/test/component_activated_question_menu_test.js
@@ -36,7 +36,7 @@ describe("QuestionMenu", function() {
     // components use it so we can use it here.
 
     var $ul = $(`<ul>
-                   <li data-action="required"><span>Required</span></li>
+                   <li data-action="required" data-validation="required"><span>Required</span></li>
                    <li data-action="remove"><span>Remove</span></li>
                    <li data-action="detonate"><span>Detonate</span></li>
                  </ul>`);
@@ -230,26 +230,16 @@ describe("QuestionMenu", function() {
     });
   });
 
-  describe("setRequiredViewState()", function() {
+  describe("setEnabledValidations", function() {
     it("should add aria-checked to required item when required is true", function() {
-      var $target = menu.$node.find("li[data-action=required]");
+      var $target = menu.$node.find("li[data-validation=required]");
       expect($target.children().first().attr("aria-checked")).to.equal("false");
 
       menu.question.data.validation.required = true;
-      menu.setRequiredViewState()
+      menu.setEnabledValidations()
       expect($target.children().first().attr("aria-checked")).to.equal("true");
     });
 
-    it("should remove class 'on' for required item when required is false", function() {
-      var $target = menu.$node.find("li[data-action=required]");
-
-      $target.children().first().attr("aria-checked", "true");
-      expect($target.children().first().attr("aria-checked")).to.equal("true");
-
-      menu.question.data.validation.required = false;
-      menu.setRequiredViewState()
-      expect($target.children().first().attr("aria-checked")).to.equal("false");
-    });
   });
 
   describe("ActivatedMenuContainer", function() {


### PR DESCRIPTION
This PR handles the modal interactions for question validations.

Each component on the page knows what validations are allowed on itself, so now there is a template question_menu in the page for each component.  

If validations are enabled, the appropriate items will be added into the menu.

All validations are handled by the same menu action `data-action="validation"`, another attribute `data-validation="{validation_type}"` is also included on the menu item.  As per other activated menus, this emits an event which is responded to in the controller.

Pages controller is then responsible for loading up the modal dialog with the appropriate template for the validation type and handling the return values from the modal form - success/errors. 

Introduces a new type of dialog `DialogValidation` which is a variation on `DialogApiRequest` adjusted to handle a contining form submitted via ajax request.

Possible further work would be:
 - refactor the revealing checkboxes into their own component.
 - refactor dialogs across the app!




