### PR TITLE
Remove Global Service Configuration table

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,15 +31,6 @@ ActiveRecord::Schema.define(version: 2022_09_01_111358) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "global_service_configurations", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "value", null: false
-    t.string "deployment_environment", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["deployment_environment"], name: "index_global_service_configurations_on_deployment_environment"
-  end
-
   create_table "identities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "provider"
     t.string "uid"


### PR DESCRIPTION
It looks like this table was accidentally added to the schema. There is no related ActiveRecord model. The global config for a service is set in an initialiser on the Rails config object.