### PR TITLE
Updating database with autocomplete items

### DIFF
--- a/app/services/publisher.rb
+++ b/app/services/publisher.rb
@@ -21,9 +21,14 @@ class Publisher
   def action
     lambda do |action_name|
       ActiveSupport::Notifications.instrument("publisher.#{action_name}") do
-        publish_service.update!(status: action_name)
+        publish_service.update!(update_params(action_name))
         adapter.new(service_provisioner).method(action_name).call
       end
     end.curry
+  end
+
+  def update_params(action_name)
+    params = { status: action_name }
+    action_name == 'publishing' ? params.merge(autocomplete_ids: service_provisioner.autocomplete_ids) : params
   end
 end

--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -28,10 +28,12 @@ class Publisher
     end
 
     def autocomplete_items
-      response = MetadataApiClient::Items.all(service_id: service_id)
-      Rails.logger.info(response.errors) if response.errors?
+      Hash(autocomplete_response['items']).to_json.inspect
+    end
 
-      convert_autocomplete_response(response)
+    def autocomplete_ids
+      # This refers to the table row IDs in the MetadataAPI
+      autocomplete_response['autocomplete_ids'] || []
     end
 
     def get_binding
@@ -163,9 +165,13 @@ class Publisher
         Rails.application.config.service_namespace_configuration[:"#{platform_environment}_#{deployment_environment}"]
     end
 
-    def convert_autocomplete_response(response)
-      items = response.respond_to?(:metadata) ? response.metadata['items'] : {}
-      items.to_json.inspect
+    def autocomplete_response
+      @autocomplete_response ||= begin
+        response = MetadataApiClient::Items.all(service_id: service_id)
+        Rails.logger.info(response.errors) if response.errors?
+
+        response.respond_to?(:metadata) ? response.metadata : {}
+      end
     end
   end
 end

--- a/db/migrate/20220901111358_add_autocomplete_ids_to_publish_services.rb
+++ b/db/migrate/20220901111358_add_autocomplete_ids_to_publish_services.rb
@@ -1,0 +1,5 @@
+class AddAutocompleteIdsToPublishServices < ActiveRecord::Migration[6.1]
+  def change
+    add_column :publish_services, :autocomplete_ids, :uuid, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_20_205146) do
+ActiveRecord::Schema.define(version: 2022_09_01_111358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 2022_07_20_205146) do
     t.datetime "updated_at", precision: 6, null: false
     t.uuid "version_id"
     t.uuid "user_id"
+    t.uuid "autocomplete_ids", default: [], array: true
     t.index ["service_id", "deployment_environment"], name: "index_publish_services_on_service_id_and_deployment_environment"
     t.index ["service_id", "status", "deployment_environment"], name: "index_publish_services_on_service_status_deployment"
     t.index ["service_id"], name: "index_publish_services_on_service_id"

--- a/spec/services/publisher/service_provisioner_spec.rb
+++ b/spec/services/publisher/service_provisioner_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Publisher::ServiceProvisioner do
     end
 
     context 'when there are autocomplete items for a service' do
-      let(:autocomplete_items) do
+      let(:autocomplete_response) do
         {
           'items' => {
             SecureRandom.uuid => [
@@ -58,23 +58,23 @@ RSpec.describe Publisher::ServiceProvisioner do
       before do
         expect(MetadataApiClient::Items).to receive(:all)
           .with(service_id: attributes[:service_id])
-          .and_return(MetadataApiClient::Items.new(autocomplete_items))
+          .and_return(MetadataApiClient::Items.new(autocomplete_response))
       end
 
       it 'generates the correct autocomplete items data structure' do
         expect(service_provisioner.autocomplete_items).to eq(
-          autocomplete_items['items'].to_json.inspect
+          autocomplete_response['items'].to_json.inspect
         )
       end
     end
 
     context 'when there are no autocomplete items for a service' do
-      let(:autocomplete_items) { { 'items' => {} } }
+      let(:autocomplete_response) { { 'items' => {} } }
 
       before do
         expect(MetadataApiClient::Items).to receive(:all)
           .with(service_id: attributes[:service_id])
-          .and_return(MetadataApiClient::Items.new(autocomplete_items))
+          .and_return(MetadataApiClient::Items.new(autocomplete_response))
       end
 
       it 'generates the correct empty json string' do
@@ -91,6 +91,57 @@ RSpec.describe Publisher::ServiceProvisioner do
 
       it 'generates the correct empty json string' do
         expect(service_provisioner.autocomplete_items).to eq('"{}"')
+      end
+    end
+  end
+
+  describe '#autocomplete_ids' do
+    let(:attributes) do
+      { service_id: SecureRandom.uuid }
+    end
+
+    context 'when there are autocomplete item for a service' do
+      let(:expected_ids) { ['foo', 'bar', 'hello'] }
+      let(:autocomplete_response) do
+        {
+          'autocomplete_ids' => expected_ids
+        }
+      end
+
+      before do
+        expect(MetadataApiClient::Items).to receive(:all)
+          .with(service_id: attributes[:service_id])
+          .and_return(MetadataApiClient::Items.new(autocomplete_response))
+      end
+
+      it 'returns the autocomplete_ids' do
+        expect(service_provisioner.autocomplete_ids).to eq(expected_ids)
+      end
+    end
+
+    context 'when there are no autocomplete items for a service' do
+      let(:autocomplete_response) { { 'autocomplete_ids' => [] } }
+
+      before do
+        expect(MetadataApiClient::Items).to receive(:all)
+          .with(service_id: attributes[:service_id])
+          .and_return(MetadataApiClient::Items.new(autocomplete_response))
+      end
+
+      it 'generates the correct empty json string' do
+        expect(service_provisioner.autocomplete_ids).to eq([])
+      end
+    end
+
+    context 'when the metadata api returns and error' do
+      before do
+        expect(MetadataApiClient::Items).to receive(:all)
+          .with(service_id: attributes[:service_id])
+          .and_return(MetadataApiClient::ErrorMessages.new('some error'))
+      end
+
+      it 'generates the correct empty json string' do
+        expect(service_provisioner.autocomplete_ids).to eq([])
       end
     end
   end

--- a/spec/services/publisher/service_provisioner_spec.rb
+++ b/spec/services/publisher/service_provisioner_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Publisher::ServiceProvisioner do
     end
 
     context 'when there are autocomplete item for a service' do
-      let(:expected_ids) { ['foo', 'bar', 'hello'] }
+      let(:expected_ids) { [SecureRandom.uuid, SecureRandom.uuid, SecureRandom.uuid] }
       let(:autocomplete_response) do
         {
           'autocomplete_ids' => expected_ids


### PR DESCRIPTION
[Trello](https://trello.com/c/AQN8Fcmj/2845-autocomplete-add-versionid-column-in-autocomplete-db)


To ensure proper auditing of published forms, we're adding identifier for autocomplete items: autocomplete ids. They are rows ids in the metadata api items table. They are different from the autocomplete component uuids. We're saving them to the database at publishing stage. Tests performed locally.