### PR TITLE
Ensure field hints are read by screenreaders and remove duplicate id attributes

### DIFF
--- a/app/views/publish/_form.html.erb
+++ b/app/views/publish/_form.html.erb
@@ -31,25 +31,29 @@
     <% f.object.errors[:username].each do |message| %>
       <span class="govuk-error-message"><%= message %></span>
     <% end %>
-    <%= f.label :username, class: 'govuk-label' %>
-    <div class="govuk-hint"><%= t('activemodel.attributes.publish_service_creation.username_hint') %></div>
+    <%= f.label :username, class: 'govuk-label', for: "username_#{deployment_environment}" %>
+    <div class="govuk-hint" id="username_<%= deployment_environment %>_hint"><%= t('activemodel.attributes.publish_service_creation.username_hint') %></div>
     <%= f.text_field :username, value: f.object.username || f.object.service_configuration(
          name: ServiceConfiguration::BASIC_AUTH_USER,
          deployment_environment: deployment_environment
         ),
-        class: 'govuk-input' %>
+        class: 'govuk-input',
+        id: "username_#{deployment_environment}",
+        'aria-describedby': "username_#{deployment_environment}_hint" %>
   </div>
 
   <div class="govuk-form-group <%= !f.object.errors[:password].empty? ? 'govuk-form-group--error' : '' %>">
     <% f.object.errors[:password].each do |message| %>
       <span class="govuk-error-message"><%= message %></span>
     <% end %>
-    <%= f.label :password, class: 'govuk-label' %>
-    <div class="govuk-hint"><%= t('activemodel.attributes.publish_service_creation.password_hint') %></div>
+    <%= f.label :password, class: 'govuk-label', for: "password_#{deployment_environment}" %>
+    <div class="govuk-hint" id="password_<%= deployment_environment %>_hint"><%= t('activemodel.attributes.publish_service_creation.password_hint') %></div>
     <%= f.password_field :password, value: f.object.password || f.object.service_configuration(
         name: ServiceConfiguration::BASIC_AUTH_PASS,
         deployment_environment: deployment_environment
       ),
-      class: 'govuk-input' %>
+      class: 'govuk-input',
+      id: "password_#{deployment_environment}",
+      'aria-describedby': "password_#{deployment_environment}_hint" %>
   </div>
 </div>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -53,11 +53,11 @@
 
     <div class="govuk-form-group <%= !f.object.errors.empty? ? 'govuk-form-group--error' :'' %>">
       <%= f.label :page_url, class: "govuk-label govuk-label--m" %>
-      <span class="govuk-hint"><%= t('activemodel.attributes.page_creation.page_url_hint') %></span>
+      <span class="govuk-hint" id="add-page-hint"><%= t('activemodel.attributes.page_creation.page_url_hint') %></span>
       <% f.object.errors.each do |error|  %>
         <span class="govuk-error-message"><%= error.message %></span>
       <% end %>
-      <%= f.text_field :page_url, class: "govuk-input"  %>
+      <%= f.text_field :page_url, class: "govuk-input", 'aria-describedby': "add-page-hint"  %>
     </div>
 
     <%= f.submit t('pages.create'), class: "govuk-button fb-govuk-button" %>


### PR DESCRIPTION
PR to resolve that field hint text was not being read by screenreaders in the 'Add page' and 'Publish' modals.

Hint text has now been correctly associated with fields using `aria-describedby` meaning that it is now read out by screenreaders.

The publish form has also had corrections to remove the issue of duplicate ids.