### PR TITLE
Remove validation dialog elements from the page on close

### DIFF
--- a/app/javascript/src/component_dialog_validation.js
+++ b/app/javascript/src/component_dialog_validation.js
@@ -75,6 +75,8 @@ class DialogValidation {
       this.#config.activator.focus();
     }
     this.$node.dialog("close");
+    this.$node.dialog('destroy'); 
+    this.$node.remove();
   }
 
   submit() {


### PR DESCRIPTION
Noticed an issue with the validation dialog where, due to it loading the template from a remote source, it creates multiple `DialogValidation` elements within the page.

This fix adds lines to destroy the jQueryUI dialog and remove the HTML node on `close()`.

Before (after opening and closing the dialog a few times):
![image](https://user-images.githubusercontent.com/595564/172177884-3215a487-f318-41a8-9a7a-34d70b1afdae.png)


After: 
![image](https://user-images.githubusercontent.com/595564/172177958-136ae4b5-739b-4e88-bfdd-9150bfe7f2f1.png)
