### PR TITLE
Encode special characters and account for Byte Order Mark in CSV file

### DIFF
--- a/app/models/autocomplete_items.rb
+++ b/app/models/autocomplete_items.rb
@@ -20,6 +20,6 @@ class AutocompleteItems
   end
 
   def file_contents
-    @file_contents ||= CSV.read(file.path)
+    @file_contents ||= CSV.read(file.path, encoding: 'utf-8')
   end
 end

--- a/app/models/autocomplete_items.rb
+++ b/app/models/autocomplete_items.rb
@@ -20,6 +20,6 @@ class AutocompleteItems
   end
 
   def file_contents
-    @file_contents ||= CSV.read(file.path, encoding: 'utf-8')
+    @file_contents ||= CSV.read(file.path, encoding: 'bom|utf-8')
   end
 end

--- a/spec/fixtures/bom.csv
+++ b/spec/fixtures/bom.csv
@@ -1,0 +1,7 @@
+﻿Text,Value
+john,wick
+john,connor
+john,smith
+john,travolta
+john,mcclane
+john,matrix

--- a/spec/fixtures/special_characters.csv
+++ b/spec/fixtures/special_characters.csv
@@ -1,0 +1,7 @@
+Text,Value
+Åland Islands,AX
+Saint Barthélemy,BL
+"Congo, Democratic Republic of",CD
+Côte d'Ivoire,CI
+Curaçao,CW
+Réunion,RE

--- a/spec/models/autocomplete_items_spec.rb
+++ b/spec/models/autocomplete_items_spec.rb
@@ -71,5 +71,13 @@ RSpec.describe AutocompleteItems do
         ])
       end
     end
+
+    context 'file has special characters' do
+      let(:path_to_file) { Rails.root.join('spec', 'fixtures', 'special_characters.csv') }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
   end
 end

--- a/spec/validators/csv_validator_spec.rb
+++ b/spec/validators/csv_validator_spec.rb
@@ -77,5 +77,13 @@ RSpec.describe CsvValidator do
         )])
       end
     end
+
+    context 'when file has bom prefix' do
+      let(:path_to_file) { Rails.root.join('spec', 'fixtures', 'bom.csv') }
+
+      it 'should be valid' do
+        expect(subject).to be_valid
+      end
+    end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/Zxje7j0O/2826-autocomplete-parsing-special-characters-in-csv-files)

## Ensure csv files are utf-8 encoded when read

Prior to this change, certain characters (eg: Å or é) would not pass validation due to them not being encoded appropriately. This would mean csv files that contained these characters would be rejected and unable to be uploaded as options in the autocomplete component.

![Screenshot 2022-08-18 at 09 23 04](https://user-images.githubusercontent.com/29227502/185347318-d4db3808-fdde-4c30-ab7b-94198260f8d7.png)

## Additional csv validator test for Byte Order Mark characters
We want to allow csv's which are created with Byte Order Mark characters to be uploaded especially as this seems to be the way that Excel saves CSV files by default.
