### PR TITLE
Update acceptance test

### DIFF
--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -144,7 +144,7 @@ feature 'Preview form' do
       expect(page).to have_content('Check your answers')
       expect(page).not_to have_content('Apples')
 
-      page.click_button 'Accept and send application'
+      page.click_button I18n.t('actions.submit')
       then_I_should_not_see_a_back_link
       expect(page).to have_content('Application complete')
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,7 @@ en:
     add_confirmation: 'Add confirmation page'
     reconnect_confirmation: 'Reconnect confirmation page'
     ok: 'Ok'
+    submit: 'Submit'
   branches:
     branch_add: 'Add another branch'
     branch_edit: 'Edit branch'


### PR DESCRIPTION
[Trello](https://trello.com/c/qphXBi71/2670-change-the-button-text-on-check-answers-to-submit)

Presenter v2.17.6 now has a change in the submission button label from 'Accept and send application' to 'Submit'.
Update acceptance test to reflect this.