### PR TITLE
Character and word count validation for text and textarea components

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.16.10'
+gem 'metadata_presenter', '2.16.11'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.16.10)
+    metadata_presenter (2.16.11)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -428,7 +428,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.16.10)
+  metadata_presenter (= 2.16.11)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/acceptance/features/component_validations_spec.rb
+++ b/acceptance/features/component_validations_spec.rb
@@ -223,7 +223,7 @@ feature 'Component validations' do
     let(:preview_field) { 'answers[number_number_1]' }
     let(:preview_first_value) { '1' }
     let(:preview_second_value) { '20' }
-    let(:preview_error_message) { 'Enter a higher number for Number' }
+    let(:preview_error_message) { 'Your answer for "Number" must be 3 or higher' }
 
     it_behaves_like 'a number component validation'
   end
@@ -238,7 +238,7 @@ feature 'Component validations' do
     let(:preview_field) { 'answers[number_number_1]' }
     let(:preview_first_value) { '100' }
     let(:preview_second_value) { '5' }
-    let(:preview_error_message) { 'Enter a lower number for Number' }
+    let(:preview_error_message) { 'Your answer for "Number" must be 50 or lower' }
 
     it_behaves_like 'a number component validation'
   end
@@ -261,7 +261,7 @@ feature 'Component validations' do
     let(:second_answers) { { 'day' => '28', 'month' => '02', 'year' => '1999' } }
     let(:preview_first_date) { { day: '01', month: '02', year: '1901' } }
     let(:preview_second_date) { { day: '28', month: '02', year: '2001' } }
-    let(:preview_error_message) { 'Enter a later date for Date' }
+    let(:preview_error_message) { 'Your answer for "Date" must be 28 02 1999 or later' }
 
     it_behaves_like 'a date component validation'
   end
@@ -284,7 +284,7 @@ feature 'Component validations' do
     let(:second_answers) { { 'day' => '14', 'month' => '08', 'year' => '2045' } }
     let(:preview_first_date) { { day: '01', month: '02', year: '2050' } }
     let(:preview_second_date) { { day: '28', month: '02', year: '2001' } }
-    let(:preview_error_message) { 'Enter an earlier date for Date' }
+    let(:preview_error_message) { 'Your answer for "Date" must be 14 08 2045 or earlier' }
 
     it_behaves_like 'a date component validation'
   end
@@ -299,7 +299,7 @@ feature 'Component validations' do
     let(:preview_field) { 'answers[text_text_1]' }
     let(:preview_first_answer) { 'Po' }
     let(:prview_second_answer) { 'Akira' }
-    let(:preview_error_message) { "Your answer for 'Text' is too short (3 characters at least)" }
+    let(:preview_error_message) { 'Your answer for "Text" must be 3 characters or more' }
 
     it_behaves_like 'a string length characters validation'
   end
@@ -314,7 +314,7 @@ feature 'Component validations' do
     let(:preview_field) { 'answers[text_text_1]' }
     let(:preview_first_answer) { 'Wolfeschlegelshteinhausenbergerdorff' }
     let(:prview_second_answer) { 'Bob' }
-    let(:preview_error_message) { "Your answer for 'Text' is too long (10 characters at most)" }
+    let(:preview_error_message) { 'Your answer for "Text" must be 10 characters or fewer' }
 
     it_behaves_like 'a string length characters validation'
   end
@@ -331,7 +331,7 @@ feature 'Component validations' do
     let(:preview_second_answer) do
       'He was an old man who fished alone in a skiff in the Gulf Stream and he had gone eighty-four days now without taking a fish.'
     end
-    let(:preview_error_message) { "Enter a higher number of words for Textarea" }
+    let(:preview_error_message) { 'Your answer for "Textarea" must be 10 words or more' }
 
     it_behaves_like 'a string length words validation'
   end
@@ -348,7 +348,7 @@ feature 'Component validations' do
       'The story so far: in the beginning, the universe was created. This has made a lot of people very angry and been widely regarded as a bad move.'
     end
     let(:preview_second_answer) { 'All this happened, more or less.' }
-    let(:preview_error_message) { "Enter a lower number of words for Textarea" }
+    let(:preview_error_message) { 'Your answer for "Textarea" must be 20 words or fewer' }
 
     it_behaves_like 'a string length words validation'
   end

--- a/acceptance/features/component_validations_spec.rb
+++ b/acceptance/features/component_validations_spec.rb
@@ -10,428 +10,347 @@ feature 'Component validations' do
     given_I_have_a_service_fixture(name: service_name, fixture: fixture)
   end
 
-  scenario 'minimum validation' do
-    and_I_visit_a_page('Number')
-    when_I_want_to_select_question_properties
-    then_I_should_see_the_minimum_and_maximum_validations
 
-    and_I_select_a_validation(I18n.t('question.menu.minimum'))
-    then_I_should_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.minimum.label'),
-      I18n.t('dialogs.component_validations.minimum.status_label')
-    )
+  shared_examples 'a number component validation' do
+    scenario 'configuring number validation' do
+      and_I_visit_a_page(page_url)
+      when_I_want_to_select_question_properties
+      then_I_should_see_the_minimum_and_maximum_validations
 
-    and_I_enable_the_validation
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_see_an_error_message(
-      I18n.t(
-      'activemodel.errors.models.base_component_validation.blank',
-      label: I18n.t('dialogs.component_validations.minimum.label')
-    ))
+      and_I_select_a_validation(menu_text)
+      then_I_should_see_the_validation_modal(label, status_label)
 
-    and_I_set_the_input_value('5')
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_not_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.minimum.label'),
-      I18n.t('dialogs.component_validations.minimum.status_label')
-    )
+      and_I_enable_the_validation
+      click_button(I18n.t('dialogs.component_validations.button'))
+      then_I_should_see_an_error_message(
+        I18n.t(
+        'activemodel.errors.models.base_component_validation.blank',
+        label: label
+      ))
 
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.minimum'))
-    then_I_should_see_the_previously_set_configuration('5')
-    and_I_set_the_input_value('3')
-    click_button(I18n.t('dialogs.component_validations.button'))
+      and_I_set_the_input_value(first_value)
+      click_button(I18n.t('dialogs.component_validations.button'))
+      then_I_should_not_see_the_validation_modal(label, status_label)
 
-    click_button(I18n.t('actions.save'))
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.minimum'))
-    then_I_should_see_the_previously_set_configuration('3')
-    click_button(I18n.t('dialogs.button_cancel'))
+      when_I_want_to_select_question_properties
+      and_I_select_a_validation(menu_text)
+      then_I_should_see_the_previously_set_configuration(first_value)
+      and_I_set_the_input_value(second_value)
+      click_button(I18n.t('dialogs.component_validations.button'))
 
-    and_I_return_to_flow_page
-    preview = when_I_preview_the_page('Number')
-    then_I_should_preview_the_page(
-      preview: preview,
-      field: 'answers[number_number_1]',
-      first_value: '1',
-      second_value: '20',
-      error_message: 'Enter a higher number for Number'
-    )
+      and_I_click_save
+      when_I_want_to_select_question_properties
+      and_I_select_a_validation(menu_text)
+      then_I_should_see_the_previously_set_configuration(second_value)
+      click_button(I18n.t('dialogs.button_cancel'))
+
+      and_I_return_to_flow_page
+      preview = when_I_preview_the_page(page_url)
+      then_I_should_preview_the_page(
+        preview: preview,
+        field: preview_field,
+        first_value: preview_first_value,
+        second_value: preview_second_value,
+        error_message: preview_error_message
+      )
+    end
   end
 
-  scenario 'maximum validation' do
-    and_I_visit_a_page('Number')
-    when_I_want_to_select_question_properties
-    then_I_should_see_the_minimum_and_maximum_validations
+  shared_examples 'a date component validation' do
+    scenario 'configuring date validation' do
+      and_I_visit_a_page(page_url)
+      when_I_want_to_select_question_properties
+      then_I_should_see_the_date_before_and_after_validations
 
-    and_I_select_a_validation(I18n.t('question.menu.maximum'))
-    then_I_should_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.maximum.label'),
-      I18n.t('dialogs.component_validations.maximum.status_label')
-    )
+      and_I_select_a_validation(menu_text)
+      then_I_should_see_the_validation_modal(label, status_label)
 
-    and_I_enable_the_validation
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_see_an_error_message(
-      I18n.t(
-      'activemodel.errors.models.base_component_validation.blank',
-      label: I18n.t('dialogs.component_validations.maximum.label')
-    ))
+      and_I_enable_the_validation
+      first_answers.each do |field, value|
+        and_I_set_the_date_input_value(field, value)
+      end
+      click_button(I18n.t('dialogs.component_validations.button'))
+      then_I_should_see_an_error_message(
+        I18n.t(
+        'activemodel.errors.models.date_validation.missing_attribute',
+        label: error_message_label,
+        attribute: error_message_attribute
+      ))
 
-    and_I_set_the_input_value('100')
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_not_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.maximum.label'),
-      I18n.t('dialogs.component_validations.maximum.status_label')
-    )
+      and_I_set_the_date_input_value(invalid_field_answer['field'], invalid_field_answer['invalid'])
+      click_button(I18n.t('dialogs.component_validations.button'))
+      then_I_should_see_an_error_message(
+        I18n.t(
+        'activemodel.errors.models.date_validation.invalid',
+        label: label
+      ))
 
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.maximum'))
-    then_I_should_see_the_previously_set_configuration('100')
-    and_I_set_the_input_value('50')
-    click_button(I18n.t('dialogs.component_validations.button'))
+      and_I_set_the_date_input_value(invalid_field_answer['field'], invalid_field_answer['valid'])
+      click_button(I18n.t('dialogs.component_validations.button'))
+      then_I_should_not_see_the_validation_modal(label, status_label)
 
-    click_button(I18n.t('actions.save'))
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.maximum'))
-    then_I_should_see_the_previously_set_configuration('50')
-    click_button(I18n.t('dialogs.button_cancel'))
+      when_I_want_to_select_question_properties
+      and_I_select_a_validation(menu_text)
+      first_answers.each do |field, value|
+        then_I_should_see_the_previously_set_date_configuration(field, value)
+      end
+      then_I_should_see_the_previously_set_date_configuration(invalid_field_answer['field'], invalid_field_answer['valid'])
 
