### PR TITLE
Add a cronjob to sync emails in our DB to AWS SES

### DIFF
--- a/app/services/from_address_creation.rb
+++ b/app/services/from_address_creation.rb
@@ -3,9 +3,7 @@ class FromAddressCreation
   attr_accessor :from_address, :from_address_params, :email_service
 
   def save
-    unless from_address_params[:email] == FromAddress::DEFAULT_EMAIL_FROM
-      status = verify_email
-    end
+    status = verify_email
     from_address.update!(from_address_params.merge(status: status))
   rescue ActiveRecord::RecordInvalid
     false
@@ -15,7 +13,7 @@ class FromAddressCreation
   end
 
   def verify_email
-    return if from_address_params[:email].blank?
+    return :default if use_default_email?
 
     if email_service.get_email_identity(from_address_params[:email]).blank?
       email_service.create_email_identity(from_address_params[:email])
@@ -42,5 +40,12 @@ class FromAddressCreation
 
   def email_identity
     all_identities.find { |i| i.identity_name == from_address_params[:email] }
+  end
+
+  private
+
+  def use_default_email?
+    from_address_params[:email].blank? ||
+      from_address_params[:email] == FromAddress::DEFAULT_EMAIL_FROM
   end
 end

--- a/app/services/from_address_sync.rb
+++ b/app/services/from_address_sync.rb
@@ -5,7 +5,7 @@ class FromAddressSync
       email_id = email_identities.find do |i|
         i.identity_name == decrypted_email
       end
-      record.update_column(:status, :verified) if email_id&.sending_enabled
+      record.verified! if email_id&.sending_enabled
     end
   end
 

--- a/app/services/from_address_sync.rb
+++ b/app/services/from_address_sync.rb
@@ -1,0 +1,27 @@
+class FromAddressSync
+  def call
+    email_pending.each do |record|
+      decrypted_email = record.decrypt_email
+      email_id = email_identities.find do |i|
+        i.identity_name == decrypted_email
+      end
+      record.update_column(:status, :verified) if email_id&.sending_enabled
+    end
+  end
+
+  private
+
+  def ses
+    @ses ||= EmailService::Adapters::AwsSesClient.new
+  end
+
+  def email_identities
+    @email_identities ||= ses.list_email_identities.email_identities.select do |id|
+      id.identity_type == 'EMAIL_ADDRESS'
+    end
+  end
+
+  def email_pending
+    @email_pending ||= FromAddress.where(status: :pending)
+  end
+end

--- a/deploy-eks/fb-editor-chart/templates/from_address.yaml
+++ b/deploy-eks/fb-editor-chart/templates/from_address.yaml
@@ -1,0 +1,72 @@
+{{- if eq .Values.from_address "enabled" }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: fb-editor-cron-from-address-{{ .Values.environmentName }}
+  namespace: formbuilder-saas-{{ .Values.environmentName }}
+spec:
+  schedule: "*/2 * * * *"
+  successfulJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            from-address: cronjob
+        spec:
+          containers:
+          - name: "fb-editor-workers-{{ .Values.environmentName }}"
+            image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-editor-workers:{{ .Values.circleSha1 }}"
+            args:
+            - /bin/sh
+            - -c
+            - bundle exec rake from_address:sync
+            securityContext:
+              runAsUser: 1001
+            imagePullPolicy: Always
+            envFrom:
+              - configMapRef:
+                  name: fb-editor-config-map
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: sentry_dsn
+              - name: SECRET_KEY_BASE
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: secret_key_base
+              - name: DATABASE_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: rds-instance-formbuilder-editor-{{ .Values.environmentName }}
+                    key: url
+              - name: EDITOR_SERVICE_ACCOUNT_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.bearer_token }}
+                    key: token
+              - name: AWS_SES_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: aws_ses_access_key_id
+              - name: AWS_SES_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: aws_ses_secret_access_key
+              - name: ENCRYPTION_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: encryption_key
+              - name: ENCRYPTION_SALT
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: encryption_salt
+          restartPolicy: Never
+{{- end }}

--- a/lib/tasks/from_address.rake
+++ b/lib/tasks/from_address.rake
@@ -1,16 +1,7 @@
 namespace 'from_address' do
   desc 'Syncs From Address status to Editor DB'
   task sync: [:environment, 'db:load_config'] do
