### PR TITLE
Update runner ingress name

### DIFF
--- a/config/publisher/cloud_platform/ingress.yaml.erb
+++ b/config/publisher/cloud_platform/ingress.yaml.erb
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: <%= service_slug %>-ingress-new
+  name: <%= service_slug %>-ingress
   namespace: <%= namespace %>
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -12,7 +12,7 @@ metadata:
         deny all;
         return 401;
       }
-    external-dns.alpha.kubernetes.io/set-identifier: <%= service_slug %>-ingress-new-<%= namespace %>-green
+    external-dns.alpha.kubernetes.io/set-identifier: <%= service_slug %>-ingress-<%= namespace %>-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   ingressClassName: default

--- a/spec/fixtures/kubernetes_configuration/ingress.yaml
+++ b/spec/fixtures/kubernetes_configuration/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: acceptance-tests-date-ingress-new
+  name: acceptance-tests-date-ingress
   namespace: formbuilder-services-test-dev
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -12,7 +12,7 @@ metadata:
         deny all;
         return 401;
       }
-    external-dns.alpha.kubernetes.io/set-identifier: acceptance-tests-date-ingress-new-formbuilder-services-test-dev-green
+    external-dns.alpha.kubernetes.io/set-identifier: acceptance-tests-date-ingress-formbuilder-services-test-dev-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   ingressClassName: default


### PR DESCRIPTION
We no longer need to use the '-new' in the runner ingress name