### PR TITLE
Autocomplete acceptance tests

### DIFF
--- a/acceptance/features/create_page_spec.rb
+++ b/acceptance/features/create_page_spec.rb
@@ -64,6 +64,13 @@ feature 'Create page' do
     then_I_should_see_the_edit_single_question_email_page
   end
 
+  scenario 'creating a single question page with autocomplete' do
+    given_I_add_a_single_question_page_with_autocomplete
+    and_I_add_a_page_url
+    when_I_add_the_page
+    then_I_should_see_the_edit_single_question_autocomplete_page
+  end
+
   scenario 'creating multiple question page' do
     given_I_add_a_multiple_question_page
     and_I_add_a_page_url
@@ -160,6 +167,14 @@ feature 'Create page' do
     expect(editor.find('input[type="email"]')).to be_visible
   end
 
+  def then_I_should_see_the_edit_single_question_autocomplete_page
+    and_I_should_see_default_values_created
+    and_I_should_see_the_save_button_visible
+    and_I_should_see_default_upload_options_warning
+    and_I_should_see_the_save_button_disabled
+    expect(editor.find('.govuk-select')).to be_visible
+  end
+
   def and_I_should_be_on_the_edit_page
     and_I_should_see_default_values_created
     and_I_should_see_the_save_button_visible
@@ -189,6 +204,10 @@ feature 'Create page' do
     expect(
       editor.checkboxes_options.map { |option| option[:value] }
     ).to match_array(%w[Option Option])
+  end
+
+  def and_I_should_see_upload_options_warning
+    expect(editor).to have_content(I18n.t('dialogs.autocomplete.component_warning'))
   end
 
   def then_I_should_see_the_edit_multiple_question_page

--- a/acceptance/features/edit_single_question_autocomplete_page_spec.rb
+++ b/acceptance/features/edit_single_question_autocomplete_page_spec.rb
@@ -1,0 +1,149 @@
+require_relative '../spec_helper'
+
+feature 'Edit single question autocomplete page' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:page_url) { 'Countries' }
+  let(:pre_edit_title) { 'Countries Question' }
+  let(:question) do
+    'What is your favourite holiday destination?'
+  end
+  let(:section_heading) { 'I open at the close' }
+  let(:default_section_heading) { I18n.t('default_text.section_heading') }
+  let(:upload_success) { I18n.t('dialogs.autocomplete.success') }
+  let(:upload_button) { I18n.t('dialogs.autocomplete.button') }
+  let(:upload_modal_warning) { I18n.t('dialogs.autocomplete.modal_warning') }
+  let(:valid_csv) { './spec/fixtures/special_characters.csv' }
+  let(:valid_csv_one_column) { './spec/fixtures/valid_one_column.csv' }
+  let(:autocomplete_option) { 'Congo, Democratic Republic of' }
+  let(:invalid_csv) { './spec/fixtures/invalid.csv' }
+  let(:incorrect_format) { I18n.t('activemodel.errors.models.autocomplete_items.incorrect_format') }
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service_fixture(fixture: 'autocomplete_page_fixture')
+  end
+
+  scenario 'when editing the autocomplete component' do
+    and_I_edit_the_page(url: pre_edit_title)
+    and_I_have_optional_section_heading_text
+    when_I_update_the_question_name
+    when_I_update_the_optional_section_heading
+    when_I_delete_the_optional_section_heading_text
+    and_I_return_to_flow_page
+    then_I_should_see_my_changes_on_preview(question)
+  end
+
+  scenario 'when uploading and overwriting csv files' do
+    and_I_edit_the_page(url: pre_edit_title)
+    and_I_should_see_default_upload_options_warning
+    when_I_click_autocomplete_options_in_three_dots_menu
+    then_I_should_see_upload_options_modal
+    when_I_upload_a_csv_file(valid_csv_one_column)
+    then_I_should_see_confrmation_message
+    when_I_click_autocomplete_options_in_three_dots_menu
+    then_I_should_see_upload_options_modal
+    then_I_should_see_overwrite_options_warning
+    when_I_upload_a_csv_file(valid_csv)
+    then_I_should_see_confrmation_message
+    and_I_return_to_flow_page
+    then_I_should_see_my_changes_on_preview(autocomplete_option)
+  end
+
+  scenario 'when uploading an invalid csv file' do
+    and_I_edit_the_page(url: pre_edit_title)
+    and_I_should_see_default_upload_options_warning
+    when_I_click_autocomplete_options_in_three_dots_menu
+    then_I_should_see_upload_options_modal
+    when_I_upload_a_csv_file(invalid_csv)
+    then_I_should_see_an_error_message(incorrect_format)
+  end
+
+  def then_I_should_see_my_changes_on_preview(change)
+    preview_form = and_I_preview_the_form
+
+    and_I_go_to_the_page_that_I_edit(preview_form)
+    then_I_should_see_my_changes_in_the_form(preview_form, change)
+
+    preview_form
+  end
+
+  def and_I_go_to_the_page_that_I_edit(preview_form)
+    within_window(preview_form) do
+      page.click_button 'Start now'
+    end
+  end
+
+  def then_I_should_see_my_changes_in_the_form(preview_form, change)
+    within_window(preview_form) do
+      page.find('.autocomplete__input').click
+      expect(page).to have_content(change)
+    end
+  end
+
+  def and_I_have_optional_section_heading_text
+    expect(page).to have_content(I18n.t('default_text.section_heading'))
+  end
+
+  def when_I_update_the_question_name
+    and_I_edit_the_question
+    when_I_save_my_changes
+  end
+
+  def when_I_update_the_optional_section_heading
+    and_I_edit_the_optional_section_heading
+    when_I_save_my_changes
+    then_I_should_see_my_updated_section_heading
+  end
+
+  def then_I_should_see_my_updated_section_heading
+    expect(editor).to have_content(section_heading)
+  end
+
+  def when_I_delete_the_optional_section_heading_text
+    editor.section_heading_hint.set(' ')
+    when_I_save_my_changes
+    then_I_should_see_the_default_section_heading
+  end
+
+  def then_I_should_see_the_default_section_heading
+    expect(editor.section_heading_hint.text).to eq(default_section_heading)
+  end
+
+  def and_I_edit_the_question
+    editor.question_heading.first.set(question)
+  end
+
+  def and_I_edit_the_optional_section_heading
+    page.first('.fb-section_heading').set(section_heading)
+  end
+
+  def when_I_click_autocomplete_options_in_three_dots_menu
+    editor.question_heading.first.click
+    editor.question_three_dots_button.click
+    expect(editor).to have_css('span', text: I18n.t('question.menu.upload_options'))
+    editor.autocomplete_options.click
+  end
+
+  def then_I_should_see_upload_options_modal
+    expect(editor.find('.govuk-file-upload')).to be_visible
+  end
+
+  def then_I_should_see_overwrite_options_warning
+    expect(page).to have_content(upload_modal_warning)
+  end
+
+  def when_I_upload_a_csv_file(csv_file)
+    attach_file 'autocomplete_items_file',
+    csv_file
+    editor.find('.ui-dialog').find(:button, text: upload_button).click
+  end
+
+  def then_I_should_see_confrmation_message
+    expect(page).to have_content(upload_success)
+  end
+
+  def then_I_should_see_an_error_message(error_message)
+    expect(page).to have_content(error_message)
+  end
+end

