### PR TITLE
Fix broken links by stripping out injected angle brackets in markdown…

### DIFF
--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -806,11 +806,27 @@ function sanitiseHtml(html) {
 }
 
 /* Opportunity safely strip out anything that we don't want here.
- * 1. Something in makeMarkdown is adding <!-- --> markup to the result so we're trying to get rid of it.
- * 2. ...
+ *
+ * 1. Something in makeMarkdown is adding <!-- --> markup to the result
+ *    so we're trying to get rid of it.
+ *
+ * 2. sanitizeHTML is altering automatic link syntax by removing
+ *    everything in (including) angle brackets added by showdown.
+ *
+ *    e.g. [link text](<http://some.url/here>)
+ *
+ *         results in this incorrect markdown (and output):
+ *         [link text]()
+ *
+ *         so we're stripping out the angle brackets to leave this:
+ *         [link text](http://some.url/here)
+ *
+ *         which give us the correct link element (url+text).
  **/
 function sanitiseMarkdown(markdown) {
+  // 1.
   markdown = markdown.replace(/\n<!--.*?-->/mig, "");
+  // 2.
   markdown = markdown.replace(/\]\(\<(.*?)\>\)/mig, "]($1)");
   return markdown;
 }

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -811,6 +811,7 @@ function sanitiseHtml(html) {
  **/
 function sanitiseMarkdown(markdown) {
   markdown = markdown.replace(/\n<!--.*?-->/mig, "");
+  markdown = markdown.replace(/\]\(\<(.*?)\>\)/mig, "]($1)");
   return markdown;
 }
 


### PR DESCRIPTION
… notation


Recent changes to strip out HTML from markdown has left a bug where HTML converted to markdown that produces link format like this:

1.
`[link text](<http://some.url/here>)`

Results in broken HTML link output that looks like this:

2.
`[link text]()`

Rather than revert the HTML sanitising function that has likely caused this, a simple filter line has been added to convert the markdown, stripping out those angle brackets. The markdown (1) above will now look like this:

3.
`[link text](http://some.url/here)`

This produces the required HTML output with a link that is just the visible text "link text" (as per this example).

See screenshots for actual examples in play.

**Original HTML output**
<img width="736" alt="Screenshot 2022-08-26 at 15 02 28" src="https://user-images.githubusercontent.com/76942244/186922290-0faff89e-0358-4beb-94bf-5a7f453cc060.png">

**Converted to this on edit**
(note the angle brackets)
<img width="786" alt="Screenshot 2022-08-26 at 15 03 04" src="https://user-images.githubusercontent.com/76942244/186922441-d6119369-5b1c-4eb0-a31c-05d72ba084a2.png">

**Converted back to HTML**
(without editing - shows original link now broken)
<img width="757" alt="Screenshot 2022-08-26 at 15 03 18" src="https://user-images.githubusercontent.com/76942244/186922546-fa2616aa-0508-4d8f-8fe2-fb0bf7da6fe4.png">
