### PR TITLE
Reinstate footer css for height and background color

### DIFF
--- a/app/javascript/packs/stylesheets/govuk.scss
+++ b/app/javascript/packs/stylesheets/govuk.scss
@@ -19,3 +19,12 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
   z-index: 0;
 }
 
+// Enables the footer color to go to the base of the window
+// and forces min height of content area
+html {
+  background-color: #F3F2F1;
+}
+
+#main-content {
+  min-height: 55vh;
+}


### PR DESCRIPTION
Quick fix to reinstate a few lines of css that set the html background color and force a min-height on the main content area in preview

These got accidentally when the assets were refactored slightly a few days back.

Applying the same fix as for the runner here: https://github.com/ministryofjustice/fb-runner/pull/989