### PR TITLE
Disable form name update (expect further changes)

### DIFF
--- a/app/views/partials/_template_warning.html.erb
+++ b/app/views/partials/_template_warning.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive"><%= t('default_text.warning') %></span>
+    <%= message %>
+  </strong>
+</div>

--- a/app/views/partials/_template_warning.html.erb
+++ b/app/views/partials/_template_warning.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-warning-text">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive"><%= t('default_text.warning') %></span>
+    <span class="govuk-warning-text__assistive"><%= t('assistive_text.warning') %></span>
     <%= message %>
   </strong>
 </div>

--- a/app/views/settings/form_information/index.html.erb
+++ b/app/views/settings/form_information/index.html.erb
@@ -9,7 +9,7 @@
     <% f.object.errors.each do |error|  %>
       <span class="govuk-error-message"><%= error.message %></span>
     <% end %>
-    <%= f.text_field :service_name, class: "govuk-input width-responsive-two-thirds", disabled: true %>
+    <%= f.text_field :service_name, class: "govuk-input width-responsive-two-thirds", readonly: true %>
   </div>
   <%= f.submit t('actions.save'), class: "govuk-button fb-govuk-button", disabled: true %>
 <% end %>

--- a/app/views/settings/form_information/index.html.erb
+++ b/app/views/settings/form_information/index.html.erb
@@ -9,8 +9,8 @@
     <% f.object.errors.each do |error|  %>
       <span class="govuk-error-message"><%= error.message %></span>
     <% end %>
-    <%= f.text_field :service_name, class: "govuk-input width-responsive-two-thirds" %>
+    <%= f.text_field :service_name, class: "govuk-input width-responsive-two-thirds", disabled: true %>
   </div>
-  <%= f.submit t('actions.save'), class: "govuk-button fb-govuk-button" %>
+  <%= f.submit t('actions.save'), class: "govuk-button fb-govuk-button", disabled: true %>
 <% end %>
 

--- a/app/views/settings/form_information/index.html.erb
+++ b/app/views/settings/form_information/index.html.erb
@@ -1,16 +1,17 @@
-<h1 class="govuk-heading-xl"><%= t('settings.form_information') %></h1>
+<h1 class="govuk-heading-xl"><%= t('settings.form_information.name') %></h1>
 
 <%= form_for @settings, as: :service, url: settings_form_information_index_path(service.service_id) do |f| %>
   <div class="govuk-form-group <%= !f.object.errors.empty? ? 'govuk-form-group--error' :'' %>">
     <%= f.label :service_name, class: "govuk-label" do %>
       <%= f.object.class.human_attribute_name :service_name %>
-      <span class="govuk-hint"><%= t('settings.form_information_help') %></span>
+      <span class="govuk-hint"><%= t('settings.form_information.form_name..hint') %></span>
     <% end %>
     <% f.object.errors.each do |error|  %>
       <span class="govuk-error-message"><%= error.message %></span>
     <% end %>
     <%# f.text_field :service_name, class: "govuk-input width-responsive-two-thirds", readonly: true %>
     <p><%= service.service_name %></p>
+    <%= render partial: 'partials/template_warning', locals: { message: t('settings.form_information.form_name.warning_message').html_safe } %>
   </div>
   <%= f.submit t('actions.save'), class: "govuk-button fb-govuk-button", disabled: true %>
 <% end %>

--- a/app/views/settings/form_information/index.html.erb
+++ b/app/views/settings/form_information/index.html.erb
@@ -9,7 +9,8 @@
     <% f.object.errors.each do |error|  %>
       <span class="govuk-error-message"><%= error.message %></span>
     <% end %>
-    <%= f.text_field :service_name, class: "govuk-input width-responsive-two-thirds", readonly: true %>
+    <%# f.text_field :service_name, class: "govuk-input width-responsive-two-thirds", readonly: true %>
+    <p><%= service.service_name %></p>
   </div>
   <%= f.submit t('actions.save'), class: "govuk-button fb-govuk-button", disabled: true %>
 <% end %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -2,9 +2,9 @@
   <h2 id="settings-navigation-heading" class="govuk-heading-xl"><%= t('settings.name') %></h2>
   <ul aria-labelledby="settings-navigation-heading" class="govuk-list">
     <li>
