### PR TITLE
Testable flowconnectorpath zindex

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -535,8 +535,6 @@ html {
   // their lines from centre of a Branch Node, which places them directly over those
   // elements, without this workaround in place (easier to fix z-index than calculations).
   // Also includes some elements that gained position:fixed because they fell off the view.
-  .FlowConnectorLine,
-  .FlowConnectorPath,
   .govuk-header,
   .govuk-navigation-app,
   .ui-widget-overlay,
@@ -546,12 +544,17 @@ html {
 
   .FlowConnectorLine,
   .FlowConnectorPath {
-    z-index: 2;
+    z-index: 0;
 
     &.active {
-      z-index: 3;
+      z-index: 1;
     }
   }
+
+  .FlowItem {
+    z-index: 2
+  }
+
 
   .ConnectionMenuActivator {
     z-index: 4;
@@ -566,6 +569,21 @@ html {
   .ui-dialog {
     z-index: 6;
   }
+  
+  // The flow conditions list is over the lines meaning that they cannot be
+  // hovered.  Removing pointer-events allows the hover to "pass-through" to the
+  // underlying line.  
+  .flow-conditions {
+    pointer-events: none;
+    
+    // The branch connection menus are within the condirtions container and
+    // still need to receive pointer events, sop we turn them back on.
+    .branch-connection-menu-activator {
+      pointer-events: all;
+    }
+  }
+
+
 }
 
 .FlowConnectorLine,

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -576,8 +576,8 @@ html {
   .flow-conditions {
     pointer-events: none;
     
-    // The branch connection menus are within the condirtions container and
-    // still need to receive pointer events, sop we turn them back on.
+    // The branch connection menus are within the conditions container and
+    // still need to receive pointer events, so we turn them back on.
     .branch-connection-menu-activator {
       pointer-events: all;
     }
@@ -925,6 +925,7 @@ html {
   box-sizing: border-box;
   overflow: visible;
   position: relative;
+  z-index: 0; // prevents very tall first flow conditions breaking out and overlapping header/preview button
 }
 
 


### PR DESCRIPTION
Fixes the issue of the start page in the flow view not being fully clickable due to the flowconnectorpath svgs being on top of the link area.

Fix is implemented using a combination of `z-index` changes and `pointer-events` to ensure a correct stacking order whilst enabling all interactive elements to remain clickable.