### PR TITLE
Add in beforeuload event to prevent leaving with unsaved changes

### DIFF
--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -174,7 +174,10 @@ module CommonSteps
   end
 
   def and_I_return_to_flow_page
-    editor.pages_link.click
+    accept_alert(wait: 1) { editor.pages_link.click }
+    rescue Capybara::ModalNotFound
+      editor.pages_link.click
+    ensure
     sleep 0.5
     page.find('#main-content', visible: true)
   end


### PR DESCRIPTION
Adds in a prompt to warn of unsaved changes when attempting to leave the edit question page.

As per spec recommendation the listener is only added when needed, and removed when it is not.