-    and_I_return_to_flow_page
-    preview = when_I_preview_the_page('Number')
-    then_I_should_preview_the_page(
-      preview: preview,
-      field: 'answers[number_number_1]',
-      first_value: '100',
-      second_value: '5',
-      error_message: 'Enter a lower number for Number'
-    )
+      second_answers.each do |field, value|
+        and_I_set_the_date_input_value(field, value)
+      end
+      click_button(I18n.t('dialogs.component_validations.button'))
+
+      and_I_click_save
+      when_I_want_to_select_question_properties
+      and_I_select_a_validation(menu_text)
+      second_answers.each do |field, value|
+        then_I_should_see_the_previously_set_date_configuration(field, value)
+      end
+      click_button(I18n.t('dialogs.button_cancel'))
+
+      and_I_return_to_flow_page
+      preview = when_I_preview_the_page(page_url)
+      then_I_should_preview_the_date_page(
+        preview: preview,
+        first_date: preview_first_date,
+        second_date: preview_second_date,
+        error_message: preview_error_message
+      )
+    end
   end
 
-  scenario 'date after validation' do
-    and_I_visit_a_page('Date')
-    when_I_want_to_select_question_properties
-    then_I_should_see_the_date_before_and_after_validations
+  shared_examples 'a string length characters validation' do
+    scenario 'configuring string length characters validation' do
+      and_I_visit_a_page(page_url)
+      when_I_want_to_select_question_properties
+      then_I_should_see_the_string_length_validations
 
-    and_I_select_a_validation(I18n.t('question.menu.date_after'))
-    then_I_should_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.date_after.label'),
-      I18n.t('dialogs.component_validations.date_after.status_label')
-    )
+      and_I_select_a_validation(menu_text)
+      then_I_should_see_the_validation_modal(label, status_label)
 
-    and_I_enable_the_validation
-    and_I_set_the_date_input_value('day', '10')
-    and_I_set_the_date_input_value('month', '11')
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_see_an_error_message(
-      I18n.t(
-      'activemodel.errors.models.date_validation.missing_attribute',
-      label: 'Earliest date',
-      attribute: I18n.t('dialogs.component_validations.date.year').downcase
-    ))
+      and_I_enable_the_validation
+      click_button(I18n.t('dialogs.component_validations.button'))
+      then_I_should_see_an_error_message(
+        I18n.t(
+        'activemodel.errors.models.base_component_validation.blank',
+        label: label
+      ))
 
-    and_I_set_the_date_input_value('year', 'this is not a year')
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_see_an_error_message(
-      I18n.t(
-      'activemodel.errors.models.date_validation.invalid',
-      label: I18n.t('dialogs.component_validations.date_after.label')
-    ))
+      and_I_set_the_input_value(first_answer)
+      click_button(I18n.t('dialogs.component_validations.button'))
+      then_I_should_not_see_the_validation_modal(label, status_label)
 
-    and_I_set_the_date_input_value('year', '2001')
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_not_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.date_after.label'),
-      I18n.t('dialogs.component_validations.date_after.status_label')
-    )
+      when_I_want_to_select_question_properties
+      and_I_select_a_validation(menu_text)
+      then_I_should_see_the_previously_set_configuration(first_answer)
+      and_I_set_the_input_value(second_answer)
+      click_button(I18n.t('dialogs.component_validations.button'))
 
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.date_after'))
-    then_I_should_see_the_previously_set_date_configuration('day', '10')
-    then_I_should_see_the_previously_set_date_configuration('month', '11')
-    then_I_should_see_the_previously_set_date_configuration('year', '2001')
+      and_I_click_save
+      when_I_want_to_select_question_properties
+      and_I_select_a_validation(menu_text)
+      then_I_should_see_the_previously_set_configuration(second_answer)
+      click_button(I18n.t('dialogs.button_cancel'))
 
-    and_I_set_the_date_input_value('day', '28')
-    and_I_set_the_date_input_value('month', '2')
-    and_I_set_the_date_input_value('year', '1999')
-    click_button(I18n.t('dialogs.component_validations.button'))
-
-    click_button(I18n.t('actions.save'))
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.date_after'))
-    then_I_should_see_the_previously_set_date_configuration('day', '28')
-    then_I_should_see_the_previously_set_date_configuration('month', '02')
-    then_I_should_see_the_previously_set_date_configuration('year', '1999')
-    click_button(I18n.t('dialogs.button_cancel'))
-
-    and_I_return_to_flow_page
-    preview = when_I_preview_the_page('Date')
-    then_I_should_preview_the_date_page(
-      preview: preview,
-      first_date: { day: '1', month: '2', year: '1901' },
-      second_date: { day: '28', month: '2', year: '2001' },
-      error_message: 'Enter a later date for Date'
-    )
+      and_I_return_to_flow_page
+      preview = when_I_preview_the_page(page_url)
+      then_I_should_preview_the_page(
+        preview: preview,
+        field: preview_field,
+        first_value: preview_first_answer,
+        second_value: prview_second_answer,
+        error_message: preview_error_message
+      )
+    end
   end
 
-  scenario 'date before validation' do
-    and_I_visit_a_page('Date')
-    when_I_want_to_select_question_properties
-    then_I_should_see_the_date_before_and_after_validations
+  shared_examples 'a string length words validation' do
+    scenario 'configuring string length words validation' do
+      and_I_visit_a_page(page_url)
+      when_I_want_to_select_question_properties
+      then_I_should_see_the_string_length_validations
 
-    and_I_select_a_validation(I18n.t('question.menu.date_before'))
-    then_I_should_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.date_before.label'),
-      I18n.t('dialogs.component_validations.date_before.status_label')
-    )
+      and_I_select_a_validation(menu_text)
+      then_I_should_see_the_validation_modal(label, status_label)
 
-    and_I_enable_the_validation
-    and_I_set_the_date_input_value('month', '6')
-    and_I_set_the_date_input_value('year', '2050')
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_see_an_error_message(
-      I18n.t(
-      'activemodel.errors.models.date_validation.missing_attribute',
-      label: 'Latest date',
-      attribute: I18n.t('dialogs.component_validations.date.day').downcase
-    ))
+      and_I_enable_the_validation
+      and_I_select_the_radio('Words')
+      click_button(I18n.t('dialogs.component_validations.button'))
+      then_I_should_see_an_error_message(
+        I18n.t(
+        'activemodel.errors.models.base_component_validation.blank',
+        label: label
+      ))
+      then_the_radio_is_selected('Words')
 
-    and_I_set_the_date_input_value('day', '30')
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_not_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.date_before.label'),
-      I18n.t('dialogs.component_validations.date_before.status_label')
-    )
+      and_I_set_the_input_value(first_answer)
+      click_button(I18n.t('dialogs.component_validations.button'))
+      then_I_should_not_see_the_validation_modal(label, status_label)
 
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.date_before'))
-    then_I_should_see_the_previously_set_date_configuration('day', '30')
-    then_I_should_see_the_previously_set_date_configuration('month', '06')
-    then_I_should_see_the_previously_set_date_configuration('year', '2050')
+      when_I_want_to_select_question_properties
+      and_I_select_a_validation(menu_text)
+      then_I_should_see_the_previously_set_configuration(first_answer)
+      and_I_set_the_input_value(second_answer)
+      click_button(I18n.t('dialogs.component_validations.button'))
 
-    and_I_set_the_date_input_value('day', '14')
-    and_I_set_the_date_input_value('month', '8')
-    and_I_set_the_date_input_value('year', '2045')
-    click_button(I18n.t('dialogs.component_validations.button'))
+      and_I_click_save
+      when_I_want_to_select_question_properties
+      and_I_select_a_validation(menu_text)
+      then_I_should_see_the_previously_set_configuration(second_answer)
+      then_the_radio_is_selected('Words')
+      click_button(I18n.t('dialogs.button_cancel'))
 
-    click_button(I18n.t('actions.save'))
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.date_before'))
-    then_I_should_see_the_previously_set_date_configuration('day', '14')
-    then_I_should_see_the_previously_set_date_configuration('month', '08')
-    then_I_should_see_the_previously_set_date_configuration('year', '2045')
-    click_button(I18n.t('dialogs.button_cancel'))
-
-    and_I_return_to_flow_page
-    preview = when_I_preview_the_page('Date')
-    then_I_should_preview_the_date_page(
-      preview: preview,
-      first_date: { day: '1', month: '2', year: '2050' },
-      second_date: { day: '28', month: '2', year: '2001' },
-      error_message: 'Enter an earlier date for Date'
-    )
+      and_I_return_to_flow_page
+      preview = when_I_preview_the_page('Textarea')
+      then_I_should_preview_the_page(
+        preview: preview,
+        field: preview_field,
+        first_value: preview_first_answer,
+        second_value: preview_second_answer,
+        error_message: preview_error_message
+      )
+    end
   end
 
-  scenario 'min length (characters)' do
-    and_I_visit_a_page('Text')
-    when_I_want_to_select_question_properties
-    then_I_should_see_the_string_length_validations
+  context 'minimum validation' do
+    let(:page_url) { 'Number' }
+    let(:menu_text) { I18n.t('question.menu.minimum') }
+    let(:label) { I18n.t('dialogs.component_validations.minimum.label') }
+    let(:status_label) { I18n.t('dialogs.component_validations.minimum.status_label') }
+    let(:first_value) { '5' }
+    let(:second_value) { '3' }
+    let(:preview_field) { 'answers[number_number_1]' }
+    let(:preview_first_value) { '1' }
+    let(:preview_second_value) { '20' }
+    let(:preview_error_message) { 'Enter a higher number for Number' }
 
