### PR TITLE
Disable form name update (expect further changes)

### DIFF
--- a/app/views/settings/form_information/index.html.erb
+++ b/app/views/settings/form_information/index.html.erb
@@ -9,8 +9,8 @@
     <% f.object.errors.each do |error|  %>
       <span class="govuk-error-message"><%= error.message %></span>
     <% end %>
-    <%= f.text_field :service_name, class: "govuk-input width-responsive-two-thirds" %>
+    <%= f.text_field :service_name, class: "govuk-input width-responsive-two-thirds", disabled: true %>
   </div>
-  <%= f.submit t('actions.save'), class: "govuk-button fb-govuk-button" %>
+  <%= f.submit t('actions.save'), class: "govuk-button fb-govuk-button", disabled: true %>
 <% end %>
 


### PR DESCRIPTION
No design available.

Changes made for https://trello.com/c/nNadIkVp/2720-change-form-name-field-to-read-only
Have disabled the name input and 'Save' button. 
At this point, expecting more tweaks and on-going changes so this is just a start