### PR TITLE
Validate CSV upload file size

### DIFF
--- a/app/models/autocomplete_items.rb
+++ b/app/models/autocomplete_items.rb
@@ -5,7 +5,7 @@ class AutocompleteItems
   attr_accessor :service_id, :component_id, :file
 
   validates :file, presence: true
-  validate :scan_file
+  validate :scan_file, :file_size
   validates_with CsvValidator, unless: proc { |obj| obj.file.blank? || obj.has_virus? }
 
   def file_headings
@@ -30,11 +30,26 @@ class AutocompleteItems
     @has_virus ||= MalwareScanner.call(file.path)
   end
 
+  def file_too_big?
+    return if file.blank?
+
+    file.size > 1.megabytes
+  end
+
   def scan_file
     if has_virus?
       errors.add(
         :message,
         I18n.t('activemodel.errors.models.autocomplete_items.virus_found', attribute: file.original_filename)
+      )
+    end
+  end
+
+  def file_size
+    if file_too_big?
+      errors.add(
+        :message,
+        I18n.t('activemodel.errors.models.autocomplete_items.too_big')
       )
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -445,6 +445,7 @@ en:
           format: "%{message}"
           virus_found: "'%{attribute}' contains a virus - choose a different file"
           scan_error: "An error has occurred, try again in a few minutes"
+          too_big: "The selected file must be smaller than 1MB"
 
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."

--- a/spec/models/autocomplete_items_spec.rb
+++ b/spec/models/autocomplete_items_spec.rb
@@ -40,6 +40,27 @@ RSpec.describe AutocompleteItems do
           expect(subject.errors.full_messages).to eq(expected_error)
         end
       end
+
+      context 'when a file is larger than 1MB' do
+        let(:expected_error) { [I18n.t('activemodel.errors.models.autocomplete_items.too_big')] }
+
+        before do
+          allow(file).to receive(:size).and_return(2.megabytes)
+        end
+
+        it 'should be invalid' do
+          expect(subject).to_not be_valid
+        end
+
+        it 'should not validate csv file' do
+          expect_any_instance_of(CsvValidator).not_to receive(:validate)
+        end
+
+        it 'should have errors' do
+          subject.valid?
+          expect(subject.errors.full_messages).to eq(expected_error)
+        end
+      end
     end
 
     context 'when a file is not present' do


### PR DESCRIPTION
[Trello](https://trello.com/c/HfUoiU4p/2846-autocomplete-add-upper-limit-of-1mb-to-csv-upload)
We want to set a limit on the CSV files uploaded onto the Editor.

Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>

![Screenshot 2022-08-23 at 15 23 18](https://user-images.githubusercontent.com/29227502/186183701-de51a6e3-2a1b-4a99-95e2-373a11567234.png)