### PR TITLE
Bump metadata-presenter to 2.17.19 along with minor govuk-frontend fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #    github: 'ministryofjustice/fb-metadata-presenter',
 #    branch: 'add-branching-title'
 # gem 'metadata_presenter', path: './fb-metadata-presenter'
-gem 'metadata_presenter', '2.17.18'
+gem 'metadata_presenter', '2.17.19'
 
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.18)
+    metadata_presenter (2.17.19)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -428,7 +428,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.17.18)
+  metadata_presenter (= 2.17.19)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -1058,7 +1058,7 @@ html {
   }
 
   .govuk-date-input__input:not(.govuk-input--error) {
-    border-color: $govuk-error-colour;
+    border-color: $govuk-input-border-colour;
 
     &:focus {
       border-color: $govuk-focus-colour;


### PR DESCRIPTION
* Bumps presenter version after govuk-frontend updates
* Fixes a small error made during the govuk-frontend changes