--- a/acceptance/features/edit_single_question_autocomplete_page_spec.rb
+++ b/acceptance/features/edit_single_question_autocomplete_page_spec.rb
@@ -118,25 +118,8 @@ feature 'Edit single question autocomplete page' do
     page.first('.fb-section_heading').set(section_heading)
   end
 
-  def when_I_click_autocomplete_options_in_three_dots_menu
-    editor.question_heading.first.click
-    editor.question_three_dots_button.click
-    expect(editor).to have_css('span', text: I18n.t('question.menu.upload_options'))
-    editor.autocomplete_options.click
-  end
-
-  def then_I_should_see_upload_options_modal
-    expect(editor.find('.govuk-file-upload')).to be_visible
-  end
-
   def then_I_should_see_overwrite_options_warning
     expect(page).to have_content(upload_modal_warning)
-  end
-
-  def when_I_upload_a_csv_file(csv_file)
-    attach_file 'autocomplete_items_file',
-    csv_file
-    editor.find('.ui-dialog').find(:button, text: upload_button).click
   end
 
   def then_I_should_see_confrmation_message

--- a/acceptance/fixtures/autocomplete_page_fixture.json
+++ b/acceptance/fixtures/autocomplete_page_fixture.json
@@ -1,0 +1,165 @@
+{
+  "_id": "service.base",
+  "flow": {
+    "6faed0c4-2dc3-4df7-9bcb-8081793848aa": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "709ca6bc-6cb3-446d-a8c1-1d1a96f9dbbc": {
+      "next": {
+        "default": "8783d5b1-c5f5-40ac-8062-091945eec6fc"
+      },
+      "_type": "flow.page"
+    },
+    "8783d5b1-c5f5-40ac-8062-091945eec6fc": {
+      "next": {
+        "default": "ee163cdb-e5ec-4dd2-9aba-5cd43146d3f4"
+      },
+      "_type": "flow.page"
+    },
+    "ee163cdb-e5ec-4dd2-9aba-5cd43146d3f4": {
+      "next": {
+        "default": "6faed0c4-2dc3-4df7-9bcb-8081793848aa"
+      },
+      "_type": "flow.page"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "_type": "page.start",
+      "_uuid": "709ca6bc-6cb3-446d-a8c1-1d1a96f9dbbc",
+      "heading": "Service name goes here",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
+    },
+    {
+      "_id": "page.countries",
+      "url": "countries",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "8783d5b1-c5f5-40ac-8062-091945eec6fc",
+      "heading": "",
+      "components": [
+        {
+          "_id": "countries_autocomplete_1",
+          "hint": "",
+          "name": "countries_autocomplete_1",
+          "_type": "autocomplete",
+          "_uuid": "a74e728b-e60e-4dd2-ace1-66eb1755c318",
+          "label": "Countries Question",
+          "errors": {
+          },
+          "legend": "Question",
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "autocomplete": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.checkanswers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "ee163cdb-e5ec-4dd2-9aba-5cd43146d3f4",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+
+      ],
+      "send_heading": "Now send your application",
+      "extra_components": [
+
+      ]
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "form-sent",
+      "_type": "page.confirmation",
+      "_uuid": "6faed0c4-2dc3-4df7-9bcb-8081793848aa",
+      "heading": "Application complete",
+      "components": [
+
+      ]
+    }
+  ],
+  "locale": "en",
+  "created_at": "2022-08-23T08:35:59Z",
+  "created_by": "c2df7129-db18-4df6-9fad-0a1f6e0cafd9",
+  "service_id": "c4805211-2ba3-4ace-ba22-bc4faa999a61",
+  "version_id": "b7669cc1-ab0e-4020-b129-9c63faef80c2",
+  "service_name": "Acceptance-test-Stormtrooper-FN-78a0f4f3-fdd6-4386-88a1-7aa23ebe582c",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "/cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "/privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "/accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "Cookies body",
+      "_type": "page.standalone",
+      "_uuid": "ef5fd7dd-71d8-480b-9cce-ae8f9f80bfeb",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "Privacy body",
+      "_type": "page.standalone",
+      "_uuid": "ead38900-5eb1-44f5-a9bd-6e65fdd21a48",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "Accessibilty body",
+      "_type": "page.standalone",
+      "_uuid": "5464d8f3-c137-4bca-8daf-c0a424a63b93",
+      "heading": "Accessibility statement",
+      "components": [
+
+      ]
+    }
+  ]
+}

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -81,6 +81,9 @@ class EditorApp < SitePrism::Page
   element :required_question,
           :xpath,
           "//*[@role='menuitemcheckbox' and contains(.,'Required...')]"