-    ses = EmailService::Adapters::AwsSesClient.new
-    email_identities = ses.list_email_identities.email_identities.select do |id|
-      id.identity_type == 'EMAIL_ADDRESS'
-    end
-
-    FromAddress.where(status: :pending).each do |record|
-      decrypted_email = record.decrypt_email
-      email_id = email_identities.find { |i| i.identity_name == decrypted_email }
-      record.update!(:status, :verified) if email_id&.sending_enabled
-    end
+    FromAddressSync.new.call
   rescue StandardError => e
     Sentry.capture_exception(e)
   end

--- a/lib/tasks/from_address.rake
+++ b/lib/tasks/from_address.rake
@@ -1,0 +1,17 @@
+namespace 'from_address' do
+  desc 'Syncs From Address status to Editor DB'
+  task sync: [:environment, 'db:load_config'] do
+    ses = EmailService::Adapters::AwsSesClient.new
+    email_identities = ses.list_email_identities.email_identities.select do |id|
+      id.identity_type == 'EMAIL_ADDRESS'
+    end
+
+    FromAddress.where(status: :pending).each do |record|
+      decrypted_email = record.decrypt_email
+      email_id = email_identities.find { |i| i.identity_name == decrypted_email }
+      record.update!(:status, :verified) if email_id&.sending_enabled
+    end
+  rescue StandardError => e
+    Sentry.capture_exception(e)
+  end
+end

--- a/spec/models/from_address_spec.rb
+++ b/spec/models/from_address_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe FromAddress, type: :model do
 
   context 'encrypting and decrypting emails' do
     before do
-      create(:from_address, service_id: service_id, email: email).save
+      create(:from_address, service_id: service_id, email: email)
     end
     let(:service_id) { SecureRandom.uuid }
     let(:created_from_address) { FromAddress.find_by(service_id: service_id) }

--- a/spec/services/from_address_creation_spec.rb
+++ b/spec/services/from_address_creation_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe FromAddressCreation, type: :model do
         expect(from_address).to be_persisted
       end
 
-      it 'doesn\'t call AWS SES' do
-        expect(from_address_creation).not_to receive(:verify_email)
+      it 'saves the default status' do
         from_address_creation.save
+        expect(from_address.reload.status).to eq('default')
       end
     end
 

--- a/spec/services/from_address_sync_spec.rb
+++ b/spec/services/from_address_sync_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe FromAddressSync do
+  subject(:from_address_sync) { described_class.new }
+  let(:identities) do
+    [
+      double(identity_name: enabled_email, identity_type: 'EMAIL_ADDRESS', sending_enabled: true),
+      double(identity_name: disabled_email, identity_type: 'EMAIL_ADDRESS', sending_enabled: false)
+    ]
+  end
+
+  let(:enabled_email) { 'paddington.bear@justice.gov.uk' }
+  let(:disabled_email) { 'yogi.bear@justice.gov.uk' }
+  let(:service_id) { SecureRandom.uuid }
+  let(:from_address) { FromAddress.find_or_initialize_by(service_id: service_id) }
+
+  describe '#call' do
+    context 'when records are pending' do
+      before do
+        allow(from_address_sync).to receive(
+          :email_identities
+        ).and_return(identities)
+      end
+
+      context 'when status is enable in AWS' do
+        before do
+          create(:from_address, :pending, service_id: service_id, email: enabled_email)
+        end
+        it 'updates record to verified' do
+          from_address_sync.call
+          expect(from_address.reload.status).to eq('verified')
+        end
+      end
+
+      context 'when status is disable in AWS' do
+        before do
+          create(:from_address, :pending, service_id: service_id, email: disabled_email)
+        end
+
+        it 'does not update record' do
+          from_address_sync.call
+          expect(from_address.reload.status).to eq('pending')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/yF6a6dGl/2917-from-address-create-a-cronjob-to-sync-validated-email-address)

### Add cron job to sync FromAddress table with AWS
We have a table that holds the verification status of a user's email. To verify an email, a user needs to click a verification link sent to their email address - this could occur at any time. Therefore, we need a cronjob that interrogates AWS SES API to ensure our database reflects what is in AWS SES.

### Move cronjob implementation to a class
This is so we can unit test the implementation.

### Update validator so it only runs on unencrypted strings