### PR TITLE
Styling links

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,7 +106,7 @@ en:
     show:
       title: MoJ Forms
       lede: Prototype, test and publish online forms quickly and easily
-      body: 'To find out more about MoJ Forms, email us at <a href="mailto:moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a>, or <a href="https://app.slack.com/client/T02DYEB3A/CE26QEL1Z">ask us a question on Slack</a>.'
+      body: 'To find out more about MoJ Forms, email us at <a class="govuk-link" href="mailto:moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a>, or <a class="govuk-link" href="https://app.slack.com/client/T02DYEB3A/CE26QEL1Z">ask us a question on Slack</a>.'
       callout: You will need a @digital.justice.gov.uk or @justice.gov.uk email address to use MoJ Forms.
       sign_in: Sign in
   auth:


### PR DESCRIPTION
Just adding the govuk-link class to our contact us links on the landing page.
Bad first impression if we immediately break the design system…