### PR TITLE
Update acceptance tests to wait for page load

### DIFF
--- a/acceptance/features/admin_spec.rb
+++ b/acceptance/features/admin_spec.rb
@@ -36,17 +36,17 @@ feature 'Visiting admin pages' do
   def then_I_should_be_redirected_to_login
     expect(page.current_path).to eq('/')
     expect(page.title).to eq(I18n.t('home.show.title'))
-    expect(page.text).to include(I18n.t('home.show.sign_in'))
+    expect(page).to have_content(I18n.t('home.show.sign_in'))
   end
 
   def then_I_should_be_redirected_to_the_unauthorised_page
     expect(page.current_path).to eq('/unauthorised')
-    expect(page.text).to include(I18n.t('auth.unauthorised.heading'))
-    expect(page.text).to include(I18n.t('auth.unauthorised.body'))
+    expect(page).to have_content(I18n.t('auth.unauthorised.heading'))
+    expect(page).to have_content(I18n.t('auth.unauthorised.body'))
   end
 
   def then_I_should_not_see_the_admin_link
-    expect(page.text).not_to include(I18n.t('partials.header.admin'))
+    expect(page).not_to have_content(I18n.t('partials.header.admin'))
   end
 
   def then_I_should_be_redirected_to_the_services_page

--- a/acceptance/features/component_validations_spec.rb
+++ b/acceptance/features/component_validations_spec.rb
@@ -367,6 +367,7 @@ feature 'Component validations' do
 
   def and_I_set_the_input_value(value)
     input_element = page.find(:css, 'input#component_validation_value')
+    input_element.set('')
     input_element.set(value)
   end
 
@@ -414,15 +415,15 @@ feature 'Component validations' do
 
   def then_I_should_preview_the_page(preview:, field:, first_value:, second_value:, error_message:)
     within_window(preview) do
-      page.find(:css, '#main-content')
+      page.find(:css, '#main-content', visible: true)
       page.find_field(field).set(first_value)
       click_button(I18n.t('actions.continue'))
-      page.find(:css, '#main-content')
+      page.find(:css, '#main-content', visible: true)
       then_I_should_see_an_error_message(error_message)
 
       page.find_field(field).set(second_value)
       click_button(I18n.t('actions.continue'))
-      page.find(:css, '#main-content')
+      page.find(:css, '#main-content', visible: true)
       then_I_should_not_see_an_error_message(error_message)
     end
   end
@@ -439,19 +440,19 @@ feature 'Component validations' do
 
   def then_I_should_preview_the_date_page(preview:, first_date:, second_date:, error_message:)
     within_window(preview) do
-      page.find(:css, '#main-content')
+      page.find(:css, '#main-content', visible: true)
       page.fill_in('answers[date_date_1(3i)]', with: first_date[:day])
       page.fill_in('answers[date_date_1(2i)]', with: first_date[:month])
       page.fill_in('answers[date_date_1(1i)]', with: first_date[:year])
       click_button(I18n.t('actions.continue'))
-      page.find(:css, '#main-content')
+      page.find(:css, '#main-content', visible: true)
       then_I_should_see_an_error_message(error_message)
 
       page.fill_in('answers[date_date_1(3i)]', with: second_date[:day])
       page.fill_in('answers[date_date_1(2i)]', with: second_date[:month])
       page.fill_in('answers[date_date_1(1i)]', with: second_date[:year])
       click_button(I18n.t('actions.continue'))
-      page.find(:css, '#main-content')
+      page.find(:css, '#main-content', visible: true)
       then_I_should_not_see_an_error_message(error_message)
     end
   end

--- a/acceptance/features/create_page_spec.rb
+++ b/acceptance/features/create_page_spec.rb
@@ -121,7 +121,7 @@ feature 'Create page' do
   end
 
   def then_I_should_see_a_validation_error_message_that_page_url_exists
-    expect(editor.text).to include(error_message)
+    expect(editor).to have_content(error_message)
   end
 
   def then_I_should_see_the_edit_single_question_text_page
@@ -171,13 +171,13 @@ feature 'Create page' do
   end
 
   def and_I_should_see_default_values_created
