### PR TITLE
Export services to CSV from admin dashboard

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    administrate (0.16.0)
+    administrate (0.17.0)
       actionpack (>= 5.0)
       actionview (>= 5.0)
       activerecord (>= 5.0)

--- a/app/controllers/admin/overviews_controller.rb
+++ b/app/controllers/admin/overviews_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class OverviewsController < Admin::ApplicationController
+    require 'csv'
+
     def index
       @stats = [
         {
@@ -29,6 +31,15 @@ module Admin
       ]
     end
 
+    def export_services
+      @headers = ['Service name', 'User email', 'Published Test', 'Published Live']
+      @services = services_to_export.sort_by { |s| s[:name] }
+
+      response.headers['Content-Type'] = 'text/csv'
+      response.headers['Content-Disposition'] = "attachment; filename=#{csv_filename}"
+      render template: '/admin/overviews/export_services.csv.erb'
+    end
+
     private
 
     def active_sessions
@@ -36,6 +47,39 @@ module Admin
       ActiveRecord::SessionStore::Session.where(
         'updated_at < ?', cutoff_period
       ).count
+    end
+
+    def services_to_export
+      User.all.each_with_object([]) do |user, array|
+        # skip any services created by the acceptance tests user
+        next if user.id == 'a5833e7a-a210-4447-904c-df050d198e33'
+
+        MetadataApiClient::Service.all(user_id: user.id).each do |service|
+          meta = service.metadata
+
+          array << {
+            name: meta['service_name'],
+            user: user.email,
+            published_test: published_state(meta['service_id'], 'dev'),
+            published_live: published_state(meta['service_id'], 'production')
+          }
+        end
+      end
+    end
+
+    def published_state(service_id, environment)
+      currently_published?(service_id, environment) ? 'Yes' : 'No'
+    end
+
+    def currently_published?(service_id, environment)
+      PublishService.where(
+        service_id: service_id,
+        deployment_environment: environment
+      ).last&.published?
+    end
+
+    def csv_filename
+      "#{ENV['PLATFORM_ENV']}-services-#{Time.zone.now.strftime('%Y-%m-%d')}.csv"
     end
   end
 end

--- a/app/views/admin/overviews/export_services.csv.erb
+++ b/app/views/admin/overviews/export_services.csv.erb
@@ -1,0 +1,4 @@
+<%= CSV.generate_line @headers %>
+<%- @services.each do |service| -%>
+  <%= CSV.generate_line([service[:name], service[:user], service[:published_test], service[:published_live]]) -%>
+<%- end -%>

--- a/app/views/admin/overviews/index.html.erb
+++ b/app/views/admin/overviews/index.html.erb
@@ -46,4 +46,8 @@ It renders the `_table` partial to display details about the resources.
       </div>
     <% end %>
   </dl>
+
+  <a href="<%= admin_export_services_path %>" data-disable-with="Exporting..." class="govuk-button fb-govuk-button">
+    Export Services
+  </a>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     resources :users
     resources :publish_services
     get '/test-service/:test_service_name/(:fixture)', to: 'test_services#create', as: :test_service
+    get '/export-services', to: 'overviews#export_services'
 
     root to: "overviews#index"
   end


### PR DESCRIPTION
This creates the ability to export some details about all the services
from the Editor. The details include:

- service name
- email address of user who created the service
- Whether it is published to Test
- Whether it is published to Live

Also bump the version of Administrate gem

![Screenshot 2022-05-30 at 16 39 38](https://user-images.githubusercontent.com/3466862/171025212-8545c3ad-74ff-4fcc-b7ee-17422f5d4a77.png)

