### PR TITLE
Error warning messages

### DIFF
--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -1,11 +1,10 @@
 class PublishController < FormController
-  before_action :assign_form_objects
+  before_action :assign_form_objects, :assign_autocomplete_warning
 
   def index
     @published_dev = published?(service.service_id, 'dev')
     @published_production = published?(service.service_id, 'production')
     @publish_warning = PublishPresenter.new(service)
-    @autocomplete_warning = AutocompleteItemsPresenter.new(service, service_autocomplete_items)
   end
 
   def create
@@ -50,6 +49,10 @@ class PublishController < FormController
       service_id: service.service_id,
       deployment_environment: 'production'
     )
+  end
+
+  def assign_autocomplete_warning
+    @autocomplete_warning = AutocompleteItemsPresenter.new(service, service_autocomplete_items)
   end
 
   def published?(service_id, environment)

--- a/app/javascript/styles/_component_warning_text.scss
+++ b/app/javascript/styles/_component_warning_text.scss
@@ -29,4 +29,26 @@
       color:  $govuk-brand-colour;
     }
   }
+
+  &--error {
+    .govuk-warning-text__icon {
+      border: none;
+      background-color: $govuk-error-colour;
+      border-radius: unset;
+      clip-path: polygon(50% 0, 100% 100%, 0 100%);
+      min-width: 40px;
+      padding-top: 5px;
+
+    }
+
+    .govuk-warning-text__text {
+      color:  $govuk-error-colour;
+
+      a,
+      a:visited {
+        @include govuk-link-style-error;
+      }
+    }
+
+  }
 }

--- a/app/views/publish/_autocomplete_warning.html.erb
+++ b/app/views/publish/_autocomplete_warning.html.erb
@@ -1,9 +1,9 @@
 <% @autocomplete_warning.messages.each do |message| %>
-  <div class="govuk-warning-text">
+  <div class="govuk-warning-text <%= environment == t('publish.environment.live') ? 'govuk-warning-text--error' : '' -%>">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive"><%= t('publish.warning.heading') %></span>
-        <%= t('publish.warning.autocomplete_items',
+        <%= t(text,
           title: link_to(message[:component_title],
           edit_page_path(service.service_id, message[:page_uuid]))).html_safe %>
   </strong>

--- a/app/views/publish/_publish_warning.html.erb
+++ b/app/views/publish/_publish_warning.html.erb
@@ -1,5 +1,5 @@
 <% if warning.message.present? %>
-  <div class="govuk-warning-text">
+<div class="govuk-warning-text">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive"><%= t('publish.warning.heading') %></span>

--- a/app/views/publish/index.html.erb
+++ b/app/views/publish/index.html.erb
@@ -8,7 +8,7 @@
   <%# TODO: Require BE to expose this data before we can see it %>
   <%# last updated by <span class="name by">C. Smith</span      %>
 </p>
-<%= render partial: 'publish_warning', locals: { warning: @publish_warning } %>
+<%= render 'publish_warning', warning: @publish_warning %>
 
 <dl id="publish-environments">
   <dt class="environment govuk-heading-l"><%= t('publish.test.heading') %></dt>
@@ -30,7 +30,7 @@
       <%= render 'service_output_warning', environment: t('publish.environment.test') %>
     <% end %>
 
-    <%= render partial: 'autocomplete_warning' %>
+    <%= render 'autocomplete_warning', environment: t('publish.environment.test'), text: 'publish.warning.autocomplete_items' %>
 
     <%# TODO: Need an indicator from BE code that shows whether this is first-time publish   %>
     <%#       Currently have hardcoded 'false' value to avoid dialog showing but this should %>
@@ -70,7 +70,7 @@
       <%= render 'service_output_warning', environment: t('publish.environment.live') %>
     <% end %>
 
-    <%= render partial: 'autocomplete_warning' %>
+    <%= render 'autocomplete_warning', environment: t('publish.environment.live'), text: 'publish.error.autocomplete_items' %>
 
     <%# TODO: Hardcoded 'firstpublish' (see comment above) %>
     <%= form_for(@publish_service_creation_production,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -304,7 +304,9 @@ en:
       confirmation: 'Your form has no confirmation page - you won’t receive any user data without one'
       cya: 'Your form has no check answers page - you won’t receive any user data without one'
       both_pages: 'Your form has no check answers page or confirmation page - you won’t receive any user data without them'
-      autocomplete_items: 'Question %{title} has no autocomplete items'
+      autocomplete_items: '"%{title}" has no autocomplete options and cannot be answered.'
+    error:
+      autocomplete_items: 'You need to upload some autocomplete options for "%{title}"'
     environment:
       test: Test
       live: Live


### PR DESCRIPTION
* Adds in new warning message style for blocking errors on the publishing page.
* Fixes error where @autocomplete_items was `nil` on the `publish_controller#create` action

![image](https://user-images.githubusercontent.com/595564/184391381-419b5cb2-3f78-4c3c-9aa6-069af75d3c7b.png)