-    and_I_select_a_validation(I18n.t('question.menu.min_string_length'))
-    then_I_should_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.string.min.label'),
-      I18n.t('dialogs.component_validations.string.min.status_label')
-    )
-
-    and_I_enable_the_validation
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_see_an_error_message(
-      I18n.t(
-      'activemodel.errors.models.base_component_validation.blank',
-      label: I18n.t('dialogs.component_validations.string.min.label')
-    ))
-
-    and_I_set_the_input_value('5')
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_not_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.string.min.label'),
-      I18n.t('dialogs.component_validations.string.min.status_label')
-    )
-
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.min_string_length'))
-    then_I_should_see_the_previously_set_configuration('5')
-    and_I_set_the_input_value('3')
-    click_button(I18n.t('dialogs.component_validations.button'))
-
-    click_button(I18n.t('actions.save'))
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.min_string_length'))
-    then_I_should_see_the_previously_set_configuration('3')
-    click_button(I18n.t('dialogs.button_cancel'))
-
-    and_I_return_to_flow_page
-    preview = when_I_preview_the_page('Text')
-    then_I_should_preview_the_page(
-      preview: preview,
-      field: 'answers[text_text_1]',
-      first_value: 'Po',
-      second_value: 'Akira',
-      error_message: "Your answer for 'Text' is too short (3 characters at least)"
-    )
+    it_behaves_like 'a number component validation'
   end
 
-  scenario 'max length (characters)' do
-    and_I_visit_a_page('Text')
-    when_I_want_to_select_question_properties
-    then_I_should_see_the_string_length_validations
+  context 'maximum validation' do
+    let(:page_url) { 'Number' }
+    let(:menu_text) { I18n.t('question.menu.maximum') }
+    let(:label) { I18n.t('dialogs.component_validations.maximum.label') }
+    let(:status_label) { I18n.t('dialogs.component_validations.maximum.status_label') }
+    let(:first_value) { '100' }
+    let(:second_value) { '50' }
+    let(:preview_field) { 'answers[number_number_1]' }
+    let(:preview_first_value) { '100' }
+    let(:preview_second_value) { '5' }
+    let(:preview_error_message) { 'Enter a lower number for Number' }
 
-    and_I_select_a_validation(I18n.t('question.menu.max_string_length'))
-    then_I_should_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.string.max.label'),
-      I18n.t('dialogs.component_validations.string.max.status_label')
-    )
-
-    and_I_enable_the_validation
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_see_an_error_message(
-      I18n.t(
-      'activemodel.errors.models.base_component_validation.blank',
-      label: I18n.t('dialogs.component_validations.string.max.label')
-    ))
-
-    and_I_set_the_input_value('20')
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_not_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.string.max.label'),
-      I18n.t('dialogs.component_validations.string.max.status_label')
-    )
-
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.max_string_length'))
-    then_I_should_see_the_previously_set_configuration('20')
-    and_I_set_the_input_value('10')
-    click_button(I18n.t('dialogs.component_validations.button'))
-
-    click_button(I18n.t('actions.save'))
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.max_string_length'))
-    then_I_should_see_the_previously_set_configuration('10')
-    click_button(I18n.t('dialogs.button_cancel'))
-
-    and_I_return_to_flow_page
-    preview = when_I_preview_the_page('Text')
-    then_I_should_preview_the_page(
-      preview: preview,
-      field: 'answers[text_text_1]',
-      first_value: 'Wolfeschlegelshteinhausenbergerdorff',
-      second_value: 'Bob',
-      error_message: "Your answer for 'Text' is too long (10 characters at most)"
-    )
+    it_behaves_like 'a number component validation'
   end
 
-  scenario 'min word' do
-    and_I_visit_a_page('Textarea')
-    when_I_want_to_select_question_properties
-    then_I_should_see_the_string_length_validations
+  context 'date after validation' do
+    let(:page_url) { 'Date' }
+    let(:menu_text) { I18n.t('question.menu.date_after') }
+    let(:label) { I18n.t('dialogs.component_validations.date_after.label') }
+    let(:status_label) { I18n.t('dialogs.component_validations.date_after.status_label') }
+    let(:first_answers) { { 'day' => '10', 'month' => '11' } }
+    let(:invalid_field_answer) do
+      {
+        'field' => 'year',
+        'invalid' => 'this is not a year' ,
+        'valid' => '2001'
+      }
+    end
+    let(:error_message_label) { 'Earliest date'}
+    let(:error_message_attribute) { I18n.t('dialogs.component_validations.date.year').downcase }
+    let(:second_answers) { { 'day' => '28', 'month' => '02', 'year' => '1999' } }
+    let(:preview_first_date) { { day: '01', month: '02', year: '1901' } }
+    let(:preview_second_date) { { day: '28', month: '02', year: '2001' } }
+    let(:preview_error_message) { 'Enter a later date for Date' }
 
-    and_I_select_a_validation(I18n.t('question.menu.min_string_length'))
-    then_I_should_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.string.min.label'),
-      I18n.t('dialogs.component_validations.string.min.status_label')
-    )
-
-    and_I_enable_the_validation
-    and_I_select_the_radio('Words')
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_see_an_error_message(
-      I18n.t(
-      'activemodel.errors.models.base_component_validation.blank',
-      label: I18n.t('dialogs.component_validations.string.min.label')
-    ))
-    then_the_radio_is_selected('Words')
-
-    and_I_set_the_input_value('10')
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_not_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.string.min.label'),
-      I18n.t('dialogs.component_validations.string.min.status_label')
-    )
-
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.min_string_length'))
-    then_I_should_see_the_previously_set_configuration('10')
-    and_I_set_the_input_value('5')
-    click_button(I18n.t('dialogs.component_validations.button'))
-
-    click_button(I18n.t('actions.save'))
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.min_string_length'))
-    then_I_should_see_the_previously_set_configuration('5')
-    then_the_radio_is_selected('Words')
-    click_button(I18n.t('dialogs.button_cancel'))
-
-    and_I_return_to_flow_page
-    preview = when_I_preview_the_page('Textarea')
-    then_I_should_preview_the_page(
-      preview: preview,
-      field: 'answers[textarea_textarea_1]',
-      first_value: 'Once upon a time',
-      second_value: "Mother died today. Or, maybe, yesterday; I can't be sure",
-      error_message: "Enter a higher number of words for Textarea"
-    )
+    it_behaves_like 'a date component validation'
   end
 
-  scenario 'max word' do
-    and_I_visit_a_page('Textarea')
-    when_I_want_to_select_question_properties
-    then_I_should_see_the_string_length_validations
+  context 'date before validation' do
+    let(:page_url) { 'Date' }
+    let(:menu_text) { I18n.t('question.menu.date_before') }
+    let(:label) { I18n.t('dialogs.component_validations.date_before.label') }
+    let(:status_label) { I18n.t('dialogs.component_validations.date_before.status_label') }
+    let(:first_answers) { { 'month' => '06', 'year' => '2050' } }
+    let(:invalid_field_answer) do
+      {
+        'field' => 'day',
+        'invalid' => 'this is not a day' ,
+        'valid' => '30'
+      }
+    end
+    let(:error_message_label) { 'Latest date'}
+    let(:error_message_attribute) { I18n.t('dialogs.component_validations.date.day').downcase }
+    let(:second_answers) { { 'day' => '14', 'month' => '08', 'year' => '2045' } }
+    let(:preview_first_date) { { day: '01', month: '02', year: '2050' } }
+    let(:preview_second_date) { { day: '28', month: '02', year: '2001' } }
+    let(:preview_error_message) { 'Enter an earlier date for Date' }
 
-    and_I_select_a_validation(I18n.t('question.menu.max_string_length'))
-    then_I_should_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.string.max.label'),
-      I18n.t('dialogs.component_validations.string.max.status_label')
-    )
+    it_behaves_like 'a date component validation'
+  end
 
-    and_I_enable_the_validation
-    and_I_select_the_radio('Words')
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_see_an_error_message(
-      I18n.t(
-      'activemodel.errors.models.base_component_validation.blank',
-      label: I18n.t('dialogs.component_validations.string.max.label')
-    ))
-    then_the_radio_is_selected('Words')
+  context 'min length (characters)' do
+    let(:page_url) { 'Text' }
+    let(:menu_text) { I18n.t('question.menu.min_string_length') }
+    let(:label) { I18n.t('dialogs.component_validations.string.min.label') }
+    let(:status_label) { I18n.t('dialogs.component_validations.string.min.status_label') }
+    let(:first_answer) { '5' }
+    let(:second_answer) { '3' }
+    let(:preview_field) { 'answers[text_text_1]' }
+    let(:preview_first_answer) { 'Po' }
+    let(:prview_second_answer) { 'Akira' }
+    let(:preview_error_message) { "Your answer for 'Text' is too short (3 characters at least)" }
 
-    and_I_set_the_input_value('50')
-    click_button(I18n.t('dialogs.component_validations.button'))
-    then_I_should_not_see_the_validation_modal(
-      I18n.t('dialogs.component_validations.string.max.label'),
-      I18n.t('dialogs.component_validations.string.max.status_label')
-    )
+    it_behaves_like 'a string length characters validation'
+  end
 
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.max_string_length'))
-    then_I_should_see_the_previously_set_configuration('50')
-    and_I_set_the_input_value('20')
-    click_button(I18n.t('dialogs.component_validations.button'))
+  context 'max length (characters)' do
+    let(:page_url) { 'Text' }
+    let(:menu_text) { I18n.t('question.menu.max_string_length') }
+    let(:label) { I18n.t('dialogs.component_validations.string.max.label') }
+    let(:status_label) { I18n.t('dialogs.component_validations.string.max.status_label') }
+    let(:first_answer) { '20' }
+    let(:second_answer) { '10' }
+    let(:preview_field) { 'answers[text_text_1]' }
+    let(:preview_first_answer) { 'Wolfeschlegelshteinhausenbergerdorff' }
+    let(:prview_second_answer) { 'Bob' }
+    let(:preview_error_message) { "Your answer for 'Text' is too long (10 characters at most)" }
 
-    click_button(I18n.t('actions.save'))
-    when_I_want_to_select_question_properties
-    and_I_select_a_validation(I18n.t('question.menu.max_string_length'))
-    then_I_should_see_the_previously_set_configuration('20')
-    then_the_radio_is_selected('Words')
-    click_button(I18n.t('dialogs.button_cancel'))
+    it_behaves_like 'a string length characters validation'
+  end
 
