### PR TITLE
Fix failing test after html changes

### DIFF
--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -140,7 +140,7 @@ feature 'Publishing' do
 
   def and_I_set_the_email_field
     editor.find(:css, '#configure-dev').click
-    editor.find(:css, '#email_settings_service_email_output').set('paul@atreides.com')
+    editor.find(:css, '#service_email_output_dev').set('paul@atreides.com')
   end
 
   def and_I_save_my_email_settings
@@ -246,7 +246,7 @@ feature 'Publishing' do
     and_I_click_the_submission_settings_link
     and_I_click_the_send_data_by_email_link
     editor.find(:css, '#configure-dev').click
-    editor.find(:css, '#email_settings_service_email_output').set('')
+    editor.find(:css, '#service_email_output_dev').set('')
     and_I_save_my_email_settings
   end
 end

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -37,7 +37,7 @@ module CommonSteps
       editor.sign_in_submit.click
     end
 
-    page.find('button.DialogActivator.govuk-button.fb-govuk-button', minimum: 1, visible: true)
+    page.find('button.DialogActivator.govuk-button.fb-govuk-button', visible: true)
     expect(page).to have_content(I18n.t('services.create'))
   end
 


### PR DESCRIPTION
 - Fixes a failing test after chaging ids in the template
 - Removes `minimmum: 1` count from a finder as it isn't valid capybara syntax and is ignored.