-      <%= link_to t('settings.form_information'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %>
+      <%= link_to t('settings.form_information.name'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %>
       <br />
-      <span class="govuk-hint" style= "display:block"><%= t('settings.form_information_hint') %></span>
+      <span class="govuk-hint" style= "display:block"><%= t('settings.form_information.description') %></span>
     </li>
     <br />
     <% if ENV['FORM_ANALYTICS'] == 'enabled' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
     hint: '[Optional hint text]'
     option: 'Option'
     option_hint: '[Optional hint text]'
+    warning: Warning
   default_values:
     service_email_output: ''
     service_email_from: 'moj-forms@digital.justice.gov.uk'
@@ -113,7 +114,7 @@ en:
     show:
       title: MoJ Forms
       lede: Prototype, test and publish online forms quickly and easily
-      body: 'To find out more about MoJ Forms, email us at <a class="govuk-link" href="mailto:moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a>, or <a class="govuk-link" href="https://app.slack.com/client/T02DYEB3A/CE26QEL1Z">ask us a question on Slack</a>.'
+      body: To find out more about MoJ Forms, email us at <a class="govuk-link" href="mailto:moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a>, or <a class="govuk-link" href="https://app.slack.com/client/T02DYEB3A/CE26QEL1Z" target="_blank">ask us a question on Slack</a>.
       callout: You will need a @digital.justice.gov.uk or @justice.gov.uk email address to use MoJ Forms.
       sign_in: Sign in
   auth:
@@ -261,10 +262,13 @@ en:
       negative: 'No'
   settings:
     name: 'Settings'
-    form_information: 'Form details'
-    form_information_hint: "Set your form's name, URL and phase (e.g. Alpha, Beta)."
-    form_information_label: 'Form name'
-    form_information_help: 'The visible name of your form'
+    form_information:
+      name: 'Form details'
+      description: "Set your form's name, URL and phase (e.g. Alpha, Beta)."
+      form_name:
+        label: 'Form name'
+        hint: 'The visible name of your form'
+        warning_message: 'We are making some changes in this area. In the meantime, <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/contact/">contact us</a> to change your form’s name.'
     form_analytics:
       name: Google Analytics
       hint:  Monitor your form's performance (requires a Google Analytics account).

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,8 @@ en:
       confirmation: Confirmation page
       content: Content page
       exit: Exit page
+  assistive_text:
+    warning: Warning
   default_text:
     section_heading: '[Optional section heading]'
     lede: '[Optional lede paragraph]'
@@ -21,7 +23,6 @@ en:
     hint: '[Optional hint text]'
     option: 'Option'
     option_hint: '[Optional hint text]'
-    warning: Warning
   default_values:
     service_email_output: ''
     service_email_from: 'moj-forms@digital.justice.gov.uk'

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -11,31 +11,32 @@ RSpec.describe 'Settings' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
   end
 
-  describe 'POST /services/:id/settings/form_information' do
-    before do
-      expect_any_instance_of(ApplicationController).to receive(:service).at_least(:once).and_return(service)
-      expect_any_instance_of(Settings).to receive(:update).and_return(valid)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
-      allow_any_instance_of(PermissionsController).to receive(:require_user!).and_return(true)
+  
+  #describe 'POST /services/:id/settings/form_information' do
+  #  before do
+  #    expect_any_instance_of(ApplicationController).to receive(:service).at_least(:once).and_return(service)
+  #    expect_any_instance_of(Settings).to receive(:update).and_return(valid)
+  #    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
+  #    allow_any_instance_of(PermissionsController).to receive(:require_user!).and_return(true)
 
-      post "/services/#{service.service_id}/settings/form_information",
-           params: { service: { service_name: 'R2-D2' } }
-    end
+  #    post "/services/#{service.service_id}/settings/form_information",
+  #         params: { service: { service_name: 'R2-D2' } }
+  #  end
 
-    context 'when valid' do
-      let(:valid) { true }
+  #  context 'when valid' do
+  #    let(:valid) { true }
 
-      it 'redirects to form information index' do
-        expect(response).to redirect_to(settings_form_information_index_path(service.service_id))
-      end
-    end
+  #    it 'redirects to form information index' do
+  #      expect(response).to redirect_to(settings_form_information_index_path(service.service_id))
+  #    end
+  #  end
 
-    context 'when invalid' do
-      let(:valid) { false }
+  #  context 'when invalid' do
+  #    let(:valid) { false }
 
-      it 'shows the previous service name' do
-        expect(response.body).to include('R2-D2')
-      end
-    end
-  end
+  #    it 'shows the previous service name' do
+  #      expect(response.body).to include('R2-D2')
+  #    end
+  #  end
+  #end
 end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -11,32 +11,31 @@ RSpec.describe 'Settings' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
   end
 
-  
-  #describe 'POST /services/:id/settings/form_information' do
-  #  before do
-  #    expect_any_instance_of(ApplicationController).to receive(:service).at_least(:once).and_return(service)
-  #    expect_any_instance_of(Settings).to receive(:update).and_return(valid)
-  #    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
-  #    allow_any_instance_of(PermissionsController).to receive(:require_user!).and_return(true)
+  # describe 'POST /services/:id/settings/form_information' do
+  #   before do
+  #     expect_any_instance_of(ApplicationController).to receive(:service).at_least(:once).and_return(service)
+  #     expect_any_instance_of(Settings).to receive(:update).and_return(valid)
+  #     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
+  #     allow_any_instance_of(PermissionsController).to receive(:require_user!).and_return(true)
 
-  #    post "/services/#{service.service_id}/settings/form_information",
-  #         params: { service: { service_name: 'R2-D2' } }
-  #  end
+  #     post "/services/#{service.service_id}/settings/form_information",
+  #          params: { service: { service_name: 'R2-D2' } }
+  #   end
 
-  #  context 'when valid' do
-  #    let(:valid) { true }
+  #   context 'when valid' do
+  #     let(:valid) { true }
 
-  #    it 'redirects to form information index' do
-  #      expect(response).to redirect_to(settings_form_information_index_path(service.service_id))
-  #    end
-  #  end
+  #     it 'redirects to form information index' do
+  #       expect(response).to redirect_to(settings_form_information_index_path(service.service_id))
+  #     end
+  #   end
 
-  #  context 'when invalid' do
-  #    let(:valid) { false }
+  #   context 'when invalid' do
+  #     let(:valid) { false }
 
-  #    it 'shows the previous service name' do
-  #      expect(response.body).to include('R2-D2')
-  #    end
-  #  end
-  #end
+  #     it 'shows the previous service name' do
+  #       expect(response.body).to include('R2-D2')
+  #     end
+  #   end
+  # end
 end


### PR DESCRIPTION
NOT READY FOR MERGE
Created just for interaction with Testable environment.
-------------------------------------------------------

No design available.

Changes made for https://trello.com/c/nNadIkVp/2720-change-form-name-field-to-read-only
Have disabled the name input and 'Save' button. 

At this point, expecting more tweaks and on-going changes so this is just a start.