### PR TITLE
Add warning message when there is no service output configuration set

### DIFF
--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -48,6 +48,8 @@ feature 'Publishing' do
     when_I_visit_the_publishing_page
     then_I_should_see_the_service_output_warning(I18n.t('publish.environment.test'))
     then_I_should_see_the_service_output_warning(I18n.t('publish.environment.live'))
+
+    cleanup_service_configuration
   end
 
   scenario 'when visiting the publishing page with submitting pages present' do
@@ -233,5 +235,17 @@ feature 'Publishing' do
       environment: deployment_environment
     )
     expect(editor.text).to_not include(warning_message)
+  end
+
+  def cleanup_service_configuration
+    # The service config is saved to the DB only using the service id as an identifier.
+    # This is just to stop the build up of table rows related to services that
+    # will have been deleted by the Metadata API as it cleans up after acceptance
+    # test runs.
+    and_I_click_the_submission_settings_link
+    and_I_click_the_send_data_by_email_link
+    editor.find(:css, '#configure-dev').click
+    editor.find(:css, '#email_settings_service_email_output').set('')
+    and_I_save_my_email_settings
   end
 end

--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -25,6 +25,31 @@ feature 'Publishing' do
     given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
   end
 
+  scenario 'service email output warning message' do
+    when_I_visit_the_publishing_page
+    then_I_should_see_the_service_output_warning(I18n.t('publish.environment.test'))
+    then_I_should_see_the_service_output_warning(I18n.t('publish.environment.live'))
+
+    and_I_click_the_submission_settings_link
+    and_I_click_the_send_data_by_email_link
+    and_I_set_sending_email_for_test_checkbox(true)
+    and_I_set_the_email_field
+    and_I_save_my_email_settings
+
+    when_I_visit_the_publishing_page
+    then_I_should_not_see_the_service_output_warning(I18n.t('publish.environment.test'))
+    then_I_should_see_the_service_output_warning(I18n.t('publish.environment.live'))
+
+    and_I_click_the_submission_settings_link
+    and_I_click_the_send_data_by_email_link
+    and_I_set_sending_email_for_test_checkbox(false)
+    and_I_save_my_email_settings
+
+    when_I_visit_the_publishing_page
+    then_I_should_see_the_service_output_warning(I18n.t('publish.environment.test'))
+    then_I_should_see_the_service_output_warning(I18n.t('publish.environment.live'))
+  end
+
   scenario 'when visiting the publishing page with submitting pages present' do
     given_I_have_a_single_question_page_with_upload
     and_I_return_to_flow_page
@@ -97,6 +122,29 @@ feature 'Publishing' do
     editor.find('#publish-environments').find(:button, text: "Publish to #{environment}").click
   end
 
+  def and_I_click_the_submission_settings_link
+    # Test environment submission settings
+    editor.all('a', text: I18n.t('publish.service_output.link')).first.click
+  end
+
+  def and_I_click_the_send_data_by_email_link
+    click_link(I18n.t('settings.submission.email.label'))
+  end
+
+  def and_I_set_sending_email_for_test_checkbox(value)
+    editor.find(:css, '#email_settings_send_by_email_dev', visible: false).set(value)
+  end
+
+  def and_I_set_the_email_field
+    editor.find(:css, '#configure-dev').click
+    editor.find(:css, '#email_settings_service_email_output').set('paul@atreides.com')
+  end
+
+  def and_I_save_my_email_settings
+    # Save button ids and text are the same so pick the first one which is for Test
+    editor.all(:button, I18n.t('actions.save')).first.click
+  end
+
   def then_username_and_password_should_be_selected(environment)
     # defaults to requiring a username and password so the radio is pre selected
 
@@ -167,5 +215,23 @@ feature 'Publishing' do
 
   def then_I_should_not_see_publish_to_test_modal
     expect(editor.text).to_not include(modal_description)
+  end
+
+  def then_I_should_see_the_service_output_warning(deployment_environment)
+    warning_message = I18n.t(
+      'publish.service_output.message',
+      href: I18n.t('publish.service_output.link'),
+      environment: deployment_environment
+    )
+    expect(editor.text).to include(warning_message)
+  end
+
+  def then_I_should_not_see_the_service_output_warning(deployment_environment)
+    warning_message = I18n.t(
+      'publish.service_output.message',
+      href: I18n.t('publish.service_output.link'),
+      environment: deployment_environment
+    )
+    expect(editor.text).to_not include(warning_message)
   end
 end

