### PR TITLE
Add ClamAV for virus scanning of uploads

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 docs/
+config/clamd/*

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ yarn-debug.log*
 
 # macOS finder #
 .DS_Store
+
+# Clamd config
+/config/clamd/*.conf

--- a/app/controllers/api/autocomplete_controller.rb
+++ b/app/controllers/api/autocomplete_controller.rb
@@ -21,8 +21,14 @@ module Api
           @items.errors.add(:message, error)
         end
       end
-
-      render partial: 'show', status: :unprocessable_entity, layout: false
+      render_unprocessable_entity
+    rescue ClamdscanError => e
+      Rails.logger.warn("ClamdscanError message: #{e.message}")
+      @items.errors.add(
+        :message,
+        I18n.t('activemodel.errors.models.autocomplete_items.scan_error')
+      )
+      render_unprocessable_entity
     end
 
     private
@@ -51,6 +57,10 @@ module Api
 
     def assign_items
       @items = AutocompleteItems.new(base_params)
+    end
+
+    def render_unprocessable_entity
+      render partial: 'show', status: :unprocessable_entity, layout: false
     end
   end
 end

--- a/app/exceptions/clamdscan_error.rb
+++ b/app/exceptions/clamdscan_error.rb
@@ -1,0 +1,2 @@
+class ClamdscanError < StandardError
+end

--- a/app/models/autocomplete_items.rb
+++ b/app/models/autocomplete_items.rb
@@ -32,7 +32,10 @@ class AutocompleteItems
 
   def scan_file
     if has_virus?
-      errors.add(:message, I18n.t('activemodel.errors.models.autocomplete_items.virus_found', attribute: file.original_filename))
+      errors.add(
+        :message,
+        I18n.t('activemodel.errors.models.autocomplete_items.virus_found', attribute: file.original_filename)
+      )
     end
   end
 end

--- a/app/services/malware_scanner.rb
+++ b/app/services/malware_scanner.rb
@@ -1,7 +1,6 @@
 require 'open3'
 
 class MalwareScanner
-  ClamdscanError = Class.new(StandardError)
   COMMAND = "/usr/bin/clamdscan -c config/clamd/#{Rails.env}.conf --stream --no-summary".freeze
 
   def self.call(file_path)

--- a/app/services/malware_scanner.rb
+++ b/app/services/malware_scanner.rb
@@ -1,0 +1,46 @@
+require 'open3'
+
+class MalwareScanner
+  ClamdscanError = Class.new(StandardError)
+  COMMAND = "/usr/bin/clamdscan -c config/clamd/#{Rails.env}.conf --stream --no-summary".freeze
+
+  def self.call(file_path)
+    new(file_path: file_path).call
+  end
+
+  attr_reader :file_path
+
+  def initialize(file_path:)
+    @file_path = file_path
+  end
+
+  def call
+    return false if disable_malware_scanner?
+
+    virus_found?
+  end
+
+  private
+
+  def disable_malware_scanner?
+    Rails.env.development?
+  end
+
+  def virus_found?
+    @virus_found ||= !scan_result.status.success?
+  end
+
+  def scan_result
+    @scan_result ||= begin
+      stdout, stderr, status = Open3.capture3(*[COMMAND, file_path.to_s].join(' '))
+      result = stdout.strip
+
+      raise ClamdscanError, (stderr.presence || stdout) if status.exitstatus == 2
+
+      OpenStruct.new(
+        result: result,
+        status: status
+      )
+    end
+  end
+end

--- a/brakeman.ignore
+++ b/brakeman.ignore
@@ -1,13 +1,33 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "06d6c136d77c612ede6c621952772bad1910e700020da0302d7987b8cdfe2bd2",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/services/malware_scanner.rb",
+      "line": 35,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "Open3.capture3(*\"#{COMMAND} #{file_path.to_s}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "MalwareScanner",
+        "method": "scan_result"
+      },
+      "user_input": "COMMAND",
+      "confidence": "Medium",
+      "note": "This is required for streaming file virus scanning"
+    },
+    {
       "warning_type": "Mass Assignment",
       "warning_code": 70,
       "fingerprint": "ba68e127b85a916b749bd1f7fec20219b1cb3e27b40904106d2dce53193bb5dd",
       "check_name": "MassAssignment",
       "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
       "file": "app/controllers/pages_controller.rb",
-      "line": 90,
+      "line": 91,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.require(:page).permit!",
       "render_path": null,
@@ -72,6 +92,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-07-13 14:02:38 +0100",
+  "updated": "2022-08-18 11:37:54 +0100",
   "brakeman_version": "5.2.3"
 }

--- a/config/initializers/generate_clamd_config.rb
+++ b/config/initializers/generate_clamd_config.rb
@@ -1,0 +1,6 @@
+File.open(Rails.root.join("config/clamd/#{Rails.env}.conf"), 'w') do |f|
+  f.write "TCPSocket 3310"
+  f.write "\n"
+  f.write "TCPAddr #{ENV['AV_HOST']}"
+  f.write "\n"
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -444,6 +444,7 @@ en:
           empty: The selected file must contain some data
           format: "%{message}"
           virus_found: "'%{attribute}' contains a virus - choose a different file"
+          scan_error: "An error has occurred, try again in a few minutes"
 
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -443,6 +443,7 @@ en:
           incorrect_format: The selected file must be formatted correctly
           empty: The selected file must contain some data
           format: "%{message}"
+          virus_found: "'%{attribute}' contains a virus - choose a different file"
 
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."

--- a/deploy-eks/fb-editor-chart/templates/config_map.yaml
+++ b/deploy-eks/fb-editor-chart/templates/config_map.yaml
@@ -12,4 +12,5 @@ data:
   AUTH0_DOMAIN: moj-forms.eu.auth0.com
   ENCODED_PUBLIC_KEY: {{ .Values.encoded_public_key }}
   METADATA_API_URL: http://fb-metadata-api-svc-{{ .Values.environmentName }}
+  AV_HOST: fb-av-svc-{{ .Values.environmentName }}
   AUTOCOMPLETE: {{ .Values.autocomplete }}

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add git yarn build-base postgresql-contrib postgresql-dev \
       bash libcurl curl
 
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs npm
+RUN apk add clamav-daemon
 
 RUN addgroup -g ${UID} -S appgroup && \
   adduser -u ${UID} -S appuser -G appgroup

--- a/spec/requests/api/autocomplete_spec.rb
+++ b/spec/requests/api/autocomplete_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Autocomplete spec', type: :request do
     allow_any_instance_of(
       Api::AutocompleteController
     ).to receive(:service).and_return(service)
+
+    allow(MalwareScanner).to receive(:call).and_return(false)
   end
 
   describe 'GET /api/services/:service_id/components/:component_id/autocomplete' do

--- a/spec/services/malware_scanner_spec.rb
+++ b/spec/services/malware_scanner_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe MalwareScanner do
+  subject(:malware_scanner) { described_class.new(file_path: file_path) }
+
+  describe '#call' do
+    let(:file_path) { Rails.root }
+
+    context 'when development mode' do
+      it 'returns false' do
+        allow(Rails.env).to receive(:development?).and_return(true)
+        expect(malware_scanner.call).to be_falsey
+      end
+    end
+
+    context 'when virus is found' do
+      let(:pid_status) do
+        double(exitstatus: 1, success?: false)
+      end
+
+      it 'returns true' do
+        allow(Open3).to receive(:capture3).and_return(['', '', pid_status])
+        expect(malware_scanner.call).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/services/malware_scanner_spec.rb
+++ b/spec/services/malware_scanner_spec.rb
@@ -23,5 +23,16 @@ RSpec.describe MalwareScanner do
         expect(malware_scanner.call).to be_truthy
       end
     end
+
+    context 'when clamdscan errors' do
+      let(:pid_status) do
+        double(exitstatus: 2)
+      end
+
+      it 'raises a clamdscan error' do
+        allow(Open3).to receive(:capture3).and_return(['', '', pid_status])
+        expect { malware_scanner.call }.to raise_error(ClamdscanError)
+      end
+    end
   end
 end

--- a/spec/validators/csv_validator_spec.rb
+++ b/spec/validators/csv_validator_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe CsvValidator do
   let(:file) { Rack::Test::UploadedFile.new(path_to_file, 'text/csv') }
 
   describe '#validate' do
-    before { subject.validate }
+    before do
+      allow(MalwareScanner).to receive(:call).and_return(false)
+      subject.validate
+    end
 
     context 'when not a csv file' do
       let(:path_to_file) { Rails.root.join('spec', 'fixtures', 'computer_says_no.gif') }


### PR DESCRIPTION
[Trello](https://trello.com/c/MPnUo7jW/2752-autocomplete-editor-fb-av)

For the autocomplete component, we require form editors to upload a CSV file that contains their options.
We need to ensure these files uploaded are free from viruses.
We have deployed the FB-AV app into the saas namespace and allowed the Editor to communicate with the app.

With regards to the brakeman check, we require the command for file virus scanning - therefore we have added this warning to the brakeman.ignore list.

Co-authored-by: Brendan Butler <[brendan.butler@digital.justice.gov.uk](mailto:brendan.butler@digital.justice.gov.uk)>
Co-authored-by: Hellema Ibrahim <[hellema.ibrahim@digital.justice.gov.uk](mailto:hellema.ibrahim@digital.justice.gov.uk)>