### PR TITLE
Remove dev only flag for autocomplete option

### DIFF
--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -26,7 +26,7 @@
               data-component-type="checkboxes"><span><%= t('components.list.checkboxes') -%></span></li>
           <li data-page-type="singlequestion"
               data-component-type="upload"><span><%= t('components.list.upload') -%></span></li>
-          <% if moj_forms_dev? && ENV['AUTOCOMPLETE'] == 'enabled'%>
+          <% if ENV['AUTOCOMPLETE'] == 'enabled'%>
             <li data-page-type="singlequestion"
             data-component-type="autocomplete"><span><%= t('components.list.autocomplete') -%></span></li>
           <% end %>


### PR DESCRIPTION
This flag was for development purposes. Now we would like the rest of the team to be able to test the autocomplete feature.
Note: This will still only be available in the TEST editor.