### PR TITLE
Re-publish live radio buttons

### DIFF
--- a/app/views/publish/_form.html.erb
+++ b/app/views/publish/_form.html.erb
@@ -6,7 +6,7 @@
   </h2>
   <div class="govuk-radios">
     <div class="govuk-radios__item">
-      <%= f.radio_button :require_authentication, 0, class: 'govuk-radios__input', checked: f.object.existing_authentication?(deployment_environment: deployment_environment), id: "require_authentication_#{deployment_environment}_1" %>
+      <%= f.radio_button :require_authentication, 0, class: 'govuk-radios__input', checked: !f.object.existing_authentication?(deployment_environment: deployment_environment), id: "require_authentication_#{deployment_environment}_1" %>
       <%= f.label :allow_anonymous, class: 'govuk-label govuk-radios__label', for: "require_authentication_#{deployment_environment}_1" %>
     </div>
     <div class="govuk-radios__item">


### PR DESCRIPTION
[Trello](https://trello.com/c/QruUxdH5/2547-radio-button-on-live-republish-not-displaying-correctly-prioritisation-score-7)
When a form user publishes their form to live without authentication, and then clicks the 'Publish to Live' button again, neither radio buttons are selected.

This is because the `existing_authentication?` method checks whether:
- A service has previously been published or
- If authentication has been previously set

We want the 'Set a username and password' radio to be selected when:
- A user has not previously published a form
- A user has published a form with authentication

We want the 'Allow anyone with the link to view' radio to be selected when:
- A user has published a form without authentication

### Before
![Screenshot 2022-05-25 at 10 48 22](https://user-images.githubusercontent.com/29227502/170234389-ffb1244c-2575-41f1-880a-5e08b98d0702.png)

### After
![Screenshot 2022-05-25 at 10 48 41](https://user-images.githubusercontent.com/29227502/170234408-2a3bd231-d186-4452-88d9-7bf9c59a3e5a.png)