### PR TITLE
Fix tests

### DIFF
--- a/app/javascript/src/component_dialog_activator.js
+++ b/app/javascript/src/component_dialog_activator.js
@@ -57,7 +57,7 @@ class DialogActivator {
    * @classes (String) Classes added to button.
    **/
   #createActivator($target, text) {
-    var $activator = $("<button>\</button>");
+    var $activator = $("<button></button>");
     $activator.text((text || "open dialog"));
     $target.before($activator);
     return $activator;

--- a/app/javascript/src/component_dialog_api_request.js
+++ b/app/javascript/src/component_dialog_api_request.js
@@ -58,14 +58,20 @@ class DialogApiRequest {
       buttons: []
     }, config);
 
-    var jxhr = $.get(url, function(response) {
-      dialog.$node = $(response);
+    this.$node = $(); // Should be overwritten on successful GET
+    this.$container = $(); // Should be overwritten on successful GET
+    this.#config = conf;
+    this.#state = "closed";
+
+    $.get(url)
+    .done( (response) => {
+        this.$node = $(response);
 
       // Allow a passed function to run against the created $node (response HTML) before creating a dialog effect
-      utilities.safelyActivateFunction(dialog.#config.build, dialog);
+      utilities.safelyActivateFunction( dialog.#config.build, dialog);
 
-      dialog.$node.data("instance", dialog);
-      dialog.$node.dialog({
+      this.$node.data("instance", dialog);
+      this.$node.dialog({
         classes: conf.classes,
         closeOnEscape: true,
         height: "auto",
@@ -76,16 +82,9 @@ class DialogApiRequest {
       });
 
       // Now jQueryUI dialog is in place let's initialise container and put class on it.
-      dialog.$container = dialog.$node.parents(".ui-dialog");
-      dialog.$container.addClass("DialogApiRequest");
-    });
-
-    this.$node = $(); // Should be overwritten on successful GET
-    this.$container = $(); // Should be overwritten on successful GET
-    this.#config = conf;
-    this.#state = "closed";
-
-    jxhr.done(function() {
+      this.$container = this.$node.parents(".ui-dialog");
+      this.$container.addClass("DialogApiRequest");
+      
       if(conf.closeOnClickSelector) {
         let $buttons = $(conf.closeOnClickSelector, dialog.$node);
         $buttons.eq(0).focus();
@@ -94,7 +93,7 @@ class DialogApiRequest {
         });
       }
       else {
-        dialog.$node.dialog("option", "buttons",
+        this.$node.dialog("option", "buttons",
           [
             {
               text: dialog.#config.buttons.length > 0 && dialog.#config.buttons[0].text || "ok",

--- a/app/javascript/src/component_dialog_form.js
+++ b/app/javascript/src/component_dialog_form.js
@@ -13,6 +13,7 @@ class DialogForm {
     this.#config = mergeObjects({
       activator: false,
       autoOpen: false,
+      classes: {},
       closeOnClickSelector: 'button[type="button"]',
       submitOnClickSelector: 'button[type="submit"]',
       remote: false,
@@ -169,6 +170,7 @@ class DialogForm {
     // Add the jQueryUI dialog functionality.
     this.$node.dialog({
       autoOpen: false,
+      classes: this.#config.classes,
       closeOnEscape: true,
       height: "auto",
       modal: true,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "version": "0.1.0",
   "devDependencies": {
     "chai": "^4.3.6",
+    "form-data": "^4.0.0",
     "jquery-ui": "^1.13.2",
     "jsdom": "^20.0.0",
     "mocha": "^9.2.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": ">=14.19.0"
   },
   "scripts": {
-    "jstest": "mocha"
+    "jstest": "mocha --recursive"
   },
   "dependencies": {
     "@rails/actioncable": "^7.0.3",

--- a/test/dialogs/activated_dialog/component.js
+++ b/test/dialogs/activated_dialog/component.js
@@ -19,6 +19,7 @@ describe("ActivatedDialog", function() {
 
     after(function() {
       helpers.teardownView();
+      created.dialog.activator.$node.remove();
       created.$node.remove();
       created = {};
     });
@@ -41,8 +42,8 @@ describe("ActivatedDialog", function() {
 
     it("should apply CSS classnames passed in config", function() {
       var $container = created.$node.parent('[role=dialog]');
-      expect($container.hasClass(c.CLASSNAME_1));
-      expect($container.hasClass(c.CLASSNAME_2));
+      expect($container.hasClass(c.CLASSNAME_1)).to.be.true;
+      expect($container.hasClass(c.CLASSNAME_2)).to.be.true;
     });
 
     it("should use config.okText as button text", function() {

--- a/test/dialogs/activated_dialog/events.js
+++ b/test/dialogs/activated_dialog/events.js
@@ -25,6 +25,7 @@ describe("ActivatedDialog", function() {
 
       after(function() {
         helpers.teardownView();
+        created.dialog.activator.$node.remove();
         created.$node.remove();
         created = {};
       });

--- a/test/dialogs/activated_dialog/helpers.js
+++ b/test/dialogs/activated_dialog/helpers.js
@@ -40,7 +40,9 @@ function createDialog(id, config) {
   var html = $template.text();
   var $node = $(html);
   var conf = {
-    classes: constants.CLASSNAME_1 + " " + constants.CLASSNAME_2,
+    classes: {
+      "ui-dialog": constants.CLASSNAME_1 + " " + constants.CLASSNAME_2,
+    },
     onOk: function() {},
     onCancel: function() {},
     onClose: function() {},
@@ -85,6 +87,7 @@ function setupView() {
  **/
 function teardownView() {
   $("[data-component-template=ActivatedDialog]").remove();
+  $(".DialogActivator").remove();
 }
 
 

--- a/test/dialogs/activated_dialog/methods.js
+++ b/test/dialogs/activated_dialog/methods.js
@@ -74,6 +74,7 @@ describe("ActivatedDialog", function() {
 
   function teardown(created) {
     helpers.teardownView();
+    created.dialog.activator.$node.remove();
     created.$node.remove();
     created = {};
   }

--- a/test/dialogs/dialog_activator/component.js
+++ b/test/dialogs/dialog_activator/component.js
@@ -36,8 +36,8 @@ describe("DialogActivator", function() {
       });
 
       it("should apply CSS classnames passed as param", function() {
-        expect(created.$node.hasClass(c.CLASSNAME_1));
-        expect(created.$node.hasClass(c.CLASSNAME_2));
+        expect(created.$node.hasClass(c.CLASSNAME_1)).to.be.true;
+        expect(created.$node.hasClass(c.CLASSNAME_2)).to.be.true;
       });
 
       it("should expose the $node as public", function() {

--- a/test/dialogs/dialog_activator/helpers.js
+++ b/test/dialogs/dialog_activator/helpers.js
@@ -65,6 +65,7 @@ function setupView() {
  **/
 function teardownView() {
   $("#" + constants.ID_LINK).remove();
+  $(".DialogActivator").remove();
 }
 
 

--- a/test/dialogs/dialog_api_request/component.js
+++ b/test/dialogs/dialog_api_request/component.js
@@ -1,4 +1,5 @@
 require('../../setup');
+const GlobalHelpers = require("../../helpers.js");
 
 describe("DialogApiRequest", function() {
 
@@ -9,19 +10,20 @@ describe("DialogApiRequest", function() {
     // Note: Due to component makeup, the component is actually the
     // parent/container element to original target $node.
     var created;
+    var server;
 
-    before(function(done) {
+    before(function() {
       var response = `<div class="component component-dialog" id="` + c.COMPONENT_ID + `">
                         <h3>Heading content here</h3>
                         <p>Message content here</p>
                       </div>`;
 
-      helpers.setupView();
-      created = helpers.createDialog(response, done);
+      server = GlobalHelpers.createServer();
+      created = helpers.createDialog(response, server);
     });
 
     after(function() {
-      helpers.teardownView();
+      server.restore();
       created.$node.remove();
       created = {};
     });
@@ -29,7 +31,6 @@ describe("DialogApiRequest", function() {
     it("should have the basic HTML in place", function() {
       var $dialog = $("#" + c.COMPONENT_ID);
       var $container = $dialog.parent('[role=dialog]');
-
       expect($dialog.length).to.equal(1);
       expect($dialog.get(0).nodeName.toLowerCase()).to.equal("div");
       expect($dialog.hasClass("component-dialog")).to.be.true;
@@ -44,8 +45,8 @@ describe("DialogApiRequest", function() {
     it("should apply CSS classnames passed in config", function() {
       var $dialog = $("#" + c.COMPONENT_ID);
       var $container = $dialog.parent('[role=dialog]');
-      expect($container.hasClass(c.CLASSNAME_1));
-      expect($container.hasClass(c.CLASSNAME_2));
+      expect($container.hasClass(c.CLASSNAME_1)).to.be.true;
+      expect($container.hasClass(c.CLASSNAME_2)).to.be.true;
     });
 
     it("should make the $node public", function() {
@@ -83,22 +84,23 @@ describe("DialogApiRequest", function() {
       const COMPONENT_ID = "dialog-api-request-component-test-without-buttons";
       const CLASSNAME_BUTTON_TEMPLATE = "dialog-api-request-component-test-without-buttons-button-template";
       var createdWithoutButtons;
+      var server;
 
-      before(function(done) {
+      before(function() {
         var response = `<div class="component component-dialog" id="` + COMPONENT_ID + `">
                         <h3>Heading content here</h3>
                         <p>Message content here</p>
                         <button class="` + CLASSNAME_BUTTON_TEMPLATE + `">Text for template button</button>
                       </div>`;
 
-        helpers.setupView();
-        createdWithoutButtons = helpers.createDialog(response, done, {
+        server = GlobalHelpers.createServer();
+        createdWithoutButtons = helpers.createDialog(response, server, {
           closeOnClickSelector: "." + CLASSNAME_BUTTON_TEMPLATE
         });
       });
 
       after(function() {
-        helpers.teardownView();
+        server.restore();
         createdWithoutButtons.$node.remove();
         createdWithoutButtons = null;
       });

--- a/test/dialogs/dialog_api_request/helpers.js
+++ b/test/dialogs/dialog_api_request/helpers.js
@@ -87,7 +87,6 @@ function createDialog(response, server, config) {
  * and anything else required.
  **/
 function setupView() {
-  //$_get = new GlobalHelpers.jQueryGetOverride();
 }
 
 

--- a/test/dialogs/dialog_api_request/helpers.js
+++ b/test/dialogs/dialog_api_request/helpers.js
@@ -9,7 +9,8 @@ const constants = {
   TEXT_BUTTON_OK: "This is ok button text",
   TEXT_BUTTON_CANCEL: "This is cancel button text",
   TEXT_HEADING: "General heading text",
-  TEXT_CONTENT: "General content text"
+  TEXT_CONTENT: "General content text",
+  REMOTE_URL: "/dialog-api-request.html"
 }
 
 const view = {
@@ -20,10 +21,6 @@ const view = {
     }
   }
 }
-
-var $_get; // Used in overriding $.get (see below)
-
-
 
 /* Creates a new dialog from only passing in an id and optional config.
  *
@@ -40,20 +37,22 @@ var $_get; // Used in overriding $.get (see below)
  *  }
  *
  **/
-function createDialog(response, ready, config) {
+function createDialog(response, server, config) {
   var conf = {
-    classes: constants.CLASSNAME_1 + " " + constants.CLASSNAME_2,
+    classes: {
+      "ui-dialog": constants.CLASSNAME_1 + " " + constants.CLASSNAME_2,
+    },
     buttons: [
       {
         text: constants.TEXT_BUTTON_OK,
         click: function() {
-          console.log("ok clicked");
+          //console.log("ok clicked");
         }
       }, 
       {
         text: constants.TEXT_BUTTON_CANCEL,
         click: function() {
-          console.log("cancel clicked");
+          //console.log("cancel clicked");
         }
       }
     ]
@@ -68,12 +67,18 @@ function createDialog(response, ready, config) {
     }
   }
 
-  $_get.html(response, ready); // Hijacks $.get and returns the response passed in.
+  server.respondWith(constants.REMOTE_URL, [
+    200,
+    { "Content-Type": "text/html" },
+    response,
+  ])
+
+  var dialog = new DialogApiRequest(constants.REMOTE_URL, conf)
 
   return {
     html: response,
     $node: $(response), // WARNING! Will not same as will be same element/node as dialog.$node
-    dialog: new DialogApiRequest("/url/not/used/in/testing", conf)
+    dialog: dialog,
   }
 }
 
@@ -82,14 +87,15 @@ function createDialog(response, ready, config) {
  * and anything else required.
  **/
 function setupView() {
-  $_get = new GlobalHelpers.jQueryGetOverride();
+  //$_get = new GlobalHelpers.jQueryGetOverride();
 }
 
 
 /* Reset DOM to pre setupView() state
  **/
-function teardownView() {
-  $_get.restore();
+function teardownView(id) {
+  $('#'+id).remove();
+  $(".DialogActivator").remove();
 }
 
 

--- a/test/dialogs/dialog_api_request/methods_test.js
+++ b/test/dialogs/dialog_api_request/methods_test.js
@@ -1,4 +1,5 @@
 require('../../setup');
+const GlobalHelpers = require("../../helpers.js");
 
 describe("DialogApiRequest", function() {
 
@@ -9,19 +10,20 @@ describe("DialogApiRequest", function() {
     // Note: Due to component makeup, the component is actually the
     // parent/container element to original target $node.
     var created;
+    var server;
 
-    before(function(done) {
+    before(function() {
       var response = `<div class="component component-dialog" id="` + c.COMPONENT_ID + `">
                         <h3>Heading content here</h3>
                         <p>Message content here</p>
                       </div>`;
 
-      helpers.setupView();
-      created = helpers.createDialog(response, done);
+      server = GlobalHelpers.createServer();
+      created = helpers.createDialog(response, server);
     });
 
     after(function() {
-      helpers.teardownView();
+      server.restore();
       created.$node.remove();
       created = {};
     });
@@ -74,22 +76,23 @@ describe("DialogApiRequest", function() {
       const COMPONENT_ID = "dialog-api-request-methods-test-without-buttons";
       const CLASSNAME_BUTTON_TEMPLATE = "dialog-api-request-methods-test-without-buttons-button-template";
       var createdWithoutButtons;
+      var server;
 
-      before(function(done) {
+      before(function() {
         var response = `<div class="component component-dialog" id="` + COMPONENT_ID + `">
                         <h3>Heading content here</h3>
                         <p>Message content here</p>
                         <button class="` + CLASSNAME_BUTTON_TEMPLATE + `">Text for template button</button>
                       </div>`;
-
-        helpers.setupView();
-        createdWithoutButtons = helpers.createDialog(response, done, {
+        
+        server = GlobalHelpers.createServer();
+        createdWithoutButtons = helpers.createDialog(response, server, {
           closeOnClickSelector: "." + CLASSNAME_BUTTON_TEMPLATE
         });
       });
 
       after(function() {
-        helpers.teardownView();
+        server.restore();
         createdWithoutButtons.$node.remove();
         createdWithoutButtons = null;
       });

--- a/test/dialogs/dialog_form/callbacks_test.js
+++ b/test/dialogs/dialog_form/callbacks_test.js
@@ -111,38 +111,45 @@ describe("DialogForm", function() {
   describe('Remote Template Callbacks', function() {
     var created = {};
     var server;
-    var onLoadCallback;
-    var onReadyCallback;
 
     beforeEach(function(){
       server = GlobalHelpers.createServer(); 
-      onLoadCallback = sinon.spy();
-      onReadyCallback = sinon.spy();
-
-      created = helpers.createRemoteDialog(COMPONENT_ID, server, {
-        onLoad: onLoadCallback,
-        onReady: onReadyCallback,
-      });
     });
 
     afterEach(function(){
       server.restore();
       helpers.teardownView(COMPONENT_ID);
-      onLoadCallback = null;
-      onReadyCallback = null;
       created = {};
     });
 
     it('should call onLoad', function() {
+      var onLoadCallback = sinon.spy();
+      
+      console.log(server)
+
+      created = helpers.createRemoteDialog(COMPONENT_ID, server, {
+        onLoad: onLoadCallback,
+      });
+
+
+      console.log(server)
+
       expect(onLoadCallback).to.have.been.called
       expect(onLoadCallback).to.have.been.calledWith(created.dialog);
     });
 
     it('should call onReady when created', function() {
+      var onLoadCallback = sinon.spy();
+      var onReadyCallback = sinon.spy();
+
+      created = helpers.createRemoteDialog(COMPONENT_ID, server, {
+        onLoad: onLoadCallback,
+        onReady: onReadyCallback,
+      });
+
       expect(onReadyCallback).to.have.been.called;
       expect(onReadyCallback).to.have.been.calledAfter(onLoadCallback);
       expect(onReadyCallback).to.have.been.calledWith(created.dialog);
-
     });
   });
 

--- a/test/dialogs/dialog_form/component_test.js
+++ b/test/dialogs/dialog_form/component_test.js
@@ -35,8 +35,8 @@ describe("DialogForm", function() {
 
     it("should apply CSS classnames passed in config", function() {
       var $container = created.$node.parent('[role=dialog]');
-      expect($container.hasClass(c.CLASSNAME_1));
-      expect($container.hasClass(c.CLASSNAME_2));
+      expect($container.hasClass(c.CLASSNAME_1)).to.be.true;
+      expect($container.hasClass(c.CLASSNAME_2)).to.be.true;
     });
 
     it("should make the instance available as data on the $node", function() {

--- a/test/dialogs/dialog_form/helpers.js
+++ b/test/dialogs/dialog_form/helpers.js
@@ -11,8 +11,8 @@ const constants = {
   TEXT_BUTTON_OK: "This is ok button text",
   TEXT_BUTTON_CANCEL: "This is cancel button text",
   TEXT_ERROR_MESSAGE: "This is an error message",
-  REMOTE_TEMPLATE_URL: '/dialog-test.html',
-  REMOTE_SUBMIT_URL: '/dialog-submit',
+  REMOTE_TEMPLATE_URL: 'dialog-test.html',
+  REMOTE_SUBMIT_URL: 'dialog-submit',
 }
 
 const view = {
@@ -43,6 +43,9 @@ function createDialog(id, config) {
   var $node = $("#" + id);
   var conf = {
     id: id,
+    classes: {
+      "ui-dialog": constants.CLASSNAME_1 + " " + constants.CLASSNAME_2, 
+    }
   }
 
   // Include any passed config items.
@@ -66,6 +69,9 @@ function createDialog(id, config) {
 function createRemoteDialog(id, server, config) {
   var conf = {
     id: id,
+    classes: {
+      "ui-dialog": constants.CLASSNAME_1 + " " + constants.CLASSNAME_2, 
+    }
   }
 
   // Include any passed config items.

--- a/test/dialogs/dialog_form/properties_test.js
+++ b/test/dialogs/dialog_form/properties_test.js
@@ -47,8 +47,8 @@ describe("DialogForm", function() {
 
       it("should make the activator public", function() {
         created = helpers.createDialog(COMPONENT_ID, { activator: true,});
-        
         var $activator = $(".DialogActivator");
+
         expect(created.dialog.activator).to.exist;
         expect(created.dialog.activator.$node).to.exist;
         expect(created.dialog.activator.$node.get(0)).to.equal($activator.get(0));

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,41 +6,6 @@
  *
  **/
 
-
-// Hijack $.get to fake a server response
-class jQueryGetOverride {
-  #original;
-  #done;
-
-  constructor() {
-    this.#original = $.get;
-  }
-
-  html(response, ready) {
-    var self = this;
-    $.get = function(urlNotNeeded, callback) {
-      setTimeout(function() {
-        callback(response);
-        if(self.#done && typeof self.#done == "function") {
-          self.#done();
-          ready();
-        }
-      }, 100); // Don't need much here. Just adding a little to simulate asynchronous delay
-      return self;
-    }
-  }
-
-  // Mimic (basic) done functionality.
-  done(func) {
-    this.#done = func || function() {};
-  }
-
-  restore() {
-    $.get = this.#original;
-  }
-}
-
-
 /* Due to jQueryUI Dialog we cannot identify the added buttons
  * (they have no class, etc) but we can loop over all buttons
  * to match text we seek to get a 'best guess' type of test.
@@ -87,7 +52,6 @@ function mergeConfig(defaultConfig, extraConfig) {
 }
 
 module.exports = {
-  jQueryGetOverride: jQueryGetOverride,
   findButtonByText: findButtonByText,
   createServer: createServer,
   mergeConfig: mergeConfig

--- a/test/setup.js
+++ b/test/setup.js
@@ -4,6 +4,7 @@ const sinonChai = require("sinon-chai");
 const jsdom = require("jsdom");
 const jquery = require('jquery');
 const { JSDOM } = jsdom;
+const FormData = require('form-data');
 
 var dom = new JSDOM(`<html>
     <head>
@@ -22,6 +23,7 @@ chai.use(sinonChai);
 global.expect = expect;
 global.window = dom.window;
 global.document = window.document;
+global.FormData = FormData;
 global.jQuery = require( 'jquery' )( window );
 global.$ = jQuery;
 global.XMLHttpRequest = global.window.XMLHttpRequest; // needs to exist for sinon


### PR DESCRIPTION
This PR fixes a few things around tests:

1. Fixes the error `FormData is not defined` coming from the form_dialog tests by requiring the node package to polyfill the browser FormData API.  the frontend code was all working because browsers have access to the FormData API.  The tests run in a node environment so do not natively have access to the API.

2. This issue wasn't spotted because the test command in circle was only running top-level tests! so anything in a sub-directory of `/test` wasn't being run.  The `yarn test` command now calls `mocha --recursive` to ensure all tests are run.

3. Making the above change highlighted an issue where the `FormDialog` tests ran in isolation but not as part of the whole suite.  This was caused by `jQueryGetOverride` causing issues with `sinon.fakeServer`. This PR replaces `jQueryGetOverride` with `sinon.fakeServer`.

4. Add in teardown for DialogActivators, which were hanging around from previous tests and causing later tests to fail.

5. Added expactations to tests checking for css class addition, and made required changes to ensure the classes would be applied correctly by jQuery UI dialog (both in tests and in application code)