-    and_I_return_to_flow_page
-    preview = when_I_preview_the_page('Textarea')
-    then_I_should_preview_the_page(
-      preview: preview,
-      field: 'answers[textarea_textarea_1]',
-      first_value: 'The story so far: in the beginning, the universe was created. This has made a lot of people very angry and been widely regarded as a bad move.',
-      second_value: 'All this happened, more or less.',
-      error_message: "Enter a lower number of words for Textarea"
-    )
+  context 'min word' do
+    let(:page_url) { 'Textarea' }
+    let(:menu_text) { I18n.t('question.menu.min_string_length') }
+    let(:label) { I18n.t('dialogs.component_validations.string.min.label') }
+    let(:status_label) { I18n.t('dialogs.component_validations.string.min.status_label') }
+    let(:first_answer) { '20' }
+    let(:second_answer) { '10' }
+    let(:preview_field) { 'answers[textarea_textarea_1]' }
+    let(:preview_first_answer) { 'Mother died today.' }
+    let(:preview_second_answer) do
+      'He was an old man who fished alone in a skiff in the Gulf Stream and he had gone eighty-four days now without taking a fish.'
+    end
+    let(:preview_error_message) { "Enter a higher number of words for Textarea" }
+
+    it_behaves_like 'a string length words validation'
+  end
+
+  context 'max word' do
+    let(:page_url) { 'Textarea' }
+    let(:menu_text) { I18n.t('question.menu.max_string_length') }
+    let(:label) { I18n.t('dialogs.component_validations.string.max.label') }
+    let(:status_label) { I18n.t('dialogs.component_validations.string.max.status_label') }
+    let(:first_answer) { '50' }
+    let(:second_answer) { '20' }
+    let(:preview_field) { 'answers[textarea_textarea_1]' }
+    let(:preview_first_answer) do
+      'The story so far: in the beginning, the universe was created. This has made a lot of people very angry and been widely regarded as a bad move.'
+    end
+    let(:preview_second_answer) { 'All this happened, more or less.' }
+    let(:preview_error_message) { "Enter a lower number of words for Textarea" }
+
+    it_behaves_like 'a string length words validation'
   end
 
   def and_I_visit_a_page(flow_title)
@@ -447,8 +366,8 @@ feature 'Component validations' do
   end
 
   def and_I_set_the_input_value(value)
-    page.find(:css, 'input#component_validation_value').set('')
-    page.find(:css, 'input#component_validation_value').set(value)
+    input_element = page.find(:css, 'input#component_validation_value')
+    input_element.set(value)
   end
 
   def and_I_select_the_radio(text)
@@ -495,11 +414,15 @@ feature 'Component validations' do
 
   def then_I_should_preview_the_page(preview:, field:, first_value:, second_value:, error_message:)
     within_window(preview) do
+      page.find(:css, '#main-content')
       page.find_field(field).set(first_value)
       click_button(I18n.t('actions.continue'))
+      page.find(:css, '#main-content')
       then_I_should_see_an_error_message(error_message)
+
       page.find_field(field).set(second_value)
       click_button(I18n.t('actions.continue'))
+      page.find(:css, '#main-content')
       then_I_should_not_see_an_error_message(error_message)
     end
   end
@@ -516,16 +439,19 @@ feature 'Component validations' do
 
   def then_I_should_preview_the_date_page(preview:, first_date:, second_date:, error_message:)
     within_window(preview) do
+      page.find(:css, '#main-content')
       page.fill_in('answers[date_date_1(3i)]', with: first_date[:day])
       page.fill_in('answers[date_date_1(2i)]', with: first_date[:month])
       page.fill_in('answers[date_date_1(1i)]', with: first_date[:year])
       click_button(I18n.t('actions.continue'))
+      page.find(:css, '#main-content')
       then_I_should_see_an_error_message(error_message)
 
       page.fill_in('answers[date_date_1(3i)]', with: second_date[:day])
       page.fill_in('answers[date_date_1(2i)]', with: second_date[:month])
       page.fill_in('answers[date_date_1(1i)]', with: second_date[:year])
       click_button(I18n.t('actions.continue'))
+      page.find(:css, '#main-content')
       then_I_should_not_see_an_error_message(error_message)
     end
   end
@@ -536,8 +462,11 @@ feature 'Component validations' do
   end
 
   def then_the_radio_is_selected(text)
-    sleep(1)
     expect(page.find("#component_validation_#{text.downcase}", visible: false)).to be_selected
-    # page.find("#component_validation_#{text.downcase}", visible: false).selected?
+  end
+
+  def and_I_click_save
+    sleep(1)
+    click_button(I18n.t('actions.save'))
   end
 end

--- a/acceptance/features/component_validations_spec.rb
+++ b/acceptance/features/component_validations_spec.rb
@@ -50,8 +50,9 @@ feature 'Component validations' do
 
     and_I_return_to_flow_page
     preview = when_I_preview_the_page('Number')
