### PR TITLE
Reduce dependabot PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,11 @@ updates:
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
-  allow:
-    - dependency-type: all
   reviewers:
   - brenetic
   - mattempty
   - njseeto
+  - chrispymm
 - package-ecosystem: npm
   directory: "/"
   schedule:
@@ -20,13 +19,12 @@ updates:
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
-  allow:
-    - dependency-type: all
   reviewers:
   - mattempty
   - form-builder-developers
   - brenetic
   - njseeto
+  - chrispymm
 - package-ecosystem: docker
   directory: "/docker/web"
   schedule:
@@ -38,6 +36,7 @@ updates:
   - brenetic
   - mattempty
   - njseeto
+  - chrispymm
 - package-ecosystem: docker
   directory: "/docker/workers"
   schedule:
@@ -49,6 +48,7 @@ updates:
   - brenetic
   - mattempty
   - njseeto
+  - chrispymm
 - package-ecosystem: docker
   directory: "/acceptance"
   schedule:
@@ -60,3 +60,4 @@ updates:
   - brenetic
   - mattempty
   - njseeto
+  - chrispymm


### PR DESCRIPTION
Set dependabot back to the default dependency config. This will only do
the direct dependencies of the app.

It raises too many PRs that we cannot get through reviewing.

Also add chris as a reviewer.