### PR TITLE
Create Enabled Validations Presenter

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@ module ApplicationHelper
   include MetadataPresenter::ApplicationHelper
 
   def enabled_validations(component)
-    Rails.application.config.enabled_validations & component.supported_validations
+    EnabledValidationsPresenter.new(component).enabled_list
   end
 
   # Used on service flow page

--- a/app/presenters/enabled_validations_presenter.rb
+++ b/app/presenters/enabled_validations_presenter.rb
@@ -1,0 +1,31 @@
+class EnabledValidationsPresenter
+  def initialize(component)
+    @component = component
+  end
+
+  STRING_VALIDATIONS = %w[max_length min_length max_word min_word].freeze
+  STRING_LENGTH_SUFFIX = '_string_length'.freeze
+
+  def enabled_list
+    validations = enabled_validations.map do |validation|
+      if validation.in?(STRING_VALIDATIONS)
+        "#{prefix(validation)}#{STRING_LENGTH_SUFFIX}"
+      else
+        validation
+      end
+    end
+    validations.uniq
+  end
+
+  private
+
+  attr_reader :component
+
+  def enabled_validations
+    Rails.application.config.enabled_validations & component.supported_validations
+  end
+
+  def prefix(validation)
+    validation.split('_').first
+  end
+end

--- a/spec/presenters/enabled_validations_presenter_spec.rb
+++ b/spec/presenters/enabled_validations_presenter_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe EnabledValidationsPresenter do
+  subject(:enabled_validations_presenter) { described_class.new(component) }
+
+  describe '#enabled_list' do
+    context 'when not a text component' do
+      let(:component) { service.find_page_by_url('your-age').components.first }
+      let(:expected_validations_list) { %w[minimum maximum] }
+
+      before do
+        allow(Rails.application.config).to receive(
+          :enabled_validations
+        ).and_return(%w[minimum maximum])
+      end
+
+      it 'keeps the component validation names' do
+        expect(subject.enabled_list).to eq(expected_validations_list)
+      end
+    end
+
+    context 'when a text component that supports string validations' do
+      let(:component) { service.find_page_by_url('name').components.first }
+      let(:expected_validations_list) { %w[max_string_length min_string_length] }
+
+      before do
+        allow(Rails.application.config).to receive(
+          :enabled_validations
+        ).and_return(%w[max_length min_length max_word min_word])
+        allow(component).to receive(:supported_validations).and_return(
+          %w[min_length max_length min_word max_word pattern format]
+        )
+      end
+
+      it 'maps the component validation names to *_string_length' do
+        expect(subject.enabled_list).to eq(expected_validations_list)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The majority of validations use a single modal when a user is
interacting with the configuration. However for the text and textarea
components their validation modals are grouped into pairs.

There is a separation between the min and max config, however the same
modal is used to set the character ('*_length') and the word ('*_word')
validations. As a result of this it is not possible to have a direct
mapping of validation type when the API is called.

In terms of the list of menu items instead of the text and textarea
components having:

- max_length
- min_length
- max_word
- min_word

they will have:

- max_string_length
- min_string_length

The BaseComponentValidation model will have to be able to assign the correct
component validation object during the API request.