### PR TITLE
Ensure close button is handled by component event listener

### DIFF
--- a/app/javascript/src/component_dialog_validation.js
+++ b/app/javascript/src/component_dialog_validation.js
@@ -127,7 +127,7 @@ class DialogValidation {
   #setupCloseButtons() {
     var dialog = this;
     if(this.#config.closeOnClickSelector) {
-      let $buttons = $(this.#config.closeOnClickSelector, this.$node);
+      let $buttons = $(this.#config.closeOnClickSelector, this.$container);
       $buttons.on("click", function() {
         dialog.close();
       });
@@ -138,7 +138,7 @@ class DialogValidation {
   #setupSubmitButton() {
     var dialog = this;
     if(this.#config.submitOnClickSelector) {
-      let $buttons = $(this.#config.submitOnClickSelector, this.$node);
+      let $buttons = $(this.#config.submitOnClickSelector, this.$container);
       $buttons.on("click", function(e) {
         e.preventDefault();
         utilities.safelyActivateFunction(dialog.#config.beforeSubmit, dialog );


### PR DESCRIPTION
Due to a scoping issue, the close button in the validation dialog was being handled by the underlying jQuery UI close method, and not the implementation within the component containing the other actions we want to do on close - most notably the tidying up of the html to remove the modal.

