### PR TITLE
Autocomplete publish warning

### DIFF
--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -5,6 +5,7 @@ class PublishController < FormController
     @published_dev = published?(service.service_id, 'dev')
     @published_production = published?(service.service_id, 'production')
     @publish_warning = PublishPresenter.new(service)
+    @autocomplete_warning = AutocompleteItemsPresenter.new(service, service_autocomplete_items)
   end
 
   def create
@@ -22,6 +23,10 @@ class PublishController < FormController
   end
 
   private
+
+  def service_autocomplete_items
+    MetadataApiClient::Items.all(service_id: service.service_id)
+  end
 
   def publish_service_params
     params.require(:publish_service_creation).permit(

--- a/app/presenters/autocomplete_items_presenter.rb
+++ b/app/presenters/autocomplete_items_presenter.rb
@@ -1,0 +1,37 @@
+class AutocompleteItemsPresenter
+  attr_reader :autocomplete_items, :service
+
+  def initialize(service, autocomplete_items)
+    @service = service
+    @autocomplete_items = autocomplete_items
+  end
+
+  def autocomplete_component_uuids
+    pages_with_autocomplete_component.map { |page|
+      page.components.map(&:uuid)
+    }.flatten
+  end
+
+  def component_uuids_without_items
+    autocomplete_component_uuids - autocomplete_items.metadata['items'].keys
+  end
+
+  def pages_with_autocomplete_component
+    service.pages.select do |page|
+      page.components.any?(&:autocomplete?)
+    end
+  end
+
+  def messages
+    @messages ||=
+      pages_with_autocomplete_component.each_with_object([]) do |page, arry|
+        page.components.each do |component|
+          next unless component.uuid.in?(component_uuids_without_items)
+
+          arry.push(
+            { component_title: component.humanised_title, page_uuid: page.uuid }
+          )
+        end
+      end
+  end
+end

--- a/app/views/publish/_autocomplete_warning.html.erb
+++ b/app/views/publish/_autocomplete_warning.html.erb
@@ -1,0 +1,11 @@
+<% @autocomplete_warning.messages.each do |message| %>
+  <div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive"><%= t('publish.warning.heading') %></span>
+        <%= t('publish.warning.autocomplete_items',
+          title: link_to(message[:component_title],
+          edit_page_path(service.service_id, message[:page_uuid]))).html_safe %>
+  </strong>
+</div>
+<% end %>

--- a/app/views/publish/_publish_warning.html.erb
+++ b/app/views/publish/_publish_warning.html.erb
@@ -1,0 +1,9 @@
+<% if warning.message.present? %>
+  <div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive"><%= t('publish.warning.heading') %></span>
+    <%= warning.message %>
+  </strong>
+</div>
+<% end %>

--- a/app/views/publish/index.html.erb
+++ b/app/views/publish/index.html.erb
@@ -8,16 +8,7 @@
   <%# TODO: Require BE to expose this data before we can see it %>
   <%# last updated by <span class="name by">C. Smith</span      %>
 </p>
-
-<% if @publish_warning.message.present? %>
-  <div class="govuk-warning-text">
-  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-  <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive"><%= t('publish.warning.heading') %></span>
-    <%= @publish_warning.message %>
-  </strong>
-</div>
-<% end %>
+<%= render partial: 'publish_warning', locals: { warning: @publish_warning } %>
 
 <dl id="publish-environments">
   <dt class="environment govuk-heading-l"><%= t('publish.test.heading') %></dt>
@@ -39,6 +30,8 @@
       <%= render 'service_output_warning', environment: t('publish.environment.test') %>
     <% end %>
 
+    <%= render partial: 'autocomplete_warning' %>
+
     <%# TODO: Need an indicator from BE code that shows whether this is first-time publish   %>
     <%#       Currently have hardcoded 'false' value to avoid dialog showing but this should %>
     <%#       be dynamic to control dialog visibility.                                        %>
@@ -48,7 +41,7 @@
       <%= render 'form', f: f, deployment_environment: 'dev' %>
       <div class="govuk-button-group govuk-!-margin-bottom-0">
         <button class="govuk-button fb-govuk-button" type="submit">
-          <%= t('actions.publish_to_test') %> 
+          <%= t('actions.publish_to_test') %>
         </button>
 
         <button class="govuk-button govuk-button--secondary" data-module="govuk-button" type="button">
@@ -77,6 +70,8 @@
       <%= render 'service_output_warning', environment: t('publish.environment.live') %>
     <% end %>
 
+    <%= render partial: 'autocomplete_warning' %>
+
     <%# TODO: Hardcoded 'firstpublish' (see comment above) %>
     <%= form_for(@publish_service_creation_production,
         url: publish_index_path(service.service_id),
@@ -84,7 +79,7 @@
       <%= render 'form', f: f, deployment_environment: 'production' %>
       <div class="govuk-button-group govuk-!-margin-bottom-0">
         <button class="govuk-button fb-govuk-button" type="submit">
-          <%= t('actions.publish_to_live') %> 
+          <%= t('actions.publish_to_live') %>
         </button>
         <button class="govuk-button govuk-button--secondary" data-module="govuk-button" type="button">
           <%= t('actions.cancel') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -304,6 +304,7 @@ en:
       confirmation: 'Your form has no confirmation page - you won’t receive any user data without one'
       cya: 'Your form has no check answers page - you won’t receive any user data without one'
       both_pages: 'Your form has no check answers page or confirmation page - you won’t receive any user data without them'
+      autocomplete_items: 'Question %{title} has no autocomplete items'
     environment:
       test: Test
       live: Live

--- a/spec/presenters/autocomplete_items_presenter_spec.rb
+++ b/spec/presenters/autocomplete_items_presenter_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe AutocompleteItemsPresenter do
+  subject(:autocomplete_items_presenter) { described_class.new(service, autocomplete_items) }
+  let(:autocomplete_warning) do
+    I18n.t('publish.warning.autocomplete_items')
+  end
+  let(:page) { service.find_page_by_url('countries') }
+  let(:component_uuid) { page.components.first.uuid }
+  let(:component_title) { page.components.first.humanised_title }
+  let(:page_uuid) { page.uuid }
+  let(:warning_messages) do
+    [
+      { component_title: component_title, page_uuid: page_uuid }
+    ]
+  end
+
+  describe '#messages' do
+    context 'when all components have items' do
+      let(:autocomplete_items) do
+        double(metadata: {
+          'items' => { component_uuid => { 'text': '123', 'value': 'abc' } }
+        })
+      end
+
+      it 'should return empty' do
+        expect(autocomplete_items_presenter.messages).to be_empty
+      end
+    end
+
+    context 'when a component does not have items' do
+      let(:autocomplete_items) do
+        double(metadata: {
+          'items' => { SecureRandom.uuid => { 'text': '123', 'value': 'abc' } }
+        })
+      end
+
+      it 'should return an array with warning messages' do
+        expect(autocomplete_items_presenter.messages).to eq(warning_messages)
+      end
+    end
+
+    context 'when there are no items for a service' do
+      let(:autocomplete_items) { double(metadata: { 'items' => {} }) }
+
+      it 'it should return an array with warning messages' do
+        expect(autocomplete_items_presenter.messages).to eq(warning_messages)
+      end
+    end
+  end
+end

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Authorisation spec', type: :request do
     allow_any_instance_of(ApplicationController).to receive(:require_user!).and_return(true)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(current_user)
     allow_any_instance_of(ApplicationController).to receive(:service).and_return(service)
+    allow(MetadataApiClient::Items).to receive(:all).and_return({})
   end
 
   context 'all services page' do


### PR DESCRIPTION
[Trello](https://trello.com/c/dJAvQ1Iy/2755-autocomplete-show-warning-in-publishing-menu-if-an-autocomplete-component-has-no-items)

We want to have warnings on the publishing page when an autocomplete component does not have any associated items.
These warnings should link to the autocomplete component without items.

![Screenshot 2022-08-10 at 14 38 03](https://user-images.githubusercontent.com/29227502/183915479-acfd79ca-b51a-44b6-be61-800f2e0b5d11.png)

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>