### PR TITLE
Update CSV validator to allow for excel mime type

### DIFF
--- a/app/validators/csv_validator.rb
+++ b/app/validators/csv_validator.rb
@@ -45,7 +45,8 @@ class CsvValidator < ActiveModel::Validator
   private
 
   def not_csv?(record)
-    ['text/csv', 'application/csv'].exclude?(record.file.content_type)
+    !record.file.original_filename.end_with?('.csv') &&
+      ['text/csv', 'application/csv', 'application/vnd.ms-excel'].exclude?(record.file.content_type)
   end
 
   def invalid_headings?(record, headings)


### PR DESCRIPTION
THis PR fixes an issue in Firefox on windows where valid CSV files are rejected on upload.

This is triggered when the user has Excel installed on their machine, which means that Firefox reports the mime type of a CSV file on upload as `application/vnd.ms-excel`.

This seems to be because excel claims that mime type for CSV files in the Windows registry, and Firefox defers to that instead of using an internal list mime-types.

The solution is to allow the mime type `application/vnd.ms-excel` in the validation, but also add in a chekc that the file extension is `.csv`.  This isn't perfect, but does mean that the average windows user saving a CSV out of excel will now be able to upload in Firefox.