### PR TITLE
Add back links to all settings screens

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,6 +66,15 @@ module ApplicationHelper
     flow_object.title || service.find_page_by_uuid(flow_object.uuid).title
   end
 
+  def fb_back_link(path)
+    link_to path, class: 'fb-back-link' do
+      concat tag.span '<svg width="7" height="12" viewBox="0 0 7 12" fill="none" role="image" aria-hidden="true">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M5.75345 0L6.46045 0.706L1.41445 5.753L6.46045 10.799L5.75345 11.507L0.000449181 5.753L5.75345 0Z" fill="currentColor"/>
+        </svg>'.html_safe
+      concat tag.span 'Back'
+    end
+  end
+
   def moj_forms_team?
     return if current_user.blank?
 

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,0 +1,12 @@
+module SettingsHelper
+  def fb_settings_screen(back_link)
+    content_tag :div, class: 'fb-settings-screen' do
+      content_tag :div, class: 'govuk-grid-row' do
+        content_tag :div, class: 'govuk-grid-column-two-thirds' do
+          concat fb_back_link(back_link) if back_link
+          yield
+        end
+      end
+    end
+  end
+end

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -142,6 +142,29 @@ html {
   @include button_as_link;
 }
 
+.fb-back-link {
+  @extend %govuk-link;
+  @extend %govuk-body-s;
+  @include govuk-link-style-text;
+  @include govuk-link-style-no-underline;
+
+  display: inline-flex;
+  align-items: center;
+  position: absolute;
+  top: 16px;
+  left: 0;
+
+  > span:first-child {
+    margin-right: 4px;
+  }
+}
+
+.fb-settings-screen {
+  h1 {
+    margin-top: govuk-spacing(6);
+  }
+}
+
 
 /* Publishing
  * ------------------- */

--- a/app/views/settings/email/index.html.erb
+++ b/app/views/settings/email/index.html.erb
@@ -1,62 +1,60 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t('settings.submission.email.label') %></h1>
-    <p><%= t('settings.submission.email.help') %></p>
+<%= fb_settings_screen(settings_submission_index_path) do %>
+  <h1 class="govuk-heading-xl"><%= t('settings.submission.email.label') %></h1>
+  <p><%= t('settings.submission.email.help') %></p>
 
-    <%= form_for @email_settings_dev,
-      url: settings_email_index_path(service.service_id),
-      html: { id: 'email-submission-dev' } do |f| %>
-      <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-              <h2 class="govuk-fieldset__heading"><%= t('publish.test.heading') %></h2>
-            </legend>
-            <div class="govuk-hint"><%= t('publish.test.hint') %></div>
-            <div class="govuk-checkboxes">
-              <div class="govuk-checkboxes__item">
-                <%= f.check_box :send_by_email_dev, class: 'govuk-checkboxes__input',
-                  checked: f.object.send_by_email_checked? %>
-                <%= f.label :send_by_email_dev,
-                  f.object.class.human_attribute_name(:send_by_email_dev),
-                  class: 'govuk-label govuk-checkboxes__label' %>
-              </div>
-            </div>
-          </fieldset>
-      </div>
-
-      <%= render 'form', f: f, deployment_environment: 'dev' %>
-
-      <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
-        <%= t('settings.submission.email.save_test') %>
-      </button>
-    <% end %>
-
-    <%= form_for @email_settings_production,
-      url: settings_email_index_path(service.service_id),
-      html: { id: 'email-submission-production' } do |f| %>
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h2 class="govuk-fieldset__heading"><%= t('publish.live.heading') %></h2>
-          </legend>
-          <div class="govuk-hint"><%= t('publish.live.hint') %></div>
-          <div class="govuk-checkboxes">
-            <div class="govuk-checkboxes__item">
-              <%= f.check_box :send_by_email_production, class: 'govuk-checkboxes__input',
-                checked: f.object.send_by_email_checked? %>
-              <%= f.label :send_by_email_production,
-                f.object.class.human_attribute_name(:send_by_email_production),
-                class: 'govuk-label govuk-checkboxes__label' %>
-            </div>
+  <%= form_for @email_settings_dev,
+    url: settings_email_index_path(service.service_id),
+    html: { id: 'email-submission-dev' } do |f| %>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <h2 class="govuk-fieldset__heading"><%= t('publish.test.heading') %></h2>
+        </legend>
+        <div class="govuk-hint"><%= t('publish.test.hint') %></div>
+        <div class="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <%= f.check_box :send_by_email_dev, class: 'govuk-checkboxes__input',
+              checked: f.object.send_by_email_checked? %>
+            <%= f.label :send_by_email_dev,
+              f.object.class.human_attribute_name(:send_by_email_dev),
+              class: 'govuk-label govuk-checkboxes__label' %>
           </div>
