### PR TITLE
Fix autocomplete error for malformed CSV

### DIFF
--- a/app/models/autocomplete_items.rb
+++ b/app/models/autocomplete_items.rb
@@ -19,15 +19,7 @@ class AutocompleteItems
     'show'
   end
 
-  private
-
   def file_contents
     @file_contents ||= CSV.read(file.path)
-  rescue CSV::MalformedCSVError
-    errors.add(
-      I18n.t(
-        'activemodel.errors.models.autocomplete_items.incorrect_format'
-      )
-    )
   end
 end

--- a/app/validators/csv_validator.rb
+++ b/app/validators/csv_validator.rb
@@ -1,27 +1,36 @@
 class CsvValidator < ActiveModel::Validator
   def validate(record)
-    if not_csv?(record)
-      record.errors.add(
-        :file,
-        I18n.t(
-          'activemodel.errors.models.autocomplete_items.invalid_type'
+    if record.file_contents
+      if not_csv?(record)
+        record.errors.add(
+          :file,
+          I18n.t(
+            'activemodel.errors.models.autocomplete_items.invalid_type'
+          )
         )
-      )
-    elsif record.file_values.empty?
-      record.errors.add(
-        :file,
-        I18n.t(
-          'activemodel.errors.models.autocomplete_items.empty'
+      elsif record.file_values.empty?
+        record.errors.add(
+          :file,
+          I18n.t(
+            'activemodel.errors.models.autocomplete_items.empty'
+          )
         )
-      )
-    elsif invalid_headings?(record) || record.file_values.map(&:size).max > 2
-      record.errors.add(
-        :file,
-        I18n.t(
-          'activemodel.errors.models.autocomplete_items.incorrect_format'
+      elsif invalid_headings?(record) || record.file_values.map(&:size).max > 2
+        record.errors.add(
+          :file,
+          I18n.t(
+            'activemodel.errors.models.autocomplete_items.incorrect_format'
+          )
         )
-      )
+      end
     end
+  rescue CSV::MalformedCSVError
+    record.errors.add(
+      :file,
+      I18n.t(
+        'activemodel.errors.models.autocomplete_items.incorrect_format'
+      )
+    )
   end
 
   private

--- a/spec/validators/csv_validator_spec.rb
+++ b/spec/validators/csv_validator_spec.rb
@@ -67,5 +67,15 @@ RSpec.describe CsvValidator do
         expect(subject).to_not be_valid
       end
     end
+
+    context 'when a file is malformed' do
+      let(:path_to_file) {  Rails.root.join('spec', 'fixtures', 'malformed.csv') }
+
+      it 'throws a malformed csv error' do
+        expect(subject.errors.full_messages).to eq([I18n.t(
+          'activemodel.errors.models.autocomplete_items.incorrect_format'
+        )])
+      end
+    end
   end
 end


### PR DESCRIPTION
The CSV::Malformed error in the `file_contents` method is triggered too late, we have moved this method to the CsvValidator so it can be triggered earlier.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>