### PR TITLE
Add Form Analytics Configuration Settings Page

### DIFF
--- a/acceptance/features/component_validations_spec.rb
+++ b/acceptance/features/component_validations_spec.rb
@@ -367,7 +367,6 @@ feature 'Component validations' do
 
   def and_I_set_the_input_value(value)
     input_element = page.find(:css, 'input#component_validation_value')
-    input_element.set('')
     input_element.set(value)
   end
 

--- a/acceptance/features/form_analytics_spec.rb
+++ b/acceptance/features/form_analytics_spec.rb
@@ -38,7 +38,7 @@ feature 'Form analytics configuration' do
       and_I_set_the_analytics_tracking_id("ga4_#{environment}", valid_ids["ga4_#{environment}"])
       click_button(I18n.t('actions.save'))
       then_I_should_see_no_error_message
-      then_I_should_see_my_saved_ids
+      then_I_should_see_my_saved_ids(environment)
 
       when_I_disable_the_analytics(environment)
       click_button(I18n.t('actions.save'))
@@ -139,8 +139,11 @@ feature 'Form analytics configuration' do
     expect(page).to_not have_content(I18n.t('activemodel.errors.summary_title'))
   end
 
-  def then_I_should_see_my_saved_ids
+  def then_I_should_see_my_saved_ids(environment)
     page.find(:css, '#main-content', visible: true)
+    page.find(:css, "#form_analytics_settings_#{environment}")
+        .find(:css, 'span', text: I18n.t('settings.form_analytics.details')).click
+
     valid_ids.each do |id, value|
       input_element = page.find(:css, "input#form_analytics_settings_#{id}")
       expect(input_element.value).to eq(value)

--- a/acceptance/features/form_analytics_spec.rb
+++ b/acceptance/features/form_analytics_spec.rb
@@ -21,6 +21,8 @@ feature 'Form analytics configuration' do
   shared_examples 'a form analytics settings' do
     scenario 'configuring form analytics settings' do
       when_I_enable_the_analytics(environment)
+      then_I_should_see_the_account_ids_fields(environment)
+
       click_button(I18n.t('actions.save'))
       then_I_should_see_error_messages([I18n.t('activemodel.errors.models.form_analytics_settings.blank')])
 
@@ -40,6 +42,10 @@ feature 'Form analytics configuration' do
 
       when_I_disable_the_analytics(environment)
       click_button(I18n.t('actions.save'))
+
+      when_I_enable_the_analytics(environment)
+      then_I_should_see_the_account_ids_fields(environment)
+      then_I_should_not_see_my_saved_ids
     end
   end
 
@@ -138,6 +144,14 @@ feature 'Form analytics configuration' do
     valid_ids.each do |id, value|
       input_element = page.find(:css, "input#form_analytics_settings_#{id}")
       expect(input_element.value).to eq(value)
+    end
+  end
+
+  def then_I_should_not_see_my_saved_ids
+    page.find(:css, '#main-content', visible: true)
+    valid_ids.each do |id, value|
+      input_element = page.find(:css, "input#form_analytics_settings_#{id}")
+      expect(input_element.value).to_not eq(value)
     end
   end
 end

--- a/acceptance/features/form_analytics_spec.rb
+++ b/acceptance/features/form_analytics_spec.rb
@@ -1,0 +1,143 @@
+require_relative '../spec_helper'
+
+feature 'Form analytics configuration' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:error_messages) do
+    [
+      I18n.t('activemodel.errors.models.form_analytics_settings.ua'),
+      I18n.t('activemodel.errors.models.form_analytics_settings.gtm'),
+      I18n.t('activemodel.errors.models.form_analytics_settings.ga4')
+    ]
+  end
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service_fixture(name: service_name)
+    when_I_visit_the_form_analytics_page
+    then_I_should_see_the_settings_configuration
+  end
+
+  shared_examples 'a form analytics settings' do
+    scenario 'configuring form analytics settings' do
+      when_I_enable_the_analytics(environment)
+      click_button(I18n.t('actions.save'))
+      then_I_should_see_error_messages([I18n.t('activemodel.errors.models.form_analytics_settings.blank')])
+
+      then_I_should_see_the_account_ids_fields(environment)
+      and_I_set_the_analytics_tracking_id("ua_#{environment}", invalid_ids["ua_#{environment}"])
+      and_I_set_the_analytics_tracking_id("gtm_#{environment}", invalid_ids["gtm_#{environment}"])
+      and_I_set_the_analytics_tracking_id("ga4_#{environment}", invalid_ids["ga4_#{environment}"])
+      click_button(I18n.t('actions.save'))
+      then_I_should_see_error_messages(error_messages)
+
+      and_I_set_the_analytics_tracking_id("ua_#{environment}", valid_ids["ua_#{environment}"])
+      and_I_set_the_analytics_tracking_id("gtm_#{environment}", valid_ids["gtm_#{environment}"])
+      and_I_set_the_analytics_tracking_id("ga4_#{environment}", valid_ids["ga4_#{environment}"])
+      click_button(I18n.t('actions.save'))
+      then_I_should_see_no_error_message
+      then_I_should_see_my_saved_ids
+
+      when_I_disable_the_analytics(environment)
+      click_button(I18n.t('actions.save'))
+    end
+  end
+
+  context 'Test environment' do
+    let(:environment) { 'test' }
+    let(:invalid_ids) do
+      {
+        'ua_test' => 'not',
+        'gtm_test'=> 'real',
+        'ga4_test' => 'ids'
+      }
+    end
+    let(:valid_ids) do
+      {
+        'ua_test' =>'UA-12345',
+        'gtm_test' => 'GTM-12345',
+        'ga4_test' => 'G-12345'
+      }
+    end
+
+    it_behaves_like 'a form analytics settings'
+  end
+
+  context 'Live environment' do
+    let(:environment) { 'live' }
+    let(:invalid_ids) do
+      {
+        'ua_live' => 'more',
+        'gtm_live'=> 'fake',
+        'ga4_live' => 'analytics'
+      }
+    end
+    let(:valid_ids) do
+      {
+        'ua_live' =>'UA-67890',
+        'gtm_live' => 'GTM-67890',
+        'ga4_live' => 'G-67890'
+      }
+    end
+
+    it_behaves_like 'a form analytics settings'
+  end
+
+  def when_I_visit_the_form_analytics_page
+    page.find(:css, '#main-content', visible: true)
+    editor.click_link(I18n.t('settings.name'))
+    expect(page).to have_content(I18n.t('settings.form_analytics.hint'))
+    editor.click_link(I18n.t('settings.form_analytics.name'))
+  end
+
+  def when_I_enable_the_analytics(environment)
+    page.find(:css, "input#form_analytics_settings_enabled_#{environment}", visible: false).set(true)
+  end
+
+  def when_I_disable_the_analytics(environment)
+    page.find(:css, "input#form_analytics_settings_enabled_#{environment}", visible: false).set(false)
+  end
+
+  def and_I_set_the_analytics_tracking_id(id, value)
+    input_element = page.find(:css, "input#form_analytics_settings_#{id}")
+    input_element.set(value)
+  end
+
+  def then_I_should_see_the_settings_configuration
+    expect(page).to have_content(I18n.t('settings.form_analytics.name'))
+    expect(page).to have_content(I18n.t('settings.form_analytics.intro'))
+    expect(page).to have_content(I18n.t('settings.form_analytics.test.heading'))
+    expect(page).to have_content(I18n.t('settings.form_analytics.test.description'))
+    expect(page).to have_content(I18n.t('settings.form_analytics.live.heading'))
+    expect(page).to have_content(I18n.t('settings.form_analytics.live.description'))
+  end
+
+  def then_I_should_see_the_account_ids_fields(environment)
+    expect(page).to have_content(I18n.t('settings.form_analytics.details_hint'))
+    expect(page).to have_content(I18n.t('activemodel.attributes.form_analytics_settings.ua'))
+    expect(page).to have_content(I18n.t('activemodel.attributes.form_analytics_settings.ua_hint'))
+    expect(page).to have_content(I18n.t('activemodel.attributes.form_analytics_settings.gtm'))
+    expect(page).to have_content(I18n.t('activemodel.attributes.form_analytics_settings.gtm_hint'))
+    expect(page).to have_content(I18n.t('activemodel.attributes.form_analytics_settings.ga4'))
+    expect(page).to have_content(I18n.t('activemodel.attributes.form_analytics_settings.ga4_hint'))
+  end
+
+  def then_I_should_see_error_messages(messages)
+    page.find(:css, '#main-content', visible: true)
+    expect(page).to have_content(I18n.t('activemodel.errors.summary_title'))
+    messages.each { |message| expect(page).to have_content(message) }
+  end
+
+  def then_I_should_see_no_error_message
+    page.find(:css, '#main-content', visible: true)
+    expect(page).to_not have_content(I18n.t('activemodel.errors.summary_title'))
+  end
+
+  def then_I_should_see_my_saved_ids
+    page.find(:css, '#main-content', visible: true)
+    valid_ids.each do |id, value|
+      input_element = page.find(:css, "input#form_analytics_settings_#{id}")
+      expect(input_element.value).to eq(value)
+    end
+  end
+end

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -349,6 +349,7 @@ module CommonSteps
   end
 
   def and_I_click_on_the_three_dots
