### PR TITLE
Accessibility changes to branching screen

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -133,6 +133,10 @@ html {
   float: right;
 }
 
+.fb-link-button {
+  @include button_as_link;
+}
+
 
 /* Publishing
  * ------------------- */

--- a/app/javascript/styles/_mixins.scss
+++ b/app/javascript/styles/_mixins.scss
@@ -19,7 +19,8 @@
   @include govuk-link-common;
   @include govuk-link-style-default;
   @include govuk-font($size: 19);
-
+  
+  background: transparent;
   border: none;
   color: $govuk-link-colour;
   cursor: pointer;

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -4,15 +4,15 @@
 <p class="branch-or">or</p>
 
 <div class="branch-actions">
-  <a class="govuk-link" href="#" id="add-another-branch"><%= t('branches.branch_add') %></a>
+  <button class="govuk-link fb-link-button" id="add-another-branch"><%= t('branches.branch_add') %></button>
 </div>
 <p class="branch-or">or</p>
 
 <div class="branch" id="branch-otherwise">
-  <p class="name govuk-heading-l">
+  <h3 class="name govuk-heading-l">
     <%= t('branches.title_otherwise') %>
     <span class="name govuk-heading-m"><%= t('branches.hint_otherwise') %></span>
-  </p>
+  </h3>
   <div class="destination govuk-form-group <%= @branch.errors[:default_next].empty? ? '' : 'govuk-form-group--error' %>">
     <% @branch.errors[:default_next].each do |message| %>
       <p class="govuk-error-message"><%= message %></p>

--- a/app/views/branches/_form_conditionals.html.erb
+++ b/app/views/branches/_form_conditionals.html.erb
@@ -1,6 +1,6 @@
 <%= f.fields_for :conditionals, child_index: conditional_index do |conditional| %>
   <div class="branch" data-conditional-index="<%= conditional.index %>">
-    <p class="govuk-heading-l"><%= t('branches.conditional_title') + (conditional.index + 1).to_s %></p>
+    <h3 class="govuk-heading-l"><%= t('branches.conditional_title') + (conditional.index + 1).to_s %></h3>
     <ul class="govuk-navigation component-activated-menu">
       <li>
         <a class="govuk-link destructive branch-remover"><%= t('branches.branch_remove') %></a>

--- a/app/views/branches/edit.html.erb
+++ b/app/views/branches/edit.html.erb
@@ -8,7 +8,7 @@
   </h1>
 
   <% if @branch.previous_page_title.present? %>
-    <p class="govuk-heading-m"><%= t('branches.after', page_title: @branch.previous_page_title) %></p>
+    <h2 class="govuk-heading-m"><%= t('branches.after', page_title: @branch.previous_page_title) %></h2>
   <% end %>
 
   <%= form_for @branch,

--- a/app/views/branches/new.html.erb
+++ b/app/views/branches/new.html.erb
@@ -7,7 +7,7 @@
     <%= @branch.title %>
   </h1>
 
-  <p class="govuk-heading-m"><%= t('branches.after', page_title: @branch.previous_flow_title) %></p>
+  <h2 class="govuk-heading-m"><%= t('branches.after', page_title: @branch.previous_flow_title) %></h2>
 
   <%= form_for @branch, url: branches_path(service.service_id), method: :post do |f| %>
     <%= render 'form', f: f %>


### PR DESCRIPTION
Small changes to the New Branch / Edit Branch screen with accessibility improvements.

- 'Add another branch' is now a button not a link (as it doesn't perform a navigation).
- 'After question 2' text is now an `<h2>`
- Branch names are now `<h3>` 

There is still much to do on this page to provide good accessibility but these are some simple fixes that improve things, and appease the automated tools!