### PR TITLE
Check the button is present before running the expectation

### DIFF
--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -37,6 +37,7 @@ module CommonSteps
       editor.sign_in_submit.click
     end
 
+    page.find('button.DialogActivator.govuk-button.fb-govuk-button', minimum: 1, visible: true)
     expect(page).to have_content(I18n.t('services.create'))
   end
 


### PR DESCRIPTION
Our acceptance tests have been failing more regularly in the last couple of days.
Primarily when the tests run the `given_I_am_logged_in` method. This could be due to the fact that we log in using Auth0 and the tests are not waiting for long enough before running the assertion.
[CircleCI Run](https://app.circleci.com/pipelines/github/ministryofjustice/fb-editor/5791/workflows/e6722c7c-98ba-43c6-9e07-91a1f855728b/jobs/30457)