### PR TITLE
Inject autocomplete items into container during publishing

### DIFF
--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -27,6 +27,13 @@ class Publisher
       service.to_json.inspect
     end
 
+    def autocomplete_items
+      response = MetadataApiClient::Items.all(service_id: service_id)
+      Rails.logger.info(response.errors) if response.errors?
+
+      convert_autocomplete_response(response)
+    end
+
     def get_binding
       binding
     end
@@ -154,6 +161,11 @@ class Publisher
     def service_namespace_configuration
       @service_namespace_configuration ||=
         Rails.application.config.service_namespace_configuration[:"#{platform_environment}_#{deployment_environment}"]
+    end
+
+    def convert_autocomplete_response(response)
+      items = response.respond_to?(:metadata) ? response.metadata['items'] : {}
+      items.to_json.inspect
     end
   end
 end

--- a/config/publisher/cloud_platform/deployment.yaml.erb
+++ b/config/publisher/cloud_platform/deployment.yaml.erb
@@ -52,6 +52,8 @@ spec:
             value: <%= secret_key_base %>
           - name: SERVICE_METADATA
             value: <%= ERB::Util.json_escape(service_metadata) %>
+          - name: AUTOCOMPLETE_ITEMS
+            value: <%= autocomplete_items %>
           - name: SENTRY_DSN
             value: '<%= service_sentry_dsn %>'
         <% secrets.each do |secret|  %>

--- a/spec/fixtures/kubernetes_configuration/deployment.yaml
+++ b/spec/fixtures/kubernetes_configuration/deployment.yaml
@@ -52,6 +52,8 @@ spec:
             value: 'fdfdd491d611aa1abef54cbf24a709a1bb31ff881a487f8c58c69399202b08f77019920f481e17b40dd7452361055534b9f91f172719ed98a088498242f96f59'
           - name: SERVICE_METADATA
             value: "{\"service_name\":\"acceptance-tests-date\",\"test_escaping\":\"I don't know\"}"
+          - name: AUTOCOMPLETE_ITEMS
+            value: "{\"some-component-uuid\":[{\"text\":\"some text\",\"value\":\"some value\"}]}"
           - name: SENTRY_DSN
             value: 'sentry-dsn-test'
           - name: ENCODED_PRIVATE_KEY

--- a/spec/services/publisher/service_provisioner_spec.rb
+++ b/spec/services/publisher/service_provisioner_spec.rb
@@ -39,6 +39,62 @@ RSpec.describe Publisher::ServiceProvisioner do
     end
   end
 
+  describe '#autocomplete_items' do
+    let(:attributes) do
+      { service_id: SecureRandom.uuid }
+    end
+
+    context 'when there are autocomplete items for a service' do
+      let(:autocomplete_items) do
+        {
+          'items' => {
+            SecureRandom.uuid => [
+              { 'text' => 'some text', 'value' => 'some value' }
+            ]
+          }
+        }
+      end
+
+      before do
+        expect(MetadataApiClient::Items).to receive(:all)
+          .with(service_id: attributes[:service_id])
+          .and_return(MetadataApiClient::Items.new(autocomplete_items))
+      end
+
+      it 'generates the correct autocomplete items data structure' do
+        expect(service_provisioner.autocomplete_items).to eq(
+          autocomplete_items['items'].to_json.inspect
+        )
+      end
+    end
+
+    context 'when there are no autocomplete items for a service' do
+      let(:autocomplete_items) { { 'items' => {} } }
+
+      before do
+        expect(MetadataApiClient::Items).to receive(:all)
+          .with(service_id: attributes[:service_id])
+          .and_return(MetadataApiClient::Items.new(autocomplete_items))
+      end
+
+      it 'generates the correct empty json string' do
+        expect(service_provisioner.autocomplete_items).to eq('"{}"')
+      end
+    end
+
+    context 'when the metadata api returns and error' do
+      before do
+        expect(MetadataApiClient::Items).to receive(:all)
+          .with(service_id: attributes[:service_id])
+          .and_return(MetadataApiClient::ErrorMessages.new('some error'))
+      end
+
+      it 'generates the correct empty json string' do
+        expect(service_provisioner.autocomplete_items).to eq('"{}"')
+      end
+    end
+  end
+
   describe '#service_slug' do
     let(:attributes) { { service_id: SecureRandom.uuid } }
 

--- a/spec/services/publisher/utils/kubernetes_configuration_spec.rb
+++ b/spec/services/publisher/utils/kubernetes_configuration_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe Publisher::Utils::KubernetesConfiguration do
   let(:service_secret) do
     EncryptionService.new.encrypt('be04689a805f07acc74d493a6107e17d')
   end
+  let(:autocomplete_items) do
+    {
+      'items' => {
+        'some-component-uuid' => [
+          { 'text' => 'some text', 'value' => 'some value' }
+        ]
+      }
+    }
+  end
+
   before do
     allow(service_provisioner).to receive(:service).and_return(
       MetadataPresenter::Service.new(
@@ -52,6 +62,9 @@ RSpec.describe Publisher::Utils::KubernetesConfiguration do
     allow(ENV).to receive(:[])
       .with('SERVICE_SENTRY_DSN_TEST')
       .and_return('sentry-dsn-test')
+    allow(MetadataApiClient::Items).to receive(:all)
+      .with(service_id: '0da69306-cafd-4d32-bbee-fff98cac74ce')
+      .and_return(MetadataApiClient::Items.new(autocomplete_items))
   end
 
   describe '#generate' do


### PR DESCRIPTION
This adds the ability for the publisher to request the autocomplete
items for a given service and then set them onto the environment
variable AUTOCOMPLETE_ITEMS before adding that to the deployment
configuration in Kubernetes.

For times when there are no autocomplete items for a service we just set
"{}" as the value. The Runners initialiser will just create an empty
hash on start up in those instances.