### PR TITLE
Fix self-referential page deletion

### DIFF
--- a/app/services/page_destroyer.rb
+++ b/app/services/page_destroyer.rb
@@ -37,7 +37,7 @@ class PageDestroyer
 
     @latest_metadata['flow'].each do |_flow_uuid, properties|
       if properties['next']['default'] == uuid
-        properties['next']['default'] = linked_to_uuid
+        properties['next']['default'] = uuid == linked_to_uuid ? '' : linked_to_uuid
       end
 
       next if properties['next']['conditionals'].blank?

--- a/spec/services/page_destroyer_spec.rb
+++ b/spec/services/page_destroyer_spec.rb
@@ -81,6 +81,30 @@ RSpec.describe PageDestroyer do
           expect(page.destroy).to eq(updated_metadata)
         end
       end
+
+      context 'page is pointing to itself' do
+        let(:uuid) { '2ef7d11e-0307-49e9-9fe2-345dc528dd66' }
+        let(:last_page_uuid) { '80420693-d6f2-4fce-a860-777ca774a6f5' }
+        let(:fixture) do
+          meta = metadata_fixture(:version)
+          meta['flow'][uuid]['next']['default'] = uuid
+          meta
+        end
+        let(:updated_metadata) do
+          metadata = fixture.deep_dup
+          page_index = metadata['pages'].find_index do |page|
+            page['_uuid'] == uuid
+          end
+          metadata['pages'].delete_at(page_index)
+          metadata['flow'].delete(uuid)
+          metadata['flow'][last_page_uuid]['next']['default'] = ''
+          metadata
+        end
+
+        it 'updates the next page to empty string' do
+          expect(page.destroy).to eq(updated_metadata)
+        end
+      end
     end
 
     context 'when deleting a page after a branch condition' do


### PR DESCRIPTION
[Trello](https://trello.com/c/GK7AgK0Y/2577-bug-form-breaks-when-you-delete-a-page-that-points-to-itself)
When a page that has itself as its default next is deleted, the app does not know how to deal with this.
This is because the page preceding the deleted page is trying to find the default next of the deleted page, which does not exist.
This commit replaces the default next of the preceding page with an empty string if the page that has been deleted is self-referential.

![Screenshot 2022-05-18 at 15 08 45](https://user-images.githubusercontent.com/29227502/169082031-91c6a5ae-9dea-48d3-b81d-e0deeace6c19.png)

At present, deleting the 'Transport' page in the above example would break the app. With this commit the form is able to render the following:

![Screenshot 2022-05-18 at 15 39 50](https://user-images.githubusercontent.com/29227502/169083361-e38c3181-da66-4bfa-83b4-c2f524dcabaf.png)
 