-        </fieldset>
-      </div>
+        </div>
+      </fieldset>
+    </div>
 
-      <%= render 'form', f: f, deployment_environment: 'production' %>
+    <%= render 'form', f: f, deployment_environment: 'dev' %>
 
-      <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
-        <%= t('settings.submission.email.save_live') %>
-      </button>
-    <% end %>
-  </div>
-</div>
+    <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
+      <%= t('settings.submission.email.save_test') %>
+    </button>
+  <% end %>
+
+  <%= form_for @email_settings_production,
+    url: settings_email_index_path(service.service_id),
+    html: { id: 'email-submission-production' } do |f| %>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <h2 class="govuk-fieldset__heading"><%= t('publish.live.heading') %></h2>
+        </legend>
+        <div class="govuk-hint"><%= t('publish.live.hint') %></div>
+        <div class="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+            <%= f.check_box :send_by_email_production, class: 'govuk-checkboxes__input',
+              checked: f.object.send_by_email_checked? %>
+            <%= f.label :send_by_email_production,
+              f.object.class.human_attribute_name(:send_by_email_production),
+              class: 'govuk-label govuk-checkboxes__label' %>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+
+    <%= render 'form', f: f, deployment_environment: 'production' %>
+
+    <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
+      <%= t('settings.submission.email.save_live') %>
+    </button>
+  <% end %>
+<% end %>

--- a/app/views/settings/form_analytics/index.html.erb
+++ b/app/views/settings/form_analytics/index.html.erb
@@ -1,25 +1,23 @@
-<div class="govuk-grid-row">
-  <% if @form_analytics.errors.present? %>
-    <div class="govuk-grid-column-two-thirds govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
-      <h2 class="govuk-error-summary__title" id="error-summary-title">
-        <%= t('activemodel.errors.summary_title') %>
-      </h2>
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          <% @form_analytics.errors.each do |error|  %>
-            <li><a href="#<%= error.attribute %>"><%= error.message %></a></li>
-          <% end %>
-        </ul>
+<%= fb_settings_screen(settings_path) do %>
+    <% if @form_analytics.errors.present? %>
+      <div class="govuk-grid-column-two-thirds govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
+        <h2 class="govuk-error-summary__title" id="error-summary-title">
+          <%= t('activemodel.errors.summary_title') %>
+        </h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <% @form_analytics.errors.each do |error|  %>
+              <li><a href="#<%= error.attribute %>"><%= error.message %></a></li>
+            <% end %>
+          </ul>
+        </div>
       </div>
-    </div>
-  <% end %>
-
-  <div class="govuk-grid-column-two-thirds">
+    <% end %>
     <h1 class="govuk-heading-xl"><%= t('settings.form_analytics.name') %></h1>
     <p class="govuk-body"><%= t('settings.form_analytics.intro') %></p>
 
     <%= form_for @form_analytics, url: settings_form_analytics_path(service.service_id),
-        html: { id: 'form-analytics-settings' } do |f| %>
+      html: { id: 'form-analytics-settings' } do |f| %>
 
       <%= render partial: 'form', locals: { f: f, environment: 'test' } %>
       <%= render partial: 'form', locals: { f: f, environment: 'live' } %>
@@ -27,6 +25,5 @@
       <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
         <%= t('actions.save') %>
       </button>
-    <% end %>
-  </div>
-</div>
+  <% end %>
+<% end %>

--- a/app/views/settings/form_information/index.html.erb
+++ b/app/views/settings/form_information/index.html.erb
@@ -1,20 +1,22 @@
-<h1 class="govuk-heading-xl"><%= t('settings.form_information.name') %></h1>
+<%= fb_settings_screen(settings_path) do %>
+  <h1 class="govuk-heading-xl"><%= t('settings.form_information.name') %></h1>
 
