### PR TITLE
Trigger validation if autocomplete answer is changed to be invalid

### DIFF
--- a/app/javascript/packs/runner_application.js
+++ b/app/javascript/packs/runner_application.js
@@ -8,9 +8,9 @@ require("@rails/ujs").start()
 const accessibleAutocomplete = require("accessible-autocomplete")
 import 'accessible-autocomplete/dist/accessible-autocomplete.min.css' 
 
-const elements = document.querySelectorAll('.fb-autocomplete');
-
-Array.prototype.forEach.call(elements, function(element) {
+// Initialise autocomplete components
+const autocompleteElements = document.querySelectorAll('.fb-autocomplete');
+Array.prototype.forEach.call(autocompleteElements, function(element) {
   accessibleAutocomplete.enhanceSelectElement({
     defaultValue: '',
     autoselect: false,
@@ -18,6 +18,34 @@ Array.prototype.forEach.call(elements, function(element) {
     selectElement: element,
   });
 });
+
+// the autocomplete component only updates the underlying <select> element when
+// a valid option is chosen. If a user sets an answer, then returns to change
+// their answer and either blanks the autocomplete or enters an invalid/partial string
+// the submitted value will not be changed. This is strange UX and confusing for
+// the user.
+// On autocomoplete pages, on submit, we compare the value in the autocomplete
+// input with the underlying select* if they are different we set the selects
+// value to empty in order to trigger validation
+// * the autocomplete value will just be text, the selects value will be a json
+// string {'text': 'United Kingdom', value: 'UK'}
+
+const autocompleteComponent = document.querySelector('[data-fb-content-type="autocomplete"]');
+if(autocompleteComponent) {
+  const autocompleteForm = autocompleteComponent.parentNode;
+
+  autocompleteForm.addEventListener('submit', function(event) {
+    const form = event.target;
+    const autocompleteField = form.querySelector('input.autocomplete__input');
+    const autocompleteSelect = form.querySelector('.fb-autocomplete');
+    
+    // if the select is not empty and the values do not match or if the
+    // autocomplete is empty trigger validation
+    if(autocompleteSelect.value != '' && !autocompleteSelect.value.includes(autocompleteField.value) || autocompleteField.value == '') {
+      autocompleteSelect.value = '';
+    }
+  });
+}
 
 //window.analytics = require("../src/analytics")
 


### PR DESCRIPTION
This matches the PR adding this functionalityinto the runner.

The autocomplete component only updates the underlying `<select>` element when a valid option is chosen. If a user sets an answer, then returns to change their answer and either blanks the autocomplete or enters an invalid/partial string the submitted value will not be changed. 

This is strange UX and confusing for the user.

On autocomoplete pages, on submit, we compare the value in the autocompleteinput with the underlying select if they are different we set the selects value to empty in order to trigger validation