### PR TITLE
Accessibly disable save button on edit question screen

### DIFF
--- a/acceptance/features/create_page_spec.rb
+++ b/acceptance/features/create_page_spec.rb
@@ -236,7 +236,7 @@ feature 'Create page' do
   end
 
   def and_I_should_see_the_save_button_disabled
-    expect(editor.save_page_button).to be_disabled
+    expect(editor.save_page_button[:'aria-disabled']).to eq("true")
   end
 
   def add_existing_url(url = nil)

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -150,7 +150,6 @@ PagesController.create = function() {
 
 class DataController {
   constructor(view) {
-    var controller = this;
     var $form = $("#editContentForm");
 
     this.text = view.text;
@@ -158,48 +157,23 @@ class DataController {
     this.$submitButton = this.$form.find(':submit');
     this.$saveDescription = this.$form.find('#save_description');
 
-    this.$form.on('keydown', {controller: controller} , this.onKeyDownListener); 
-    this.$form.on('submit', {controller: controller} , this.onSubmitListener);
-    this.$form.find(':submit').on('click', {controller: controller} , this.onClickListener);
-  }
-
-  onClickListener(event) {
-    let controller = event.data.controller;
-
-    if(controller.submitEnabled) {
-      window.removeEventListener('beforeunload', event.data.controller.beforeUnloadListener, {capture: true});
-      $(event.target).prop("value", event.data.controller.text.actions.saving );
-    } else {
-      event.preventDefault();
-    }
-  }
-
-  onSubmitListener(event) {
-    let controller = event.data.controller;
-
-    if(controller.submitEnabled) {
-      event.data.controller.update();
-      event.data.controller.removeBeforeUnloadListener();
-    } else {
-      event.preventDefault();
-    }
-  }
-
-  onKeyDownListener(event) {
-    let key = event.key;
-    let controller = event.data.controller;
-
-    if(!controller.submitEnabled) {
-      switch(key) {
-        case('Enter'):
-          event.preventDefault();
-          break;
-        case(' '):
-          event.preventDefault();
-          break;
+    this.$form.on('submit', (event) => {
+      if(this.submitEnabled) {
+        this.update();
+        this.removeBeforeUnloadListener();
+      } else {
+        event.preventDefault();
       }
-      return false;
-    }
+    });
+
+    this.$submitButton.on('click', (event) => {
+      if(this.submitEnabled) {
+        this.removeBeforeUnloadListener();
+        $(event.target).prop("value", this.text.actions.saving );
+      } else {
+        event.preventDefault();
+      }
+    });
   }
   
   beforeUnloadListener(event) {

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -156,7 +156,7 @@ class DataController {
     this.text = view.text;
     this.$form = $form;
     this.$submitButton = this.$form.find(':submit');
-    this.submitEnabled;
+    this.$saveDescription = this.$form.find('#save_description');
 
     this.$form.on('keydown', {controller: controller} , this.onKeyDownListener); 
     this.$form.on('submit', {controller: controller} , this.onSubmitListener);
@@ -219,12 +219,14 @@ class DataController {
     if(required) { 
       this.$submitButton.prop("value", this.text.actions.save );
       this.$submitButton.attr("aria-disabled", false);
+      this.$saveDescription.text("");
       this.submitEnabled = true;
       this.addBeforeUnloadListener();
     } else {
       this.$submitButton.prop("value", this.text.actions.saved );
       // Use aria-disabled so AT users can still discover the button
       this.$submitButton.attr("aria-disabled", true);
+      this.$saveDescription.text(this.text.aria.disabled_save_description);
       this.submitEnabled = false;
       this.removeBeforeUnloadListener();
     }

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -27,7 +27,8 @@
     <% end %>
   <% end %>
 
-  <%= f.submit t('actions.save'), class: 'govuk-button fb-govuk-button', id: 'fb-editor-save' %>
+  <%= f.submit t('actions.save'), class: 'govuk-button fb-govuk-button', id: 'fb-editor-save', 'aria-describedby': "save_description" %>
+  <span class="sr-only" id="save_description"></span>
 <% end %>
 
 <% # app.page is initialised in partials/properties. %>

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -29,7 +29,8 @@
         answers: "<%= t('aria.answers') %>",
         hint: "<%= t('aria.hint') %>",
         question: "<%= t('aria.question') %>",
-        section_heading: "<%= t('aria.section_heading') %>"
+        section_heading: "<%= t('aria.section_heading') %>",
+        disabled_save_description: "<%= t('aria.disabled_save_description') %>",
       },
       branches: {
         branch_edit: "<%= t('branches.branch_edit') %>",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
     question: Question
     section_heading: Section Heading
     flow_thumbnail: 'Form page'
+    disabled_save_description: 'No changes to save'
     page:
       start: Start page
       singlequestion: Single question page


### PR DESCRIPTION
Updates the question edit view save button to use `aria-disabled` instead of `disabled`.

This allows users of assistive technology to access the button in its disabled state.

Becasue `aria-disabled` only updates the buttons semantics, we add in liseners to capture `click`, `submit` and `keydown` events to prevent the submission of the form when the button is disabled. 

We also override these listeners for actions that need to submit the form: Add New Component and Add Content