+  element :autocomplete_options,
+          :xpath,
+          "//*[@role='menuitem' and contains(.,'Autocomplete options...')]"
 
   elements :add_page_submit_button, :button, I18n.t('pages.create')
   elements :form_pages, '#flow-overview .flow-item'

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -447,4 +447,14 @@ module CommonSteps
       click_button('.ui-dialog-titlebar-close')
     end
   end
+
+  # Autocomplete component
+  def given_I_add_a_single_question_page_with_autocomplete
+    given_I_want_to_add_a_single_question_page
+    editor.add_component(I18n.t('components.list.autocomplete')).click
+  end
+
+  def and_I_should_see_default_upload_options_warning
+    expect(editor).to have_content(I18n.t('dialogs.autocomplete.component_warning'))
+  end
 end

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -457,4 +457,21 @@ module CommonSteps
   def and_I_should_see_default_upload_options_warning
     expect(editor).to have_content(I18n.t('dialogs.autocomplete.component_warning'))
   end
+
+  def when_I_click_autocomplete_options_in_three_dots_menu
+    editor.question_heading.first.click
+    editor.question_three_dots_button.click
+    expect(editor).to have_css('span', text: I18n.t('question.menu.upload_options'))
+    editor.autocomplete_options.click
+  end
+
+  def then_I_should_see_upload_options_modal
+    expect(editor.find('.govuk-file-upload')).to be_visible
+  end
+
+  def when_I_upload_a_csv_file(csv_file)
+    attach_file 'autocomplete_items_file',
+    csv_file
+    editor.find('.ui-dialog').find(:button, text: upload_button).click
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/SK6YNXfj/2754-autocomplete-editor-acceptance-tests)

## Create and edit autocomplete page
These test checks for expected behaviour when:
-  Adding a new autocomplete component to a form from the flow view
- The correct warning messages are present in on the component view on initial creation
- Uploading a CSV file (happy path)
- Uploading an invalid csv file
- Overwriting a CSV file and ensuring the correct options are presented in preview

## Autocomplete publish page warnings
Tests behaviour for when:
- An autocomplete component does not have options uploaded
- All autocomplete components have options