### PR TITLE
Allow autocomplete components to work in preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,8 @@ gem 'delayed_job_active_record'
 # gem 'metadata_presenter',
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
-# gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.17.11'
+# gem 'metadata_presenter', path: './fb-metadata-presenter'
+gem 'metadata_presenter', '2.17.13'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.11)
+    metadata_presenter (2.17.13)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -431,7 +431,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.17.11)
+  metadata_presenter (= 2.17.13)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/javascript/packs/runner_application.js
+++ b/app/javascript/packs/runner_application.js
@@ -4,7 +4,22 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-// window.analytics = require("packs/analytics")
+
+const accessibleAutocomplete = require("accessible-autocomplete")
+import 'accessible-autocomplete/dist/accessible-autocomplete.min.css' 
+
+const elements = document.querySelectorAll('.fb-autocomplete');
+
+Array.prototype.forEach.call(elements, function(element) {
+  accessibleAutocomplete.enhanceSelectElement({
+    defaultValue: '',
+    autoselect: false,
+    showAllValues: true,
+    selectElement: element,
+  });
+});
+
+//window.analytics = require("../src/analytics")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/packs/stylesheets/govuk.scss
+++ b/app/javascript/packs/stylesheets/govuk.scss
@@ -1,2 +1,21 @@
 $govuk-assets-path: "~govuk-frontend/govuk/assets/";
 @import "govuk-frontend/govuk/all";
+
+// Corrective tweak to make area non-full width in large view
+// Pointed out by design and shown in this example (at time of writing)
+// https://design-system.service.gov.uk/patterns/confirmation-pages/default/index.html 
+.govuk-panel--confirmation {
+  width: govuk-grid-width("two-thirds");
+
+  @include govuk-media-query($until: tablet) {
+    width: 100%;
+  }
+}
+
+// Now the design system has white bg for fields, the autocomplete dropdown
+// triangle is hidden.  This z-index change fixes that.
+// See: https://github.com/alphagov/accessible-autocomplete/issues/351
+.autocomplete__wrapper {
+  z-index: 0;
+}
+

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@rails/activestorage": "^7.0.3",
     "@rails/ujs": "^7.0.3",
     "@rails/webpacker": "^5.4.3",
+    "accessible-autocomplete": "^2.0.4",
     "govuk-frontend": "^3.14.0",
     "jquery": "^3.6.0",
     "jquery-ui-dist": "^1.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,6 +1253,13 @@ abab@^2.0.6:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
 
+accessible-autocomplete@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz#e295256c8d268b97c5ab456a1cb084b553ed3eb0"
+  integrity sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==
+  dependencies:
+    preact "^8.3.1"
+
 acorn-globals@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
@@ -5472,6 +5479,11 @@ postcss@^8.2.14, postcss@^8.3.11:
     nanoid "^3.3.4"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+preact@^8.3.1:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.3.tgz#78c2a5562fcecb1fed1d0055fa4ac1e27bde17c1"
+  integrity sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Include required JS / Styles for autocomplete components to work in preview.

Bumps Metadata Presenter to 2.17.13