### PR TITLE
2839 refactor FlowConnectorPath

### DIFF
--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -54,7 +54,12 @@ class FlowConnectorPath {
     var conf = utilities.mergeObjects({
                  container: $(),
                  top: 0,
-                 bottom: 0 // Nonsense number as should be set by calculating height of container and passing in.
+                 bottom: 0, // Nonsense number as should be set by calculating height of container and passing in.
+                 dimensions: {
+                    // Base class does not expect to set any values for these.
+                    original: {},
+                    lines: []
+                  }
                }, config);
 
     // Public
@@ -66,12 +71,6 @@ class FlowConnectorPath {
 
     this.from = conf.from;
     this.to = conf.to;
-
-    // Base class does not expect to set any values for these.
-    this._dimensions = {
-                         original: {},
-                         lines: []
-                       }
 
     // Private
     this.#config = conf;
@@ -111,7 +110,7 @@ class FlowConnectorPath {
 
   // Return all FlowConnectorLines or just those matching the passed type.
   lines(type="") {
-    var lineArr = this._dimensions.lines;
+    var lineArr = this.#config.dimensions.lines;
     var filtered = [];
 
     for(var i=0; i<lineArr.length; ++i) {
@@ -171,8 +170,8 @@ class FlowConnectorPath {
     // DEVELOPMENT ONLY FUNCTION
     // When debugging problems with creates Lines (used in comparison for overlapping FlowConnectorPaths),
     // this funciton can be called to make things visible and, therefore, a bit easier. See this.build().
-    for(var i=0; i<this._dimensions.lines.length; ++i) {
-      this.#config.container.append(this._dimensions.lines[i].testOnlySvg());
+    for(var i=0; i<this.#config.dimensions.lines.length; ++i) {
+      this.#config.container.append(this.#config.dimensions.lines[i].testOnlySvg());
     }
   }
 

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -77,6 +77,12 @@ class FlowConnectorPath {
     this._path = "";
   }
 
+  // Because JS doesn't allow inheritance of private variables,
+  // we're providing a Getter and setting privately in subclass.
+  get config() {
+    return this.#config;
+  }
+
   path() {
     return this._path;
   }
@@ -250,13 +256,18 @@ FlowConnectorPath.compareLines = function(path, comparisonPath, direction) {
 
 
 class ForwardPath extends FlowConnectorPath {
+
+  #config;
+
   constructor(points, config) {
     super(points, config);
     var dimensions = {
       forward: Math.round(this.points.xDifference)
     }
 
-    this._dimensions = { original: dimensions  } // Not expected to change.
+    this.#config = this.config; // Initialise private inheritance.
+
+    this.#config.dimensions = { original: dimensions  } // Not expected to change.
     this.type = "ForwardPath";
     this.path(dimensions);
     this.build();
@@ -275,8 +286,8 @@ class ForwardPath extends FlowConnectorPath {
                       overlapAllowed: true
                     });
 
-      this._dimensions.current = dimensions;
-      this._dimensions.lines = [ forward ];
+      this.#config.dimensions.current = dimensions;
+      this.#config.dimensions.lines = [ forward ];
 
       this._path = pathD(
                      xy(this.points.from_x, this.points.from_y),

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -48,6 +48,7 @@ const LINE_PIXEL_TOLERANCE = 2; // Arbitrary number just for some pixel toleranc
 class FlowConnectorPath {
 
   #config;
+  #path;
 
   constructor(points, config) {
     var id = config.id || utilities.uniqueString("flowconnectorpath-");
@@ -74,7 +75,7 @@ class FlowConnectorPath {
 
     // Private
     this.#config = conf;
-    this._path = "";
+    this.#path = "";
   }
 
   // Because JS doesn't allow inheritance of private variables,
@@ -84,13 +85,13 @@ class FlowConnectorPath {
   }
 
   path() {
-    return this._path;
+    return this.#path;
   }
 
   build() {
     var flowConnectorPath = this;
 
-    this.$node = createSvg(createPath(this._path) + createArrowPath(this.points));
+    this.$node = createSvg(createPath(this.#path) + createArrowPath(this.points));
     this.$node.addClass("FlowConnectorPath")
               .addClass(this.type)
               .attr("id", this.id)
@@ -258,6 +259,7 @@ FlowConnectorPath.compareLines = function(path, comparisonPath, direction) {
 class ForwardPath extends FlowConnectorPath {
 
   #config;
+  #path;
 
   constructor(points, config) {
     super(points, config);
@@ -265,7 +267,9 @@ class ForwardPath extends FlowConnectorPath {
       forward: Math.round(this.points.xDifference)
     }
 
-    this.#config = this.config; // Initialise private inheritance.
+    // Initialise private inheritance.
+    this.#config = this.config;
+    this.#path = this.path;
 
     this.#config.dimensions = { original: dimensions  } // Not expected to change.
     this.type = "ForwardPath";
@@ -289,13 +293,13 @@ class ForwardPath extends FlowConnectorPath {
       this.#config.dimensions.current = dimensions;
       this.#config.dimensions.lines = [ forward ];
 
-      this._path = pathD(
+      this.#path = pathD(
                      xy(this.points.from_x, this.points.from_y),
                      forward.path
                    );
     }
 
-    return this._path;
+    return this.#path;
   }
 
   // Since this arrow simply goes from point A to B, which is expected to
@@ -307,6 +311,7 @@ class ForwardPath extends FlowConnectorPath {
 class ForwardUpForwardPath extends FlowConnectorPath {
 
   #config;
+  #path;
 
   constructor(points, config) {
     super(points, config);
@@ -316,7 +321,9 @@ class ForwardUpForwardPath extends FlowConnectorPath {
       forward2: Math.round(utilities.difference((this.points.from_x + this.points.via_x), this.points.to_x) - (CURVE_SPACING * 2))
     }
 
-    this.#config = this.config; // Initialise private inheritance.
+    this.#config = this.config;
+    this.#path = this.path;
+
     this.#config.dimensions = { original: dimensions }; // dimensions.current will be added in set path()
     this.type = "ForwardUpForwardPath";
     this.path(dimensions);
@@ -359,7 +366,7 @@ class ForwardUpForwardPath extends FlowConnectorPath {
       this.#config.dimensions.current = dimensions;
       this.#config.dimensions.lines = [ forward1, up, forward2 ];
 
-      this._path = pathD(
+      this.#path = pathD(
                      xy(this.points.from_x, this.points.from_y),
                      forward1.path,
                      CURVE_RIGHT_UP,
@@ -369,7 +376,7 @@ class ForwardUpForwardPath extends FlowConnectorPath {
                    );
     }
 
-    return this._path;
+    return this.#path;
   }
 
   nudge(linename) {
@@ -388,7 +395,7 @@ class ForwardUpForwardPath extends FlowConnectorPath {
     }
 
     this.path(d);
-    this.$node.find("path:first").attr("d", this._path);
+    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 }
@@ -397,6 +404,7 @@ class ForwardUpForwardPath extends FlowConnectorPath {
 class ForwardUpForwardDownPath extends FlowConnectorPath {
 
   #config;
+  #path;
 
   constructor(points, config) {
     super(points, config);
@@ -409,6 +417,8 @@ class ForwardUpForwardDownPath extends FlowConnectorPath {
     }
 
     this.#config = this.config;
+    this.#path = this.path;
+
     this.#config.dimensions = { original: dimensions };
     this.type = "ForwardUpForwardDownPath";
     this.path(dimensions);
@@ -467,7 +477,7 @@ class ForwardUpForwardDownPath extends FlowConnectorPath {
       this.#config.dimensions.current = dimensions;
       this.#config.dimensions.lines = [ forward1, up, forward2, down, forward3 ];
 
-      this._path = pathD(
+      this.#path = pathD(
                      xy(this.points.from_x, this.points.from_y),
                      forward1.path,
                      CURVE_RIGHT_UP,
@@ -481,7 +491,7 @@ class ForwardUpForwardDownPath extends FlowConnectorPath {
                    );
     }
 
-    return this._path;
+    return this.#path;
   }
 
   nudge(linename) {
@@ -512,7 +522,7 @@ class ForwardUpForwardDownPath extends FlowConnectorPath {
     }
 
     this.path(d);
-    this.$node.find("path:first").attr("d", this._path);
+    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 }
@@ -521,6 +531,7 @@ class ForwardUpForwardDownPath extends FlowConnectorPath {
 class ForwardDownBackwardUpPath extends FlowConnectorPath {
 
   #config;
+  #path;
 
   constructor(points, config) {
     super(points, config);
@@ -533,6 +544,8 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
     }
 
     this.#config = this.config;
+    this.#path = this.path;
+
     this.#config.dimensions = { original: dimensions };
     this.type = "ForwardDownBackwardUpPath";
     this.path(dimensions);
@@ -592,7 +605,7 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
       this.#config.dimensions.current = dimensions;
       this.#config.dimensions.lines = [ forward1, down, backward, up, forward2 ];
 
-      this._path = pathD(
+      this.#path = pathD(
                      xy(this.points.from_x, this.points.from_y),
                      forward1.path,
                      CURVE_RIGHT_DOWN,
@@ -605,7 +618,7 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
                      forward2.path);
     }
 
-    return this._path;
+    return this.#path;
   }
 
   nudge(linename) {
@@ -634,7 +647,7 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
     }
 
     this.path(d);
-    this.$node.find("path:first").attr("d", this._path);
+    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 }
@@ -642,6 +655,7 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
 class ForwardDownForwardPath extends FlowConnectorPath {
 
   #config;
+  #path;
 
   constructor(points, config) {
     super(points, config);
@@ -652,6 +666,8 @@ class ForwardDownForwardPath extends FlowConnectorPath {
     }
 
     this.#config = this.config;
+    this.#path = this.path;
+
     this.#config.dimensions = { original: dimensions };
     this.type = "ForwardDownForwardPath";
     this.path(dimensions);
@@ -693,7 +709,7 @@ class ForwardDownForwardPath extends FlowConnectorPath {
       this.#config.dimensions.current = dimensions;
       this.#config.dimensions.lines = [ forward1, down, forward2 ];
 
-      this._path = pathD(
+      this.#path = pathD(
                      xy(this.points.from_x, this.points.from_y),
                      forward1.path,
                      CURVE_RIGHT_DOWN,
@@ -702,7 +718,7 @@ class ForwardDownForwardPath extends FlowConnectorPath {
                      forward2.path);
     }
 
-    return this._path;
+    return this.#path;
   }
 
   nudge(linename) {
@@ -721,7 +737,7 @@ class ForwardDownForwardPath extends FlowConnectorPath {
     }
 
     this.path(d);
-    this.$node.find("path:first").attr("d", this._path);
+    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 }
@@ -729,6 +745,7 @@ class ForwardDownForwardPath extends FlowConnectorPath {
 class DownForwardDownBackwardUpPath extends FlowConnectorPath {
 
   #config;
+  #path;
 
   constructor(points, config) {
     super(points, config);
@@ -742,6 +759,8 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
     }
 
     this.#config = this.config;
+    this.#path = this.path;
+
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardDownBackwardUpPath";
     this.path(dimensions);
@@ -811,7 +830,7 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
       this.#config.dimensions.current = dimensions;
       this.#config.dimensions.lines = [ down1, forward1, down2, backward, up, forward2 ];
 
-      this._path = pathD(
+      this.#path = pathD(
                      xy(this.points.from_x, this.points.from_y),
                      down1.path,
                      CURVE_DOWN_RIGHT,
@@ -827,7 +846,7 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
                    );
     }
 
-    return this._path;
+    return this.#path;
   }
 
   nudge(linename) {
@@ -858,7 +877,7 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
     }
 
     this.path(d);
-    this.$node.find("path:first").attr("d", this._path);
+    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 }
@@ -867,6 +886,7 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
 class DownForwardUpPath extends FlowConnectorPath {
 
   #config;
+  #path;
 
   constructor(points, config) {
     super(points, config);
@@ -878,6 +898,8 @@ class DownForwardUpPath extends FlowConnectorPath {
     }
 
     this.#config = this.config;
+    this.#path = this.path;
+
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardUpPath";
     this.path(dimensions);
@@ -929,7 +951,7 @@ class DownForwardUpPath extends FlowConnectorPath {
       this.#config.dimensions.current = dimensions;
       this.#config.dimensions.lines = [ down, forward1, up, forward2 ];
 
-      this._path = pathD(
+      this.#path = pathD(
                      xy(this.points.from_x, this.points.from_y),
                      down.path,
                      CURVE_DOWN_RIGHT,
@@ -941,7 +963,7 @@ class DownForwardUpPath extends FlowConnectorPath {
                    );
     }
 
-    return this._path;
+    return this.#path;
   }
 
   nudge(linename) {
@@ -961,7 +983,7 @@ class DownForwardUpPath extends FlowConnectorPath {
     }
 
     this.path(d);
-    this.$node.find("path:first").attr("d", this._path);
+    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 }
@@ -970,6 +992,7 @@ class DownForwardUpPath extends FlowConnectorPath {
 class DownForwardUpForwardDownPath extends FlowConnectorPath {
 
   #config;
+  #path;
 
   constructor(points, config) {
     super(points, config);
@@ -983,6 +1006,8 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
     }
 
     this.#config = this.config;
+    this.#path = this.path;
+
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardUpForwardDownPath";
     this.path(dimensions);
@@ -1053,7 +1078,7 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
       this.#config.dimensions.current = dimensions;
       this.#config.dimensions.lines = [ down1, forward1, up, forward2, down2, forward3 ];
 
-      this._path = pathD(
+      this.#path = pathD(
                      xy(this.points.from_x, this.points.from_y),
                      down1.path,
                      CURVE_DOWN_RIGHT,
@@ -1069,7 +1094,7 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
                    );
     }
 
-    return this._path;
+    return this.#path;
   }
 
   nudge(linename) {
@@ -1100,7 +1125,7 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
     }
 
     this.path(d);
-    this.$node.find("path:first").attr("d", this._path);
+    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 }
@@ -1109,6 +1134,7 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
 class DownForwardDownForwardPath extends FlowConnectorPath {
 
   #config;
+  #path;
 
   constructor(points, config) {
     super(points, config);
@@ -1120,6 +1146,8 @@ class DownForwardDownForwardPath extends FlowConnectorPath {
     }
 
     this.#config = this.config;
+    this.#path = this.path;
+
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardDownForwardPath";
     this.path(dimensions);
@@ -1172,7 +1200,7 @@ class DownForwardDownForwardPath extends FlowConnectorPath {
       this.#config.dimensions.current = dimensions;
       this.#config.dimensions.lines = [ down1, forward1, down2, forward2 ];
 
-      this._path = pathD(
+      this.#path = pathD(
                      xy(this.points.from_x, this.points.from_y),
                      down1.path,
                      CURVE_DOWN_RIGHT,
@@ -1184,7 +1212,7 @@ class DownForwardDownForwardPath extends FlowConnectorPath {
                    );
     }
 
-    return this._path;
+    return this.#path;
   }
 
   nudge(linename) {
@@ -1204,7 +1232,7 @@ class DownForwardDownForwardPath extends FlowConnectorPath {
     }
 
     this.path(d);
-    this.$node.find("path:first").attr("d", this._path);
+    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 }
@@ -1213,6 +1241,7 @@ class DownForwardDownForwardPath extends FlowConnectorPath {
 class DownForwardPath extends FlowConnectorPath {
 
   #config;
+  #path;
 
   constructor(points, config) {
     super(points, config);
@@ -1222,6 +1251,8 @@ class DownForwardPath extends FlowConnectorPath {
     }
 
     this.#config = this.config;
+    this.#path = this.path;
+
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardPath";
     this.path(dimensions);
@@ -1255,7 +1286,7 @@ class DownForwardPath extends FlowConnectorPath {
       this.#config.dimensions.current = dimensions;
       this.#config.dimensions.lines = [ down, forward ];
 
-      this._path = pathD(
+      this.#path = pathD(
                      xy(this.points.from_x, this.points.from_y),
                      down.path,
                      CURVE_DOWN_RIGHT,
@@ -1263,7 +1294,7 @@ class DownForwardPath extends FlowConnectorPath {
                    );
     }
 
-    return this._path;
+    return this.#path;
   }
 
   // Since this arrow simply goes from Branch, via Condition A to point B, which is expected

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -46,6 +46,9 @@ const LINE_PIXEL_TOLERANCE = 2; // Arbitrary number just for some pixel toleranc
  *                  }
  **/
 class FlowConnectorPath {
+
+  #config;
+
   constructor(points, config) {
     var id = config.id || utilities.uniqueString("flowconnectorpath-");
     var conf = utilities.mergeObjects({
@@ -71,7 +74,7 @@ class FlowConnectorPath {
                        }
 
     // Private
-    this._config = conf;
+    this.#config = conf;
     this._path = "";
   }
 
@@ -86,11 +89,11 @@ class FlowConnectorPath {
     this.$node.addClass("FlowConnectorPath")
               .addClass(this.type)
               .attr("id", this.id)
-              .attr("data-from", this._config.from.id)
-              .attr("data-to", this._config.to.id)
+              .attr("data-from", this.#config.from.id)
+              .attr("data-to", this.#config.to.id)
               .data("instance", this);
 
-    this._config.container.append(this.$node);
+    this.#config.container.append(this.$node);
 
     this.$node.find("path").on("mouseover", function() {
       $(document).trigger("FlowConnectorPathOver", flowConnectorPath);
@@ -169,7 +172,7 @@ class FlowConnectorPath {
     // When debugging problems with creates Lines (used in comparison for overlapping FlowConnectorPaths),
     // this funciton can be called to make things visible and, therefore, a bit easier. See this.build().
     for(var i=0; i<this._dimensions.lines.length; ++i) {
-      this._config.container.append(this._dimensions.lines[i].testOnlySvg());
+      this.#config.container.append(this._dimensions.lines[i].testOnlySvg());
     }
   }
 
@@ -382,9 +385,9 @@ class ForwardUpForwardDownPath extends FlowConnectorPath {
     super(points, config);
     var dimensions = {
       forward1: Math.round(this.points.via_x - CURVE_SPACING),
-      up: Math.round(utilities.difference(this.points.from_y, this._config.top)),
+      up: Math.round(utilities.difference(this.points.from_y, config.top)),
       forward2: Math.round(this.points.xDifference - (this.points.via_x + (CURVE_SPACING * 4))),
-      down: Math.round(utilities.difference(this._config.top, this.points.to_y)),
+      down: Math.round(utilities.difference(config.top, this.points.to_y)),
       forward3: 0 // Expected start value
     }
 
@@ -502,9 +505,9 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
     super(points, config);
     var dimensions = {
       forward1: Math.round(this.points.via_x - CURVE_SPACING),
-      down: Math.round(utilities.difference(this.points.from_y, this._config.bottom) - (CURVE_SPACING * 2)),
+      down: Math.round(utilities.difference(this.points.from_y, config.bottom) - (CURVE_SPACING * 2)),
       backward: Math.round(utilities.difference(this.points.from_x + this.points.via_x, this.points.to_x)),
-      up: Math.round(utilities.difference(this._config.bottom, this.points.from_y) + utilities.difference(this.points.from_y, this.points.to_y) - (CURVE_SPACING * 2)),
+      up: Math.round(utilities.difference(config.bottom, this.points.from_y) + utilities.difference(this.points.from_y, this.points.to_y) - (CURVE_SPACING * 2)),
       forward2: 0
     }
 
@@ -936,7 +939,7 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
     var dimensions = {
       down1: Math.round(utilities.difference(points.from_y, this.points.via_y) - CURVE_SPACING),
       forward1: Math.round(points.via_x - (CURVE_SPACING * 2)),
-      up: Math.round(utilities.difference(this.points.via_y, this._config.top)),
+      up: Math.round(utilities.difference(this.points.via_y, config.top)),
       forward2: Math.round(utilities.difference(points.from_x + this.points.via_x, this.points.to_x) - (CURVE_SPACING * 4)),
       down2: Math.round(points.to_y),
       forward3: 0 // start value

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -161,8 +161,8 @@ class FlowConnectorPath {
     //
     //   nudge(nH, nV) {
     //     var dimensions = {
-    //       horizontal: this._dimensions.current.horizontal - (nH * NUDGE_SPACING),
-    //       vertical: this._dimensions.current.vertical - (nV * NUDGE_SPACING)
+    //       horizontal: this.#config.dimensions.current.horizontal - (nH * NUDGE_SPACING),
+    //       vertical: this.#config.dimensions.current.vertical - (nV * NUDGE_SPACING)
     //     }
     //
     //     this.path = dimensions;
@@ -305,6 +305,9 @@ class ForwardPath extends FlowConnectorPath {
 
 
 class ForwardUpForwardPath extends FlowConnectorPath {
+
+  #config;
+
   constructor(points, config) {
     super(points, config);
     var dimensions = {
@@ -313,7 +316,8 @@ class ForwardUpForwardPath extends FlowConnectorPath {
       forward2: Math.round(utilities.difference((this.points.from_x + this.points.via_x), this.points.to_x) - (CURVE_SPACING * 2))
     }
 
-    this._dimensions = { original: dimensions }; // dimensions.current will be added in set path()
+    this.#config = this.config; // Initialise private inheritance.
+    this.#config.dimensions = { original: dimensions }; // dimensions.current will be added in set path()
     this.type = "ForwardUpForwardPath";
     this.path(dimensions);
     this.build();
@@ -352,8 +356,8 @@ class ForwardUpForwardPath extends FlowConnectorPath {
                       overlapAllowed: true
                     });
 
-      this._dimensions.current = dimensions;
-      this._dimensions.lines = [ forward1, up, forward2 ];
+      this.#config.dimensions.current = dimensions;
+      this.#config.dimensions.lines = [ forward1, up, forward2 ];
 
       this._path = pathD(
                      xy(this.points.from_x, this.points.from_y),
@@ -369,7 +373,7 @@ class ForwardUpForwardPath extends FlowConnectorPath {
   }
 
   nudge(linename) {
-    var d = this._dimensions.current;
+    var d = this.#config.dimensions.current;
     var nudged = false;
     switch(linename) {
       case "up":
@@ -391,6 +395,9 @@ class ForwardUpForwardPath extends FlowConnectorPath {
 
 
 class ForwardUpForwardDownPath extends FlowConnectorPath {
+
+  #config;
+
   constructor(points, config) {
     super(points, config);
     var dimensions = {
@@ -401,7 +408,8 @@ class ForwardUpForwardDownPath extends FlowConnectorPath {
       forward3: 0 // Expected start value
     }
 
-    this._dimensions = { original: dimensions };
+    this.#config = this.config;
+    this.#config.dimensions = { original: dimensions };
     this.type = "ForwardUpForwardDownPath";
     this.path(dimensions);
     this.build();
@@ -456,8 +464,8 @@ class ForwardUpForwardDownPath extends FlowConnectorPath {
                        prefix: "h"
                      });
 
-      this._dimensions.current = dimensions;
-      this._dimensions.lines = [ forward1, up, forward2, down, forward3 ];
+      this.#config.dimensions.current = dimensions;
+      this.#config.dimensions.lines = [ forward1, up, forward2, down, forward3 ];
 
       this._path = pathD(
                      xy(this.points.from_x, this.points.from_y),
@@ -477,7 +485,7 @@ class ForwardUpForwardDownPath extends FlowConnectorPath {
   }
 
   nudge(linename) {
-    var d = this._dimensions.current;
+    var d = this.#config.dimensions.current;
     var nudged = false;
     switch(linename) {
       case "forward2":
@@ -511,6 +519,9 @@ class ForwardUpForwardDownPath extends FlowConnectorPath {
 
 
 class ForwardDownBackwardUpPath extends FlowConnectorPath {
+
+  #config;
+
   constructor(points, config) {
     super(points, config);
     var dimensions = {
@@ -521,7 +532,8 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
       forward2: 0
     }
 
-    this._dimensions = { original: dimensions };
+    this.#config = this.config;
+    this.#config.dimensions = { original: dimensions };
     this.type = "ForwardDownBackwardUpPath";
     this.path(dimensions);
     this.build();
@@ -577,8 +589,8 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
                        prefix: "h"
                      });
 
-      this._dimensions.current = dimensions;
-      this._dimensions.lines = [ forward1, down, backward, up, forward2 ];
+      this.#config.dimensions.current = dimensions;
+      this.#config.dimensions.lines = [ forward1, down, backward, up, forward2 ];
 
       this._path = pathD(
                      xy(this.points.from_x, this.points.from_y),
@@ -597,7 +609,7 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
   }
 
   nudge(linename) {
-    var d = this._dimensions.current;
+    var d = this.#config.dimensions.current;
     var nudged = false;
     switch(linename) {
       case "down":
@@ -628,6 +640,9 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
 }
 
 class ForwardDownForwardPath extends FlowConnectorPath {
+
+  #config;
+
   constructor(points, config) {
     super(points, config);
     var dimensions = {
@@ -636,7 +651,8 @@ class ForwardDownForwardPath extends FlowConnectorPath {
       forward2: Math.round( utilities.difference( this.points.from_x + this.points.via_x, this.points.to_x ) - (CURVE_SPACING * 2)),
     }
 
-    this._dimensions = { original: dimensions };
+    this.#config = this.config;
+    this.#config.dimensions = { original: dimensions };
     this.type = "ForwardDownForwardPath";
     this.path(dimensions);
     this.build();
@@ -674,8 +690,8 @@ class ForwardDownForwardPath extends FlowConnectorPath {
                        prefix: "h"
                      });
 
-      this._dimensions.current = dimensions;
-      this._dimensions.lines = [ forward1, down, forward2 ];
+      this.#config.dimensions.current = dimensions;
+      this.#config.dimensions.lines = [ forward1, down, forward2 ];
 
       this._path = pathD(
                      xy(this.points.from_x, this.points.from_y),
@@ -690,7 +706,7 @@ class ForwardDownForwardPath extends FlowConnectorPath {
   }
 
   nudge(linename) {
-    var d = this._dimensions.current;
+    var d = this.#config.dimensions.current;
     var nudged = false;
     switch(linename) {
       case "down":
@@ -711,6 +727,9 @@ class ForwardDownForwardPath extends FlowConnectorPath {
 }
 
 class DownForwardDownBackwardUpPath extends FlowConnectorPath {
+
+  #config;
+
   constructor(points, config) {
     super(points, config);
     var dimensions = {
@@ -722,7 +741,8 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
       forward2: 0
     }
 
-    this._dimensions = { original: dimensions };
+    this.#config = this.config;
+    this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardDownBackwardUpPath";
     this.path(dimensions);
     this.build();
@@ -788,8 +808,8 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
                        prefix: "h"
                      });
 
-      this._dimensions.current = dimensions;
-      this._dimensions.lines = [ down1, forward1, down2, backward, up, forward2 ];
+      this.#config.dimensions.current = dimensions;
+      this.#config.dimensions.lines = [ down1, forward1, down2, backward, up, forward2 ];
 
       this._path = pathD(
                      xy(this.points.from_x, this.points.from_y),
@@ -811,7 +831,7 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
   }
 
   nudge(linename) {
-    var d = this._dimensions.current;
+    var d = this.#config.dimensions.current;
     var nudged = false;
     switch(linename) {
       case "down2":
@@ -845,6 +865,9 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
 
 
 class DownForwardUpPath extends FlowConnectorPath {
+
+  #config;
+
   constructor(points, config) {
     super(points, config);
     var dimensions = {
@@ -854,7 +877,8 @@ class DownForwardUpPath extends FlowConnectorPath {
       forward2: Math.round(utilities.difference(points.from_x, points.to_x) - (points.via_x + CURVE_SPACING))
     }
 
-    this._dimensions = { original: dimensions };
+    this.#config = this.config;
+    this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardUpPath";
     this.path(dimensions);
     this.build();
@@ -902,8 +926,8 @@ class DownForwardUpPath extends FlowConnectorPath {
                        prefix: "h"
                      });
 
-      this._dimensions.current = dimensions;
-      this._dimensions.lines = [ down, forward1, up, forward2 ];
+      this.#config.dimensions.current = dimensions;
+      this.#config.dimensions.lines = [ down, forward1, up, forward2 ];
 
       this._path = pathD(
                      xy(this.points.from_x, this.points.from_y),
@@ -921,7 +945,7 @@ class DownForwardUpPath extends FlowConnectorPath {
   }
 
   nudge(linename) {
-    var d = this._dimensions.current;
+    var d = this.#config.dimensions.current;
     var nudged = false;
     switch(linename) {
       case "up":
@@ -944,6 +968,9 @@ class DownForwardUpPath extends FlowConnectorPath {
 
 
 class DownForwardUpForwardDownPath extends FlowConnectorPath {
+
+  #config;
+
   constructor(points, config) {
     super(points, config);
     var dimensions = {
@@ -955,7 +982,8 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
       forward3: 0 // start value
     }
 
-    this._dimensions = { original: dimensions };
+    this.#config = this.config;
+    this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardUpForwardDownPath";
     this.path(dimensions);
     this.build();
@@ -1022,8 +1050,8 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
                        overlapAllowed: true
                      });
 
-      this._dimensions.current = dimensions;
-      this._dimensions.lines = [ down1, forward1, up, forward2, down2, forward3 ];
+      this.#config.dimensions.current = dimensions;
+      this.#config.dimensions.lines = [ down1, forward1, up, forward2, down2, forward3 ];
 
       this._path = pathD(
                      xy(this.points.from_x, this.points.from_y),
@@ -1045,7 +1073,7 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
   }
 
   nudge(linename) {
-    var d = this._dimensions.current;
+    var d = this.#config.dimensions.current;
     var nudged = false;
     switch(linename) {
       case "up":
@@ -1079,6 +1107,9 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
 
 
 class DownForwardDownForwardPath extends FlowConnectorPath {
+
+  #config;
+
   constructor(points, config) {
     super(points, config);
     var dimensions = {
@@ -1088,7 +1119,8 @@ class DownForwardDownForwardPath extends FlowConnectorPath {
       forward2: Math.round(utilities.difference(points.from_x + this.points.via_x, this.points.to_x) - (CURVE_SPACING * 2))
     }
 
-    this._dimensions = { original: dimensions };
+    this.#config = this.config;
+    this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardDownForwardPath";
     this.path(dimensions);
     this.build();
@@ -1137,8 +1169,8 @@ class DownForwardDownForwardPath extends FlowConnectorPath {
                        overlapAllowed: true
                      });
 
-      this._dimensions.current = dimensions;
-      this._dimensions.lines = [ down1, forward1, down2, forward2 ];
+      this.#config.dimensions.current = dimensions;
+      this.#config.dimensions.lines = [ down1, forward1, down2, forward2 ];
 
       this._path = pathD(
                      xy(this.points.from_x, this.points.from_y),
@@ -1156,7 +1188,7 @@ class DownForwardDownForwardPath extends FlowConnectorPath {
   }
 
   nudge(linename) {
-    var d = this._dimensions.current;
+    var d = this.#config.dimensions.current;
     var nudged = false;
     switch(linename) {
       case "down2":
@@ -1179,6 +1211,9 @@ class DownForwardDownForwardPath extends FlowConnectorPath {
 
 
 class DownForwardPath extends FlowConnectorPath {
+
+  #config;
+
   constructor(points, config) {
     super(points, config);
     var dimensions = {
@@ -1186,7 +1221,8 @@ class DownForwardPath extends FlowConnectorPath {
       forward: Math.round(this.points.xDifference - CURVE_SPACING)
     }
 
-    this._dimensions = { original: dimensions };
+    this.#config = this.config;
+    this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardPath";
     this.path(dimensions);
     this.build();
@@ -1216,8 +1252,8 @@ class DownForwardPath extends FlowConnectorPath {
                       overlapAllowed: true
                     });
 
-      this._dimensions.current = dimensions;
-      this._dimensions.lines = [ down, forward ];
+      this.#config.dimensions.current = dimensions;
+      this.#config.dimensions.lines = [ down, forward ];
 
       this._path = pathD(
                      xy(this.points.from_x, this.points.from_y),

--- a/test/dialogs/dialog_form/callbacks_test.js
+++ b/test/dialogs/dialog_form/callbacks_test.js
@@ -125,14 +125,14 @@ describe("DialogForm", function() {
     it('should call onLoad', function() {
       var onLoadCallback = sinon.spy();
       
-      console.log(server)
+      //console.log(server)
 
       created = helpers.createRemoteDialog(COMPONENT_ID, server, {
         onLoad: onLoadCallback,
       });
 
 
-      console.log(server)
+      //console.log(server)
 
       expect(onLoadCallback).to.have.been.called
       expect(onLoadCallback).to.have.been.calledWith(created.dialog);

--- a/test/flow_connector_path/down_forward_down_backward_up_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_down_backward_up_path/methods_test.js
@@ -104,7 +104,7 @@ describe("DownForwardDownBackwardUpPath", function() {
     });
 
     it("should add the $node to $container", function() {
-      expect(created.connector.$node.parent().get(0)).to.equal(created.connector._config.container.get(0));
+      expect(created.connector.$node.parent().get(0)).to.equal(created.config.container.get(0));
     });
 
     /* TEST METHOD: lines()

--- a/test/flow_connector_path/down_forward_down_backward_up_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_down_backward_up_path/methods_test.js
@@ -44,7 +44,7 @@ describe("DownForwardDownBackwardUpPath", function() {
     });
 
     it("should update (set) the path value when receiving new dimensions", function() {
-      var original = created.connector._dimensions.original;
+      var original = created.connector.config.dimensions.original;
       var updated = {
                       down1: 188,
                       forward1: 515,
@@ -56,16 +56,16 @@ describe("DownForwardDownBackwardUpPath", function() {
 
       // Original value created by constructor.
       expect(created.connector.path()).to.equal(expectedPathValue);
-      expect(created.connector._dimensions.current).to.eql(original);
+      expect(created.connector.config.dimensions.current).to.eql(original);
 
       // Update with some new dimensions.
       created.connector.path(updated);
-      expect(created.connector._dimensions.current).to.eql(updated);
+      expect(created.connector.config.dimensions.current).to.eql(updated);
       expect(created.connector.path()).to.equal(String("M 1951,125 v188 a10,10 0 0 0 10,10 h515 a10,10 0 0 1 10,10 v293 a10,10 0 0 1 -10,10 h-616 a10,10 0 0 1 -10,-10 v--588 a10,10 0 0 1 10,-10 h0"));
 
       // Reset to avoid breaking any other tests.
       created.connector.path(original);
-      expect(created.connector._dimensions.current).to.eql(original);
+      expect(created.connector.config.dimensions.current).to.eql(original);
       expect(created.connector.path()).to.equal(expectedPathValue);
     });
 
@@ -199,7 +199,7 @@ describe("DownForwardDownBackwardUpPath", function() {
       });
 
       var originalPath = clashingPath.connector.path();
-      expect(clashingPath.connector._dimensions).to.eql(created.connector._dimensions);
+      expect(clashingPath.connector.config.dimensions).to.eql(created.connector.config.dimensions);
       expect(created.connector.avoidOverlap(clashingPath.connector)).to.be.true;
       expect(clashingPath.connector.path()).to.not.eql(originalPath);
 

--- a/test/flow_connector_path/down_forward_down_forward_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_down_forward_path/methods_test.js
@@ -104,7 +104,7 @@ describe("DownForwardDownForwardPath", function() {
     });
 
     it("should add the $node to $container", function() {
-      expect(created.connector.$node.parent().get(0)).to.equal(created.connector._config.container.get(0));
+      expect(created.connector.$node.parent().get(0)).to.equal(created.config.container.get(0));
     });
 
     /* TEST METHOD: lines()

--- a/test/flow_connector_path/down_forward_down_forward_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_down_forward_path/methods_test.js
@@ -45,7 +45,7 @@ describe("DownForwardDownForwardPath", function() {
     });
 
     it("should update (set) the path value when receiving new dimensions", function() {
-      var original = created.connector._dimensions.original;
+      var original = created.connector.config.dimensions.original;
       var updated = {
                       down1: 278,
                       forward1: 605,
@@ -55,17 +55,17 @@ describe("DownForwardDownForwardPath", function() {
 
       // Original value created by constructor.
       expect(created.connector.path()).to.equal(expectedPathValue);
-      expect(created.connector._dimensions.current).to.eql(original);
+      expect(created.connector.config.dimensions.current).to.eql(original);
 
       // Update with some new dimensions.
       created.connector.path(updated);
       expect(original).to.not.eql(updated);
-      expect(created.connector._dimensions.current).to.eql(updated);
+      expect(created.connector.config.dimensions.current).to.eql(updated);
       expect(created.connector.path()).to.equal(String("M 701,125 v278 a10,10 0 0 0 10,10 h605 a10,10 0 0 1 10,10 v431 a10,10 0 0 0 10,10 h404"));
 
       // Reset to avoid breaking any other tests.
       created.connector.path(original);
-      expect(created.connector._dimensions.current).to.eql(original);
+      expect(created.connector.config.dimensions.current).to.eql(original);
       expect(created.connector.path()).to.equal(expectedPathValue);
     });
 
@@ -196,7 +196,7 @@ describe("DownForwardDownForwardPath", function() {
       });
 
       var originalPath = clashingPath.connector.path();
-      expect(clashingPath.connector._dimensions).to.eql(created.connector._dimensions);
+      expect(clashingPath.connector.config.dimensions).to.eql(created.connector.config.dimensions);
       expect(created.connector.avoidOverlap(clashingPath.connector)).to.be.true;
       expect(clashingPath.connector.path()).to.not.eql(originalPath);
 

--- a/test/flow_connector_path/down_forward_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_path/methods_test.js
@@ -46,7 +46,7 @@ describe("DownForwardPath", function() {
     });
 
     it("should update (set) the path value when receiving new dimensions", function() {
-      var original = created.connector._dimensions.original;
+      var original = created.connector.config.dimensions.original;
       var updated = {
                       down: 278,
                       forward: 639
@@ -54,16 +54,16 @@ describe("DownForwardPath", function() {
 
       // Original value created by constructor.
       expect(created.connector.path()).to.equal(expectedPathValue);
-      expect(created.connector._dimensions.current).to.eql(original);
+      expect(created.connector.config.dimensions.current).to.eql(original);
 
       // Update with some new dimensions.
       created.connector.path(updated);
-      expect(created.connector._dimensions.current).to.eql(updated);
+      expect(created.connector.config.dimensions.current).to.eql(updated);
       expect(created.connector.path()).to.equal(String("M 701,125 v278 a10,10 0 0 0 10,10 h639"));
 
       // Reset to avoid breaking any other tests.
       created.connector.path(original);
-      expect(created.connector._dimensions.current).to.eql(original);
+      expect(created.connector.config.dimensions.current).to.eql(original);
       expect(created.connector.path()).to.equal(expectedPathValue);
     });
 

--- a/test/flow_connector_path/down_forward_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_path/methods_test.js
@@ -102,7 +102,7 @@ describe("DownForwardPath", function() {
     });
 
     it("should add the $node to $container", function() {
-      expect(created.connector.$node.parent().get(0)).to.equal(created.connector._config.container.get(0));
+      expect(created.connector.$node.parent().get(0)).to.equal(created.config.container.get(0));
     });
 
     /* TEST METHOD: lines()

--- a/test/flow_connector_path/down_forward_up_forward_down_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_up_forward_down_path/methods_test.js
@@ -105,7 +105,7 @@ describe("DownForwardUpForwardDownPath", function() {
     });
 
     it("should add the $node to $container", function() {
-      expect(created.connector.$node.parent().get(0)).to.equal(created.connector._config.container.get(0));
+      expect(created.connector.$node.parent().get(0)).to.equal(created.config.container.get(0));
     });
 
     /* TEST METHOD: lines()

--- a/test/flow_connector_path/down_forward_up_forward_down_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_up_forward_down_path/methods_test.js
@@ -44,7 +44,7 @@ describe("DownForwardUpForwardDownPath", function() {
     });
 
     it("should update (set) the path value when receiving new dimensions", function() {
-      var original = created.connector._dimensions.original;
+      var original = created.connector.config.dimensions.original;
       var updated = {
                       down1: 188,
                       forward1: 515,
@@ -56,17 +56,17 @@ describe("DownForwardUpForwardDownPath", function() {
 
       // Original value created by constructor.
       expect(created.connector.path()).to.equal(expectedPathValue);
-      expect(created.connector._dimensions.current).to.eql(original);
+      expect(created.connector.config.dimensions.current).to.eql(original);
 
       // Update with some new dimensions.
       created.connector.path(updated);
       expect(original).to.not.eql(updated);
-      expect(created.connector._dimensions.current).to.eql(updated);
+      expect(created.connector.config.dimensions.current).to.eql(updated);
       expect(created.connector.path()).to.equal(String("M 701,125 v188 a10,10 0 0 0 10,10 h515 a10,10 0 0 0 10,-10 v-318 a10,10 0 0 1 10,-10 h294 a10,10 0 0 1 10,10 v73 a10,10 0 0 0 10,10 h10"));
 
       // Reset to avoid breaking any other tests.
       created.connector.path(original);
-      expect(created.connector._dimensions.current).to.eql(original);
+      expect(created.connector.config.dimensions.current).to.eql(original);
       expect(created.connector.path()).to.equal(expectedPathValue);
     });
 
@@ -199,7 +199,7 @@ describe("DownForwardUpForwardDownPath", function() {
       });
 
       var originalPath = clashingPath.connector.path();
-      expect(clashingPath.connector._dimensions).to.eql(created.connector._dimensions);
+      expect(clashingPath.connector.config.dimensions).to.eql(created.connector.config.dimensions);
       expect(created.connector.avoidOverlap(clashingPath.connector)).to.be.true;
       expect(clashingPath.connector.path()).to.not.eql(originalPath);
 

--- a/test/flow_connector_path/down_forward_up_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_up_path/methods_test.js
@@ -44,7 +44,7 @@ describe("DownForwardUpPath", function() {
     });
 
     it("should update (set) the path value when receiving new dimensions", function() {
-      var original = created.connector._dimensions.original;
+      var original = created.connector.config.dimensions.original;
       var updated = {
                       down: 428,
                       forward1: 505,
@@ -54,16 +54,16 @@ describe("DownForwardUpPath", function() {
 
       // Original value created by constructor.
       expect(created.connector.path()).to.equal(expectedPathValue);
-      expect(created.connector._dimensions.current).to.eql(original);
+      expect(created.connector.config.dimensions.current).to.eql(original);
 
       // Update with some new dimensions.
       created.connector.path(updated);
-      expect(created.connector._dimensions.current).to.eql(updated);
+      expect(created.connector.config.dimensions.current).to.eql(updated);
       expect(created.connector.path()).to.equal(String("M 701,125 v428 a10,10 0 0 0 10,10 h505 a10,10 0 0 0 10,-10 v-480 a10,10 0 0 1 10,-10 h14"));
 
       // Reset to avoid breaking any other tests.
       created.connector.path(original);
-      expect(created.connector._dimensions.current).to.eql(original);
+      expect(created.connector.config.dimensions.current).to.eql(original);
       expect(created.connector.path()).to.equal(expectedPathValue);
     });
 
@@ -194,7 +194,7 @@ describe("DownForwardUpPath", function() {
       });
 
       var originalPath = clashingPath.connector.path();
-      expect(clashingPath.connector._dimensions).to.eql(created.connector._dimensions);
+      expect(clashingPath.connector.config.dimensions).to.eql(created.connector.config.dimensions);
       expect(created.connector.avoidOverlap(clashingPath.connector)).to.be.true;
       expect(clashingPath.connector.path()).to.not.eql(originalPath);
 

--- a/test/flow_connector_path/down_forward_up_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_up_path/methods_test.js
@@ -102,7 +102,7 @@ describe("DownForwardUpPath", function() {
     });
 
     it("should add the $node to $container", function() {
-      expect(created.connector.$node.parent().get(0)).to.equal(created.connector._config.container.get(0));
+      expect(created.connector.$node.parent().get(0)).to.equal(created.config.container.get(0));
     });
 
     /* TEST METHOD: lines()

--- a/test/flow_connector_path/forward_down_backward_up_path/methods_test.js
+++ b/test/flow_connector_path/forward_down_backward_up_path/methods_test.js
@@ -93,7 +93,7 @@ describe("ForwardDownBackwardUpPath", function() {
     });
 
     it("should add the $node to $container", function() {
-      expect(created.connector.$node.parent().get(0)).to.equal(created.connector._config.container.get(0));
+      expect(created.connector.$node.parent().get(0)).to.equal(created.config.container.get(0));
     });
 
     /* TEST METHOD: lines()

--- a/test/flow_connector_path/forward_down_forward_path/methods_test.js
+++ b/test/flow_connector_path/forward_down_forward_path/methods_test.js
@@ -96,7 +96,7 @@ describe("ForwardDownForwardPath", function() {
     });
 
     it("should add the $node to $container", function() {
-      expect(created.connector.$node.parent().get(0)).to.equal(created.connector._config.container.get(0));
+      expect(created.connector.$node.parent().get(0)).to.equal(created.config.container.get(0));
     });
 
     /* TEST METHOD: lines()

--- a/test/flow_connector_path/forward_down_forward_path/methods_test.js
+++ b/test/flow_connector_path/forward_down_forward_path/methods_test.js
@@ -43,21 +43,21 @@ describe("ForwardDownForwardPath", function() {
     });
 
     it("should update (set) the path value when receiving new dimensions", function() {
-      var original = created.connector._dimensions.original;
+      var original = created.connector.config.dimensions.original;
       var updated = { forward1: 80, down: 240, forward2: 2 }
 
       // Original value created by constructor.
       expect(created.connector.path()).to.equal(expectedPathValue);
-      expect(created.connector._dimensions.current).to.eql(original);
+      expect(created.connector.config.dimensions.current).to.eql(original);
 
       // Update with some new dimensions.
       created.connector.path(updated);
-      expect(created.connector._dimensions.current).to.eql(updated);
+      expect(created.connector.config.dimensions.current).to.eql(updated);
       expect(created.connector.path()).to.equal(String("M 1751,313 h80 a10,10 0 0 1 10,10 v240 a10,10 0 0 0 10,10 h2"));
 
       // Reset to avoid breaking any other tests.
       created.connector.path(original);
-      expect(created.connector._dimensions.current).to.eql(original);
+      expect(created.connector.config.dimensions.current).to.eql(original);
       expect(created.connector.path()).to.equal(expectedPathValue);
     });
 
@@ -187,7 +187,7 @@ describe("ForwardDownForwardPath", function() {
       });
 
       var originalPath = clashingPath.connector.path();
-      expect(clashingPath.connector._dimensions).to.eql(created.connector._dimensions);
+      expect(clashingPath.connector.config.dimensions).to.eql(created.connector.config.dimensions);
       expect(created.connector.avoidOverlap(clashingPath.connector)).to.be.true;
       expect(clashingPath.connector.path()).to.not.eql(originalPath);
 

--- a/test/flow_connector_path/forward_path/methods_test.js
+++ b/test/flow_connector_path/forward_path/methods_test.js
@@ -89,7 +89,7 @@ describe("ForwardPath", function() {
     });
 
     it("should add the $node to $container", function() {
-      expect(created.connector.$node.parent().get(0)).to.equal(created.connector._config.container.get(0));
+      expect(created.connector.$node.parent().get(0)).to.equal(created.config.container.get(0));
     });
 
     /* TEST METHOD: lines()

--- a/test/flow_connector_path/forward_up_forward_down_path/methods_test.js
+++ b/test/flow_connector_path/forward_up_forward_down_path/methods_test.js
@@ -94,7 +94,7 @@ describe("ForwardUpForwardDownPath", function() {
     });
 
     it("should add the $node to $container", function() {
-      expect(created.connector.$node.parent().get(0)).to.equal(created.connector._config.container.get(0));
+      expect(created.connector.$node.parent().get(0)).to.equal(created.config.container.get(0));
     });
 
     /* TEST METHOD: lines()

--- a/test/flow_connector_path/forward_up_forward_path/methods_test.js
+++ b/test/flow_connector_path/forward_up_forward_path/methods_test.js
@@ -93,7 +93,7 @@ describe("ForwardUpForwardPath", function() {
     });
 
     it("should add the $node to $container", function() {
-      expect(created.connector.$node.parent().get(0)).to.equal(created.connector._config.container.get(0));
+      expect(created.connector.$node.parent().get(0)).to.equal(created.config.container.get(0));
     });
 
     /* TEST METHOD: lines()


### PR DESCRIPTION
Mainly turning indicated-private variables into actual-private variables found in FlowConnectorPath class (and variants).
Also includes commenting out console.log output on unrelated test, noticed when running all tests for possible recently created errors.