-    expect(editor.text).to include('Question')
-    expect(editor.text).to include('[Optional hint text]')
+    expect(editor).to have_content('Question')
+    expect(editor).to have_content('[Optional hint text]')
   end
 
   def and_I_should_see_default_values_for_email_created
-    expect(editor.text).to include('Email address question')
-    expect(editor.text).to include('[Optional hint text]')
+    expect(editor).to have_content('Email address question')
+    expect(editor).to have_content('[Optional hint text]')
   end
   def and_I_should_see_default_radio_options_created
     expect(
@@ -192,14 +192,14 @@ feature 'Create page' do
   end
 
   def then_I_should_see_the_edit_multiple_question_page
-    expect(editor.text).to include('Title')
+    expect(editor).to have_content('Title')
     and_I_should_see_the_save_button_visible
     and_I_should_see_the_save_button_disabled
   end
 
   def then_I_should_see_the_edit_check_answers_page
-    expect(editor.text).to include('Check your answers')
-    expect(editor.text).to include(
+    expect(editor).to have_content('Check your answers')
+    expect(editor).to have_content(
       'By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct'
     )
     and_I_should_see_the_save_button_visible
@@ -207,7 +207,7 @@ feature 'Create page' do
   end
 
   def then_I_should_see_the_edit_confirmation_page
-    expect(editor.text).to include('Application complete')
+    expect(editor).to have_content('Application complete')
     and_I_should_see_the_save_button_visible
     and_I_should_see_the_save_button_disabled
   end

--- a/acceptance/features/create_service_spec.rb
+++ b/acceptance/features/create_service_spec.rb
@@ -92,25 +92,25 @@ feature 'Create a service' do
   end
 
   def then_I_should_see_a_validation_message_for_required
-    expect(editor.text).to include(
+    expect(editor).to have_content(
       I18n.t('activemodel.errors.messages.blank', attribute: 'Give your form a name')
     )
   end
 
   def then_I_should_see_a_validation_message_for_min_length
-    expect(editor.text).to include(
+    expect(editor).to have_content(
       I18n.t('activemodel.errors.messages.too_short', attribute: 'Give your form a name', count: '3')
     )
   end
 
   def then_I_should_see_a_validation_message_for_max_length
-    expect(editor.text).to include(
+    expect(editor).to have_content(
       I18n.t('activemodel.errors.messages.too_long', attribute: 'Give your form a name', count: '128')
     )
   end
 
   def then_I_should_see_the_unique_validation_message
-    expect(editor.text).to include(
+    expect(editor).to have_content(
       I18n.t('activemodel.errors.messages.taken', attribute: 'Give your form a name')
     )
   end

--- a/acceptance/features/default_text_spec.rb
+++ b/acceptance/features/default_text_spec.rb
@@ -77,7 +77,7 @@ feature 'Default text' do
   end
 
   def and_I_see_the_custom_hint
-    expect(page.text).to include('This is where you add your name')
+    expect(page).to have_content('This is where you add your name')
   end
 
   def then_I_should_see_default_text_in_label_and_options
@@ -97,6 +97,6 @@ feature 'Default text' do
   end
 
   def and_I_see_all_custom_hints
-    expect(page.text).to include('This is a radio button')
+    expect(page).to have_content('This is a radio button')
   end
 end

--- a/acceptance/features/deleting_page_spec.rb
+++ b/acceptance/features/deleting_page_spec.rb
@@ -151,7 +151,7 @@ feature 'Deleting page' do
 
   def then_I_should_see_the_delete_page_no_default_next_modal
     dialog = page.find('.ui-dialog')
-    expect(dialog.text).to include(
+    expect(dialog).to have_content(
       I18n.t(
         'pages.delete_modal.delete_branch_destination_page_no_default_next_message'
       )

--- a/acceptance/features/edit_multiple_questions_page_spec.rb
+++ b/acceptance/features/edit_multiple_questions_page_spec.rb
@@ -120,7 +120,7 @@ feature 'Edit multiple questions page' do
 
   def then_I_can_answer_the_questions_in_the_page(preview_form)
     within_window(preview_form) do
-      expect(page.text).to include('Service name goes here')
+      expect(page).to have_content('Service name goes here')
       page.click_button 'Start now'
       page.fill_in 'C-3P0 is fluent in how many languages?',
         with: 'Fluent in over six million forms of communication.'
@@ -131,7 +131,7 @@ feature 'Edit multiple questions page' do
       page.choose '900 years old', visible: false
       page.check 'Prequels', visible: false
       page.click_button 'Continue'
-      expect(page.text).to include("Check your answers")
+      expect(page).to have_content("Check your answers")
     end
   end
 

--- a/acceptance/features/edit_single_checkboxes_question_page_spec.rb
+++ b/acceptance/features/edit_single_checkboxes_question_page_spec.rb
@@ -81,7 +81,7 @@ feature 'Edit single radios question page' do
       when_I_want_to_select_component_properties('label', 'Hulk')
       page.find('span', text: I18n.t('question.menu.remove')).click
       expect(page).to have_selector('.ui-dialog')
-      expect(page.text).to include(I18n.t('question_items.delete_modal.can_not_delete_heading'))
+      expect(page).to have_content(I18n.t('question_items.delete_modal.can_not_delete_heading'))
     end
   end
 
@@ -148,7 +148,7 @@ feature 'Edit single radios question page' do
   end
 
   def and_I_have_optional_section_heading_text
-    expect(page.text).to include(I18n.t('default_text.section_heading'))
+    expect(page).to have_content(I18n.t('default_text.section_heading'))
   end
 
   def and_I_go_to_the_page_that_I_edit(preview_form)
@@ -158,7 +158,7 @@ feature 'Edit single radios question page' do
   end
 
   def then_I_should_see_my_updated_section_heading
-    expect(editor.text).to include(section_heading)
+    expect(editor).to have_content(section_heading)
   end
 
   def then_I_should_see_the_default_section_heading
@@ -168,7 +168,7 @@ feature 'Edit single radios question page' do
   def then_I_should_see_the_options(options)
     expect(editor.checkboxes_options.size).to eql options.size
     options.each do |option|
-      expect(page.text).to include(option)
+      expect(page).to have_content(option)
     end
   end
 
@@ -184,14 +184,14 @@ feature 'Edit single radios question page' do
 
   def then_I_should_see_my_changes_in_the_form(preview_form)
     within_window(preview_form) do
-      expect(page.text).to include(question)
+      expect(page).to have_content(question)
     end
   end
 
   def and_I_should_see_the_options_that_I_added(preview_form, options)
     within_window(preview_form) do
       options.each do |option|
-        expect(page.text).to include(option)
+        expect(page).to have_content(option)
       end
     end
   end

--- a/acceptance/features/edit_single_question_page_spec.rb
+++ b/acceptance/features/edit_single_question_page_spec.rb
@@ -110,7 +110,7 @@ feature 'Edit single question page' do
   end
 
   def then_I_should_see_my_updated_section_heading
-    expect(editor.text).to include(section_heading)
+    expect(editor).to have_content(section_heading)
   end
 
   def then_I_should_see_the_default_section_heading
@@ -168,19 +168,19 @@ feature 'Edit single question page' do
 
   def then_I_should_see_my_changes_in_the_form(preview_form)
     within_window(preview_form) do
-      expect(page.text).to include(question)
+      expect(page).to have_content(question)
     end
   end
 
   def and_I_should_see_the_options_that_I_added(preview_form)
     within_window(preview_form) do
       editable_options.each do |option|
-        expect(page.text).to include(option)
+        expect(page).to have_content(option)
       end
     end
   end
 
   def and_I_have_optional_section_heading_text
-    expect(page.text).to include(I18n.t('default_text.section_heading'))
+    expect(page).to have_content(I18n.t('default_text.section_heading'))
   end
 end

--- a/acceptance/features/edit_single_radios_question_page_spec.rb
+++ b/acceptance/features/edit_single_radios_question_page_spec.rb
@@ -125,7 +125,7 @@ feature 'Edit single radios question page' do
   end
 
   def and_I_have_optional_section_heading_text
-    expect(page.text).to include(I18n.t('default_text.section_heading'))
+    expect(page).to have_content(I18n.t('default_text.section_heading'))
   end
 
   def and_I_go_to_the_page_that_I_edit(preview_form)
@@ -135,7 +135,7 @@ feature 'Edit single radios question page' do
   end
 
   def then_I_should_see_my_updated_section_heading
-    expect(editor.text).to include(section_heading)
+    expect(editor).to have_content(section_heading)
   end
 
   def then_I_should_see_the_default_section_heading
@@ -145,7 +145,7 @@ feature 'Edit single radios question page' do
   def then_I_should_see_the_options(options)
     expect(editor.radio_options.size).to eql options.size
     options.each do |option|
-      expect(page.text).to include(option)
+      expect(page).to have_content(option)
     end
   end
 
@@ -162,14 +162,14 @@ feature 'Edit single radios question page' do
 
   def then_I_should_see_my_changes_in_the_form(preview_form)
     within_window(preview_form) do
-      expect(page.text).to include(question)
+      expect(page).to have_content(question)
     end
   end
 
   def and_I_should_see_the_options_that_I_added(preview_form, options)
     within_window(preview_form) do
       options.each do |option|
-        expect(page.text).to include(option)
+        expect(page).to have_content(option)
       end
     end
   end

--- a/acceptance/features/mark_questions_as_optional_spec.rb
+++ b/acceptance/features/mark_questions_as_optional_spec.rb
@@ -33,12 +33,12 @@ feature 'Mark question as optional' do
 
   def then_I_should_pass_the_question_without_answering(preview_form)
     within_window(preview_form) do
-      expect(page.text).to include('Service name goes here')
+      expect(page).to have_content('Service name goes here')
       page.click_button 'Start now'
-      expect(page.text).to include('Full name (Optional)')
+      expect(page).to have_content('Full name (Optional)')
       page.click_button 'Continue'
       expect(page.text).to_not include('Full name')
-      expect(page.text).to include('Option')
+      expect(page).to have_content('Option')
     end
   end
 end

--- a/acceptance/features/move_page_spec.rb
+++ b/acceptance/features/move_page_spec.rb
@@ -164,7 +164,7 @@ feature 'Move a page' do
 
   def then_I_should_see_the_move_target_list(page_title)
     find('div#move_targets_list', visible: true)
-    expect(editor.text).to include(I18n.t('dialogs.move.label', title: page_title))
+    expect(editor).to have_content(I18n.t('dialogs.move.label', title: page_title))
   end
 
   def then_page_H_should_be_after_page_B
@@ -182,12 +182,12 @@ feature 'Move a page' do
 
   def then_I_should_see_the_no_default_next_warning
     find('div#branch_destination_no_default_next', visible: true)
-    expect(editor.text).to include(I18n.t('dialogs.move.branch_destination_no_default_next_message'))
+    expect(editor).to have_content(I18n.t('dialogs.move.branch_destination_no_default_next_message'))
   end
 
   def then_I_should_see_the_stacked_branches_not_supported_warning
     find('div#stacked_branches_not_supported', visible: true)
-    expect(editor.text).to include(I18n.t('dialogs.move.stacked_branches_not_supported_message'))
+    expect(editor).to have_content(I18n.t('dialogs.move.stacked_branches_not_supported_message'))
   end
 
   def then_no_pages_should_have_moved

--- a/acceptance/features/preview_a_page_spec.rb
+++ b/acceptance/features/preview_a_page_spec.rb
@@ -38,7 +38,7 @@ feature 'Preview page' do
   def then_I_should_preview_the_start_page(preview_page)
     within_window(preview_page) do
       expect(page.find('button')).to_not be_disabled
-      expect(page.text).to include('Before you start')
+      expect(page).to have_content('Before you start')
       then_I_should_not_see_optional_text
     end
   end
@@ -78,8 +78,8 @@ feature 'Preview page' do
   end
 
   def then_I_should_see_that_I_should_add_a_file
-    expect(page.text).to include('There is a problem')
-    expect(page.text).to include('Enter an answer for')
+    expect(page).to have_content('There is a problem')
+    expect(page).to have_content('Enter an answer for')
   end
 
   def and_I_remove_the_file

--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -70,11 +70,11 @@ feature 'Preview form' do
 
   def then_I_can_navigate_until_the_end_of_the_form(preview_form)
     within_window(preview_form) do
-      expect(page.text).to include('Service name goes here')
+      expect(page).to have_content('Service name goes here')
       then_I_should_not_see_a_back_link
       page.click_button 'Start now'
 
-      expect(page.text).to include('Full name')
+      expect(page).to have_content('Full name')
       then_I_should_not_see_optional_text
       then_I_should_see_a_back_link
       page.click_button 'Continue'
@@ -82,7 +82,7 @@ feature 'Preview form' do
       page.fill_in 'Full name', with: 'Charmy Pappitson'
       page.click_button 'Continue'
 
-      expect(page.text).to include(content_component)
+      expect(page).to have_content(content_component)
       then_I_should_not_see_optional_text
       then_I_should_see_a_back_link
       page.click_button 'Continue'
@@ -91,12 +91,12 @@ feature 'Preview form' do
       page.fill_in textarea_component_question, with: 'R2-Detour'
       page.click_button 'Continue'
 
-      expect(page.text).to include(content_page_heading)
+      expect(page).to have_content(content_page_heading)
       then_I_should_not_see_optional_text
       then_I_should_see_a_back_link
       page.click_button 'Continue'
 
-      expect(page.text).to include('Date of birth')
+      expect(page).to have_content('Date of birth')
       then_I_should_not_see_optional_text
       then_I_should_see_a_back_link
       page.click_button 'Continue'
@@ -106,16 +106,16 @@ feature 'Preview form' do
       page.fill_in 'Year', with: '2002'
       page.click_button 'Continue'
 
-      expect(page.text).to include('What is your favourite fruit?')
+      expect(page).to have_content('What is your favourite fruit?')
       then_I_should_see_a_back_link
       and_I_select_an_option_item
       page.click_button 'Continue'
 
-      expect(page.text).to include('Upload your file')
+      expect(page).to have_content('Upload your file')
       then_I_should_see_a_back_link
       page.click_button 'Continue'
 
-      expect(page.text).to include('Email address')
+      expect(page).to have_content('Email address')
       then_I_should_not_see_optional_text
       then_I_should_see_a_back_link
       page.click_button 'Continue'
@@ -123,30 +123,30 @@ feature 'Preview form' do
       page.fill_in 'Email address', with: 'nymphadora.tonks@digital.justice.gov.uk'
       page.click_button 'Continue'
 
-      expect(page.text).to include('Check your answers')
-      expect(page.text).to include('Charmy Pappitson')
-      expect(page.text).to include('Car Car Binks')
-      expect(page.text).to include('R2-Detour')
-      expect(page.text).to include('03 June 2002')
-      expect(page.text).to include('Apples')
-      expect(page.text).to include('Upload your file')
-      expect(page.text).to include('nymphadora.tonks@digital.justice.gov.uk')
+      expect(page).to have_content('Check your answers')
+      expect(page).to have_content('Charmy Pappitson')
+      expect(page).to have_content('Car Car Binks')
+      expect(page).to have_content('R2-Detour')
+      expect(page).to have_content('03 June 2002')
+      expect(page).to have_content('Apples')
+      expect(page).to have_content('Upload your file')
+      expect(page).to have_content('nymphadora.tonks@digital.justice.gov.uk')
       then_I_should_not_see_optional_text
       then_I_should_see_a_back_link
       then_I_should_not_see_content_page_in_check_your_answers(page)
       then_I_should_not_see_content_components_in_check_your_answers(page)
 
       and_I_want_to_change_the_checkbox_answer
-      expect(page.text).to include('What is your favourite fruit?')
+      expect(page).to have_content('What is your favourite fruit?')
       and_I_unselect_an_option_item
       page.click_button 'Continue'
 
-      expect(page.text).to include('Check your answers')
-      expect(page.text).not_to include('Apples')
+      expect(page).to have_content('Check your answers')
+      expect(page).not_to have_content('Apples')
 
       page.click_button 'Accept and send application'
       then_I_should_not_see_a_back_link
-      expect(page.text).to include('Application complete')
+      expect(page).to have_content('Application complete')
     end
   end
 

--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -121,6 +121,7 @@ feature 'Publishing' do
   end
 
   def and_I_want_to_publish(environment)
+    page.find('#main-content', visible: true)
     editor.find('#publish-environments').find(:button, text: "Publish to #{environment}").click
   end
 
@@ -171,6 +172,7 @@ feature 'Publishing' do
   end
 
   def then_I_should_see_an_error_message(environment, button_environment)
+    page.find(:css, '#main-content', visible: true)
     errors = editor.all("#publish-form-#{environment} .govuk-error-message").map(&:text)
     expect(errors).to match_array(username_and_password_errors)
   end
@@ -191,7 +193,7 @@ feature 'Publishing' do
   end
 
   def then_I_should_not_see_warning_cya_text
-    expect(editor.text).to_not include(warning_cya)
+    expect(editor).to_not have_content(warning_cya)
   end
 
   def then_I_should_not_see_warning_confirmation_text
@@ -199,23 +201,23 @@ feature 'Publishing' do
   end
 
   def then_I_should_see_warning_both_text
-    expect(editor.text).to include(warning_both)
+    expect(editor).to have_content(warning_both)
   end
 
   def then_I_should_see_warning_cya_text
-    expect(editor.text).to include(warning_cya)
+    expect(editor).to have_content(warning_cya)
   end
 
   def then_I_should_see_warning_confirmation_text
-    expect(editor.text).to include(warning_confirmation)
+    expect(editor).to have_content(warning_confirmation)
   end
 
   def then_I_should_see_publish_to_test_modal
-    expect(editor.text).to include(modal_description)
+    expect(editor).to have_content(modal_description)
   end
 
   def then_I_should_not_see_publish_to_test_modal
-    expect(editor.text).to_not include(modal_description)
+    expect(editor).to_not have_content(modal_description)
   end
 
   def then_I_should_see_the_service_output_warning(deployment_environment)
@@ -224,7 +226,7 @@ feature 'Publishing' do
       href: I18n.t('publish.service_output.link'),
       environment: deployment_environment
     )
-    expect(editor.text).to include(warning_message)
+    expect(editor).to have_content(warning_message)
   end
 
   def then_I_should_not_see_the_service_output_warning(deployment_environment)

--- a/acceptance/features/update_settings_form_information_spec.rb
+++ b/acceptance/features/update_settings_form_information_spec.rb
@@ -89,25 +89,25 @@ feature 'Update settings form information' do
   end
 
   def then_I_should_see_a_validation_message_for_required
-    expect(editor.text).to include(
+    expect(editor).to have_content(
       I18n.t('activemodel.errors.messages.blank', attribute: 'Form name')
     )
   end
 
   def then_I_should_see_a_validation_message_for_min_length
-    expect(editor.text).to include(
+    expect(editor).to have_content(
       I18n.t('activemodel.errors.messages.too_short', attribute: 'Form name', count: '3')
     )
   end
 
   def then_I_should_see_a_validation_message_for_max_length
-    expect(editor.text).to include(
+    expect(editor).to have_content(
       I18n.t('activemodel.errors.messages.too_long', attribute: 'Form name', count: '128')
     )
   end
 
   def then_I_should_see_the_unique_validation_message
-    expect(editor.text).to include(
+    expect(editor).to have_content(
       I18n.t('activemodel.errors.messages.taken', attribute: 'Form name')
     )
   end

--- a/acceptance/support/branching_steps.rb
+++ b/acceptance/support/branching_steps.rb
@@ -263,7 +263,7 @@ module BranchingSteps
 
     editor.save_button.click
     and_I_return_to_flow_page
-    expect(editor.text).to include('Branching point 1')
+    expect(editor).to have_content('Branching point 1')
   end
 
   def given_I_have_a_branching_point_two

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -15,7 +15,7 @@ module CommonSteps
 
   def given_I_am_logged_in
     editor.load
-    page.find(:css, '#main-content')
+    page.find(:css, '#main-content', visible: true)
     editor.sign_in_button.click
 
     if ENV['CI_MODE'].present?
@@ -42,7 +42,7 @@ module CommonSteps
 
   def given_I_have_a_service(service = service_name)
     editor.load
-    page.find(:css, '#main-content')
+    page.find(:css, '#main-content', visible: true)
     given_I_want_to_create_a_service
     given_I_add_a_service(service)
     when_I_create_the_service
@@ -234,7 +234,7 @@ module CommonSteps
       expect(
         page.find('button', text: 'Continue')
       ).to_not be_disabled
-      expect(page.text).to include('Question')
+      expect(page).to have_content('Question')
       then_I_should_not_see_optional_text
       yield if block_given?
     end
@@ -323,24 +323,24 @@ module CommonSteps
   end
 
   def then_I_should_not_see_optional_text
-    OPTIONAL_TEXT.each { |optional| expect(page.text).not_to include(optional) }
+    OPTIONAL_TEXT.each { |optional| expect(page).not_to have_content(optional) }
   end
 
   def then_I_should_see_an_error_message(*fields)
-    expect(page.text).to include(ERROR_MESSAGE)
+    expect(page).to have_content(ERROR_MESSAGE)
     if fields.empty?
-      expect(page.text).to include('Enter an answer for')
+      expect(page).to have_content('Enter an answer for')
     else
       fields.each { |field| expect(text).to include("Enter an answer for \"#{field}\"")}
     end
   end
 
   def then_I_should_see_my_content(*expected_text)
-    expected_text.each { |text| expect(page.text).to include(text)}
+    expected_text.each { |text| expect(page).to have_content(text)}
   end
 
   def then_I_should_not_see_my_content(*expected_text)
-    expected_text.each { |text| expect(page.text).to_not include(text)}
+    expected_text.each { |text| expect(page).to_not have_content(text)}
   end
 
   def when_I_want_to_select_component_properties(attribute, text)
@@ -376,14 +376,14 @@ module CommonSteps
   def then_I_should_not_be_able_to_add_page(page_title, page_link)
     find('#main-content', visible: true)
     editor.connection_menu(page_title).click
-    expect(editor.text).not_to include(page_link)
+    expect(editor).not_to have_content(page_link)
     editor.flow_thumbnail(page_title).hover #hides the connection menu
   end
 
   def then_I_should_be_able_to_add_page(page_title, page_link)
     find('#main-content', visible: true)
     editor.connection_menu(page_title).click
-    expect(editor.text).to include(page_link)
+    expect(editor).to have_content(page_link)
     editor.flow_thumbnail(page_title).hover #hides the connection menu
   end
 
@@ -409,24 +409,24 @@ module CommonSteps
 
   def then_I_should_not_see_delete_warnings
     find('#main-content', visible: true)
-    expect(editor.text).not_to include(DELETE_WARNING[0])
-    expect(editor.text).not_to include(DELETE_WARNING[1])
-    expect(editor.text).not_to include(DELETE_WARNING[2])
+    expect(editor).not_to have_content(DELETE_WARNING[0])
+    expect(editor).not_to have_content(DELETE_WARNING[1])
+    expect(editor).not_to have_content(DELETE_WARNING[2])
   end
 
   def then_I_should_see_delete_warning_cya
     find('#main-content', visible: true)
-    expect(editor.text).to include(DELETE_WARNING[0])
+    expect(editor).to have_content(DELETE_WARNING[0])
   end
 
   def then_I_should_see_delete_warning_confirmation
     find('#main-content', visible: true)
-    expect(editor.text).to include(DELETE_WARNING[1])
+    expect(editor).to have_content(DELETE_WARNING[1])
   end
 
   def then_I_should_see_delete_warning_both
     find('#main-content', visible: true)
-    expect(editor.text).to include(DELETE_WARNING[2])
+    expect(editor).to have_content(DELETE_WARNING[2])
   end
 
   def then_I_should_see_the_modal(modal_title, modal_text)


### PR DESCRIPTION
The have_content should wait for the page to load. We can use that when
checking for content which should slow down the acceptance tests a
little bit. This may help with performance related issues.