--- a/app/services/publish_service_creation.rb
+++ b/app/services/publish_service_creation.rb
@@ -71,6 +71,10 @@ class PublishServiceCreation
     ).present?
   end
 
+  def no_service_output?
+    send_by_email.blank? || (send_by_email.present? && service_email_output.blank?)
+  end
+
   private
 
   def create_publish_service
@@ -136,5 +140,20 @@ class PublishServiceCreation
                               else
                                 REQUIRE_AUTHENTICATION
                               end
+  end
+
+  def send_by_email
+    SubmissionSetting.find_by(
+      service_id: service_id,
+      deployment_environment: deployment_environment
+    ).try(:send_email?)
+  end
+
+  def service_email_output
+    ServiceConfiguration.find_by(
+      service_id: service_id,
+      deployment_environment: deployment_environment,
+      name: 'SERVICE_EMAIL_OUTPUT'
+    )
   end
 end

--- a/app/views/publish/_service_output_warning.html.erb
+++ b/app/views/publish/_service_output_warning.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive"><%= t('publish.service_output.warning') %></span>
+    <%= t('publish.service_output.message', href: link_to(t('publish.service_output.link'),
+        settings_submission_index_path(service.service_id), class: 'govuk-link'),
+        environment: environment).html_safe %>
+  </strong>
+</div>

--- a/app/views/publish/index.html.erb
+++ b/app/views/publish/index.html.erb
@@ -35,6 +35,10 @@
       <p><%= PublishServicePresenter.hostname_for(deployment_environment: 'dev', view: self) %></p>
     <% end %>
 
+    <% if @publish_service_creation_dev.no_service_output? %>
+      <%= render 'service_output_warning', environment: t('publish.environment.test') %>
+    <% end %>
+
     <%# TODO: Need an indicator from BE code that shows whether this is first-time publish   %>
     <%#       Currently have hardcoded 'false' value to avoid dialog showing but this should %>
     <%#       be dynamic to control dialog visibility.                                        %>
@@ -59,6 +63,10 @@
 
     <% if @published_production %>
       <p><%= PublishServicePresenter.hostname_for(deployment_environment: 'production', view: self) %></p>
+    <% end %>
+
+    <% if @publish_service_creation_production.no_service_output? %>
+      <%= render 'service_output_warning', environment: t('publish.environment.live') %>
     <% end %>
 
     <%# TODO: Hardcoded 'firstpublish' (see comment above) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,6 +260,13 @@ en:
       confirmation: 'Your form has no confirmation page - you won’t receive any user data without one'
       cya: 'Your form has no check answers page - you won’t receive any user data without one'
       both_pages: 'Your form has no check answers page or confirmation page - you won’t receive any user data without them'
+    environment:
+      test: Test
+      live: Live
+    service_output:
+      warning: Warning
+      message: "Update your %{environment} site %{href} to receive data from this form"
+      link: submission settings
     dialog:
       heading: Publish to Test?
       option_1: Allow anyone with the link to view

--- a/spec/services/publish_service_creation_spec.rb
+++ b/spec/services/publish_service_creation_spec.rb
@@ -265,4 +265,40 @@ RSpec.describe PublishServiceCreation, type: :model do
       end
     end
   end
+
+  describe '#no_service_output?' do
+    %w[dev production].each do |environment|
+      context "when #{environment} environment" do
+        let(:attributes) { { deployment_environment: environment } }
+
+        context 'when send by email is enabled' do
+          before do
+            create(:submission_setting, environment.to_sym, :send_email, service_id: service_id)
+          end
+
+          context 'when service email output exists' do
+            before do
+              create(:service_configuration, environment.to_sym, :service_email_output, service_id: service_id)
+            end
+
+            it 'should return falsey' do
+              expect(publish_service_creation.no_service_output?).to be_falsey
+            end
+          end
+
+          context 'when there is no service email output' do
+            it 'should return truthy' do
+              expect(publish_service_creation.no_service_output?).to be_truthy
+            end
+          end
+        end
+
+        context 'when send by email is disabled (does not exist)' do
+          it 'should return truthy' do
+            expect(publish_service_creation.no_service_output?).to be_truthy
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Whenever a service has no output configuration set then we should show a
warning message to let the user know. At this moment there is only
output using email so we check with `SERVICE_EMAIL_OUTPUT` config is
saved for a given environment or not.

![Screenshot 2022-05-23 at 13 46 18](https://user-images.githubusercontent.com/3466862/169822477-64aa6b2a-48e9-4b33-b17a-3f3ad362ddce.png)

