### PR TITLE
Allow `justice.gsi` domain for FromAddress emails

### DIFF
--- a/app/models/from_address.rb
+++ b/app/models/from_address.rb
@@ -7,7 +7,7 @@ class FromAddress < ApplicationRecord
     message: I18n.t('activemodel.errors.models.from_address.invalid')
   }, allow_blank: true
   validates :email, format: {
-    with: /\A\b[A-Z0-9._%a-z\-]+@(digital\.justice|justice)\.gov\.uk\z/,
+    with: /\A\b[A-Z0-9._%a-z\-]+@(digital\.justice|justice|justice.gsi)\.gov\.uk\z/,
     message: I18n.t('activemodel.errors.models.from_address.invalid_domain')
   }, allow_blank: true
 

--- a/spec/models/from_address_spec.rb
+++ b/spec/models/from_address_spec.rb
@@ -18,13 +18,22 @@ RSpec.describe FromAddress, type: :model do
   let(:email) { 'buck.rogers@digital.justice.gov.uk' }
 
   describe '#email_address' do
-    context 'when it is a valid email' do
-      it 'is valid' do
-        expect(from_address).to be_valid
-      end
+    valid_emails = [
+      'buck.rogers@digital.justice.gov.uk',
+      'atticus.finch@justice.gov.uk',
+      'jane.eyre@justice.gsi.gov.uk'
+    ]
+    valid_emails.each do |valid_email|
+      context "when it is a valid email: #{valid_email}" do
+        let(:email) { valid_email }
 
-      it 'returns the decrypted email value' do
-        expect(from_address.email_address).to eq(email)
+        it 'is valid' do
+          expect(from_address).to be_valid
+        end
+
+        it 'returns the decrypted email value' do
+          expect(from_address.email_address).to eq(valid_email)
+        end
       end
     end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/1MBG56LO/2922-from-address-add-gsi-domain-to-email-validation)
There are some teams in MoJ that use the `justice.gsi` domain. As such, we should allow teams to set up their From Address with this domain.