### PR TITLE
Fix to deployment fails due to acceptances tests not updated

### DIFF
--- a/acceptance/features/edit_single_question_autocomplete_page_spec.rb
+++ b/acceptance/features/edit_single_question_autocomplete_page_spec.rb
@@ -13,10 +13,10 @@ feature 'Edit single question autocomplete page' do
   let(:upload_success) { I18n.t('dialogs.autocomplete.success') }
   let(:upload_button) { I18n.t('dialogs.autocomplete.button') }
   let(:upload_modal_warning) { I18n.t('dialogs.autocomplete.modal_warning') }
-  let(:valid_csv) { './spec/fixtures/special_characters.csv' }
-  let(:valid_csv_one_column) { './spec/fixtures/valid_one_column.csv' }
+  let(:valid_csv) { './spec/fixtures/autocomplete/special_characters.csv' }
+  let(:valid_csv_one_column) { './spec/fixtures/autocomplete/valid_one_column.csv' }
   let(:autocomplete_option) { 'Congo, Democratic Republic of' }
-  let(:invalid_csv) { './spec/fixtures/invalid.csv' }
+  let(:invalid_csv) { './spec/fixtures/autocomplete/invalid.csv' }
   let(:incorrect_format) { I18n.t('activemodel.errors.models.autocomplete_items.invalid_headings') }
 
   background do

--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -25,7 +25,7 @@ feature 'Publishing' do
   let(:test_warning_message) {I18n.t('publish.warning.autocomplete_items', title: 'Question') }
   let(:live_warning_message) { I18n.t('publish.error.autocomplete_items', title: 'Question') }
   let(:upload_button) { I18n.t('dialogs.autocomplete.button') }
-  let(:valid_csv_one_column) { './spec/fixtures/valid_one_column.csv' }
+  let(:valid_csv_one_column) { './spec/fixtures/autocomplete/valid_one_column.csv' }
 
   background do
     given_I_am_logged_in


### PR DESCRIPTION
Acceptances tests failed due to move of fixtures files in a specific autocomplete folder.

Update to correct path in acceptances tests was required.