### PR TITLE
Add in route and controller and frontend resend validation link

### DIFF
--- a/app/controllers/api/from_address_controller.rb
+++ b/app/controllers/api/from_address_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  class FromAddressController < ApiController
+    def resend_validation
+      head :ok
+    end
+  end
+end

--- a/app/javascript/src/controller_from_address.js
+++ b/app/javascript/src/controller_from_address.js
@@ -1,0 +1,43 @@
+const DefaultController = require('./controller_default');
+const { meta } = require('./utilities.js');
+
+class FromAddressController extends DefaultController {
+  constructor(app) {
+    super(app);
+    switch(app.page.action) {
+      case 'create':
+      case 'index':
+        this.index();
+      break;
+    }
+  }
+
+  index() {
+    this.#enhanceRemoteButtons();
+  }
+
+  #enhanceRemoteButtons() {
+    $('button[data-remote]').each(function(index) {
+      const $button = $(this);
+      const token = meta("csrf-token");
+      const url = this.dataset.url;
+      const method = this.dataset.method || 'get';
+      const message = this.dataset.success;
+
+      $button.on('click', (e) => {
+        e.preventDefault();
+        $.ajax({
+          url: url,
+          type: method,
+          headers: { 'X-CSRF-Token': token },
+          success: () => {
+            // If it happens too quickly, it feels like it hasn't done anything
+            setTimeout( () =>  { $button.parent().find('[role="alert"]').text(message); $button.remove() }, 400 );
+          }
+        })
+      });
+    })
+  }
+}
+
+module.exports = FromAddressController;

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -5,6 +5,7 @@ const FormListPage = require('./page_form_list');
 const PublishController = require('./controller_publish');
 const BranchesController = require('./controller_branches');
 const FormAnalyticsController = require('./controller_form_analytics');
+const FromAddressController = require('./controller_from_address');
 
 
 // Determine the controller we need to use
@@ -63,6 +64,11 @@ switch(controllerAndAction()) {
   case "Form_analyticsController#create":
   case "Form_analyticsController#index":
        Controller = FormAnalyticsController;
+  break;
+
+  case "From_addressController#index":
+  case "From_addressController#create":
+      Controller = FromAddressController;
   break;
 
   default:

--- a/app/views/settings/from_address/index.html.erb
+++ b/app/views/settings/from_address/index.html.erb
@@ -11,7 +11,17 @@
     <% if @presenter.message[:status] == 'pending' %>
       <%= govuk_notification_banner(title_text: t('notification_banners.important')) do %>
         <%= @presenter.message[:text].html_safe %>
-        <p><%= govuk_link_to t('settings.from_address.resend_link_text'), "#" %></p>
+        <p>
+          <span role="alert"></span> 
+          <%= tag.button t('settings.from_address.resend_link_text'),
+            class: 'fb-link-button',
+            data: {
+              remote: true,
+              method: 'post',
+              url: api_service_settings_from_address_resend_path(service.service_id),
+              success: t('settings.from_address.link_resent_success')
+            } %>
+        </p>
       <% end %>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,6 +286,7 @@ en:
         pending: <strong>Now check the email you set for a validation link</strong><br /><br />The email will come from <b>Amazon Web Services</b>. The link is valid for 24 hours. 
         verified: This email address has been validated.
       resend_link_text: Resend validation link
+      link_resent_success: Link resent - now check your email 
     form_analytics:
       name: Google Analytics
       hint:  Monitor your form's performance (requires a Google Analytics account).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,8 @@ Rails.application.routes.draw do
 
       get '/components/:component_id/autocomplete', to: 'autocomplete#show', as: :autocomplete
       post '/components/:component_id/autocomplete', to: 'autocomplete#create'
+
+      post 'settings/from_address/resend', to: 'from_address#resend_validation'
     end
   end
 


### PR DESCRIPTION
Adds in frontend functionality for the resend validation email link.

Button in frontend posts asynchronously to the `Api::FromAddressController#resend_validation` action.  This is currently stubbed to simply respond with `200 OK` status. Which is the only response it will ever send.

On successful response the button is hidden and an aria-live region is updated with the success message, allowing AT users to be notified of the need to go check their email.

