### PR TITLE
Migration Kubernetes Controllers for the Runner

### DIFF
--- a/config/publisher/cloud_platform/ingress.yaml.erb
+++ b/config/publisher/cloud_platform/ingress.yaml.erb
@@ -1,10 +1,9 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: <%= service_slug %>-ingress
+  name: <%= service_slug %>-ingress-new
   namespace: <%= namespace %>
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/custom-http-errors: "400, 401, 403, 404, 500, 503"
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -13,9 +12,10 @@ metadata:
         deny all;
         return 401;
       }
-    external-dns.alpha.kubernetes.io/set-identifier: <%= service_slug %>-ingress-<%= namespace %>-green
+    external-dns.alpha.kubernetes.io/set-identifier: <%= service_slug %>-ingress-new-<%= namespace %>-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
+  ingressClassName: default
   tls:
     - hosts:
       - <%= hostname %>

--- a/spec/fixtures/kubernetes_configuration/ingress.yaml
+++ b/spec/fixtures/kubernetes_configuration/ingress.yaml
@@ -1,10 +1,9 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: acceptance-tests-date-ingress
+  name: acceptance-tests-date-ingress-new
   namespace: formbuilder-services-test-dev
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/custom-http-errors: "400, 401, 403, 404, 500, 503"
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -13,9 +12,10 @@ metadata:
         deny all;
         return 401;
       }
-    external-dns.alpha.kubernetes.io/set-identifier: acceptance-tests-date-ingress-formbuilder-services-test-dev-green
+    external-dns.alpha.kubernetes.io/set-identifier: acceptance-tests-date-ingress-new-formbuilder-services-test-dev-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
+  ingressClassName: default
   tls:
     - hosts:
       - acceptance-tests-date.dev.test.form.service.justice.gov.uk


### PR DESCRIPTION
Cloud Platform is updating their version of Kubernetes Controllers and
an update of Ingress Controllers Version is required

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>