### PR TITLE
Fix layering issue caused by svg overlapping thumbnail

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -575,19 +575,13 @@ html {
   // allow for use of hover over event in making Conneciton menus appear.
   // However, although this setting works fine in Firefox, there seems to
   // be a bug in Chrome that simply hides FlowConnectorPath elements from
-  // being seen. By accidental tinkering, it seems that giving them a
-  // value of 100px works !?!? Not sure why, at time of writing. Also,
-  // after playing with it for a couple minutes, it seems setting to 10px
-  // still does not work and, setting to 50px makes them appear but gives
-  // an incorrectly placed layout. So, 100px is perhaps the magic number
-  // although, that doesn't rule out others having equally magical
-  // properties. For now, will be leaving as 100px with fingers crossed.
+  // being seen. Smallest possible size of 1x1px has been used instead.
   left: 0px;
-  height: 100px;
+  height: 1px;
   overflow: visible;
   position: absolute;
   top: 0px;
-  width: 100px;
+  width: 1px;
 
   path {
     display: block; // So we can capture a jQuery height calculation


### PR DESCRIPTION
Originally, svg elements on the Flow page had been given a 100px by 100px sizing. This was not desired but helped avoid a bug in Chrome where anything less (ie. the preferred 1x1) resulted in a loss of FlowConnectorLine visibility. As this was recently noticed and flagged to be a bug (due to causing overlapping issues when attempting to click the first thumbnail in a form overview), it was given another look. Seems Chrome (probably some update since) can now work with the preferred 1x1 sizing, so the CSS has been updated and bug eliminated.

See screenshots for Firefox, Chrome, and Safari.

Cursor cannot be seen on capture but it is placed in top left corner of first image, for each, where you can see it is triggering the hover style that reveals the three button menu activator. Lines are clearly still visible.

**Firefox**
<img width="695" alt="Screenshot 2022-08-26 at 10 09 02" src="https://user-images.githubusercontent.com/76942244/186871154-bbec10c8-e125-4e93-8620-0d07c5849c63.png">

**Chrome**
<img width="566" alt="Screenshot 2022-08-26 at 10 08 13" src="https://user-images.githubusercontent.com/76942244/186871104-e900bb1f-1bd0-407f-827a-b3d8a8fa29c7.png">

**Safari**
<img width="546" alt="Screenshot 2022-08-26 at 10 09 42" src="https://user-images.githubusercontent.com/76942244/186871254-d1baa3c4-03b6-4705-a989-5e3932b9a7e8.png">
