### PR TITLE
Update publishing ingress names

### DIFF
--- a/app/services/publisher/configuration_naming.rb
+++ b/app/services/publisher/configuration_naming.rb
@@ -5,7 +5,7 @@ class Publisher
     end
 
     def ingress
-      "#{service_slug}-ingress"
+      "#{service_slug}-ingress-new"
     end
 
     def service_monitor_network_policy_name

--- a/lib/scripts/remove_services.rb
+++ b/lib/scripts/remove_services.rb
@@ -13,7 +13,7 @@ def delete_deployment(target:, namespace:)
 end
 
 def delete_ingress(target:, namespace:)
-  kubectl(namespace: namespace, config: 'ingress', target: "#{target}-ingress")
+  kubectl(namespace: namespace, config: 'ingress', target: "#{target}-ingress-new")
 end
 
 def delete_service(target:, namespace:)


### PR DESCRIPTION
We changed the name of the ingress configurations to include '-new' on
the end. Sorry.

Therefore we need to update the publishing and unpublishing models to
correctly use the right ingress names.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>