### PR TITLE
Accessibly disable publish button

### DIFF
--- a/app/javascript/src/component_dialog_activator.js
+++ b/app/javascript/src/component_dialog_activator.js
@@ -38,7 +38,12 @@ class DialogActivator {
     $node.data("instance", this);
     $node.addClass("DialogActivator");
     $node.addClass(config.classes);
-    $node.on( "click", () => {
+    $node.removeAttr('hidden');
+
+    $node.on( "click", (e) => {
+      if(e.target.getAttribute("aria-disabled") === "true") {
+        return;
+      }
       conf.dialog.open();
     });
 

--- a/app/javascript/src/controller_publish.js
+++ b/app/javascript/src/controller_publish.js
@@ -69,17 +69,13 @@ class PublishForm {
   constructor($node) {
     var $content = $node.find(".govuk-form");
     var $radios = $node.find("input[type=radio]");
-    var $submit = $node.find("button[type=submit]");
+    var $activator = $node.parent().find('button[data-fb-action="publish"]');
     var $errors = $node.find(".govuk-error-message");
 
     new ContentVisibilityController($content, $radios);
     new DialogForm($node, {
       autoOpen: $errors.length ? true : false,
-      activator: true,
-      activatorText: $submit.text(),
-      classes: {
-        'activator': "govuk-button fb-govuk-button",
-      },
+      activator: $activator,
       onClose: function(dialog) {
         $errors.parents().removeClass('error');
         $errors.remove(); // Remove from DOM (includes removing all jQuery data)

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -35,6 +35,11 @@ html {
   }
 }
 
+[hidden],
+[hidden="hidden"] {
+  display: none;
+}
+
 .sr-only {
   height: 1px;
   left: -10000px;

--- a/app/javascript/styles/_mixins.scss
+++ b/app/javascript/styles/_mixins.scss
@@ -58,9 +58,16 @@
   background-color: govuk-colour("blue");
 
   &:hover,
+  &[disabled],
   &[disabled='disabled'],
-  &[disabled='disabled']:hover {
+  &[disabled='disabled']:hover,
+  &[aria-disabled="true"]:hover {
     background-color: govuk-colour("dark-blue");
+  }
+
+  &[aria-disabled="true"] {
+    opacity: 0.5;
+    pointer-events: none;
   }
 }
 

--- a/app/views/publish/index.html.erb
+++ b/app/views/publish/index.html.erb
@@ -32,6 +32,14 @@
 
     <%= render partial: 'autocomplete_warning' %>
 
+    <button class="govuk-button fb-govuk-button"
+        data-module="govuk-button"
+        type="button" 
+        data-fb-action="publish"
+        hidden >
+        <%= t('actions.publish_to_test') %>
+    </button>
+
     <%# TODO: Need an indicator from BE code that shows whether this is first-time publish   %>
     <%#       Currently have hardcoded 'false' value to avoid dialog showing but this should %>
     <%#       be dynamic to control dialog visibility.                                        %>
@@ -72,12 +80,21 @@
 
     <%= render partial: 'autocomplete_warning' %>
 
+    <button class="govuk-button fb-govuk-button"
+            data-module="govuk-button"
+            type="button" 
+            aria-disabled="<%= @autocomplete_warning.messages.blank? ? 'false' : 'true' %>"
+            data-fb-action="publish"
+            hidden >
+            <%= t('actions.publish_to_live') %>
+    </button>
+
     <%# TODO: Hardcoded 'firstpublish' (see comment above) %>
     <%= form_for(@publish_service_creation_production,
         url: publish_index_path(service.service_id),
         html: { id: 'publish-form-live', class: 'publish-form', data: { first_publish: false } }) do |f| %>
       <%= render 'form', f: f, deployment_environment: 'production' %>
-      <div class="govuk-button-group govuk-!-margin-bottom-0">
+      <div class="govuk-button-group govuk-!-margin-bottom-0" <%= @autocomplete_warning.messages.blank? ? '' : 'disabled="disabled"' %>>
         <button class="govuk-button fb-govuk-button" type="submit">
           <%= t('actions.publish_to_live') %>
         </button>


### PR DESCRIPTION
Adds the ability for the 'Publish to Live' button to be accessibly disabled if there are blocking errors^.

Accessibly disabled means using `aria-disabled="true"` which means the button can still be focused by AT users and will be announced as disabled. We then have to ensure the button has no action on click/keyboard interaction.

In order to avoid having to pass the aria-disabled attribute through the `PublishController`, `PublishForm` and `FormDialog` class into the `DialogActivator` class it has been moved into the main view.

The button is initially given the `hidden` attribute, which is then removed by the `DialogActivator` class in order to provide the same progressive enhancement as before. If there is no JS there wil be no activator button, just the form, and the button will be `disabled` normally (we need JS to prevent the submit of an `aria-disabled` button)

^ currently just missing autocomplete items, but soon to include more things.

![image](https://user-images.githubusercontent.com/595564/184379060-a0dfb5b0-b112-4aa8-84cc-40b17bcf7645.png)

