### PR TITLE
Make admin area service search work

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -3,7 +3,8 @@ module Admin
     def index
       response = MetadataApiClient::Service.all_services(
         page: page,
-        per_page: per_page
+        per_page: per_page,
+        name_query: params[:search] || ''
       )
 
       @services = Kaminari.paginate_array(

--- a/app/services/metadata_api_client/service.rb
+++ b/app/services/metadata_api_client/service.rb
@@ -1,11 +1,12 @@
 module MetadataApiClient
   class Service < Resource
-    def self.all_services(page:, per_page:)
+    def self.all_services(page:, per_page:, name_query: '')
       response = connection.get(
         '/services',
         {
           page: page,
-          per_page: per_page
+          per_page: per_page,
+          name_query: name_query
         }
       ).body
 

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -25,7 +25,6 @@ By default, it renders:
     <%= csrf_meta_tags %>
     <%= csp_meta_tag if defined?(csp_meta_tag) %>
     <%= stylesheet_pack_tag 'application', media: 'all' %>
-    <%= javascript_pack_tag 'application' %>
   </head>
   <body>
     <%= render "icons" %>

--- a/spec/services/metadata_api_client/service_spec.rb
+++ b/spec/services/metadata_api_client/service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe MetadataApiClient::Service do
   end
 
   describe '.all_services' do
-    let(:expected_url) { "#{metadata_api_url}/services?page=1&per_page=20" }
+    let(:expected_url) { "#{metadata_api_url}/services?name_query=&page=1&per_page=20" }
     let(:expected_body) do
       {
         "services": [service_attributes],


### PR DESCRIPTION
Pass the search param on the administrate serviecs page through to the metadata api to be able to search the services.