-<%= form_for @settings, as: :service, url: settings_form_information_index_path(service.service_id) do |f| %>
-  <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
-    <%#= f.label :service_name, class: "govuk-label" do %>
-      <%#= f.object.class.human_attribute_name :service_name %>
-    <%# end %>
-    <p>
-      <%= f.object.class.human_attribute_name :service_name %>
-      <div class="govuk-hint" id="<%= "#{:service_name}-hint" %>"><%= t('settings.form_information.form_name.hint') %></div>
-      <span class="width-responsive-two-thirds"><%= @settings.service_name %></span>
-      </p>
-    <% f.object.errors.each do |error|  %>
-      <p class="govuk-error-message"><%= error.message %></p>
-    <% end %>
-    <%#= f.text_field :service_name, class: "govuk-input width-responsive-two-thirds", aria: { describedby: "#{:service_name}-hint #{:service_name}-warning" } %>
-    <%= render partial: 'partials/template_warning', locals: { id: "#{:service_name}-warning", message: t('settings.form_information.form_name.warning_message').html_safe } %>
-  </div>
-  <%= f.submit t('actions.save'), class: "govuk-button fb-govuk-button", disabled: true %>
+  <%= form_for @settings, as: :service, url: settings_form_information_index_path(service.service_id) do |f| %>
+    <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
+      <%#= f.label :service_name, class: "govuk-label" do %>
+        <%#= f.object.class.human_attribute_name :service_name %>
+        <%# end %>
+        <p>
+          <%= f.object.class.human_attribute_name :service_name %>
+          <div class="govuk-hint" id="<%= "#{:service_name}-hint" %>"><%= t('settings.form_information.form_name.hint') %></div>
+          <span class="width-responsive-two-thirds"><%= @settings.service_name %></span>
+        </p>
+        <% f.object.errors.each do |error|  %>
+          <p class="govuk-error-message"><%= error.message %></p>
+        <% end %>
+        <%#= f.text_field :service_name, class: "govuk-input width-responsive-two-thirds", aria: { describedby: "#{:service_name}-hint #{:service_name}-warning" } %>
+        <%= render partial: 'partials/template_warning', locals: { id: "#{:service_name}-warning", message: t('settings.form_information.form_name.warning_message').html_safe } %>
+    </div>
+    <%= f.submit t('actions.save'), class: "govuk-button fb-govuk-button", disabled: true %>
+  <% end %>
 <% end %>

--- a/app/views/settings/from_address/index.html.erb
+++ b/app/views/settings/from_address/index.html.erb
@@ -1,10 +1,8 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-
-    <%= form_for @from_address,
-      method: :post,
-      url: settings_from_address_index_path(service.service_id),
-      builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+<%= fb_settings_screen(settings_submission_index_path) do %>
+  <%= form_for @from_address,
+    method: :post,
+    url: settings_from_address_index_path(service.service_id),
+    builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
 
     <%= f.govuk_error_summary link_base_errors_to: :email %>
 
@@ -50,5 +48,4 @@
       <%= t('actions.save') %>
     </button>
   <% end %>
