### PR TITLE
Handle autocomplete component with no uploaded items

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,7 +65,7 @@ class ApplicationController < ActionController::Base
       response = MetadataApiClient::Items.find(service_id: service.service_id, component_id: component.uuid)
 
       if response.errors?
-        Rails.logger.warn(response.errors)
+        Rails.logger.info(response.errors)
       else
         hash[component.uuid] = response.metadata['items'][component.uuid]
       end

--- a/app/services/metadata_api_client/items.rb
+++ b/app/services/metadata_api_client/items.rb
@@ -29,8 +29,10 @@ module MetadataApiClient
         "/services/#{service_id}/components/#{component_id}/items"
       )
       new(response.body)
-    rescue Faraday::UnprocessableEntityError, Faraday::ResourceNotFound => e
+    rescue Faraday::UnprocessableEntityError => e
       error_messages(e)
+    rescue Faraday::ResourceNotFound => e
+      error_messages(e, send_sentry: false)
     end
   end
 end

--- a/app/services/metadata_api_client/resource.rb
+++ b/app/services/metadata_api_client/resource.rb
@@ -14,13 +14,15 @@ module MetadataApiClient
       Connection.new
     end
 
-    def self.error_messages(exception)
+    def self.error_messages(exception, send_sentry: true)
       errors = JSON.parse(
         exception.response_body, symbolize_names: true
       )[:message]
 
-      sentry_errors = errors.reject { |err| err == SERVICE_NAME_EXISTS }
-      Sentry.capture_message(sentry_errors.join(' | ')) if sentry_errors.present?
+      if send_sentry
+        sentry_errors = errors.reject { |err| err == SERVICE_NAME_EXISTS }
+        Sentry.capture_message(sentry_errors.join(' | ')) if sentry_errors.present?
+      end
 
       MetadataApiClient::ErrorMessages.new(errors)
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe ApplicationController do
       let(:api_response) { MetadataApiClient::ErrorMessages.new(['the component has no autocomplete items']) }
 
       it 'logs the error message' do
-        expect(Rails.logger).to receive(:warn).with(['the component has no autocomplete items'])
+        expect(Rails.logger).to receive(:info).with(['the component has no autocomplete items'])
         expect(controller.autocomplete_items(page_without_items.components)).to eq({})
       end
     end


### PR DESCRIPTION
The ResourceNotFound will always be a possibility, especially as it
is always the case immediately after a page has been created. Therefore
there is no need to keep notifying Sentry and we can downgrade the
logger message to be an info instead of a warn.