### PR TITLE
Do not allow empty fields when there is a Value column in CSV file

### DIFF
--- a/app/controllers/api/autocomplete_controller.rb
+++ b/app/controllers/api/autocomplete_controller.rb
@@ -13,7 +13,7 @@ module Api
           service_id: params[:service_id],
           component_id: params[:component_id],
           created_by: service.created_by,
-          data: items_hash(@items.file_values)
+          data: items_hash(@items.file_rows)
         )
         return head :created unless response.errors?
 

--- a/app/controllers/api/autocomplete_controller.rb
+++ b/app/controllers/api/autocomplete_controller.rb
@@ -33,6 +33,10 @@ module Api
 
     private
 
+    def has_headers?
+      @items.file_headings == %w[text value]
+    end
+
     def autocomplete_items_file
       @autocomplete_items_file ||= params.dig(:autocomplete_items, :file)
     end
@@ -50,7 +54,7 @@ module Api
       csv_items.map do |r|
         {
           text: r[0],
-          value: r[1].nil? ? r[0] : r[1]
+          value: has_headers? ? r[1] : r[0]
         }
       end
     end

--- a/app/controllers/api/autocomplete_controller.rb
+++ b/app/controllers/api/autocomplete_controller.rb
@@ -34,7 +34,7 @@ module Api
     private
 
     def has_headers?
-      @items.file_headings == %w[text value]
+      @items.file_headings.size == 2
     end
 
     def autocomplete_items_file

--- a/app/models/autocomplete_items.rb
+++ b/app/models/autocomplete_items.rb
@@ -12,7 +12,7 @@ class AutocompleteItems
     file_contents.first.compact.map(&:downcase)
   end
 
-  def file_values
+  def file_rows
     file_contents.drop(1)
   end
 

--- a/app/models/autocomplete_items.rb
+++ b/app/models/autocomplete_items.rb
@@ -9,7 +9,7 @@ class AutocompleteItems
   validates_with CsvValidator, unless: proc { |obj| obj.file.blank? || obj.has_virus? }
 
   def file_headings
-    file_contents.first.compact.map(&:downcase)
+    file_contents.first
   end
 
   def file_rows

--- a/app/validators/csv_validator.rb
+++ b/app/validators/csv_validator.rb
@@ -22,6 +22,13 @@ class CsvValidator < ActiveModel::Validator
             'activemodel.errors.models.autocomplete_items.incorrect_format'
           )
         )
+      elsif empty_value_cell?(record)
+        record.errors.add(
+          :file,
+          I18n.t(
+            'activemodel.errors.models.autocomplete_items.empty_value_cell'
+          )
+        )
       end
     end
   rescue CSV::MalformedCSVError
@@ -42,5 +49,9 @@ class CsvValidator < ActiveModel::Validator
   def invalid_headings?(record)
     (record.file_headings.count == 1 && record.file_headings != %w[text]) ||
       (record.file_headings.count == 2 && record.file_headings != %w[text value])
+  end
+
+  def empty_value_cell?(record)
+    record.file_contents.any? { |cell| cell[1].blank? }
   end
 end

--- a/app/validators/csv_validator.rb
+++ b/app/validators/csv_validator.rb
@@ -19,7 +19,7 @@ class CsvValidator < ActiveModel::Validator
         record.errors.add(
           :file,
           I18n.t(
-            'activemodel.errors.models.autocomplete_items.incorrect_format'
+            'activemodel.errors.models.autocomplete_items.invalid_headings'
           )
         )
       elsif empty_value_cell?(record) || empty_text_cell?(record)

--- a/app/validators/csv_validator.rb
+++ b/app/validators/csv_validator.rb
@@ -52,6 +52,6 @@ class CsvValidator < ActiveModel::Validator
   end
 
   def empty_value_cell?(record)
-    record.file_contents.any? { |cell| cell[1].blank? }
+    record.file_contents.any? { |cell| cell[1].blank? } if record.file_headings.count == 2
   end
 end

--- a/app/validators/csv_validator.rb
+++ b/app/validators/csv_validator.rb
@@ -22,7 +22,7 @@ class CsvValidator < ActiveModel::Validator
             'activemodel.errors.models.autocomplete_items.incorrect_format'
           )
         )
