### PR TITLE
Fix settings screen accessibility issues

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -1099,3 +1099,9 @@ html {
 .govuk-select {
   background-color: govuk-colour("white");
 }
+
+.govuk-navigation .govuk-list {
+  li {
+    margin-bottom: govuk-spacing(5);
+  }
+}

--- a/app/views/settings/email/_form.html.erb
+++ b/app/views/settings/email/_form.html.erb
@@ -1,4 +1,4 @@
-<%= f.hidden_field :deployment_environment, value: deployment_environment %>
+<%= f.hidden_field :deployment_environment, value: deployment_environment, id: "deployment_environment_#{deployment_environment}" %>
 
 <details class="govuk-details" data-module="govuk-details">
   <summary class="govuk-details__summary">
@@ -15,21 +15,26 @@
       <% f.object.errors[:service_email_output].each do |message| %>
         <span class="govuk-error-message"><%= message %></span>
       <% end %>
-      <%= f.label :service_email_output, class: "govuk-label" %>
-      <%= f.text_field :service_email_output, class: "govuk-input width-responsive-two-thirds" %>
+      <%= f.label :service_email_output, class: "govuk-label", for: "service_email_output_#{deployment_environment}" %>
+      <%= f.text_field :service_email_output, class: "govuk-input width-responsive-two-thirds", id: "service_email_output_#{deployment_environment}" %>
     </div>
 
     <div class="govuk-form-group">
-      <%= f.label :service_email_subject, class: "govuk-label" %>
-      <%= f.text_field :service_email_subject, class: "govuk-input width-responsive-two-thirds" %>
+      <%= f.label :service_email_subject, class: "govuk-label", for: "service_email_subject_#{deployment_environment}"  %>
+      <%= f.text_field :service_email_subject, class: "govuk-input width-responsive-two-thirds", id: "service_email_subject_#{deployment_environment}"  %>
     </div>
 
     <div class="govuk-form-group">
-      <%= f.label :service_email_body, class: "govuk-label" do %>
+      <%= f.label :service_email_body, class: "govuk-label", for: "service_email_body_#{deployment_environment}" do %>
         <%= f.object.class.human_attribute_name :service_email_body %>
-        <span class="govuk-hint"><%= f.object.class.human_attribute_name :service_email_body_hint %></span>
       <% end %>
-      <%= f.text_area :service_email_body, class: "govuk-textarea width-responsive-two-thirds", rows: '5' %>
+      <span class="govuk-hint" id="service_email_body_hint_<%= deployment_environment%>"><%= f.object.class.human_attribute_name :service_email_body_hint %></span>
+      <%= f.text_area :service_email_body,
+        class: "govuk-textarea width-responsive-two-thirds", 
+        rows: '5',
+        id: "service_email_body_#{deployment_environment}",
+        'aria-describedby': "service_email_body_hint_#{deployment_environment}"
+      %>
     </div>
   </fieldset>
 
@@ -46,13 +51,13 @@
     </div>
 
     <div class="govuk-form-group">
-      <%= f.label :service_email_pdf_heading, class: "govuk-label" %>
-      <%= f.text_field :service_email_pdf_heading, class: "govuk-input width-responsive-two-thirds", rows: '5' %>
+      <%= f.label :service_email_pdf_heading, class: "govuk-label", for: "service_email_pdf_heading_#{deployment_environment}" %>
+      <%= f.text_field :service_email_pdf_heading, class: "govuk-input width-responsive-two-thirds", rows: '5', id: "service_email_pdf_heading_#{deployment_environment}"  %>
     </div>
 
     <div class="govuk-form-group">
-      <%= f.label :service_email_pdf_subheading, class: "govuk-label" %>
-      <%= f.text_field :service_email_pdf_subheading, class: "govuk-input width-responsive-two-thirds" %>
+      <%= f.label :service_email_pdf_subheading, class: "govuk-label", for: "service_email_pdf_subheading_#{deployment_environment}"  %>
+      <%= f.text_field :service_email_pdf_subheading, class: "govuk-input width-responsive-two-thirds", id: "service_email_pdf_subheading_#{deployment_environment}"  %>
     </div>
   </fieldset>
 
@@ -71,10 +76,10 @@
     <div class="govuk-checkboxes">
       <div class="govuk-checkboxes__item">
         <%= f.check_box :service_csv_output, class: 'govuk-checkboxes__input',
-          checked: f.object.service_csv_output_checked? %>
+          checked: f.object.service_csv_output_checked?, id: "service_csv_output_#{deployment_environment}" %>
         <%= f.label :service_csv_output,
           f.object.class.human_attribute_name(:csv_checkbox),
-          class: 'govuk-label govuk-checkboxes__label' %>
+          class: 'govuk-label govuk-checkboxes__label', for: "service_csv_output_#{deployment_environment}" %>
       </div>
     </div>
   </fieldset>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,19 +1,17 @@
 <nav class="govuk-navigation" aria-label="Settings navigation">
-  <h2 id="settings-navigation-heading" class="govuk-heading-xl"><%= t('settings.name') %></h2>
-  <ul aria-labelledby="settings-navigation-heading" class="govuk-list">
+  <h1 id="settings-navigation-heading" class="govuk-heading-xl"><%= t('settings.name') %></h1>
+  <ul aria-labelledby="settings-navigation-heading" class="govuk-list fb-settings-list">
     <li>
       <%= link_to t('settings.form_information.name'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %>
       <br />
       <span class="govuk-hint" style= "display:block"><%= t('settings.form_information.description') %></span>
     </li>
-    <br />
     <% if ENV['FORM_ANALYTICS'] == 'enabled' %>
     <li>
       <%= link_to t('settings.form_analytics.name'), settings_form_analytics_path(service.service_id), class: 'govuk-link' %>
       <br />
       <span class="govuk-hint" style= "display:block"><%= t('settings.form_analytics.hint') %></span>
     </li>
-    <br />
     <% end %>
     <li>
       <%= link_to t('settings.submission.name'), settings_submission_index_path(service.service_id), class: 'govuk-link' %>


### PR DESCRIPTION
Fixes for a accessibility issues raised by automated chwecking tools.
- Use `<h1>` instead of `<h2>` for main heading
- Remove `<br />` elements in the list (invalid html) and add margin instead
- Add unique ids to all elements on the settings send by email screen