### PR TITLE
Add Crown Presecution Service domain to allow list

### DIFF
--- a/app/services/auth0_user_session.rb
+++ b/app/services/auth0_user_session.rb
@@ -5,7 +5,8 @@ class Auth0UserSession
 
   VALID_EMAIL_DOMAINS = [
     'justice.gov.uk',
-    'Justice.gov.uk'
+    'Justice.gov.uk',
+    'cps.gov.uk'
   ].freeze
 
   attr_accessor :user_info, :user_id, :created_at, :new_user


### PR DESCRIPTION
Adding in the Crown Prosecution Service domain into the allow list as
they would like to start using the Editor.