-      elsif empty_value_cell?(record)
+      elsif empty_value_cell?(record) || empty_text_cell?(record)
         record.errors.add(
           :file,
           I18n.t(
@@ -53,5 +53,9 @@ class CsvValidator < ActiveModel::Validator
 
   def empty_value_cell?(record)
     record.file_contents.any? { |cell| cell[1].blank? } if record.file_headings.count == 2
+  end
+
+  def empty_text_cell?(record)
+    record.file_contents.any? { |cell| cell[0].blank? }
   end
 end

--- a/app/validators/csv_validator.rb
+++ b/app/validators/csv_validator.rb
@@ -8,14 +8,14 @@ class CsvValidator < ActiveModel::Validator
             'activemodel.errors.models.autocomplete_items.invalid_type'
           )
         )
-      elsif record.file_values.empty?
+      elsif record.file_rows.empty?
         record.errors.add(
           :file,
           I18n.t(
             'activemodel.errors.models.autocomplete_items.empty'
           )
         )
-      elsif invalid_headings?(record) || record.file_values.map(&:size).max > 2
+      elsif invalid_headings?(record) || record.file_rows.map(&:size).max > 2
         record.errors.add(
           :file,
           I18n.t(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -447,6 +447,9 @@ en:
           scan_error: "An error has occurred, try again in a few minutes"
           too_big: "The selected file must be smaller than 1MB"
           empty_value_cell: "CSV file has an empty value cell"
+          scan_error:  There was a problem with the file upload - try again later
+          empty_value_cell: "The selected file cannot contain blank fields"
+          invalid_headings: "The selected file's header fields must be labelled correctly"
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."
         too_short: "Your answer for ‘%{attribute}’ is too short (%{count} characters at least)"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -446,7 +446,7 @@ en:
           virus_found: "'%{attribute}' contains a virus - choose a different file"
           scan_error: "An error has occurred, try again in a few minutes"
           too_big: "The selected file must be smaller than 1MB"
-
+          empty_value_cell: "CSV file has an empty value cell"
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."
         too_short: "Your answer for ‘%{attribute}’ is too short (%{count} characters at least)"

--- a/spec/fixtures/empty_value_cell.csv
+++ b/spec/fixtures/empty_value_cell.csv
@@ -1,5 +1,6 @@
 Text,Value
 1,Hey
 2,
+,
 3,Ho
 4

--- a/spec/fixtures/empty_value_cell.csv
+++ b/spec/fixtures/empty_value_cell.csv
@@ -1,0 +1,5 @@
+Text,Value
+1,Hey
+2,
+3,Ho
+4

--- a/spec/fixtures/malformed.csv
+++ b/spec/fixtures/malformed.csv
@@ -1,4 +1,18 @@
-text,value,
-Foo,\xAB,bar
-b,2,5
-c,3,6
+Text,Value
+Andorra,AD
+United Arab Emirates,AE
+Afghanistan,AF
+Canada,CA
+Cocos (Keeling) Islands,CC
+"Congo, Democratic Republic of",CD
+Central African Republic,CF
+Congo,CG
+Estonia,EE
+Egypt,EG
+Western Sahara,EH
+Yemen,YE
+Mayotte,YT
+South Africa,ZA
+Zambia,ZM
+Zimbabwe,ZW
+Curaçao,CW

--- a/spec/models/autocomplete_items_spec.rb
+++ b/spec/models/autocomplete_items_spec.rb
@@ -87,12 +87,12 @@ RSpec.describe AutocompleteItems do
     end
   end
 
-  describe '#file_values' do
-    context 'has the correct file values' do
-      let(:expected_values) { [%w[b 1], %w[c 2], %w[d 3]] }
+  describe '#file_rows' do
+    context 'has the correct file rows' do
+      let(:expected_rows) { [%w[b 1], %w[c 2], %w[d 3]] }
 
       it 'returns the contents' do
-        expect(subject.file_values).to eq(expected_values)
+        expect(subject.file_rows).to eq(expected_rows)
       end
     end
   end

--- a/spec/models/autocomplete_items_spec.rb
+++ b/spec/models/autocomplete_items_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe AutocompleteItems do
 
   describe '#file_headings' do
     context 'file has headings' do
-      let(:expected_headings) { %w[text value] }
+      let(:expected_headings) { %w[Text Value] }
 
       it 'returns headings' do
         expect(subject.file_headings).to eq(expected_headings)

--- a/spec/validators/csv_validator_spec.rb
+++ b/spec/validators/csv_validator_spec.rb
@@ -57,6 +57,21 @@ RSpec.describe CsvValidator do
       end
     end
 
+    context 'when the file has one heading but two columns of values' do
+      let(:path_to_file) do
+        CSV.open(Rails.root.join('tmp', 'invalid.csv'), 'w') do |csv|
+          csv << %w[Text]
+          csv << %w[something something]
+          csv << %w[dark side]
+        end
+        'tmp/invalid.csv'
+      end
+
+      it 'returns invalid' do
+        expect(subject).to_not be_valid
+      end
+    end
+
     context 'when the file has one column' do
       let(:path_to_file) { Rails.root.join('spec', 'fixtures', 'valid_one_column.csv') }
 

--- a/spec/validators/csv_validator_spec.rb
+++ b/spec/validators/csv_validator_spec.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 RSpec.describe CsvValidator do
   let(:subject) { AutocompleteItems.new(params) }
   let(:params) do
@@ -89,17 +91,40 @@ RSpec.describe CsvValidator do
       end
     end
 
-    context 'when file has an empty value cell' do
-      let(:path_to_file) { Rails.root.join('spec', 'fixtures', 'empty_value_cell.csv') }
+    context 'when file has an empty cell' do
+      context 'empty value cell' do
+        let(:path_to_file) { Rails.root.join('spec', 'fixtures', 'empty_value_cell.csv') }
 
-      it 'returns invalid' do
-        expect(subject).to_not be_valid
+        it 'returns invalid' do
+          expect(subject).to_not be_valid
+        end
+
+        it 'returns the correct message' do
+          expect(subject.errors.full_messages).to eq([I18n.t(
+            'activemodel.errors.models.autocomplete_items.empty_value_cell'
+          )])
+        end
       end
 
-      it 'returns the correct message' do
-        expect(subject.errors.full_messages).to eq([I18n.t(
-          'activemodel.errors.models.autocomplete_items.empty_value_cell'
-        )])
+      context 'empty text cell' do
+        let(:path_to_file) do
+          CSV.open(Rails.root.join('tmp', 'missing_text.csv'), 'w') do |csv|
+            csv << %w[Text]
+            csv << []
+            csv << %w[a]
+          end
+          'tmp/missing_text.csv'
+        end
+
+        it 'returns invalid' do
+          expect(subject).to_not be_valid
+        end
+
+        it 'returns the correct message' do
+          expect(subject.errors.full_messages).to eq([I18n.t(
+            'activemodel.errors.models.autocomplete_items.empty_value_cell'
+          )])
+        end
       end
     end
   end

--- a/spec/validators/csv_validator_spec.rb
+++ b/spec/validators/csv_validator_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CsvValidator do
 
       it 'returns the correct message' do
         expect(subject.errors.full_messages).to eq([I18n.t(
-          'activemodel.errors.models.autocomplete_items.incorrect_format'
+          'activemodel.errors.models.autocomplete_items.invalid_headings'
         )])
       end
     end

--- a/spec/validators/csv_validator_spec.rb
+++ b/spec/validators/csv_validator_spec.rb
@@ -88,5 +88,19 @@ RSpec.describe CsvValidator do
         expect(subject).to be_valid
       end
     end
+
+    context 'when file has an empty value cell' do
+      let(:path_to_file) { Rails.root.join('spec', 'fixtures', 'empty_value_cell.csv') }
+
+      it 'returns invalid' do
+        expect(subject).to_not be_valid
+      end
+
+      it 'returns the correct message' do
+        expect(subject.errors.full_messages).to eq([I18n.t(
+          'activemodel.errors.models.autocomplete_items.empty_value_cell'
+        )])
+      end
+    end
   end
 end


### PR DESCRIPTION
See [Trello](https://trello.com/c/Tl4aHGip/2827-autocomplete-do-not-allow-empty-fields-when-there-is-a-value-column) and [Trello](https://trello.com/c/7ySh2qbd/2834-autocomplete-update-error-message-on-csv-upload)

## Do not allow empty fields when there is a Value column in CSV file
Currently when a user add an file with an empty cell in the value
column, we use the corresponding Text column value.
We assume there could be a mistake in the csv file and would prefer to
confirm with the user.
Adding tests, fixture and implementation in the validator.
 
## Renaming file_values to file_rows
 
## Remove conditional Filling the Value property to be the Text property
The validator doesn't allow empty cells anymore and this condition is not required anymore

## Add error when there is an empty 'Text' row
We currently do not have a helpful error message for when a user attempts to upload a CSV with empty Text rows.
For the associated test we have created a csv file rather than add another fixture to the project.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>