### PR TITLE
Preview mechanism for autocomplete component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.17.9'
+gem 'metadata_presenter', '2.17.10'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.9)
+    metadata_presenter (2.17.10)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -430,7 +430,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.17.9)
+  metadata_presenter (= 2.17.10)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,4 +57,18 @@ class ApplicationController < ActionController::Base
   def service_id_param
     params[:service_id] || params[:id]
   end
+
+  def autocomplete_items(components)
+    components.each_with_object({}) do |component, hash|
+      next unless component.type == 'autocomplete'
+
+      response = MetadataApiClient::Items.find(service_id: service.service_id, component_id: component.uuid)
+
+      if response.errors?
+        Rails.logger.warn(response.errors)
+      else
+        hash[component.uuid] = response.metadata['items'][component.uuid]
+      end
+    end
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,8 +8,9 @@ class PagesController < FormController
   def edit
     return if @page.components.nil?
 
-    if autocomplete_component_present?
-      @service_items = MetadataApiClient::Items.all(service_id: service_id).metadata['items'] || {}
+    if @page.autocomplete_component_present?
+      items = autocomplete_items(@page.components)
+      @page.assign_autocomplete_items(items)
     end
   end
 
@@ -150,9 +151,5 @@ class PagesController < FormController
 
   def parameterize_url
     { page_url: params[:page][:page_url].parameterize }
-  end
-
-  def autocomplete_component_present?
-    @page.components.any? { |component| component.type == 'autocomplete' }
   end
 end

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -198,7 +198,8 @@ RSpec.describe Branch do
           'What would you like on your burger?',
           "What was the name of the band playing in Jabba's palace?",
           "What is The Mandalorian's real name?",
-          'Upload your best dog photo'
+          'Upload your best dog photo',
+          'Countries'
         ]
       )
     end
@@ -216,6 +217,7 @@ RSpec.describe Branch do
           { 'data-supports-branching': true },
           { 'data-supports-branching': false },
           { 'data-supports-branching': true },
+          { 'data-supports-branching': false },
           { 'data-supports-branching': false }
         ]
       )

--- a/spec/models/pages_flow_spec.rb
+++ b/spec/models/pages_flow_spec.rb
@@ -140,10 +140,21 @@ RSpec.describe PagesFlow do
               type: 'page.singlequestion',
               title: 'Upload your best dog photo',
               uuid: '2ef7d11e-0307-49e9-9fe2-345dc528dd66',
-              next: 'e337070b-f636-49a3-a65c-f506675265f0',
+              next: 'c7755991-436b-4495-afa6-803db58cefbc',
               previous_uuid: '80420693-d6f2-4fce-a860-777ca774a6f5',
               thumbnail: 'upload',
               url: 'dog-picture'
+            }
+          ],
+          [
+            {
+              type: 'page.singlequestion',
+              title: 'Countries',
+              uuid: 'c7755991-436b-4495-afa6-803db58cefbc',
+              next: 'e337070b-f636-49a3-a65c-f506675265f0',
+              previous_uuid: '2ef7d11e-0307-49e9-9fe2-345dc528dd66',
+              thumbnail: 'autocomplete',
+              url: 'countries'
             }
           ],
           [
@@ -152,7 +163,7 @@ RSpec.describe PagesFlow do
               title: 'Check your answers',
               uuid: 'e337070b-f636-49a3-a65c-f506675265f0',
               next: '778e364b-9a7f-4829-8eb2-510e08f156a3',
-              previous_uuid: '2ef7d11e-0307-49e9-9fe2-345dc528dd66',
+              previous_uuid: 'c7755991-436b-4495-afa6-803db58cefbc',
               thumbnail: 'checkanswers',
               url: 'check-answers'
             }

--- a/spec/models/traversable_spec.rb
+++ b/spec/models/traversable_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Traversable do
             burgers
             star-wars-knowledge
             dog-picture
+            countries
           ]
         end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/82s692KP/2714-autocomplete-preview-mechanism)

To enable preview in the editor we require an API call to get the items related to a component. This will be different in the
Runner, whereby the items will be present in an environment variable.
The items will also be available in the autocomplete template once a user uploads their items.

### Bump presenter 2.17.10