### PR TITLE
Allowing the use of parenthesis in the form title

### DIFF
--- a/app/services/editor/service.rb
+++ b/app/services/editor/service.rb
@@ -5,7 +5,7 @@ module Editor
 
     validates :service_name, presence: true
     validates :service_name, length: { minimum: 3, maximum: 128 }, allow_blank: true
-    validates :service_name, format: { with: /\A[\sa-zA-Z0-9-'’]*\z/ }, allow_blank: true
+    validates :service_name, format: { with: /\A[\sa-zA-Z0-9-'’()]*\z/ }, allow_blank: true
     validates :service_name, legacy_service_name: true
 
     def add_errors(service)

--- a/spec/services/service_creation_spec.rb
+++ b/spec/services/service_creation_spec.rb
@@ -130,6 +130,27 @@ RSpec.describe ServiceCreation do
       end
     end
 
+    context 'when service name has parenthesis' do
+      let(:attributes) do
+        { service_name: 'Public Trustee (NL1)', current_user: double(id: '1') }
+      end
+      let(:service) do
+        double(id: '05e12a93-3978-4624-a875-e59893f2c262', errors?: false)
+      end
+
+      before do
+        expect(
+          MetadataApiClient::Service
+        ).to receive(:create).and_return(service)
+
+        expect_any_instance_of(DefaultConfiguration).to receive(:create)
+      end
+
+      it 'returns true' do
+        expect(service_creation.create).to be_truthy
+      end
+    end
+
     context 'when name is invalid format' do
       ['something.invalid', 'with_underscore'].each do |invalid|
         let(:attributes) { { service_name: invalid } }


### PR DESCRIPTION
[Trello](https://trello.com/c/nMgXnTGJ/2607-allow-parentheses-in-form-names)

Allowing the use of parenthesis in the form title to specify post code for example. Requiring updating the format validation for name service as current implementation would show error message "Your answer for ‘Give your form a name' contains characters that are not allowed." 