+    sleep(1)
     editor.three_dots_button.click
   end
 
@@ -376,6 +377,7 @@ module CommonSteps
   def then_I_should_not_be_able_to_add_page(page_title, page_link)
     find('#main-content', visible: true)
     editor.connection_menu(page_title).click
+    sleep(1)
     expect(editor).not_to have_content(page_link)
     editor.flow_thumbnail(page_title).hover #hides the connection menu
   end

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -6,7 +6,7 @@ module CommonSteps
     I18n.t('default_text.content'),
     I18n.t('default_text.option_hint')
   ].freeze
-  ERROR_MESSAGE = 'There is a problem'.freeze
+  ERROR_MESSAGE = I18n.t('activemodel.errors.summary_title').freeze
   DELETE_WARNING = [
     I18n.t('pages.flow.delete_warning_cya_page'),
     I18n.t('pages.flow.delete_warning_confirmation_page'),

--- a/app/controllers/settings/form_analytics_controller.rb
+++ b/app/controllers/settings/form_analytics_controller.rb
@@ -1,0 +1,16 @@
+class Settings::FormAnalyticsController < FormController
+  before_action :assign_form_objects
+
+  private
+
+  def assign_form_objects
+    @form_analytics_dev = FormAnalyticsSettings.new(
+      service: service,
+      deployment_environment: 'dev'
+    )
+    @form_analytics_production = FormAnalyticsSettings.new(
+      service: service,
+      deployment_environment: 'production'
+    )
+  end
+end

--- a/app/controllers/settings/form_analytics_controller.rb
+++ b/app/controllers/settings/form_analytics_controller.rb
@@ -1,16 +1,33 @@
 class Settings::FormAnalyticsController < FormController
-  before_action :assign_form_objects
+  before_action :assign_form_object, only: :index
+
+  def index; end
+
+  def create
+    @form_analytics = FormAnalyticsSettings.new(
+      form_analytics_params.merge(service_id: service.service_id)
+    )
+
+    if @form_analytics.valid?
+      FormAnalyticsUpdater.new(
+        settings: @form_analytics,
+        service_id: service.service_id
+      ).create_or_update!
+
+      redirect_to settings_form_analytics_path(service_id: service.service_id)
+    else
+      render :index, status: :unprocessable_entity
+    end
+  end
 
   private
 
-  def assign_form_objects
-    @form_analytics_dev = FormAnalyticsSettings.new(
-      service: service,
-      deployment_environment: 'dev'
-    )
-    @form_analytics_production = FormAnalyticsSettings.new(
-      service: service,
-      deployment_environment: 'production'
-    )
+  def assign_form_object
+    @form_analytics = FormAnalyticsSettings.new(service_id: service.service_id)
+  end
+
+  def form_analytics_params
+    params.require(:form_analytics_settings)
+          .permit(*FormAnalyticsSettings::PERMITTED_PARAMS)
   end
 end

--- a/app/controllers/settings/form_analytics_controller.rb
+++ b/app/controllers/settings/form_analytics_controller.rb
@@ -1,4 +1,5 @@
 class Settings::FormAnalyticsController < FormController
+  before_action :form_analytics_enabled
   before_action :assign_form_object, only: :index
 
   def index; end
@@ -29,5 +30,9 @@ class Settings::FormAnalyticsController < FormController
   def form_analytics_params
     params.require(:form_analytics_settings)
           .permit(*FormAnalyticsSettings::PERMITTED_PARAMS)
+  end
+
+  def form_analytics_enabled
+    redirect_to unauthorised_path unless ENV['FORM_ANALYTICS'] == 'enabled'
   end
 end

--- a/app/javascript/src/controller_form_analytics.js
+++ b/app/javascript/src/controller_form_analytics.js
@@ -50,7 +50,7 @@ class FormAnalyticsController extends DefaultController {
       var $this = $(this);
       var $checkbox = $("input[type=checkbox]", $this);
       var expander = new Expander($("details", $this), {
-        auto_open: $checkbox.prop('checked') || $(".govuk-form-group--error", $this).length,
+        auto_open: $(".govuk-form-group--error", $this).length,
         wrap_content: false, 
       });
 

--- a/app/javascript/src/controller_form_analytics.js
+++ b/app/javascript/src/controller_form_analytics.js
@@ -42,16 +42,18 @@ class FormAnalyticsController extends DefaultController {
 
   /* VIEW SETUP
    * 1. Apply expand/collapse functionality.
-   * 2. ...
+   * 2. Allow Checkboxes to also control the Expander components.
    **/
   #enhanceFormSections() {
     $(".analytics-environment-configuration").each(function(index) {
       var $this = $(this);
       var $checkbox = $("input[type=checkbox]", $this);
-      new Expander($("details", $this), {
+      var expander = new Expander($("details", $this), {
         auto_open: $checkbox.prop('checked'),
         wrap_content: false, 
       });
+
+      $checkbox.on("click", () => expander.toggle() );
     });
   }
 

--- a/app/javascript/src/controller_form_analytics.js
+++ b/app/javascript/src/controller_form_analytics.js
@@ -36,20 +36,21 @@ class FormAnalyticsController extends DefaultController {
   /* VIEW ACTION
    **/
   index() {
-    this.#enhanceFormSections();
+    this.#addExpanderEnhancement();
   }
 
 
   /* VIEW SETUP
-   * 1. Apply expand/collapse functionality.
-   * 2. Allow Checkboxes to also control the Expander components.
+   * 1. Enhance native browser (<details>) functioality with Expander.
+   * 2. Make sure the Expanders will be open if Checkbox ticked or an error shows.
+   * 3. Allow Checkboxes to also control the Expander components.
    **/
-  #enhanceFormSections() {
+  #addExpanderEnhancement() {
     $(".analytics-environment-configuration").each(function(index) {
       var $this = $(this);
       var $checkbox = $("input[type=checkbox]", $this);
       var expander = new Expander($("details", $this), {
-        auto_open: $checkbox.prop('checked'),
+        auto_open: $checkbox.prop('checked') || $(".govuk-form-group--error", $this).length,
         wrap_content: false, 
       });
 

--- a/app/javascript/src/controller_form_analytics.js
+++ b/app/javascript/src/controller_form_analytics.js
@@ -50,11 +50,14 @@ class FormAnalyticsController extends DefaultController {
       var $this = $(this);
       var $checkbox = $("input[type=checkbox]", $this);
       var expander = new Expander($("details", $this), {
-        auto_open: $(".govuk-form-group--error", $this).length,
-        wrap_content: false, 
+        auto_open: $(".govuk-form-group--error", $this).length
       });
 
-      $checkbox.on("click", () => expander.toggle() );
+      $checkbox.on("click", function() {
+        if(this.checked && !expander.isOpen()) {
+          expander.open();
+        }
+      });
     });
   }
 

--- a/app/javascript/src/controller_form_analytics.js
+++ b/app/javascript/src/controller_form_analytics.js
@@ -1,0 +1,61 @@
+/**
+ * Form Analytics Controller
+ * ----------------------------------------------------
+ * Description:
+ * Adds functionality for the Settings:Analytics FB Editor view.
+ * File and controller name based on Backend controller name.
+ *
+ * Documentation:
+ *
+ *     - Requires jQuery & jQueryUI
+ *       https://api.jquery.com/
+ *       https://api.jqueryui.com/
+ *
+ *     - TODO:
+ *       (steven.burnell@digital.justice.gov.uk to add).
+ *
+ **/
+
+
+const Expander = require('./component_expander');
+const DefaultController = require('./controller_default');
+
+
+class FormAnalyticsController extends DefaultController {
+  constructor(app) {
+    super(app);
+    switch(app.page.action) {
+      case "create":
+      case "index":
+        this.index();
+        break;
+    }
+  }
+
+
+  /* VIEW ACTION
+   **/
+  index() {
+    this.#enhanceFormSections();
+  }
+
+
+  /* VIEW SETUP
+   * 1. Apply expand/collapse functionality.
+   * 2. ...
+   **/
+  #enhanceFormSections() {
+    $(".analytics-environment-configuration").each(function(index) {
+      var $this = $(this);
+      var $checkbox = $("input[type=checkbox]", $this);
+      new Expander($("details", $this), {
+        auto_open: $checkbox.prop('checked'),
+        wrap_content: false, 
+      });
+    });
+  }
+
+}
+
+
+module.exports = FormAnalyticsController;

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -4,6 +4,7 @@ const ServicesController = require('./controller_services');
 const FormListPage = require('./page_form_list');
 const PublishController = require('./controller_publish');
 const BranchesController = require('./controller_branches');
+const FormAnalyticsController = require('./controller_form_analytics');
 
 
 // Determine the controller we need to use
@@ -57,6 +58,11 @@ switch(controllerAndAction()) {
   case "PublishController#index":
   case "PublishController#create":
        Controller = PublishController;
+  break;
+
+  case "Form_analyticsController#create":
+  case "Form_analyticsController#index":
+       Controller = FormAnalyticsController;
   break;
 
   default:

--- a/app/models/component_validations/base_component_validation.rb
+++ b/app/models/component_validations/base_component_validation.rb
@@ -2,7 +2,6 @@ class BaseComponentValidation
   attr_accessor :service, :page_uuid, :component_uuid, :validator, :status, :value
 
   include ActiveModel::Model
-  include ActiveModel::Validations
 
   validates :validator, inclusion: {
     in: proc { |obj| obj.supported_validations },

--- a/app/models/form_analytics_settings.rb
+++ b/app/models/form_analytics_settings.rb
@@ -33,7 +33,7 @@ class FormAnalyticsSettings
   end
 
   def instance_param(setting_name)
-    instance_variable_get(:"@#{setting_name}")&.upcase
+    instance_variable_get(:"@#{setting_name}")&.upcase&.strip
   end
 
   def environments

--- a/app/models/form_analytics_settings.rb
+++ b/app/models/form_analytics_settings.rb
@@ -1,12 +1,78 @@
 class FormAnalyticsSettings
   include ActiveModel::Model
-  attr_accessor :deployment_environment,
-                :service,
-                :enabled,
-                :gtm,
-                :ga
+  attr_accessor :service_id,
+                :enabled_test, :ua_test, :gtm_test, :ga4_test,
+                :enabled_live, :ua_live, :gtm_live, :ga4_live
 
-  def enabled?
-    enabled == '1'
+  validate :analytics_present
+  validates_with FormAnalyticsValidator
+
+  PLATFORM_DEPLOYMENTS = { 'test' => 'dev', 'live' => 'production' }.freeze
+  CONFIGS = { ua: 'UA', gtm: 'GTM', ga4: 'GA4' }.freeze
+  PERMITTED_PARAMS = (CONFIGS.keys + [:enabled]).map { |param| [:"#{param}_test", :"#{param}_live"] }.flatten.freeze
+
+  def config_params
+    @config_params ||= CONFIGS.keys
+  end
+
+  def config_names
+    @config_names ||= CONFIGS.values
+  end
+
+  def enabled?(environment)
+    public_send("enabled_#{environment}") == '1'
+  end
+
+  def check_enabled?(environment)
+    enabled?(environment) || previously_configured?(PLATFORM_DEPLOYMENTS[environment])
+  end
+
+  def saved_param(config, environment)
+    instance_param("#{config}_#{environment}") ||
+      database(config, PLATFORM_DEPLOYMENTS[environment])
+  end
+
+  def instance_param(setting_name)
+    instance_variable_get(:"@#{setting_name}")&.upcase
+  end
+
+  def environments
+    PLATFORM_DEPLOYMENTS.keys
+  end
+
+  def errors_present?(environment)
+    errors.any? { |error| error.attribute.to_s.include?(environment) }
+  end
+
+  private
+
+  def analytics_present
+    environments.each do |environment|
+      next unless enabled?(environment) && config_params.all? { |param| public_send(:"#{param}_#{environment}").blank? }
+
+      errors.add(
+        :"form_analytics_settings_#{environment}",
+        I18n.t('activemodel.errors.models.form_analytics_settings.blank')
+      )
+    end
+  end
+
+  def previously_configured?(deployment_environment)
+    service_configurations(deployment_environment).any? { |config| config.name.in?(config_names) }
+  end
+
+  def service_configurations(deployment_environment)
+    ServiceConfiguration.where(
+      service_id: service_id,
+      deployment_environment: deployment_environment
+    )
+  end
+
+  def database(setting_name, deployment_environment)
+    ServiceConfiguration.find_by(
+      service_id: service_id,
+      deployment_environment: deployment_environment,
+      name: setting_name.upcase
+    ).try(:decrypt_value)
   end
 end

--- a/app/models/form_analytics_settings.rb
+++ b/app/models/form_analytics_settings.rb
@@ -8,7 +8,7 @@ class FormAnalyticsSettings
   validates_with FormAnalyticsValidator
 
   PLATFORM_DEPLOYMENTS = { 'test' => 'dev', 'live' => 'production' }.freeze
-  CONFIGS = { ua: 'UA', gtm: 'GTM', ga4: 'GA4' }.freeze
+  CONFIGS = { ua: 'UA', ga4: 'GA4', gtm: 'GTM' }.freeze
   PERMITTED_PARAMS = (CONFIGS.keys + [:enabled]).map { |param| [:"#{param}_test", :"#{param}_live"] }.flatten.freeze
 
   def config_params

--- a/app/models/form_analytics_settings.rb
+++ b/app/models/form_analytics_settings.rb
@@ -40,8 +40,9 @@ class FormAnalyticsSettings
     PLATFORM_DEPLOYMENTS.keys
   end
 
-  def errors_present?(environment)
-    errors.any? { |error| error.attribute.to_s.include?(environment) }
+  def errors_present?(environment, attribute = nil)
+    errors[:"form_analytics_settings_#{environment}"].present? ||
+      (attribute.present? && errors[attribute].present?)
   end
 
   private

--- a/app/models/form_analytics_settings.rb
+++ b/app/models/form_analytics_settings.rb
@@ -1,0 +1,12 @@
+class FormAnalyticsSettings
+  include ActiveModel::Model
+  attr_accessor :deployment_environment,
+                :service,
+                :enabled,
+                :gtm,
+                :ga
+
+  def enabled?
+    enabled == '1'
+  end
+end

--- a/app/models/form_analytics_updater.rb
+++ b/app/models/form_analytics_updater.rb
@@ -1,0 +1,49 @@
+class FormAnalyticsUpdater
+  attr_reader :settings, :service_id
+
+  def initialize(settings:, service_id:)
+    @settings = settings
+    @service_id = service_id
+  end
+
+  def create_or_update!
+    ActiveRecord::Base.transaction do
+      save_form_analytics_config
+    end
+  end
+
+  def save_form_analytics_config
+    settings.environments.each do |environment|
+      settings.config_names.each do |config|
+        deployment_environment = FormAnalyticsSettings::PLATFORM_DEPLOYMENTS[environment]
+        setting_name = "#{config}_#{environment}".downcase
+        value = settings.instance_param(setting_name)
+
+        if settings.enabled?(environment) && value.present?
+          create_or_update_the_service_configuration(config, value, deployment_environment)
+        else
+          remove_the_service_configuration(config, deployment_environment)
+        end
+      end
+    end
+  end
+
+  def create_or_update_the_service_configuration(config, value, deployment_environment)
+    setting = find_or_initialize_setting(config, deployment_environment)
+    setting.value = value
+    setting.save!
+  end
+
+  def remove_the_service_configuration(config, deployment_environment)
+    setting = find_or_initialize_setting(config, deployment_environment)
+    setting.destroy!
+  end
+
+  def find_or_initialize_setting(config, deployment_environment)
+    ServiceConfiguration.find_or_initialize_by(
+      service_id: service_id,
+      deployment_environment: deployment_environment,
+      name: config
+    )
+  end
+end

--- a/app/validators/form_analytics_validator.rb
+++ b/app/validators/form_analytics_validator.rb
@@ -1,0 +1,20 @@
+class FormAnalyticsValidator < ActiveModel::Validator
+  PREFIXES = { ua: 'UA-', gtm: 'GTM-', ga4: 'G-' }.freeze
+
+  def validate(record)
+    record.environments.each do |environment|
+      next unless record.enabled?(environment)
+
+      record.config_params.each do |name|
+        attribute_name = :"#{name}_#{environment}"
+        value = record.public_send(attribute_name)
+        next if value.blank? || value.upcase.starts_with?(PREFIXES[name])
+
+        record.errors.add(
+          attribute_name,
+          I18n.t("activemodel.errors.models.form_analytics_settings.#{name}")
+        )
+      end
+    end
+  end
+end

--- a/app/validators/form_analytics_validator.rb
+++ b/app/validators/form_analytics_validator.rb
@@ -7,7 +7,7 @@ class FormAnalyticsValidator < ActiveModel::Validator
 
       record.config_params.each do |name|
         attribute_name = :"#{name}_#{environment}"
-        value = record.public_send(attribute_name)
+        value = record.instance_param(attribute_name)
         next if value.blank? || value.upcase.starts_with?(PREFIXES[name])
 
         record.errors.add(

--- a/app/views/branches/_error_summary.html.erb
+++ b/app/views/branches/_error_summary.html.erb
@@ -1,7 +1,7 @@
 <% if @branch.any_errors? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
-      There is a problem
+      <%= t('activemodel.errors.summary_title') %>
     </h2>
     <div class="govuk-error-summary__body">
        <ul class="govuk-list govuk-error-summary__list">

--- a/app/views/settings/form_analytics/_form.html.erb
+++ b/app/views/settings/form_analytics/_form.html.erb
@@ -1,4 +1,4 @@
-<fieldset class="analytics-environment-configuration govuk-fieldset">
+<fieldset class="analytics-environment-configuration govuk-fieldset" id="analytics-environment-configuration-<%= environment %>">
   <div class="govuk-form-group">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h2 class="govuk-fieldset__heading"><%= t("settings.form_analytics.#{environment}.heading") %></h2>
@@ -29,7 +29,7 @@
         <% end %>
       <% end %>
 
-    <p><%= t('settings.form_analytics.details_hint') %></p>
+      <p><%= t('settings.form_analytics.details_hint') %></p>
 
       <% f.object.config_params.each do |config| %>
         <div class="govuk-form-group">

--- a/app/views/settings/form_analytics/_form.html.erb
+++ b/app/views/settings/form_analytics/_form.html.erb
@@ -1,5 +1,5 @@
-<div class="govuk-form-group">
-  <fieldset class="govuk-fieldset">
+<fieldset class="analytics-environment-configuration govuk-fieldset">
+  <div class="govuk-form-group">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h2 class="govuk-fieldset__heading"><%= t("settings.form_analytics.#{environment}.heading") %></h2>
     </legend>
@@ -11,44 +11,44 @@
         <%= f.label :"enabled_#{environment}", class: 'govuk-label govuk-checkboxes__label' %>
       </div>
     </div>
-  </fieldset>
-</div>
+  </div>
 
-<details class="govuk-details" id="form_analytics_settings_<%= environment %>" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-      <%= t('settings.form_analytics.details') %>
-    </span>
-  </summary>
+  <details class="govuk-details" id="form_analytics_settings_<%= environment %>" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        <%= t('settings.form_analytics.details') %>
+      </span>
+    </summary>
 
-  <div class="govuk-form-group <%= f.object.errors_present?(environment) ? 'govuk-form-group--error' : 'govuk-details__text' %>">
-    <% if f.object.errors[:"form_analytics_settings_#{environment}"].present? %>
-      <% f.object.errors.full_messages_for(:"form_analytics_settings_#{environment}").each do |error_message| %>
-        <p id="<%= "form_analytics_settings_#{environment}_error" %>" class="govuk-error-message">
-          <span class="govuk-visually-hidden">Error:</span> <%= error_message %>
-        </p>
+    <div class="govuk-form-group <%= f.object.errors_present?(environment) ? 'govuk-form-group--error' : 'govuk-details__text' %>">
+      <% if f.object.errors[:"form_analytics_settings_#{environment}"].present? %>
+        <% f.object.errors.full_messages_for(:"form_analytics_settings_#{environment}").each do |error_message| %>
+          <p id="<%= "form_analytics_settings_#{environment}_error" %>" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> <%= error_message %>
+          </p>
+        <% end %>
       <% end %>
-    <% end %>
 
     <p><%= t('settings.form_analytics.details_hint') %></p>
 
-    <% f.object.config_params.each do |config| %>
-      <div class="govuk-form-group">
-        <%= f.label :"#{config}_#{environment}", class: "govuk-label", for: "#{config}_#{environment}" %>
-        <div class="govuk-hint"><%= t("activemodel.attributes.form_analytics_settings.#{config}_hint") %></div>
-        <% if f.object.errors[:"#{config}_#{environment}"].present? %>
-          <p id="<%= "#{config}_#{environment}_error" %>" class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span> <%= f.object.errors.full_messages_for("#{config}_#{environment}").first %>
-          </p>
-          <%= f.text_field :"#{config}_#{environment}",
-              class: "govuk-input width-responsive-two-thirds govuk-input--error",
-              value: f.object.param(config, environment) %>
-        <% else %>
-          <%= f.text_field :"#{config}_#{environment}",
-              class: "govuk-input width-responsive-two-thirds",
-              value: f.object.param(config, environment) %>
-        <% end %>
-      </div>
-    <% end %>
-  </div>
-</details>
+      <% f.object.config_params.each do |config| %>
+        <div class="govuk-form-group">
+          <%= f.label :"#{config}_#{environment}", class: "govuk-label", for: "#{config}_#{environment}" %>
+          <div class="govuk-hint"><%= t("activemodel.attributes.form_analytics_settings.#{config}_hint") %></div>
+          <% if f.object.errors[:"#{config}_#{environment}"].present? %>
+            <p id="<%= "#{config}_#{environment}_error" %>" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> <%= f.object.errors.full_messages_for("#{config}_#{environment}").first %>
+            </p>
+            <%= f.text_field :"#{config}_#{environment}",
+            class: "govuk-input width-responsive-two-thirds govuk-input--error",
+              value: f.object.saved_param(config, environment) %>
+          <% else %>
+            <%= f.text_field :"#{config}_#{environment}",
+            class: "govuk-input width-responsive-two-thirds",
+              value: f.object.saved_param(config, environment) %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </details>
+</fieldset>

--- a/app/views/settings/form_analytics/_form.html.erb
+++ b/app/views/settings/form_analytics/_form.html.erb
@@ -1,0 +1,26 @@
+<%= f.hidden_field :deployment_environment, value: deployment_environment %>
+
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text" id="configure-<%= deployment_environment %>">
+      <%= t('settings.configure') %>
+    </span>
+  </summary>
+  <fieldset class="govuk-fieldset">
+    <div class="govuk-form-group <%= f.object.errors[:form_analytics_settings].present? ? 'govuk-form-group--error' : '' %> ">
+      <% f.object.errors[:form_analytics_settings].each do |message| %>
+        <span class="govuk-error-message"><%= message %></span>
+      <% end %>
+    </div>
+
+    <div class="govuk-form-group">
+      <%= f.label :ga, class: "govuk-label" %>
+      <%= f.text_field :ga, class: "govuk-input width-responsive-two-thirds" %>
+    </div>
+
+    <div class="govuk-form-group">
+      <%= f.label :gtm, class: "govuk-label" %>
+      <%= f.text_field :gtm, class: "govuk-input width-responsive-two-thirds" %>
+    </div>
+  </fieldset>
+</details>

--- a/app/views/settings/form_analytics/_form.html.erb
+++ b/app/views/settings/form_analytics/_form.html.erb
@@ -1,26 +1,54 @@
-<%= f.hidden_field :deployment_environment, value: deployment_environment %>
-
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text" id="configure-<%= deployment_environment %>">
-      <%= t('settings.configure') %>
-    </span>
-  </summary>
+<div class="govuk-form-group">
   <fieldset class="govuk-fieldset">
-    <div class="govuk-form-group <%= f.object.errors[:form_analytics_settings].present? ? 'govuk-form-group--error' : '' %> ">
-      <% f.object.errors[:form_analytics_settings].each do |message| %>
-        <span class="govuk-error-message"><%= message %></span>
-      <% end %>
-    </div>
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h2 class="govuk-fieldset__heading"><%= t("settings.form_analytics.#{environment}.heading") %></h2>
+    </legend>
+    <div class="govuk-hint"><%= t("settings.form_analytics.#{environment}.description") %></div>
 
-    <div class="govuk-form-group">
-      <%= f.label :ga, class: "govuk-label" %>
-      <%= f.text_field :ga, class: "govuk-input width-responsive-two-thirds" %>
-    </div>
-
-    <div class="govuk-form-group">
-      <%= f.label :gtm, class: "govuk-label" %>
-      <%= f.text_field :gtm, class: "govuk-input width-responsive-two-thirds" %>
+    <div class="govuk-checkboxes">
+      <div class="govuk-checkboxes__item">
+        <%= f.check_box :"enabled_#{environment}", class: 'govuk-checkboxes__input', checked: f.object.check_enabled?(environment) %>
+        <%= f.label :"enabled_#{environment}", class: 'govuk-label govuk-checkboxes__label' %>
+      </div>
     </div>
   </fieldset>
+</div>
+
+<details class="govuk-details" id="form_analytics_settings_<%= environment %>" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      <%= t('settings.form_analytics.details') %>
+    </span>
+  </summary>
+
+  <div class="govuk-form-group <%= f.object.errors_present?(environment) ? 'govuk-form-group--error' : 'govuk-details__text' %>">
+    <% if f.object.errors[:"form_analytics_settings_#{environment}"].present? %>
+      <% f.object.errors.full_messages_for(:"form_analytics_settings_#{environment}").each do |error_message| %>
+        <p id="<%= "form_analytics_settings_#{environment}_error" %>" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span> <%= error_message %>
+        </p>
+      <% end %>
+    <% end %>
+
+    <p><%= t('settings.form_analytics.details_hint') %></p>
+
+    <% f.object.config_params.each do |config| %>
+      <div class="govuk-form-group">
+        <%= f.label :"#{config}_#{environment}", class: "govuk-label", for: "#{config}_#{environment}" %>
+        <div class="govuk-hint"><%= t("activemodel.attributes.form_analytics_settings.#{config}_hint") %></div>
+        <% if f.object.errors[:"#{config}_#{environment}"].present? %>
+          <p id="<%= "#{config}_#{environment}_error" %>" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> <%= f.object.errors.full_messages_for("#{config}_#{environment}").first %>
+          </p>
+          <%= f.text_field :"#{config}_#{environment}",
+              class: "govuk-input width-responsive-two-thirds govuk-input--error",
+              value: f.object.param(config, environment) %>
+        <% else %>
+          <%= f.text_field :"#{config}_#{environment}",
+              class: "govuk-input width-responsive-two-thirds",
+              value: f.object.param(config, environment) %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
 </details>

--- a/app/views/settings/form_analytics/_form.html.erb
+++ b/app/views/settings/form_analytics/_form.html.erb
@@ -1,4 +1,4 @@
-<fieldset class="analytics-environment-configuration govuk-fieldset" id="analytics-environment-configuration-<%= environment %>">
+<fieldset class="analytics-environment-configuration govuk-fieldset" id="form_analytics_settings_<%= environment %>">
   <div class="govuk-form-group">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h2 class="govuk-fieldset__heading"><%= t("settings.form_analytics.#{environment}.heading") %></h2>
@@ -13,7 +13,7 @@
     </div>
   </div>
 
-  <details class="govuk-details" id="form_analytics_settings_<%= environment %>" data-module="govuk-details">
+  <details class="govuk-details" data-module="govuk-details">
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">
         <%= t('settings.form_analytics.details') %>
@@ -21,7 +21,7 @@
     </summary>
 
     <div class="govuk-form-group <%= f.object.errors_present?(environment) ? 'govuk-form-group--error' : 'govuk-details__text' %>">
-      <% if f.object.errors[:"form_analytics_settings_#{environment}"].present? %>
+      <% if f.object.errors_present?(environment) %>
         <% f.object.errors.full_messages_for(:"form_analytics_settings_#{environment}").each do |error_message| %>
           <p id="<%= "form_analytics_settings_#{environment}_error" %>" class="govuk-error-message">
             <span class="govuk-visually-hidden">Error:</span> <%= error_message %>
@@ -32,10 +32,10 @@
       <p><%= t('settings.form_analytics.details_hint') %></p>
 
       <% f.object.config_params.each do |config| %>
-        <div class="govuk-form-group">
+        <div id="<%= "#{config}_#{environment}" %>" class="govuk-form-group <%= f.object.errors_present?(environment, :"#{config}_#{environment}") ? 'govuk-form-group--error' : '' %>">
           <%= f.label :"#{config}_#{environment}", class: "govuk-label", for: "#{config}_#{environment}" %>
           <div class="govuk-hint"><%= t("activemodel.attributes.form_analytics_settings.#{config}_hint") %></div>
-          <% if f.object.errors[:"#{config}_#{environment}"].present? %>
+          <% if f.object.errors_present?(environment, :"#{config}_#{environment}") %>
             <p id="<%= "#{config}_#{environment}_error" %>" class="govuk-error-message">
               <span class="govuk-visually-hidden">Error:</span> <%= f.object.errors.full_messages_for("#{config}_#{environment}").first %>
             </p>

--- a/app/views/settings/form_analytics/_form.html.erb
+++ b/app/views/settings/form_analytics/_form.html.erb
@@ -20,7 +20,7 @@
       </span>
     </summary>
 
-    <div class="govuk-form-group <%= f.object.errors_present?(environment) ? 'govuk-form-group--error' : 'govuk-details__text' %>">
+    <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors_present?(environment) ? 'govuk-form-group--error' : 'govuk-details__text' %>">
       <% if f.object.errors_present?(environment) %>
         <% f.object.errors.full_messages_for(:"form_analytics_settings_#{environment}").each do |error_message| %>
           <p id="<%= "form_analytics_settings_#{environment}_error" %>" class="govuk-error-message">

--- a/app/views/settings/form_analytics/index.html.erb
+++ b/app/views/settings/form_analytics/index.html.erb
@@ -1,0 +1,61 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('settings.form_analytics.name') %></h1>
+    <p><%= t('settings.form_analytics.help') %></p>
+
+    <%= form_for @form_analytics_dev,
+      url: settings_form_analytics_path(service.service_id),
+      html: { id: 'form-analytics-dev' } do |f| %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h2 class="govuk-fieldset__heading"><%= t('publish.test.heading') %></h2>
+          </legend>
+          <div class="govuk-hint"><%= t('publish.test.hint') %></div>
+          <div class="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <%= f.check_box :enabled_test, class: 'govuk-checkboxes__input',
+                checked: f.object.enabled? %>
+              <%= f.label :enabled_test,
+                class: 'govuk-label govuk-checkboxes__label' %>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <%= render 'form', f: f, deployment_environment: 'dev' %>
+
+      <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
+        <%= t('settings.save_test') %>
+      </button>
+    <% end %>
+
+    <%= form_for @form_analytics_production,
+      url: settings_form_analytics_path(service.service_id),
+      html: { id: 'form-analytics-production' } do |f| %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h2 class="govuk-fieldset__heading"><%= t('publish.live.heading') %></h2>
+          </legend>
+          <div class="govuk-hint"><%= t('publish.live.hint') %></div>
+          <div class="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <%= f.check_box :enabled_live, class: 'govuk-checkboxes__input',
+                checked: f.object.enabled? %>
+              <%= f.label :enabled_live,
+                f.object.class.human_attribute_name(:enabled_live),
+                class: 'govuk-label govuk-checkboxes__label' %>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <%= render 'form', f: f, deployment_environment: 'production' %>
+
+      <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
+        <%= t('settings.save_live') %>
+      </button>
+    <% end %>
+  </div>
+</div>

--- a/app/views/settings/form_analytics/index.html.erb
+++ b/app/views/settings/form_analytics/index.html.erb
@@ -1,60 +1,31 @@
 <div class="govuk-grid-row">
+  <% if @form_analytics.errors.present? %>
+    <div class="govuk-grid-column-two-thirds  govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        <%= t('activemodel.errors.summary_title') %>
+      </h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          <% @form_analytics.errors.each do |error|  %>
+            <li><a href="#<%= error.attribute %>"><%= error.message %></a></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('settings.form_analytics.name') %></h1>
-    <p><%= t('settings.form_analytics.help') %></p>
+    <p class="govuk-body"><%= t('settings.form_analytics.intro') %></p>
 
-    <%= form_for @form_analytics_dev,
-      url: settings_form_analytics_path(service.service_id),
-      html: { id: 'form-analytics-dev' } do |f| %>
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h2 class="govuk-fieldset__heading"><%= t('publish.test.heading') %></h2>
-          </legend>
-          <div class="govuk-hint"><%= t('publish.test.hint') %></div>
-          <div class="govuk-checkboxes">
-            <div class="govuk-checkboxes__item">
-              <%= f.check_box :enabled_test, class: 'govuk-checkboxes__input',
-                checked: f.object.enabled? %>
-              <%= f.label :enabled_test,
-                class: 'govuk-label govuk-checkboxes__label' %>
-            </div>
-          </div>
-        </fieldset>
-      </div>
+    <%= form_for @form_analytics, url: settings_form_analytics_path(service.service_id),
+        html: { id: 'form-analytics-settings' } do |f| %>
 
-      <%= render 'form', f: f, deployment_environment: 'dev' %>
+      <%= render partial: 'form', locals: { f: f, environment: 'test' } %>
+      <%= render partial: 'form', locals: { f: f, environment: 'live' } %>
 
       <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
-        <%= t('settings.save_test') %>
-      </button>
-    <% end %>
-
-    <%= form_for @form_analytics_production,
-      url: settings_form_analytics_path(service.service_id),
-      html: { id: 'form-analytics-production' } do |f| %>
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h2 class="govuk-fieldset__heading"><%= t('publish.live.heading') %></h2>
-          </legend>
-          <div class="govuk-hint"><%= t('publish.live.hint') %></div>
-          <div class="govuk-checkboxes">
-            <div class="govuk-checkboxes__item">
-              <%= f.check_box :enabled_live, class: 'govuk-checkboxes__input',
-                checked: f.object.enabled? %>
-              <%= f.label :enabled_live,
-                f.object.class.human_attribute_name(:enabled_live),
-                class: 'govuk-label govuk-checkboxes__label' %>
-            </div>
-          </div>
-        </fieldset>
-      </div>
-
-      <%= render 'form', f: f, deployment_environment: 'production' %>
-
-      <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
-        <%= t('settings.save_live') %>
+        <%= t('actions.save') %>
       </button>
     <% end %>
   </div>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -7,12 +7,14 @@
       <span class="govuk-hint" style= "display:block"><%= t('settings.form_information_hint') %></span>
     </li>
     <br />
+    <% if ENV['FORM_ANALYTICS'] == 'enabled' %>
     <li>
       <%= link_to t('settings.form_analytics.name'), settings_form_analytics_path(service.service_id), class: 'govuk-link' %>
       <br />
       <span class="govuk-hint" style= "display:block"><%= t('settings.form_analytics.hint') %></span>
     </li>
     <br />
+    <% end %>
     <li>
       <%= link_to t('settings.submission.name'), settings_submission_index_path(service.service_id), class: 'govuk-link' %>
       <br />

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -3,10 +3,16 @@
   <ul aria-labelledby="settings-navigation-heading" class="govuk-list">
     <li>
       <%= link_to t('settings.form_information'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %>
-          <br />
-          <span class="govuk-hint" style= "display:block"><%= t('settings.form_information_hint') %></span>
-   </li>
-   <br />
+      <br />
+      <span class="govuk-hint" style= "display:block"><%= t('settings.form_information_hint') %></span>
+    </li>
+    <br />
+    <li>
+      <%= link_to t('settings.form_analytics.name'), settings_form_analytics_path(service.service_id), class: 'govuk-link' %>
+      <br />
+      <span class="govuk-hint" style= "display:block"><%= t('settings.form_analytics.hint') %></span>
+    </li>
+    <br />
     <li>
       <%= link_to t('settings.submission.name'), settings_submission_index_path(service.service_id), class: 'govuk-link' %>
       <br />

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,10 +251,17 @@ en:
       negative: 'No'
   settings:
     name: 'Settings'
+    save_test: Save Test settings
+    save_live: Save Live settings
+    configure: Configure
     form_information: 'Form details'
     form_information_hint: "Set your form's name, URL and phase (e.g. Alpha, Beta)."
     form_information_label: 'Form name'
     form_information_help: 'The visible name of your form'
+    form_analytics:
+      name: Analytics
+      hint: Enable Analytics or Google Tag Manager for your form.
+      help: Some helpful content for this bit.
     submission:
       name: 'Submission settings'
       hint: 'Set what happens when a user submits their data.'
@@ -316,6 +323,11 @@ en:
         service_name: 'Give your form a name'
       settings:
         service_name: 'Form name'
+      form_analytics_settings:
+        enabled_test: Enable analytics in Test
+        enabled_live: Enable analytics in Live
+        ga: Google Analytics ID
+        gtm: Google Tag Manager ID
       email_settings:
         send_by_email_dev: Send by email on Test
         send_by_email_production: Send by email on Live
@@ -367,7 +379,7 @@ en:
           format: "%{message}"
         date_validation:
           invalid: "%{label} is not a valid date"
-          missing_attribute: "%{label} should include a %{attribute}" 
+          missing_attribute: "%{label} should include a %{attribute}"
           format: "%{message}"
         number_validation:
           invalid: "%{label} needs to be a number"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,17 +251,22 @@ en:
       negative: 'No'
   settings:
     name: 'Settings'
-    save_test: Save Test settings
-    save_live: Save Live settings
-    configure: Configure
     form_information: 'Form details'
     form_information_hint: "Set your form's name, URL and phase (e.g. Alpha, Beta)."
     form_information_label: 'Form name'
     form_information_help: 'The visible name of your form'
     form_analytics:
-      name: Analytics
-      hint: Enable Analytics or Google Tag Manager for your form.
-      help: Some helpful content for this bit.
+      name: Google Analytics
+      hint:  Monitor your form's performance in Google Analytics (requires a separate Google Analytics account).
+      intro: This inserts tracking code in your form, allowing you to view performance metrics in Google Analytics. It requires your own Google Analytics account and at least one tracking ID.
+      test:
+        heading: Test site
+        description: Where you can check your form works and get feedback.
+      live:
+        heading: Live site
+        description: Where the public can access and use your form.
+      details: Add account IDs
+      details_hint: 'You can add tracking IDs for any of the following Google products:'
     submission:
       name: 'Submission settings'
       hint: 'Set what happens when a user submits their data.'
@@ -324,10 +329,18 @@ en:
       settings:
         service_name: 'Form name'
       form_analytics_settings:
-        enabled_test: Enable analytics in Test
-        enabled_live: Enable analytics in Live
-        ga: Google Analytics ID
-        gtm: Google Tag Manager ID
+        ua: &ua Universal Analytics Tracking ID
+        ua_hint: For example, UA-000000-2
+        ua_test: *ua
+        ua_live: *ua
+        gtm: &gtm Google Tag Manager Container ID
+        gtm_hint: For example, GTM-000003
+        gtm_test: *gtm
+        gtm_live: *gtm
+        ga4: &ga4 Google Analytics 4 Measurement ID
+        ga4_hint: For example, G-0000004
+        ga4_test: *ga4
+        ga4_live: *ga4
       email_settings:
         send_by_email_dev: Send by email on Test
         send_by_email_production: Send by email on Live
@@ -356,6 +369,7 @@ en:
       branch:
         default_next: Otherwise
     errors:
+      summary_title: There is a problem
       models:
         publish_service_creation:
           blank_username: 'Enter a username'
@@ -387,6 +401,12 @@ en:
         minimum_validation:
           format: "%{message}"
         maximum_validation:
+          format: "%{message}"
+        form_analytics_settings:
+          blank: Enter at least one tracking ID
+          ua: A Universal Analytics ID must start with UA
+          gtm: A Google Tag Manager Container ID must start with GTM
+          ga4: A Google Analytics 4 Measurement ID must start with G
           format: "%{message}"
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -257,7 +257,7 @@ en:
     form_information_help: 'The visible name of your form'
     form_analytics:
       name: Google Analytics
-      hint:  Monitor your form's performance in Google Analytics (requires a separate Google Analytics account).
+      hint:  Monitor your form's performance (requires a Google Analytics account).
       intro: This inserts tracking code in your form, allowing you to view performance metrics in Google Analytics. It requires your own Google Analytics account and at least one tracking ID.
       test:
         heading: Test site
@@ -265,8 +265,8 @@ en:
       live:
         heading: Live site
         description: Where the public can access and use your form.
-      details: Add account IDs
-      details_hint: 'You can add tracking IDs for any of the following Google products:'
+      details: Configure
+      details_hint: 'You can use tracking IDs for any of the following Google products:'
     submission:
       name: 'Submission settings'
       hint: 'Set what happens when a user submits their data.'
@@ -329,6 +329,8 @@ en:
       settings:
         service_name: 'Form name'
       form_analytics_settings:
+        enabled_test: Enable analytics on Test
+        enabled_live: Enable analytics on Live
         ua: &ua Universal Analytics Tracking ID
         ua_hint: For example, UA-000000-2
         ua_test: *ua

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
       resources :settings, only: [:index]
       namespace :settings do
         resources :form_information, only: [:index, :create]
-
+        resources :form_analytics, only: [:index, :create]
         resources :submission, only: [:index] do
           collection do
             resources :email, only: [:index, :create]

--- a/deploy-eks/fb-editor-chart/templates/config_map.yaml
+++ b/deploy-eks/fb-editor-chart/templates/config_map.yaml
@@ -12,3 +12,4 @@ data:
   AUTH0_DOMAIN: moj-forms.eu.auth0.com
   ENCODED_PUBLIC_KEY: {{ .Values.encoded_public_key }}
   METADATA_API_URL: http://fb-metadata-api-svc-{{ .Values.environmentName }}
+  FORM_ANALYTICS: {{ .Values.form_analytics }}

--- a/spec/factories/service_configurations.rb
+++ b/spec/factories/service_configurations.rb
@@ -44,5 +44,20 @@ FactoryBot.define do
       name { 'SERVICE_EMAIL_PDF_SUBHEADING' }
       value { 'Star killer HR' }
     end
+
+    trait :ua do
+      name { 'UA' }
+      value { 'UA-123456' }
+    end
+
+    trait :gtm do
+      name { 'GTM' }
+      value { 'GTM-123456' }
+    end
+
+    trait :ga4 do
+      name { 'GA4' }
+      value { 'G-123456' }
+    end
   end
 end

--- a/spec/models/form_analytics_settings_spec.rb
+++ b/spec/models/form_analytics_settings_spec.rb
@@ -186,10 +186,20 @@ RSpec.describe FormAnalyticsSettings do
     end
 
     context 'when errors are present' do
-      let(:analytics_params) { { "ga4_#{environment}": 'not-allowed' } }
+      let(:enabled_test) { '1' }
 
-      it 'returns truthy' do
-        expect(subject.errors_present?(environment)).to be_truthy
+      context 'enabled no params present' do
+        it 'returns truthy' do
+          expect(subject.errors_present?(environment)).to be_truthy
+        end
+      end
+
+      context 'params present' do
+        let(:analytics_params) { { "ga4_#{environment}": 'not-allowed' } }
+
+        it 'returns truthy' do
+          expect(subject.errors_present?(environment, "ga4_#{environment}")).to be_truthy
+        end
       end
     end
 
@@ -198,6 +208,14 @@ RSpec.describe FormAnalyticsSettings do
 
       it 'returns falsey' do
         expect(subject.errors_present?(environment)).to be_falsey
+      end
+
+      context 'when error is present for a different param' do
+        let(:analytics_params) { { "gtm_#{environment}": 'not-allowed' } }
+
+        it 'returns falsey' do
+          expect(subject.errors_present?(environment, 'ua_test')).to be_falsey
+        end
       end
     end
   end

--- a/spec/models/form_analytics_settings_spec.rb
+++ b/spec/models/form_analytics_settings_spec.rb
@@ -1,0 +1,204 @@
+RSpec.describe FormAnalyticsSettings do
+  subject(:form_analytics_settings) do
+    described_class.new(base_params.merge(analytics_params))
+  end
+  let(:deployment_environment) { 'dev' }
+  let(:enabled_test) { nil }
+  let(:base_params) do
+    {
+      service_id: service.service_id,
+      enabled_test: enabled_test
+    }
+  end
+  let(:analytics_params) { {} }
+
+  context 'when enabled' do
+    let(:enabled_test) { '1' }
+
+    before do
+      subject.validate
+    end
+
+    context 'when no analytics are present' do
+      it 'returns invalid' do
+        expect(subject).to_not be_valid
+      end
+    end
+
+    context 'when at least one analytics is present' do
+      let(:analytics_params) { { ga4_test: 'G-123456' } }
+
+      it 'returns valid' do
+        expect(subject).to be_valid
+      end
+    end
+  end
+
+  context 'when not enabled' do
+    it 'is valid' do
+      expect(subject.valid?).to be_truthy
+    end
+  end
+
+  describe '#config_params' do
+    let(:expected_config_params) { %i[ua gtm ga4] }
+
+    it 'returns the config parameter keys' do
+      expect(subject.config_params).to match_array(expected_config_params)
+    end
+  end
+
+  describe '#config_names' do
+    let(:expected_config_names) { %w[UA GTM GA4] }
+
+    it 'returns the config parameter values' do
+      expect(subject.config_names).to match_array(expected_config_names)
+    end
+  end
+
+  describe '#enabled?' do
+    context 'when enabled is present' do
+      let(:enabled_test) { '1' }
+
+      it 'returns truthy' do
+        expect(subject.enabled?('test')).to be_truthy
+      end
+    end
+
+    context 'when enabled is not present' do
+      it 'returns falsey' do
+        expect(subject.enabled?('test')).to be_falsey
+      end
+    end
+  end
+
+  describe '#check_enabled?' do
+    context 'when enabled' do
+      let(:enabled_test) { '1' }
+
+      it 'returns truthy' do
+        expect(subject.check_enabled?('test')).to be_truthy
+      end
+    end
+
+    context 'when not enabled' do
+      let(:enabled_test) { nil }
+
+      context 'attribute has been previously configured' do
+        before do
+          create(:service_configuration, :dev, :ua, service_id: service.service_id)
+        end
+
+        it 'returns truthy' do
+          expect(subject.check_enabled?('test')).to be_truthy
+        end
+      end
+
+      context 'attribute has not been previously configured' do
+        it 'returns falsey' do
+          expect(subject.check_enabled?('test')).to be_falsey
+        end
+      end
+    end
+  end
+
+  describe '#saved_param' do
+    context 'when attribute is present' do
+      let(:analytics_params) { { ga4_test: 'G-123456' } }
+
+      it 'returns the attribute value' do
+        expect(subject.saved_param(:ga4, 'test')).to eq('G-123456')
+      end
+    end
+
+    context 'when attribute is not present' do
+      it 'returns nil' do
+        expect(subject.saved_param(:ua, 'test')).to be_nil
+      end
+    end
+
+    context 'when value has been saved to the db' do
+      let!(:service_config) do
+        create(:service_configuration, :dev, :gtm, service_id: service.service_id)
+      end
+
+      it 'returns the value in the db' do
+        expect(subject.saved_param(:gtm, 'test')).to eq(service_config.decrypt_value)
+      end
+    end
+  end
+
+  %w[test live].each do |environment|
+    describe "#ua_#{environment}" do
+      context 'when attribute is present' do
+        let(:analytics_params) { { "ua_#{environment}": 'UA-123456' } }
+
+        it 'returns the attribute value' do
+          expect(subject.public_send("ua_#{environment}")).to eq('UA-123456')
+        end
+      end
+
+      context 'when attribute is not present' do
+        it 'returns nil' do
+          expect(subject.public_send("ua_#{environment}")).to be_nil
+        end
+      end
+    end
+
+    describe "#gtm_#{environment}" do
+      context 'when attribute is present' do
+        let(:analytics_params) { { "gtm_#{environment}": 'GTM-123456' } }
+
+        it 'returns the attribute value' do
+          expect(subject.public_send("gtm_#{environment}")).to eq('GTM-123456')
+        end
+      end
+
+      context 'when attribute is not present' do
+        it 'returns nil' do
+          expect(subject.public_send("gtm_#{environment}")).to be_nil
+        end
+      end
+    end
+
+    describe "#ga4_#{environment}" do
+      context 'when attribute is present' do
+        let(:analytics_params) { { "ga4_#{environment}": 'G-123456' } }
+
+        it 'returns the attribute value' do
+          expect(subject.public_send("ga4_#{environment}")).to eq('G-123456')
+        end
+      end
+
+      context 'when attribute is not present' do
+        it 'returns nil' do
+          expect(subject.public_send("ga4_#{environment}")).to be_nil
+        end
+      end
+    end
+  end
+
+  describe '#errors_present?' do
+    let(:environment) { 'test' }
+
+    before do
+      subject.valid?
+    end
+
+    context 'when errors are present' do
+      let(:analytics_params) { { "ga4_#{environment}": 'not-allowed' } }
+
+      it 'returns truthy' do
+        expect(subject.errors_present?(environment)).to be_truthy
+      end
+    end
+
+    context 'when errors are not present' do
+      let(:analytics_params) { { "gtm_#{environment}": 'GTM-123456' } }
+
+      it 'returns falsey' do
+        expect(subject.errors_present?(environment)).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/models/form_analytics_settings_spec.rb
+++ b/spec/models/form_analytics_settings_spec.rb
@@ -128,6 +128,14 @@ RSpec.describe FormAnalyticsSettings do
     end
   end
 
+  describe '#instance_param' do
+    let(:analytics_params) { { ua_test: '      ua-123456 ' } }
+
+    it 'removes whitespace and uppercases the value' do
+      expect(subject.instance_param(:ua_test)).to eq('UA-123456')
+    end
+  end
+
   %w[test live].each do |environment|
     describe "#ua_#{environment}" do
       context 'when attribute is present' do

--- a/spec/models/form_analytics_updater_spec.rb
+++ b/spec/models/form_analytics_updater_spec.rb
@@ -1,0 +1,87 @@
+RSpec.describe FormAnalyticsUpdater do
+  subject(:form_analytics_updater) do
+    described_class.new(settings: settings, service_id: service.service_id)
+  end
+  let(:settings) do
+    FormAnalyticsSettings.new(params.merge(service_id: service.service_id))
+  end
+  let(:params) { {} }
+
+  describe '#create_or_update!' do
+    context 'when enabled' do
+      context 'when config already exists in db' do
+        let!(:service_configuration) do
+          create(:service_configuration, :dev, :ua, service_id: service.service_id)
+        end
+        let(:params) { { enabled_test: '1', ua_test: 'UA-98765' } }
+
+        before do
+          service_configuration
+        end
+
+        it 'updates the value' do
+          subject.create_or_update!
+          service_configuration.reload
+          expect(service_configuration.decrypt_value).to eq(params[:ua_test])
+        end
+      end
+
+      context 'when config does not exist in the db' do
+        let(:service_configuration) do
+          ServiceConfiguration.find_by(
+            service_id: service.service_id,
+            deployment_environment: 'dev',
+            name: 'GTM'
+          )
+        end
+        let(:params) { { enabled_test: '1', gtm_test: 'GTM-98765' } }
+
+        before do
+          subject.create_or_update!
+        end
+
+        it 'saves the value to the db' do
+          expect(service_configuration).to be_persisted
+          expect(service_configuration.decrypt_value).to eq(params[:gtm_test])
+        end
+      end
+
+      context 'when config param is not present' do
+        context 'when config param exists in the db' do
+          let!(:service_configuration) do
+            create(:service_configuration, :dev, :ga4, service_id: service.service_id)
+          end
+          let(:params) { { ga4_test: '' } }
+
+          it 'removes the config from the db' do
+            subject.create_or_update!
+
+            expect { service_configuration.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+    end
+
+    context 'when not enabled' do
+      context 'when configs exist in the db' do
+        let!(:ua_config) do
+          create(:service_configuration, :dev, :ua, service_id: service.service_id)
+        end
+        let!(:gtm_config) do
+          create(:service_configuration, :dev, :gtm, service_id: service.service_id)
+        end
+        let!(:ga4_config) do
+          create(:service_configuration, :dev, :ga4, service_id: service.service_id)
+        end
+
+        it 'removes all the configs from the db' do
+          subject.create_or_update!
+
+          expect { ua_config.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          expect { gtm_config.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          expect { ga4_config.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+  end
+end

--- a/spec/validators/form_analytics_validator_spec.rb
+++ b/spec/validators/form_analytics_validator_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe FormAnalyticsValidator do
+  subject(:form_analytics_settings) do
+    FormAnalyticsSettings.new(base_params.merge(analytics_params))
+  end
+  let(:enabled_test) { '1' }
+  let(:base_params) do
+    {
+      service_id: service.service_id,
+      enabled_test: enabled_test
+    }
+  end
+  let(:analytics_params) do
+    {
+      ua_test: 'UA-123456',
+      gtm_live: 'GTM-123456',
+      ga4_live: 'G-123456'
+    }
+  end
+
+  describe '#validate' do
+    before { subject.validate }
+
+    context 'when all analytics are valid' do
+      it 'returns valid' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'when universal analytics is invalid' do
+      let(:analytics_params) { { ua_live: 'not-a-universal-analytics-id' } }
+
+      it 'returns invalid' do
+        expect(subject).to_not be_valid
+      end
+    end
+
+    context 'when google tag manager is invalid' do
+      let(:analytics_params) { { gtm_test: 'not-a-google-tag-manager-id' } }
+
+      it 'returns invalid' do
+        expect(subject).to_not be_valid
+      end
+    end
+
+    context 'when google analytics 4 is invalid' do
+      let(:analytics_params) { { ga4_test: 'not-a-google-analytics-4-id' } }
+
+      it 'returns invalid' do
+        expect(subject).to_not be_valid
+      end
+    end
+
+    context 'when not enabled' do
+      let(:enabled_test) { nil }
+      let(:analytics_params) { { gtm_test: 'not-a-google-tag-manager-id' } }
+
+      it 'does not add any errors' do
+        expect(subject).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the ability to add the currently available three types of
Google Analytics products:

- Universal Analytics
- Google Tag Manager
- Google Analytics 4

The same form is used for both Test and Live environments. Those
environment names map to `dev` and `production` in terms of
`deployment_environment` when they are saved as ServiceConfigurations
in the DB.

This is currently only available in the Test environment as the link and page are
behind a feature flag.

<img width="663" alt="Screenshot 2022-06-15 at 13 03 29" src="https://user-images.githubusercontent.com/3466862/173841859-9f3a865d-1bf1-400c-aab4-4b2d33184193.png">

<img width="638" alt="Screenshot 2022-06-15 at 13 03 44" src="https://user-images.githubusercontent.com/3466862/173842173-25f7163e-2add-47ea-8115-19bd91dcbe47.png">

<img width="601" alt="Screenshot 2022-06-15 at 13 03 55" src="https://user-images.githubusercontent.com/3466862/173842013-e0d3d0a8-4312-45b6-83d3-1e3b7d0a5ab0.png">

<img width="583" alt="Screenshot 2022-06-15 at 13 04 08" src="https://user-images.githubusercontent.com/3466862/173842026-5cca6aa2-bd0a-4849-a312-f6728c4aa4fa.png">

Co-authored-by Steven Burnell <steven.burnell@digital.justice.gov.uk>