### PR TITLE
Fix alignment of date question menu activator button

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -426,7 +426,8 @@ html {
 
 // Not nice but trying to work around some margin annoyance caused by GDS css
 [data-fb-pagetype="page.multiplequestions"] {
-  .EditableCollectionFieldComponent legend {
+  .EditableCollectionFieldComponent legend,
+  .EditableGroupFieldComponent {
 
     legend {
       display: contents;


### PR DESCRIPTION
Quick fix to correct the alignment of Date (EditableGroupField) question menu activators.

**Before:**
![image](https://user-images.githubusercontent.com/595564/169806137-ff0f1c96-692f-4392-9ac7-12ee04c7bd0d.png)

**After:**
![image](https://user-images.githubusercontent.com/595564/169806198-a143786c-9098-474b-a8f1-4d3dd5506370.png)