-  </div>
-</div>
+<% end %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,21 +1,19 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 id="settings-navigation-heading" class="govuk-heading-xl"><%= t('settings.name') %></h1>
-    <nav class="govuk-navigation" aria-labelledby="settings-navigation-heading">
-      <dl class="fb-settings-list">
-        <div>
-          <dt><%= link_to t('settings.form_information.name'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %></dt>
-          <dd class="govuk-hint"><%= t('settings.form_information.description') %></dd>
-        </div>
-        <div>
-          <dt><%= link_to t('settings.form_analytics.name'), settings_form_analytics_path(service.service_id), class: 'govuk-link' %></dt>
-          <dd class="govuk-hint" ><%= t('settings.form_analytics.hint') %></dd>
-        </div>
-        <div>
-          <dt><%= link_to t('settings.submission.name'), settings_submission_index_path(service.service_id), class: 'govuk-link' %></dt>
-          <dd class="govuk-hint" ><%= t('settings.submission.hint') %></dd>
-        </div>
-      </dl>
-    </nav>
-  </div>
-</div>
+<%= fb_settings_screen(false) do %>
+  <h1 id="settings-navigation-heading" class="govuk-heading-xl"><%= t('settings.name') %></h1>
+  <nav class="govuk-navigation" aria-labelledby="settings-navigation-heading">
+    <dl class="fb-settings-list">
+      <div>
+        <dt><%= link_to t('settings.form_information.name'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %></dt>
+        <dd class="govuk-hint"><%= t('settings.form_information.description') %></dd>
+      </div>
+      <div>
+        <dt><%= link_to t('settings.form_analytics.name'), settings_form_analytics_path(service.service_id), class: 'govuk-link' %></dt>
+        <dd class="govuk-hint" ><%= t('settings.form_analytics.hint') %></dd>
+      </div>
+      <div>
+        <dt><%= link_to t('settings.submission.name'), settings_submission_index_path(service.service_id), class: 'govuk-link' %></dt>
+        <dd class="govuk-hint" ><%= t('settings.submission.hint') %></dd>
+      </div>
+    </dl>
+  </nav>
+<% end %>

--- a/app/views/settings/submission/index.html.erb
+++ b/app/views/settings/submission/index.html.erb
@@ -1,19 +1,17 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 id="settings-navigation-heading" class="govuk-heading-xl"><%= t('settings.submission.name') %></h1>
-    <p class="govuk-body"><%= t('settings.submission.sub_heading') %></p>
-    <nav class="govuk-navigation" aria-labelledby="settings-navigation-heading">
-      <dl aria-labelledby="submission-settings-navigation-heading" class="fb-settings">
-        <% if ENV['FROM_ADDRESS'] == 'enabled' %>
-          <div>
-            <dt><%= link_to t('settings.submission.from_address.label'), settings_from_address_index_path(service.service_id), class: 'govuk-link' %></dt>
-            <dd class="govuk-hint"><%= t('settings.form_information.description') %></dd>
-          </div>
-        <% end %>
+<%= fb_settings_screen(settings_path) do %>
+  <h1 id="settings-navigation-heading" class="govuk-heading-xl"><%= t('settings.submission.name') %></h1>
+  <p class="govuk-body"><%= t('settings.submission.sub_heading') %></p>
+  <nav class="govuk-navigation" aria-labelledby="settings-navigation-heading">
+    <dl aria-labelledby="submission-settings-navigation-heading" class="fb-settings">
+      <% if ENV['FROM_ADDRESS'] == 'enabled' %>
         <div>
-          <dt><%= link_to t('settings.submission.email.label'), settings_email_index_path(service.service_id), class: 'govuk-link' %></dt>
+          <dt><%= link_to t('settings.submission.from_address.label'), settings_from_address_index_path(service.service_id), class: 'govuk-link' %></dt>
+          <dd class="govuk-hint"><%= t('settings.form_information.description') %></dd>
         </div>
-      </dl>
-    </nav>
-  </div>
-</div>
+      <% end %>
+      <div>
+        <dt><%= link_to t('settings.submission.email.label'), settings_email_index_path(service.service_id), class: 'govuk-link' %></dt>
+      </div>
+    </dl>
+  </nav>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,7 +277,7 @@ en:
       form_name:
         label: 'Form name'
         hint: 'The visible name of your form'
-        warning_message: 'We are making some changes in this area. In the meantime, <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/contact/">contact us</a> to change your form’s name.'
+        warning_message: 'We are making some changes in this area. In the meantime, <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/contact/">contact&nbsp;us</a> to change your form’s name.'
     from_address:
       heading: "‘From’ address"
       lede: Emails sent by your form, either to you or to people filling it in, will come from this address


### PR DESCRIPTION
This PR adds a few visual improvements to match the Figma designs:
* Add backlinks to all the setting screens
* Correct the top and bottom title spacing (both with and without back button)

![image](https://user-images.githubusercontent.com/595564/191281462-3d25babf-0a8b-41ed-acb3-f11af7e0ea85.png)

![image](https://user-images.githubusercontent.com/595564/191281537-822df7fa-c847-4c1d-afb8-1c88ef2a50c2.png)

This is implemented by adding 2 helpers:
* A back link helper 
* A setting screen helper - a wrapper for the page grid container divs and the back button (if needed) allowing new settings screens to be easily created with the correct layout/formatting and back link.

