### PR TITLE
2727 global analytics 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.17.8'
+gem 'metadata_presenter', '2.17.9'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.8)
+    metadata_presenter (2.17.9)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -430,7 +430,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.17.8)
+  metadata_presenter (= 2.17.9)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/javascript/packs/runner_application.js
+++ b/app/javascript/packs/runner_application.js
@@ -1,0 +1,14 @@
+// This file is automatically compiled by Webpack, along with any other files
+// present in this directory. You're encouraged to place your actual application logic in
+// a relevant structure within app/javascript and only use these pack files to reference
+// that code so it'll be compiled.
+
+require("@rails/ujs").start()
+// window.analytics = require("packs/analytics")
+
+// Uncomment to copy all static images under ../images to the output folder and reference
+// them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
+// or the `imagePath` JavaScript helper below.
+//
+// const images = require.context('../images', true)
+// const imagePath = (name) => images(name, true)

--- a/app/javascript/packs/runner_application.js
+++ b/app/javascript/packs/runner_application.js
@@ -12,3 +12,13 @@ require("@rails/ujs").start()
 //
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
+
+
+
+/*********************************************
+ * EDITOR ONLY ADDITIONS BELOW.
+ *********************************************/
+
+// Little bit hacky but we want to prevent the
+// Cookie banner from showing in preview mode.
+document.getElementById("govuk-cookie-banner").style.display = "none";


### PR DESCRIPTION
Replacing PR https://github.com/ministryofjustice/fb-editor/pull/1618 for better history.

https://trello.com/c/h3595yEp/2727-show-cookie-banner-when-global-analytics-is-configured-for-a-form

Use latest Metadata Presenter 2.17.9
(Workaround) Fix for JS errors when in Preview