-    then_I_should_preview_the_number_page(
+    then_I_should_preview_the_page(
       preview: preview,
+      field: 'answers[number_number_1]',
       first_value: '1',
       second_value: '20',
       error_message: 'Enter a higher number for Number'
@@ -98,8 +99,9 @@ feature 'Component validations' do
 
     and_I_return_to_flow_page
     preview = when_I_preview_the_page('Number')
-    then_I_should_preview_the_number_page(
+    then_I_should_preview_the_page(
       preview: preview,
+      field: 'answers[number_number_1]',
       first_value: '100',
       second_value: '5',
       error_message: 'Enter a lower number for Number'
@@ -230,6 +232,208 @@ feature 'Component validations' do
     )
   end
 
+  scenario 'min length (characters)' do
+    and_I_visit_a_page('Text')
+    when_I_want_to_select_question_properties
+    then_I_should_see_the_string_length_validations
+
+    and_I_select_a_validation(I18n.t('question.menu.min_string_length'))
+    then_I_should_see_the_validation_modal(
+      I18n.t('dialogs.component_validations.string.min.label'),
+      I18n.t('dialogs.component_validations.string.min.status_label')
+    )
+
+    and_I_enable_the_validation
+    click_button(I18n.t('dialogs.component_validations.button'))
+    then_I_should_see_an_error_message(
+      I18n.t(
+      'activemodel.errors.models.base_component_validation.blank',
+      label: I18n.t('dialogs.component_validations.string.min.label')
+    ))
+
+    and_I_set_the_input_value('5')
+    click_button(I18n.t('dialogs.component_validations.button'))
+    then_I_should_not_see_the_validation_modal(
+      I18n.t('dialogs.component_validations.string.min.label'),
+      I18n.t('dialogs.component_validations.string.min.status_label')
+    )
+
+    when_I_want_to_select_question_properties
+    and_I_select_a_validation(I18n.t('question.menu.min_string_length'))
+    then_I_should_see_the_previously_set_configuration('5')
+    and_I_set_the_input_value('3')
+    click_button(I18n.t('dialogs.component_validations.button'))
+
+    click_button(I18n.t('actions.save'))
+    when_I_want_to_select_question_properties
+    and_I_select_a_validation(I18n.t('question.menu.min_string_length'))
+    then_I_should_see_the_previously_set_configuration('3')
+    click_button(I18n.t('dialogs.button_cancel'))
+
+    and_I_return_to_flow_page
+    preview = when_I_preview_the_page('Text')
+    then_I_should_preview_the_page(
+      preview: preview,
+      field: 'answers[text_text_1]',
+      first_value: 'Po',
+      second_value: 'Akira',
+      error_message: "Your answer for 'Text' is too short (3 characters at least)"
+    )
+  end
+
+  scenario 'max length (characters)' do
+    and_I_visit_a_page('Text')
+    when_I_want_to_select_question_properties
+    then_I_should_see_the_string_length_validations
+
+    and_I_select_a_validation(I18n.t('question.menu.max_string_length'))
+    then_I_should_see_the_validation_modal(
+      I18n.t('dialogs.component_validations.string.max.label'),
+      I18n.t('dialogs.component_validations.string.max.status_label')
+    )
+
+    and_I_enable_the_validation
+    click_button(I18n.t('dialogs.component_validations.button'))
+    then_I_should_see_an_error_message(
+      I18n.t(
+      'activemodel.errors.models.base_component_validation.blank',
+      label: I18n.t('dialogs.component_validations.string.max.label')
+    ))
+
+    and_I_set_the_input_value('20')
+    click_button(I18n.t('dialogs.component_validations.button'))
+    then_I_should_not_see_the_validation_modal(
+      I18n.t('dialogs.component_validations.string.max.label'),
+      I18n.t('dialogs.component_validations.string.max.status_label')
+    )
+
+    when_I_want_to_select_question_properties
+    and_I_select_a_validation(I18n.t('question.menu.max_string_length'))
+    then_I_should_see_the_previously_set_configuration('20')
+    and_I_set_the_input_value('10')
+    click_button(I18n.t('dialogs.component_validations.button'))
+
+    click_button(I18n.t('actions.save'))
+    when_I_want_to_select_question_properties
+    and_I_select_a_validation(I18n.t('question.menu.max_string_length'))
+    then_I_should_see_the_previously_set_configuration('10')
+    click_button(I18n.t('dialogs.button_cancel'))
+
+    and_I_return_to_flow_page
+    preview = when_I_preview_the_page('Text')
+    then_I_should_preview_the_page(
+      preview: preview,
+      field: 'answers[text_text_1]',
+      first_value: 'Wolfeschlegelshteinhausenbergerdorff',
+      second_value: 'Bob',
+      error_message: "Your answer for 'Text' is too long (10 characters at most)"
+    )
+  end
+
+  scenario 'min word' do
+    and_I_visit_a_page('Textarea')
+    when_I_want_to_select_question_properties
+    then_I_should_see_the_string_length_validations
+
+    and_I_select_a_validation(I18n.t('question.menu.min_string_length'))
+    then_I_should_see_the_validation_modal(
+      I18n.t('dialogs.component_validations.string.min.label'),
+      I18n.t('dialogs.component_validations.string.min.status_label')
+    )
+
+    and_I_enable_the_validation
+    and_I_select_the_radio('Words')
+    click_button(I18n.t('dialogs.component_validations.button'))
+    then_I_should_see_an_error_message(
+      I18n.t(
+      'activemodel.errors.models.base_component_validation.blank',
+      label: I18n.t('dialogs.component_validations.string.min.label')
+    ))
+    then_the_radio_is_selected('Words')
+
+    and_I_set_the_input_value('10')
+    click_button(I18n.t('dialogs.component_validations.button'))
+    then_I_should_not_see_the_validation_modal(
+      I18n.t('dialogs.component_validations.string.min.label'),
+      I18n.t('dialogs.component_validations.string.min.status_label')
+    )
+
+    when_I_want_to_select_question_properties
+    and_I_select_a_validation(I18n.t('question.menu.min_string_length'))
+    then_I_should_see_the_previously_set_configuration('10')
+    and_I_set_the_input_value('5')
+    click_button(I18n.t('dialogs.component_validations.button'))
+
+    click_button(I18n.t('actions.save'))
+    when_I_want_to_select_question_properties
+    and_I_select_a_validation(I18n.t('question.menu.min_string_length'))
+    then_I_should_see_the_previously_set_configuration('5')
+    then_the_radio_is_selected('Words')
+    click_button(I18n.t('dialogs.button_cancel'))
+
+    and_I_return_to_flow_page
+    preview = when_I_preview_the_page('Textarea')
+    then_I_should_preview_the_page(
+      preview: preview,
+      field: 'answers[textarea_textarea_1]',
+      first_value: 'Once upon a time',
+      second_value: "Mother died today. Or, maybe, yesterday; I can't be sure",
+      error_message: "Enter a higher number of words for Textarea"
+    )
+  end
+
+  scenario 'max word' do
+    and_I_visit_a_page('Textarea')
+    when_I_want_to_select_question_properties
+    then_I_should_see_the_string_length_validations
+
+    and_I_select_a_validation(I18n.t('question.menu.max_string_length'))
+    then_I_should_see_the_validation_modal(
+      I18n.t('dialogs.component_validations.string.max.label'),
+      I18n.t('dialogs.component_validations.string.max.status_label')
+    )
+
+    and_I_enable_the_validation
+    and_I_select_the_radio('Words')
+    click_button(I18n.t('dialogs.component_validations.button'))
+    then_I_should_see_an_error_message(
+      I18n.t(
+      'activemodel.errors.models.base_component_validation.blank',
+      label: I18n.t('dialogs.component_validations.string.max.label')
+    ))
+    then_the_radio_is_selected('Words')
+
+    and_I_set_the_input_value('50')
+    click_button(I18n.t('dialogs.component_validations.button'))
+    then_I_should_not_see_the_validation_modal(
+      I18n.t('dialogs.component_validations.string.max.label'),
+      I18n.t('dialogs.component_validations.string.max.status_label')
+    )
+
+    when_I_want_to_select_question_properties
+    and_I_select_a_validation(I18n.t('question.menu.max_string_length'))
+    then_I_should_see_the_previously_set_configuration('50')
+    and_I_set_the_input_value('20')
+    click_button(I18n.t('dialogs.component_validations.button'))
+
+    click_button(I18n.t('actions.save'))
+    when_I_want_to_select_question_properties
+    and_I_select_a_validation(I18n.t('question.menu.max_string_length'))
+    then_I_should_see_the_previously_set_configuration('20')
+    then_the_radio_is_selected('Words')
+    click_button(I18n.t('dialogs.button_cancel'))
+
+    and_I_return_to_flow_page
+    preview = when_I_preview_the_page('Textarea')
+    then_I_should_preview_the_page(
+      preview: preview,
+      field: 'answers[textarea_textarea_1]',
+      first_value: 'The story so far: in the beginning, the universe was created. This has made a lot of people very angry and been widely regarded as a bad move.',
+      second_value: 'All this happened, more or less.',
+      error_message: "Enter a lower number of words for Textarea"
+    )
+  end
+
   def and_I_visit_a_page(flow_title)
     editor.flow_thumbnail(flow_title).click
   end
@@ -243,7 +447,12 @@ feature 'Component validations' do
   end
 
   def and_I_set_the_input_value(value)
+    page.find(:css, 'input#component_validation_value').set('')
     page.find(:css, 'input#component_validation_value').set(value)
+  end
+
+  def and_I_select_the_radio(text)
+    choose(text, visible: false)
   end
 
   def when_I_preview_the_page(flow_title)
@@ -257,8 +466,8 @@ feature 'Component validations' do
   end
 
   def then_I_should_see_the_minimum_and_maximum_validations
-    expect(editor.text).to include(I18n.t('question.menu.minimum'))
-    expect(editor.text).to include(I18n.t('question.menu.maximum'))
+    expect(page).to have_content(I18n.t('question.menu.minimum'))
+    expect(page).to have_content(I18n.t('question.menu.maximum'))
   end
 
   def then_I_should_see_the_validation_modal(label, status_label)
@@ -284,20 +493,20 @@ feature 'Component validations' do
     expect(input.value).to eq(value)
   end
 
-  def then_I_should_preview_the_number_page(preview:, first_value:, second_value:, error_message:)
+  def then_I_should_preview_the_page(preview:, field:, first_value:, second_value:, error_message:)
     within_window(preview) do
-      page.find_field('answers[number_number_1]').set(first_value)
+      page.find_field(field).set(first_value)
       click_button(I18n.t('actions.continue'))
       then_I_should_see_an_error_message(error_message)
-      page.find_field('answers[number_number_1]').set(second_value)
+      page.find_field(field).set(second_value)
       click_button(I18n.t('actions.continue'))
       then_I_should_not_see_an_error_message(error_message)
     end
   end
 
   def then_I_should_see_the_date_before_and_after_validations
-    expect(editor.text).to include(I18n.t('question.menu.date_before'))
-    expect(editor.text).to include(I18n.t('question.menu.date_after'))
+    expect(page).to have_content(I18n.t('question.menu.date_before'))
+    expect(page).to have_content(I18n.t('question.menu.date_after'))
   end
 
   def then_I_should_see_the_previously_set_date_configuration(field, value)
@@ -319,5 +528,16 @@ feature 'Component validations' do
       click_button(I18n.t('actions.continue'))
       then_I_should_not_see_an_error_message(error_message)
     end
+  end
+
+  def then_I_should_see_the_string_length_validations
+    expect(page).to have_content(I18n.t('question.menu.max_string_length'))
+    expect(page).to have_content(I18n.t('question.menu.min_string_length'))
+  end
+
+  def then_the_radio_is_selected(text)
+    sleep(1)
+    expect(page.find("#component_validation_#{text.downcase}", visible: false)).to be_selected
+    # page.find("#component_validation_#{text.downcase}", visible: false).selected?
   end
 end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -88,6 +88,7 @@ class EditorApp < SitePrism::Page
   elements :preview_page_images, '#flow-overview .flow-item .flow-thumbnail', visible: true
 
   def page_flow_items(html_class = '#flow-overview .flow-thumbnail')
+    find('#main-content', visible: true)
     preview_page_images.map do |page_flow|
       page_flow.text.gsub("Edit:\n", '')
     end

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -328,7 +328,7 @@ module CommonSteps
     if fields.empty?
       expect(page.text).to include('Enter an answer for')
     else
-      fields.each { |field| expect(text).to include("Enter an answer for #{field}")}
+      fields.each { |field| expect(text).to include("Enter an answer for \"#{field}\"")}
     end
   end
 

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -15,6 +15,7 @@ module CommonSteps
 
   def given_I_am_logged_in
     editor.load
+    page.find(:css, '#main-content')
     editor.sign_in_button.click
 
     if ENV['CI_MODE'].present?
@@ -41,6 +42,7 @@ module CommonSteps
 
   def given_I_have_a_service(service = service_name)
     editor.load
+    page.find(:css, '#main-content')
     given_I_want_to_create_a_service
     given_I_add_a_service(service)
     when_I_create_the_service

--- a/app/controllers/api/component_validations_controller.rb
+++ b/app/controllers/api/component_validations_controller.rb
@@ -38,7 +38,7 @@ module Api
 
     def component_validation_params
       params.require(:component_validation)
-            .permit(:status, :value, :day, :month, :year)
+            .permit(:status, :value, :day, :month, :year, :string_length)
             .merge(base_params)
             .compact
     end

--- a/app/javascript/src/components/menus/question_menu.js
+++ b/app/javascript/src/components/menus/question_menu.js
@@ -83,7 +83,16 @@ class QuestionMenu extends ActivatedMenu {
   }
 
   setEnabledValidations() {
-    var validationData = this.question.data.validation;
+    var validationData = Object.assign( {}, this.question.data.validation ); // don't mutate the question data
+    
+    if(validationData.hasOwnProperty('min_length') || validationData.hasOwnProperty('min_word') ){
+      validationData.min_string_length = true;
+    }
+
+    if(validationData.hasOwnProperty('max_length') || validationData.hasOwnProperty('max_word') ){
+      validationData.max_string_length = true;
+    }
+
     this.$node.find("[data-validation]").each(function() {
       var validationType = $(this).data('validation');
       if( validationData[validationType] ) {

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -281,22 +281,20 @@ function addQuestionMenuListeners(view) {
        * could be out of date
        */
       onLoad: function(dialog) {
-        var currentValue = question.data.validation[validation];
+        // Find fields that may be in the dialog
         var $statusField = dialog.$node.find('input[name="component_validation[status]"]');
         var $valueField = dialog.$node.find('input[name="component_validation[value]"]');
         var $dayField = dialog.$node.find('input[name="component_validation[day]"]');
         var $monthField = dialog.$node.find('input[name="component_validation[month]"]');
         var $yearField = dialog.$node.find('input[name="component_validation[year]"]');
-
-        if(currentValue) {
-          $statusField.prop('checked', true);
-        } else {
-          $statusField.prop('checked', false);
-        } 
+        var $charsRadio = dialog.$node.find('input[id="component_validation_characters"]');
+        var $wordsRadio = dialog.$node.find('input[id="component_validation_words"]');
 
         switch(validation) {
           case 'date_before':
           case 'date_after':
+            // Destructure date value and use to populate or clear date fields in modal
+            var currentValue = question.data.validation[validation];
             if(currentValue) {
               let [currentYear, currentMonth, currentDay] = currentValue.split('-');
               $dayField.val(currentDay);
@@ -308,10 +306,42 @@ function addQuestionMenuListeners(view) {
               $yearField.val('');
             }
             break;
+          case 'min_string_length':
+            // Check the appropriate radio in the modal based on the validation type
+            var currentValue = question.data.validation['min_length'] || question.data.validation['min_word'];
+            if( question.data.validation.hasOwnProperty('min_length')) {
+              $charsRadio.prop('checked', true); 
+            }
+            if( question.data.validation.hasOwnProperty('min_word')) {
+              $wordsRadio.prop('checked', true); 
+            }
+            break;
+          case 'max_string_length':
+            // Check the appropriate radio in the modal based on the validation type
+            var currentValue = question.data.validation['max_length'] || question.data.validation['max_word'];
+            if( question.data.validation.hasOwnProperty('max_length')) {
+              $charsRadio.prop('checked', true); 
+            }
+            if( question.data.validation.hasOwnProperty('max_word')) {
+              $wordsRadio.prop('checked', true); 
+            }
+            break;
           default:
-            $valueField.val( currentValue ?? '');
+            var currentValue = question.data.validation[validation];
             break;
         }
+        
+        // If its a standard validationl just set the value filed to the current value
+        if($valueField) {
+          $valueField.val( currentValue ?? '');
+        }
+        
+        // Presence of current value indicates whether the validation is enabled/disabled
+        if(currentValue) {
+          $statusField.prop('checked', true);
+        } else {
+          $statusField.prop('checked', false);
+        } 
       },
 
       onRefresh: function(dialog) {

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -338,6 +338,18 @@ function highestNumber(numbers) {
 
   return result;
 }
+/* Filter an object using a passed callback function
+  * @param {Object} obj - the object to be filtered
+  * @param {callable} predicate - function used for filtering, should return a
+  * boolean 
+  * @return {Object}
+  */
+function filterObject(obj, predicate) {
+  return Object.fromEntries(
+    Object.entries(obj).filter( predicate )
+  );
+}
+
 
 
 
@@ -362,5 +374,6 @@ module.exports  = {
   difference: difference,
   sortNumberArrayValues: sortNumberArrayValues,
   lowestNumber:lowestNumber,
-  highestNumber: highestNumber
+  highestNumber: highestNumber,
+  filterObject: filterObject,
 }

--- a/app/models/component_validations/base_component_validation.rb
+++ b/app/models/component_validations/base_component_validation.rb
@@ -36,7 +36,7 @@ class BaseComponentValidation
   # therefore we can allow requests with those validator types.
   def supported_validations
     validations = component.supported_validations
-    return validations + STRING_LENGTH_VALIDATIONS if component.type.in?(%w(text textarea))
+    return validations + STRING_LENGTH_VALIDATIONS if component.type.in?(%w[text textarea])
 
     validations
   end
@@ -58,10 +58,6 @@ class BaseComponentValidation
 
   def enabled?
     previously_enabled? || status.present? && status == ENABLED
-  end
-
-  def previously_enabled?
-    component_validation.key?(validator)
   end
 
   def run_validation?
@@ -93,6 +89,10 @@ class BaseComponentValidation
   def status_label; end
 
   private
+
+  def previously_enabled?
+    component_validation.key?(validator)
+  end
 
   def component_validation
     @component_validation ||= component.validation

--- a/app/models/component_validations/base_component_validation.rb
+++ b/app/models/component_validations/base_component_validation.rb
@@ -60,6 +60,10 @@ class BaseComponentValidation
     previously_enabled? || status.present? && status == ENABLED
   end
 
+  def previously_enabled?
+    component_validation.key?(validator)
+  end
+
   def run_validation?
     enabled? && value.present?
   end
@@ -89,10 +93,6 @@ class BaseComponentValidation
   def status_label; end
 
   private
-
-  def previously_enabled?
-    component_validation.key?(validator)
-  end
 
   def component_validation
     @component_validation ||= component.validation

--- a/app/models/component_validations/max_string_length_validation.rb
+++ b/app/models/component_validations/max_string_length_validation.rb
@@ -1,0 +1,19 @@
+class MaxStringLengthValidation < StringComponentLengthValidation
+  STRING_LENGTH_KEYS = %w[max_length max_word]
+
+  def label
+    I18n.t('dialogs.component_validations.string.max.label')
+  end
+
+  def status_label
+    I18n.t('dialogs.component_validations.string.max.status_label')
+  end
+
+  def characters_radio_value
+    'max_length'
+  end
+
+  def words_radio_value
+    'max_word'
+  end
+end

--- a/app/models/component_validations/max_string_length_validation.rb
+++ b/app/models/component_validations/max_string_length_validation.rb
@@ -1,5 +1,5 @@
 class MaxStringLengthValidation < StringComponentLengthValidation
-  STRING_LENGTH_KEYS = %w[max_length max_word]
+  STRING_LENGTH_KEYS = %w[max_length max_word].freeze
 
   def label
     I18n.t('dialogs.component_validations.string.max.label')

--- a/app/models/component_validations/min_string_length_validation.rb
+++ b/app/models/component_validations/min_string_length_validation.rb
@@ -1,5 +1,5 @@
 class MinStringLengthValidation < StringComponentLengthValidation
-  STRING_LENGTH_KEYS = %w[min_length min_word]
+  STRING_LENGTH_KEYS = %w[min_length min_word].freeze
 
   def label
     I18n.t('dialogs.component_validations.string.min.label')

--- a/app/models/component_validations/min_string_length_validation.rb
+++ b/app/models/component_validations/min_string_length_validation.rb
@@ -1,0 +1,19 @@
+class MinStringLengthValidation < StringComponentLengthValidation
+  STRING_LENGTH_KEYS = %w[min_length min_word]
+
+  def label
+    I18n.t('dialogs.component_validations.string.min.label')
+  end
+
+  def status_label
+    I18n.t('dialogs.component_validations.string.min.status_label')
+  end
+
+  def characters_radio_value
+    'min_length'
+  end
+
+  def words_radio_value
+    'min_word'
+  end
+end

--- a/app/models/component_validations/string_component_length_validation.rb
+++ b/app/models/component_validations/string_component_length_validation.rb
@@ -1,0 +1,42 @@
+class StringComponentLengthValidation < BaseComponentValidation
+  attr_accessor :string_length
+  validates_with NumberValidator, if: :run_validation?
+
+  def component_partial
+    'string_length_validation'
+  end
+
+  def preselect_characters?
+    previously_enabled? || no_string_length_validations_configured?
+  end
+
+  # Need to override the base component version of this to make use of string_length
+  # attribute as that is the actual validator name
+  def previously_enabled?
+    component_validation.key?(string_length)
+  end
+
+  def to_metadata
+    return self.class::STRING_LENGTH_KEYS.index_with { |_| '' } if status.blank?
+
+    meta = default_metadata(string_length)
+    meta[string_length] = main_value
+
+    if component_validation.key?(unused_validation)
+      meta.merge({ unused_validation => '' })
+    else
+      meta
+    end
+  end
+
+  private
+
+  def no_string_length_validations_configured?
+    @no_string_length_validations_configured ||=
+      (component.supported_validations & component_validation.keys).blank?
+  end
+
+  def unused_validation
+    @unused_validation ||= (self.class::STRING_LENGTH_KEYS - [string_length]).first
+  end
+end

--- a/app/views/api/component_validations/_string_length_validation.html.erb
+++ b/app/views/api/component_validations/_string_length_validation.html.erb
@@ -1,0 +1,32 @@
+<div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+  <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="component_validation_characters" name="component_validation[string_length]"
+           type="radio" value="<%= @component_validation.characters_radio_value %>"
+           <%= @component_validation.preselect_characters? ? 'checked' : '' %>>
+    <label class="govuk-label govuk-radios__label" for="component_validation_characters">
+      <%= t('activemodel.component_validations.dialogs.string.characters') %>
+    </label>
+  </div>
+  <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="component_validation_words" name="component_validation[string_length]"
+           type="radio" value="<%= @component_validation.words_radio_value %>"
+           <%= @component_validation.previously_enabled? ? 'checked' : '' %>>
+    <label class="govuk-label govuk-radios__label" for="component_validation_words">
+      <%= t('activemodel.component_validations.dialogs.string.words') %>
+    </label>
+  </div>
+</div>
+
+<label class="govuk-label govuk-label--m govuk-visually-hidden" for="component_validation_value">
+  <%= @component_validation.label %>
+</label>
+<input class="govuk-input govuk-input--width-5 <%= @component_validation.errors.present? ? 'govuk-input--error' : '' %>"
+       id="component_validation_value"
+       name="component_validation[value]"
+       pattern="[0-9]*"
+       inputmode="numeric"
+       spellcheck="false"
+       autocomplete=""
+       aria-describedby="<%= @component_validation.errors.present? ? 'component_validation_value_error' : '' %>"
+       <%=   @component_validation.errors.present? ? 'aria-invalid=true' : '' %>
+       value="<%= @component_validation.main_value %>">

--- a/app/views/api/component_validations/_string_length_validation.html.erb
+++ b/app/views/api/component_validations/_string_length_validation.html.erb
@@ -19,7 +19,7 @@
         <div class="govuk-radios__item govuk-!-margin-bottom-0">
           <input class="govuk-radios__input" id="component_validation_characters" name="component_validation[string_length]"
                  type="radio" value="<%= @component_validation.characters_radio_value %>"
-                 <%= @component_validation.preselect_characters? ? 'checked' : '' %>>
+                 <%= @component_validation.select_characters? ? 'checked' : '' %>>
           <label class="govuk-label govuk-radios__label" for="component_validation_characters">
             <%= t('activemodel.component_validations.dialogs.string.characters') %>
           </label>
@@ -27,7 +27,7 @@
         <div class="govuk-radios__item govuk-!-margin-bottom-0">
           <input class="govuk-radios__input" id="component_validation_words" name="component_validation[string_length]"
                  type="radio" value="<%= @component_validation.words_radio_value %>"
-                 <%= @component_validation.previously_enabled? ? 'checked' : '' %>>
+                 <%= @component_validation.select_words? ? 'checked' : '' %>>
           <label class="govuk-label govuk-radios__label" for="component_validation_words">
             <%= t('activemodel.component_validations.dialogs.string.words') %>
           </label>

--- a/app/views/api/component_validations/_string_length_validation.html.erb
+++ b/app/views/api/component_validations/_string_length_validation.html.erb
@@ -1,32 +1,37 @@
-<div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
-  <div class="govuk-radios__item">
-    <input class="govuk-radios__input" id="component_validation_characters" name="component_validation[string_length]"
-           type="radio" value="<%= @component_validation.characters_radio_value %>"
-           <%= @component_validation.preselect_characters? ? 'checked' : '' %>>
-    <label class="govuk-label govuk-radios__label" for="component_validation_characters">
-      <%= t('activemodel.component_validations.dialogs.string.characters') %>
-    </label>
-  </div>
-  <div class="govuk-radios__item">
-    <input class="govuk-radios__input" id="component_validation_words" name="component_validation[string_length]"
-           type="radio" value="<%= @component_validation.words_radio_value %>"
-           <%= @component_validation.previously_enabled? ? 'checked' : '' %>>
-    <label class="govuk-label govuk-radios__label" for="component_validation_words">
-      <%= t('activemodel.component_validations.dialogs.string.words') %>
-    </label>
-  </div>
-</div>
+<div style="display: flex; align-items:center;">
+  <label class="govuk-label govuk-label--m govuk-visually-hidden" for="component_validation_value">
+    <%= @component_validation.label %>
+  </label>
+  <input class="govuk-input govuk-input--width-5 <%= @component_validation.errors.present? ? 'govuk-input--error' : '' %>"
+         id="component_validation_value"
+         name="component_validation[value]"
+         pattern="[0-9]*"
+         inputmode="numeric"
+         spellcheck="false"
+         autocomplete=""
+         aria-describedby="<%= @component_validation.errors.present? ? 'component_validation_value_error' : '' %>"
+         <%=   @component_validation.errors.present? ? 'aria-invalid=true' : '' %>
+         value="<%= @component_validation.main_value %>">
 
-<label class="govuk-label govuk-label--m govuk-visually-hidden" for="component_validation_value">
-  <%= @component_validation.label %>
-</label>
-<input class="govuk-input govuk-input--width-5 <%= @component_validation.errors.present? ? 'govuk-input--error' : '' %>"
-       id="component_validation_value"
-       name="component_validation[value]"
-       pattern="[0-9]*"
-       inputmode="numeric"
-       spellcheck="false"
-       autocomplete=""
-       aria-describedby="<%= @component_validation.errors.present? ? 'component_validation_value_error' : '' %>"
-       <%=   @component_validation.errors.present? ? 'aria-invalid=true' : '' %>
-       value="<%= @component_validation.main_value %>">
+  <fieldset class="govuk-fieldset govuk-!-margin-left-9">
+    <legend class="govuk-fieldset--legend govuk-visually-hidden">Length units</legend>
+      <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+        <div class="govuk-radios__item govuk-!-margin-bottom-0">
+          <input class="govuk-radios__input" id="component_validation_characters" name="component_validation[string_length]"
+                 type="radio" value="<%= @component_validation.characters_radio_value %>"
+                 <%= @component_validation.preselect_characters? ? 'checked' : '' %>>
+          <label class="govuk-label govuk-radios__label" for="component_validation_characters">
+            <%= t('activemodel.component_validations.dialogs.string.characters') %>
+          </label>
+        </div>
+        <div class="govuk-radios__item govuk-!-margin-bottom-0">
+          <input class="govuk-radios__input" id="component_validation_words" name="component_validation[string_length]"
+                 type="radio" value="<%= @component_validation.words_radio_value %>"
+                 <%= @component_validation.previously_enabled? ? 'checked' : '' %>>
+          <label class="govuk-label govuk-radios__label" for="component_validation_words">
+            <%= t('activemodel.component_validations.dialogs.string.words') %>
+          </label>
+        </div>
+      </div>
+  </fieldset>
+</div>

--- a/config/initializers/enabled_validations.rb
+++ b/config/initializers/enabled_validations.rb
@@ -1,4 +1,4 @@
-Rails.application.config.enabled_validations = %w(
+Rails.application.config.enabled_validations = %w[
   accept
   date
   date_after
@@ -7,8 +7,12 @@ Rails.application.config.enabled_validations = %w(
   max_size
   minimum
   maximum
+  min_length
+  max_length
+  min_word
+  max_word
   number
   required
   upload
   virus_scan
-)
+]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,15 @@ en:
       maximum:
         label: Maximum answer value
         status_label: Set the highest number allowed
+      string:
+        characters: Characters
+        words: Words
+        min:
+          label: Minimum answer length
+          status_label: Set a minimum answer length
+        max:
+          label: Maximum answer length
+          status_label: Set a maximum answer length
       button: Update
   header:
     service_name: "MoJ Forms"
@@ -233,6 +242,8 @@ en:
       date_before: 'Latest date...'
       minimum: 'Minimum answer value...'
       maximum: 'Maximum answer value...'
+      max_string_length: 'Maximum answer length...'
+      min_string_length: 'Minimum answer length...'
     dialog:
       heading_remove: Delete the component '#{label}'?
       heading_required: 'Is answering this question required?'

--- a/spec/models/component_validations/max_string_length_validation_spec.rb
+++ b/spec/models/component_validations/max_string_length_validation_spec.rb
@@ -1,0 +1,89 @@
+RSpec.describe 'MaxStringLengthValidation' do
+  let(:subject) { MaxStringLengthValidation.new(validation_params) }
+  let(:latest_metadata) { metadata_fixture(:version) }
+  let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+  let(:validation_params) do
+    {
+      service: service,
+      page_uuid: page_uuid,
+      component_uuid: component_uuid,
+      validator: validator,
+      status: status,
+      value: value,
+      string_length: string_length
+    }
+  end
+  let(:page_uuid) { 'e8708909-922e-4eaf-87a5-096f7a713fcb' } # how well do you know star wars?
+  let(:component_uuid) { 'fda1e5a1-ed5f-49c9-a943-dc930a520984' }
+  let(:validator) { 'max_string_length' }
+  let(:status) { 'enabled' }
+  let(:value) { '50' }
+  let(:string_length) { 'max_length' }
+  let(:expected_number_error) { 'Maximum answer length needs to be a number' }
+  let(:expected_blank_error) { 'Enter an answer for Maximum answer length' }
+
+  it_behaves_like 'a base component validation'
+  it_behaves_like 'a number validation'
+  it_behaves_like 'a string length validation'
+
+  describe '#to_metadata' do
+    context 'when validator is max_length' do
+      let(:expected_metadata) { { 'max_length' => '50' } }
+
+      it 'returns default metadata' do
+        expect(subject.to_metadata).to eq(expected_metadata)
+      end
+    end
+
+    context 'when validator is max_word' do
+      let(:string_length) { 'max_word' }
+      let(:expected_metadata) { { 'max_word' => '50' } }
+
+      it 'returns default metadata' do
+        expect(subject.to_metadata).to eq(expected_metadata)
+      end
+    end
+
+    context 'when setting a new value for previously configured validation' do
+      let(:page_uuid) { '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' } # name
+      let(:component_uuid) { '27d377a2-6828-44ca-87d1-b83ddac98284' }
+      let(:value) { '5000' }
+      let(:expected_metadata) { { 'max_length' => '5000' } }
+
+      it 'returns the new value' do
+        expect(subject.to_metadata).to eq(expected_metadata)
+      end
+    end
+
+
+    context 'when status is not enabled' do
+      let(:status) { nil }
+      let(:expected_metadata) do
+        {
+          'max_length' => '',
+          'max_word' => ''
+        }
+      end
+
+      it 'returns both string length validations with empty strings' do
+        expect(subject.to_metadata).to eq(expected_metadata)
+      end
+    end
+
+    context 'when other maximum string validation has been configured' do
+      let(:page_uuid) { '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' } # name
+      let(:component_uuid) { '27d377a2-6828-44ca-87d1-b83ddac98284' }
+      let(:string_length) { 'max_word' }
+      let(:expected_metadata) do
+        {
+          'max_word' => value,
+          'max_length' => ''
+        }
+      end
+
+      it 'returns the correct metadata with both keys' do
+        expect(subject.to_metadata).to eq(expected_metadata)
+      end
+    end
+  end
+end

--- a/spec/models/component_validations/max_string_length_validation_spec.rb
+++ b/spec/models/component_validations/max_string_length_validation_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe 'MaxStringLengthValidation' do
       end
     end
 
-
     context 'when status is not enabled' do
       let(:status) { nil }
       let(:expected_metadata) do

--- a/spec/models/component_validations/min_string_length_validation_spec.rb
+++ b/spec/models/component_validations/min_string_length_validation_spec.rb
@@ -1,0 +1,88 @@
+RSpec.describe 'MinStringLengthValidation' do
+  let(:subject) { MinStringLengthValidation.new(validation_params) }
+  let(:latest_metadata) { metadata_fixture(:version) }
+  let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+  let(:validation_params) do
+    {
+      service: service,
+      page_uuid: page_uuid,
+      component_uuid: component_uuid,
+      validator: validator,
+      status: status,
+      value: value,
+      string_length: string_length
+    }
+  end
+  let(:page_uuid) { 'e8708909-922e-4eaf-87a5-096f7a713fcb' } # how well do you know star wars?
+  let(:component_uuid) { 'fda1e5a1-ed5f-49c9-a943-dc930a520984' }
+  let(:validator) { 'min_string_length' }
+  let(:status) { 'enabled' }
+  let(:value) { '5' }
+  let(:string_length) { 'min_length' }
+  let(:expected_number_error) { 'Minimum answer length needs to be a number' }
+  let(:expected_blank_error) { 'Enter an answer for Minimum answer length' }
+
+  it_behaves_like 'a base component validation'
+  it_behaves_like 'a number validation'
+  it_behaves_like 'a string length validation'
+
+  describe '#to_metadata' do
+    context 'when validator is min_length' do
+      let(:expected_metadata) { { 'min_length' => '5' } }
+
+      it 'returns default metadata' do
+        expect(subject.to_metadata).to eq(expected_metadata)
+      end
+    end
+
+    context 'when validator is min_word' do
+      let(:string_length) { 'min_word' }
+      let(:expected_metadata) { { 'min_word' => '5' } }
+
+      it 'returns default metadata' do
+        expect(subject.to_metadata).to eq(expected_metadata)
+      end
+    end
+
+    context 'when setting a new value for previously configured validation' do
+      let(:page_uuid) { '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' } # name
+      let(:component_uuid) { '27d377a2-6828-44ca-87d1-b83ddac98284' }
+      let(:value) { '100' }
+      let(:expected_metadata) { { 'min_length' => '100' } }
+
+      it 'returns the new value' do
+        expect(subject.to_metadata).to eq(expected_metadata)
+      end
+    end
+
+    context 'when status is not enabled' do
+      let(:status) { nil }
+      let(:expected_metadata) do
+        {
+          'min_length' => '',
+          'min_word' => ''
+        }
+      end
+
+      it 'returns both string length validations with empty strings' do
+        expect(subject.to_metadata).to eq(expected_metadata)
+      end
+    end
+
+    context 'when other minimum string validation has been configured' do
+      let(:page_uuid) { '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' } # name
+      let(:component_uuid) { '27d377a2-6828-44ca-87d1-b83ddac98284' }
+      let(:string_length) { 'min_word' }
+      let(:expected_metadata) do
+        {
+          'min_word' => value,
+          'min_length' => ''
+        }
+      end
+
+      it 'returns the correct metadata with both keys' do
+        expect(subject.to_metadata).to eq(expected_metadata)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/base_component_validation_examples.rb
+++ b/spec/support/shared_examples/base_component_validation_examples.rb
@@ -9,6 +9,26 @@ RSpec.shared_examples 'a base component validation' do
         end
       end
 
+      context 'when a text component and a string length validator' do
+        let(:validator) { 'max_string_length' }
+        let(:page_uuid) { 'e8708909-922e-4eaf-87a5-096f7a713fcb' } # How well do you know star wars?
+        let(:component_uuid) { 'fda1e5a1-ed5f-49c9-a943-dc930a520984' }
+
+        it 'returns valid' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context 'when a textarea component and a string length validator' do
+        let(:validator) { 'min_string_length' }
+        let(:page_uuid) { 'b8335af2-6642-4e2f-8192-0dd12279eec7' } # family hobbies
+        let(:component_uuid) { '9bf39533-dbd2-45ed-b2b8-9b29bf5fe9e8' }
+
+        it 'returns valid' do
+          expect(subject).to be_valid
+        end
+      end
+
       context 'when validator does not exist for component' do
         let(:validator) { 'some-non-existent-validator' }
         let(:expected_error) do

--- a/spec/support/shared_examples/string_length_validation_examples.rb
+++ b/spec/support/shared_examples/string_length_validation_examples.rb
@@ -5,10 +5,33 @@ RSpec.shared_examples 'a string length validation' do
     end
   end
 
-  describe '#preselect_characters?' do
+  describe '#select_characters?' do
     context 'when no string validation has been configured previously configured' do
-      it 'returns true (default selected radio)' do
-        expect(subject.preselect_characters?).to be_truthy
+      context 'when value is empty' do
+        let(:value) { nil }
+
+        context 'when string length is characters' do
+          it 'returns true' do
+            expect(subject.select_characters?).to be_truthy
+          end
+        end
+
+        context 'when string length is words' do
+          let(:string_length) { 'max_word' }
+
+          it 'returns false' do
+            expect(subject.select_characters?).to be_falsey
+          end
+        end
+      end
+
+      context 'when string length does not exist (GET request for modal)' do
+        let(:string_length) { nil }
+        let(:value) { nil }
+
+        it 'returns true (default selected radio)' do
+          expect(subject.select_characters?).to be_truthy
+        end
       end
     end
 
@@ -20,7 +43,7 @@ RSpec.shared_examples 'a string length validation' do
       end
 
       it 'returns false' do
-        expect(subject.preselect_characters?).to be_falsey
+        expect(subject.select_characters?).to be_falsey
       end
     end
 
@@ -29,24 +52,63 @@ RSpec.shared_examples 'a string length validation' do
       let(:component_uuid) { '27d377a2-6828-44ca-87d1-b83ddac98284' }
 
       it 'returns true' do
-        expect(subject.preselect_characters?).to be_truthy
+        expect(subject.select_characters?).to be_truthy
       end
     end
   end
 
-  describe '#previously_enabled?' do
-    context 'when string_length property does not exists in component validation' do
-      it 'returns falsey' do
-        expect(subject.previously_enabled?).to be_falsey
+  describe '#select_words?' do
+    context 'when no string validation has been configured previously configured' do
+      context 'when value is empty' do
+        let(:value) { nil }
+
+        context 'when string length is characters' do
+          it 'returns false' do
+            expect(subject.select_words?).to be_falsey
+          end
+        end
+
+        context 'when string length is words' do
+          let(:string_length) { 'max_word' }
+
+          it 'returns true' do
+            expect(subject.select_words?).to be_truthy
+          end
+        end
+      end
+
+      context 'when string length does not exist (GET request for modal)' do
+        let(:string_length) { nil }
+        let(:value) { nil }
+
+        it 'returns false' do
+          expect(subject.select_words?).to be_falsey
+        end
       end
     end
 
-    context 'when string_length property exists in component validation' do
-      let(:page_uuid) { '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' } # name
-      let(:component_uuid) { '27d377a2-6828-44ca-87d1-b83ddac98284' }
+    context 'when a characters validation has been configured' do
+      let(:latest_metadata) do
+        meta = metadata_fixture(:version)
+        meta['pages'][9]['components'][0]['validation'] = { 'min_length' => '5' }
+        meta
+      end
 
-      it 'returns truthy' do
-        expect(subject.previously_enabled?).to be_truthy
+      it 'returns false' do
+        expect(subject.select_words?).to be_falsey
+      end
+    end
+
+    context 'when a word validation has been previously configured' do
+      let(:latest_metadata) do
+        meta = metadata_fixture(:version)
+        meta['pages'][9]['components'][0]['validation'] = { 'min_word' => '500' }
+        meta
+      end
+      let(:string_length) { 'min_word' }
+
+      it 'returns true' do
+        expect(subject.select_words?).to be_truthy
       end
     end
   end

--- a/spec/support/shared_examples/string_length_validation_examples.rb
+++ b/spec/support/shared_examples/string_length_validation_examples.rb
@@ -1,0 +1,53 @@
+RSpec.shared_examples 'a string length validation' do
+  describe '#component_partial' do
+    it 'returns the correct shared string length partial' do
+      expect(subject.component_partial).to eq('string_length_validation')
+    end
+  end
+
+  describe '#preselect_characters?' do
+    context 'when no string validation has been configured previously configured' do
+      it 'returns true (default selected radio)' do
+        expect(subject.preselect_characters?).to be_truthy
+      end
+    end
+
+    context 'when a word validation has been configured' do
+      let(:latest_metadata) do
+        meta = metadata_fixture(:version)
+        meta['pages'][9]['components'][0]['validation'] = { 'max_word' => '1000' }
+        meta
+      end
+
+      it 'returns false' do
+        expect(subject.preselect_characters?).to be_falsey
+      end
+    end
+
+    context 'when a character validation has been previously configured' do
+      let(:page_uuid) { '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' } # name
+      let(:component_uuid) { '27d377a2-6828-44ca-87d1-b83ddac98284' }
+
+      it 'returns true' do
+        expect(subject.preselect_characters?).to be_truthy
+      end
+    end
+  end
+
+  describe '#previously_enabled?' do
+    context 'when string_length property does not exists in component validation' do
+      it 'returns falsey' do
+        expect(subject.previously_enabled?).to be_falsey
+      end
+    end
+
+    context 'when string_length property exists in component validation' do
+      let(:page_uuid) { '9e1ba77f-f1e5-42f4-b090-437aa9af7f73' } # name
+      let(:component_uuid) { '27d377a2-6828-44ca-87d1-b83ddac98284' }
+
+      it 'returns truthy' do
+        expect(subject.previously_enabled?).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the characters and words count validation configuration for both the text and textarea components.

<img width="451" alt="Screenshot 2022-05-26 at 14 21 39" src="https://user-images.githubusercontent.com/3466862/170496108-222f3ae7-66a7-431c-ac37-bbf0f8a6e9ad.png">

Because the modal caters for both the characters and the words in one they are collectively known as `min_string_length` and `max_string_length`. The type the user has chosen is decided by the radio button, the param for that being `string_length` which can be one of 4 values:

- `min_length`
- `max_length`
- `min_word`
- `max_word`

In order for the frontend to know whether to remove a previously set validation the backend sends the validation to remove as part of the response payload but with an empty value.

<img width="781" alt="Screenshot 2022-05-26 at 14 23 30" src="https://user-images.githubusercontent.com/3466862/170496801-4177aa69-99b3-4e89-830c-5ebca2f857fb.png">

<img width="773" alt="Screenshot 2022-05-26 at 14 23 37" src="https://user-images.githubusercontent.com/3466862/170496804-12e060df-9d62-40d1-ac52-018ef3c9b959.png">

<img width="772" alt="Screenshot 2022-05-26 at 14 24 23" src="https://user-images.githubusercontent.com/3466862/170496807-6fca74c1-f2b0-475f-930f-c0514f6408e6.png">

<img width="780" alt="Screenshot 2022-05-26 at 14 24 03" src="https://user-images.githubusercontent.com/3466862/170496811-ff1c4554-b05f-4f2a-8e0f-9f0c081de436.png">

Co-authored-by Chris Pymm <chris.pymm@digital.justice.gov.uk>