### PR TITLE
Adapt expander to handle checkbox revealed inputs

### DIFF
--- a/app/javascript/src/component_expander.js
+++ b/app/javascript/src/component_expander.js
@@ -130,6 +130,7 @@ class Expander {
   #createActivator() {
     var source = this.#config.activator_source;
     var $activator;
+    var activatorEventType;
 
     if(typeof source == 'string') {
       $activator = $('<button>' + source + '</button>');
@@ -137,7 +138,7 @@ class Expander {
     }
     else {
       // Assume source to be jQuery element from this point.
-      if(source.is('button')) {
+      if(this.#isValidActivatorElement(source)) {
         $activator = source;
       }
       else {
@@ -160,7 +161,9 @@ class Expander {
       'aria-controls': this.#id
     });
 
-    $activator.on("click", () => {
+    activatorEventType = this.#isInput($activator) ? 'change' : 'click';
+
+    $activator.on(activatorEventType, () => {
       this.toggle();
     });
 
@@ -215,7 +218,14 @@ class Expander {
     return $node;
   }
 
-}
+  #isValidActivatorElement(source) {
+    return source.is('button') || source.is('input[type="checkbox"]') || source.is('input[type="radio"]')
+  }
 
+  #isInput($activator) {
+     return $activator.is('input[type="checkbox"]') || $activator.is('input[type="radio"]')
+  }
+
+}
 
 module.exports = Expander;

--- a/app/javascript/src/controller_default.js
+++ b/app/javascript/src/controller_default.js
@@ -19,7 +19,6 @@
 
 const Dialog = require('./component_dialog');
 const DialogConfirmation = require('./component_dialog_confirmation');
-const Expander = require('./component_expander');
 const post = require('./utilities').post;
 
 
@@ -39,7 +38,6 @@ class DefaultController {
     this.$lastPoint = $(); // Use it to set a focal point in switching between components.
 
     isolatedMethodDeleteLinks();
-    addExpanderComponents();
 
     // To support keyboard navigation, try to set focus
     // for tabbing back to last important point.
@@ -127,21 +125,6 @@ function isolatedMethodDeleteLinks() {
   $("header [data-method=delete]").on("click", function(e) {
     e.preventDefault();
     post(this.href, { _method: "delete" });
-  });
-}
-
-
-/* Standard search and convert for any elements that have an expander
- * data-component attribute to make it easier to apply the effect
- * using only the template and avoid having to interact with JavaScript.
- */
-function addExpanderComponents() {
-  $("[data-component=Expander]").each(function() {
-    var $node = $(this);
-    new Expander($node, {
-      activator_source: $node.find('> h2').first(),
-      wrap_content: true,
-    });
   });
 }
 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -36,6 +36,7 @@ const DialogApiRequest = require('./component_dialog_api_request');
 const DialogValidation = require('./component_dialog_validation');
 const DefaultController = require('./controller_default');
 const ServicesController = require('./controller_services');
+const Expander = require('./component_expander');
 
 const ATTRIBUTE_DEFAULT_TEXT = "fb-default-text";
 
@@ -294,32 +295,15 @@ function addQuestionMenuListeners(view) {
       },
 
       onRefresh: function(dialog) {
-        var $revealingCheckboxes = dialog.$node.find('input[type="checkbox"][aria-controls]');
-        $revealingCheckboxes.each(function() {
-          var checkbox = $(this);
-          var id = checkbox.attr('aria-controls');
-          var checked = checkbox.prop('checked');
-          var $content = dialog.$node.find('#'+id);
-
-          if(checked) {
-            $content.removeClass('govuk-checkboxes__conditional--hidden');
-            checkbox.attr('aria-expanded', true);
-          } else {
-            $content.addClass('govuk-checkboxes__conditional--hidden');
-            checkbox.attr('aria-expanded', false);
-          }
-
-          checkbox.on('change', function() {
-            var checked = checkbox.prop('checked');
-            if(checked) {
-              $content.removeClass('govuk-checkboxes__conditional--hidden');
-              checkbox.attr('aria-expanded', true);
-            } else {
-              $content.addClass('govuk-checkboxes__conditional--hidden');
-              checkbox.attr('aria-expanded', false);
-            }
+        var $revealedInputs = dialog.$node.find('[data-component="Expander"]');
+        $revealedInputs.each(function() {
+          var $activator = $(this).parent().find('input[type="checkbox"]');
+          new Expander($(this), {
+            activator_source: $activator,
+            auto_open: $activator.prop('checked'),
+            wrap_content: false,
           });
-        }); 
+        });
       },
 
       onSuccess: function(data) {

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -25,6 +25,7 @@ const FlowConditionItem = require('./component_flow_condition_item');
 const ConnectorPath = require('./component_flow_connector_path');
 const PageMenu = require('./components/menus/page_menu');
 const ConnectionMenu = require('./components/menus/connection_menu');
+const Expander = require('./component_expander');
 
 const COLUMN_SPACING = 100;
 const SELECTOR_FLOW_BRANCH = ".flow-branch";
@@ -62,6 +63,7 @@ ServicesController.edit = function() {
   createPageAdditionDialog(view);
   createPageMenus(view);
   createConnectionMenus(view);
+  createExpanderComponents();
 
   if(view.$flowOverview.length) {
     layoutFormFlowOverview(view);
@@ -909,6 +911,21 @@ function calculateAndCreatePageFlowConnectorPath(points, config) {
     }
   }
 }
+
+/* Standard search and convert for any elements that have an expander
+ * data-component attribute to make it easier to apply the effect
+ * using only the template and avoid having to interact with JavaScript.
+ */
+function createExpanderComponents() {
+  $("[data-component=Expander]").each(function() {
+    var $node = $(this);
+    new Expander($node, {
+      activator_source: $node.find('> h2').first(),
+      wrap_content: true,
+    });
+  });
+}
+
 
 
 module.exports = ServicesController;

--- a/app/javascript/styles/_component_expander.scss
+++ b/app/javascript/styles/_component_expander.scss
@@ -10,7 +10,7 @@
  *       (steven.burnell@digital.justice.gov.uk to add).
  *
  **/
-.Expander__activator {
+button.Expander__activator {
   @include button_as_link;
   background: transparent;
   font-weight: inherit;

--- a/app/views/api/component_validations/_new.html.erb
+++ b/app/views/api/component_validations/_new.html.erb
@@ -11,13 +11,13 @@
           </legend>
           <div class="govuk-checkboxes" data-module="govuk-checkboxes">
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="component_validation_status" name="component_validation[status]" type="checkbox" value="enabled" aria-controls="conditional_component_validation" <%= @component_validation.enabled? ? 'checked' : '' %>>
+              <input class="govuk-checkboxes__input" id="component_validation_status" name="component_validation[status]" type="checkbox" value="enabled" <%= @component_validation.enabled? ? 'checked' : '' %>>
               <label class="govuk-label govuk-checkboxes__label" for="component_validation_status">
                 <%= @component_validation.status_label %>
               </label>
             </div>
 
-            <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="conditional_component_validation">
+            <div class="govuk-checkboxes__conditional" data-component="Expander" >
               <div class="govuk-form-group <%= @component_validation.errors.present? ? 'govuk-form-group--error' : '' %>">
                 <% @component_validation.errors.each do |error|  %>
                   <span class="govuk-error-message" id="component_validation_value_error"><%= error.message %></span>


### PR DESCRIPTION
Makes changes to the expander component to support using a checkbox or radio button as the activator.

Allows the expander component to be used for conditionally-revelaed inputs pattern used in the validation modals.

Doing this required moving the initializer for the flow view expanders from `controller_default` into `controller_services` to enable the different kinds of expander to be initialized without conflict. 