### PR TITLE
Update to govuk-frontend 4.3.1 (latest)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: './fb-metadata-presenter'
-gem 'metadata_presenter', '2.17.17'
+gem 'metadata_presenter', '2.17.18'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.17)
+    metadata_presenter (2.17.18)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -428,7 +428,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.17.17)
+  metadata_presenter (= 2.17.18)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/javascript/packs/runner_application.js
+++ b/app/javascript/packs/runner_application.js
@@ -64,4 +64,7 @@ if(autocompleteComponent) {
 
 // Little bit hacky but we want to prevent the
 // Cookie banner from showing in preview mode.
-document.getElementById("govuk-cookie-banner").style.display = "none";
+const cookieBanner = document.getElementById("govuk-cookie-banner");
+if(cookieBanner) {
+  cookieBanner.style.display = "none";
+}

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -698,8 +698,8 @@ function createDialogConfiguration() {
 function workaroundForDefaultText(view) {
   $(".govuk-radios__item, .govuk-checkboxes__item").each(function() {
     var $this = $(this);
-    var $span = $this.find(".govuk-hint");
-    $span.attr("data-" + ATTRIBUTE_DEFAULT_TEXT, view.text.defaults.option_hint);
+    var $hint = $this.find(".govuk-hint");
+    $hint.attr("data-" + ATTRIBUTE_DEFAULT_TEXT, view.text.defaults.option_hint);
   });
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -1002,7 +1002,7 @@ html {
 }
 
 // For when a user is signed in
-.govuk-navigation-header {
+.fb-navigation-header {
   color: govuk-colour("white");
   float: right;
 
@@ -1050,7 +1050,7 @@ html {
   }
 
   .govuk-input:not(.govuk-date-input__input) {
-    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
+    border-color: $govuk-error-colour;
 
     &:focus {
       border-color: $govuk-input-border-colour;
@@ -1058,7 +1058,7 @@ html {
   }
 
   .govuk-date-input__input:not(.govuk-input--error) {
-    border: $govuk-border-width-form-element-error solid $govuk-input-border-colour;
+    border-color: $govuk-error-colour;
 
     &:focus {
       border-color: $govuk-focus-colour;

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -1107,6 +1107,7 @@ html {
 
 .govuk-select {
   background-color: govuk-colour("white");
+  min-width: unset;
 }
 
 .govuk-navigation .govuk-list {

--- a/app/views/api/autocomplete/_show.html.erb
+++ b/app/views/api/autocomplete/_show.html.erb
@@ -19,9 +19,9 @@
 
       <div class="govuk-form-group <%= @items.errors.present? ? 'govuk-form-group--error' : '' %>">
         <% @items.errors.each do |error|  %>
-          <span class="govuk-error-message" id="autocomplete_items_<%=error.attribute%>_error">
+          <p class="govuk-error-message" id="autocomplete_items_<%=error.attribute%>_error">
             <span class="govuk-visually-hidden">Error:</span><%= error.message %>
-          </span>
+          </p>
         <% end %>
 
         <%= form.file_field :file, class: "govuk-file-upload", 'aria-describedby': 'file_hint autocomplete_items_file_error', accept: ".csv" %>

--- a/app/views/api/component_validations/_new.html.erb
+++ b/app/views/api/component_validations/_new.html.erb
@@ -20,9 +20,9 @@
             <div class="govuk-checkboxes__conditional" data-component="Expander" >
               <div class="govuk-form-group <%= @component_validation.errors.present? ? 'govuk-form-group--error' : '' %>">
                 <% @component_validation.errors.each do |error|  %>
-                  <span class="govuk-error-message" id="component_validation_<%=error.attribute%>_error">
+                  <p class="govuk-error-message" id="component_validation_<%=error.attribute%>_error">
                     <span class="govuk-visually-hidden">Error:</span><%= error.message %>
-                  </span>
+                  </p>
                 <% end %>
 
                 <% if @component_validation.respond_to?(:component_partial) %>

--- a/app/views/api/destinations/new.html.erb
+++ b/app/views/api/destinations/new.html.erb
@@ -2,9 +2,9 @@
   <%= form_for @destination, url: api_service_flow_destinations_path(service.service_id, @destination.flow_uuid) do |f| %>
     <div class="govuk-form-group ">
       <%= f.label :destination_uuid, t('dialogs.destination.label'), class: "govuk-label govuk-label--m"  %>
-      <span class="govuk-hint">
+      <div class="govuk-hint">
         <%= t('dialogs.destination.lede', title: @destination.title) %>
-      </span>
+      </div>
       <span><%= t('dialogs.destination.go_to') %></span>
        <div class="govuk-form-group">
         <select class="govuk-select" name="destination_uuid" id="destination_uuid">

--- a/app/views/branches/_error_summary.html.erb
+++ b/app/views/branches/_error_summary.html.erb
@@ -1,5 +1,5 @@
 <% if @branch.any_errors? %>
-  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
       <%= t('activemodel.errors.summary_title') %>
     </h2>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -1,7 +1,7 @@
 <% if @page.errors.present? %>
-  <div class="govuk-grid-column-two-thirds govuk-error-summary">
+  <div class="govuk-grid-column-two-thirds govuk-error-summary" data-module="govuk-error-summary">
     <% @page.errors.each do |error|  %>
-      <span class="govuk-error-message"><%= error.message %></span>
+      <p class="govuk-error-message"><%= error.message %></p>
     <% end %>
   </div>
 <% end %>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -1,33 +1,34 @@
 <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 <header class="govuk-header govuk-header__container" role="banner" data-module="govuk-header">
-  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+  <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 
   <div class="govuk-width-container">
     <a href="/" aria-label="<%= t('header.home_link_text') %>" id="header-logo-link" class="page-header__logo" tabindex="-1" aria-hidden="true">
       <%= image_pack_tag "logo--white.svg", alt: t('header.home_link_alt') %>
     </a>
-    <a href="/" class="govuk-header__link govuk-header__link--service-name" aria-label="<%= t('header.home_link_text') %>">
+
+    <a href="/" class="govuk-header__link govuk-header__service-name" aria-label="<%= t('header.home_link_text') %>">
       <%= t('header.service_name') %>
     </a>
 
     <% if user_signed_in? %>
-      <nav class="govuk-navigation-header" aria-label="Site menu">
-      <ul class="govuk-navigation  govuk-!-font-size-19">
-        <li>
-          <%= link_to t('.forms'), services_path %>
-        </li>
-        <li>
-          <%= link_to t('.user_guide'), t('.user_guide_url'), target: :_blank %>
-        </li>
-        <% if moj_forms_dev? || moj_forms_team? %>
-        <li>
-          <%= link_to t('.admin'), admin_root_path %>
-        </li>
-        <% end %>
-        <li>
-          <%= link_to t('.sign_out', user_name: user_name), user_session_path, method: :delete %>
-        </li>
-      </ul>
+      <nav class="fb-navigation-header" aria-label="Site menu">
+        <ul class="govuk-navigation  govuk-!-font-size-19">
+          <li>
+            <%= link_to t('.forms'), services_path %>
+          </li>
+          <li>
+            <%= link_to t('.user_guide'), t('.user_guide_url'), target: :_blank %>
+          </li>
+          <% if moj_forms_dev? || moj_forms_team? %>
+            <li>
+              <%= link_to t('.admin'), admin_root_path %>
+            </li>
+          <% end %>
+          <li>
+            <%= link_to t('.sign_out', user_name: user_name), user_session_path, method: :delete %>
+          </li>
+        </ul>
       </nav>
     <% end %>
   </div>

--- a/app/views/publish/_form.html.erb
+++ b/app/views/publish/_form.html.erb
@@ -33,7 +33,7 @@
   <div class="govuk-form-group <%= !f.object.errors[:username].empty? ? 'govuk-form-group--error' : '' %>">
 
     <% f.object.errors[:username].each do |message| %>
-      <span class="govuk-error-message"><%= message %></span>
+      <p class="govuk-error-message"><%= message %></p>
     <% end %>
     <%= f.label :username, class: 'govuk-label', for: "username_#{deployment_environment}" %>
     <div class="govuk-hint" id="username_<%= deployment_environment %>_hint"><%= t('activemodel.attributes.publish_service_creation.username_hint') %></div>
@@ -48,7 +48,7 @@
 
   <div class="govuk-form-group <%= !f.object.errors[:password].empty? ? 'govuk-form-group--error' : '' %>">
     <% f.object.errors[:password].each do |message| %>
-      <span class="govuk-error-message"><%= message %></span>
+      <p class="govuk-error-message"><%= message %></p>
     <% end %>
     <%= f.label :password, class: 'govuk-label', for: "password_#{deployment_environment}" %>
     <div class="govuk-hint" id="password_<%= deployment_environment %>_hint"><%= t('activemodel.attributes.publish_service_creation.password_hint') %></div>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -53,9 +53,9 @@
 
     <div class="govuk-form-group <%= !f.object.errors.empty? ? 'govuk-form-group--error' :'' %>">
       <%= f.label :page_url, class: "govuk-label govuk-label--m" %>
-      <span class="govuk-hint" id="add-page-hint"><%= t('activemodel.attributes.page_creation.page_url_hint') %></span>
+      <div class="govuk-hint" id="add-page-hint"><%= t('activemodel.attributes.page_creation.page_url_hint') %></div>
       <% f.object.errors.each do |error|  %>
-        <span class="govuk-error-message"><%= error.message %></span>
+        <p class="govuk-error-message"><%= error.message %></p>
       <% end %>
       <%= f.text_field :page_url, class: "govuk-input", 'aria-describedby': "add-page-hint"  %>
     </div>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -29,7 +29,7 @@
           <div class="govuk-form-group <%= !f.object.errors.empty? ? 'govuk-form-group--error' :'' %>">
             <%= f.label :service_name, class: "govuk-label govuk-label--m" %>
             <% f.object.errors.each do |error|  %>
-              <span class="govuk-error-message"><%= error.message %></span>
+              <p class="govuk-error-message"><%= error.message %></p>
             <% end %>
             <%= f.text_field :service_name, class: "govuk-input" %>
           </div>

--- a/app/views/settings/email/_form.html.erb
+++ b/app/views/settings/email/_form.html.erb
@@ -13,7 +13,7 @@
 
     <div class="govuk-form-group <%= !f.object.errors[:service_email_output].empty? ? 'govuk-form-group--error' : '' %> ">
       <% f.object.errors[:service_email_output].each do |message| %>
-        <span class="govuk-error-message"><%= message %></span>
+        <p class="govuk-error-message"><%= message %></p>
       <% end %>
       <%= f.label :service_email_output, class: "govuk-label", for: "service_email_output_#{deployment_environment}" %>
       <%= f.text_field :service_email_output, class: "govuk-input width-responsive-two-thirds", id: "service_email_output_#{deployment_environment}" %>
@@ -28,7 +28,7 @@
       <%= f.label :service_email_body, class: "govuk-label", for: "service_email_body_#{deployment_environment}" do %>
         <%= f.object.class.human_attribute_name :service_email_body %>
       <% end %>
-      <span class="govuk-hint" id="service_email_body_hint_<%= deployment_environment%>"><%= f.object.class.human_attribute_name :service_email_body_hint %></span>
+      <div class="govuk-hint" id="service_email_body_hint_<%= deployment_environment%>"><%= f.object.class.human_attribute_name :service_email_body_hint %></div>
       <%= f.text_area :service_email_body,
         class: "govuk-textarea width-responsive-two-thirds", 
         rows: '5',

--- a/app/views/settings/form_analytics/index.html.erb
+++ b/app/views/settings/form_analytics/index.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <% if @form_analytics.errors.present? %>
-    <div class="govuk-grid-column-two-thirds  govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+    <div class="govuk-grid-column-two-thirds govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
       <h2 class="govuk-error-summary__title" id="error-summary-title">
         <%= t('activemodel.errors.summary_title') %>
       </h2>

--- a/app/views/settings/form_information/index.html.erb
+++ b/app/views/settings/form_information/index.html.erb
@@ -7,11 +7,11 @@
     <%# end %>
     <p>
       <%= f.object.class.human_attribute_name :service_name %>
-      <span class="govuk-hint" id="<%= "#{:service_name}-hint" %>"><%= t('settings.form_information.form_name.hint') %></span>
+      <div class="govuk-hint" id="<%= "#{:service_name}-hint" %>"><%= t('settings.form_information.form_name.hint') %></div>
       <span class="width-responsive-two-thirds"><%= @settings.service_name %></span>
       </p>
     <% f.object.errors.each do |error|  %>
-      <span class="govuk-error-message"><%= error.message %></span>
+      <p class="govuk-error-message"><%= error.message %></p>
     <% end %>
     <%#= f.text_field :service_name, class: "govuk-input width-responsive-two-thirds", aria: { describedby: "#{:service_name}-hint #{:service_name}-warning" } %>
     <%= render partial: 'partials/template_warning', locals: { id: "#{:service_name}-warning", message: t('settings.form_information.form_name.warning_message').html_safe } %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -4,17 +4,17 @@
     <li>
       <%= link_to t('settings.form_information.name'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %>
       <br />
-      <span class="govuk-hint" style= "display:block"><%= t('settings.form_information.description') %></span>
+      <div class="govuk-hint" style= "display:block"><%= t('settings.form_information.description') %></div>
     </li>
     <li>
       <%= link_to t('settings.form_analytics.name'), settings_form_analytics_path(service.service_id), class: 'govuk-link' %>
       <br />
-      <span class="govuk-hint" style= "display:block"><%= t('settings.form_analytics.hint') %></span>
+      <div class="govuk-hint" style= "display:block"><%= t('settings.form_analytics.hint') %></div>
     </li>
     <li>
       <%= link_to t('settings.submission.name'), settings_submission_index_path(service.service_id), class: 'govuk-link' %>
       <br />
-      <span class="govuk-hint" style= "display:block"><%= t('settings.submission.hint') %></span>
+      <div class="govuk-hint" style= "display:block"><%= t('settings.submission.hint') %></div>
     </li>
   </ul>
 </nav>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@rails/ujs": "^7.0.3",
     "@rails/webpacker": "^5.4.3",
     "accessible-autocomplete": "^2.0.4",
-    "govuk-frontend": "^3.14.0",
+    "govuk-frontend": "4.3.1",
     "jquery": "^3.6.0",
     "jquery-ui-dist": "^1.13.1",
     "resolve-url-loader": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3189,10 +3189,10 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-govuk-frontend@^3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.14.0.tgz#d3a9c54437c08f5188f87b1f4480ba60e95c8eb6"
-  integrity sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==
+govuk-frontend@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.3.1.tgz#d9c581aca3d23bbfe9bd27c25fee65322b276393"
+  integrity sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.10"


### PR DESCRIPTION
Changes required to update to the latest version of govuk-frontend (4.3.1)
changes mostly consist of
* changing `.govuk-hint` elements from `<span>` to `<div>`
* changing `.govuk-error-message` elements from `<span>` to `<p>`