### PR TITLE
Add email domain allowlist for FromAddress

### DIFF
--- a/app/models/from_address.rb
+++ b/app/models/from_address.rb
@@ -6,11 +6,8 @@ class FromAddress < ApplicationRecord
     with: URI::MailTo::EMAIL_REGEXP,
     message: I18n.t('activemodel.errors.models.from_address.invalid')
   }, allow_blank: true
-  validates :email, format: {
-    if: proc { |obj| obj.run_validation? },
-    with: /\A\b[A-Z0-9._%a-z\-]+@(digital\.justice|justice)\.gov\.uk\z/,
-    message: I18n.t('activemodel.errors.models.from_address.invalid_domain')
-  }, allow_blank: true
+
+  validates_with EmailDomainValidator, if: proc { |obj| obj.run_validation? }, allow_blank: true
 
   enum status: {
     default: 0,

--- a/app/validators/email_domain_validator.rb
+++ b/app/validators/email_domain_validator.rb
@@ -1,0 +1,21 @@
+class EmailDomainValidator < ActiveModel::Validator
+  ALLOWED_DOMAINS = [
+    'justice.gov.uk',
+    'digital.justice.gov.uk'
+  ].freeze
+
+  def validate(record)
+    return if record.email.blank?
+
+    unless allowed_domain?(record.email)
+      record.errors.add(:base, I18n.t('activemodel.errors.models.from_address.invalid_domain'))
+    end
+  end
+
+  private
+
+  def allowed_domain?(email)
+    domain = email.split('@').last
+    domain.in?(ALLOWED_DOMAINS)
+  end
+end

--- a/spec/validators/email_domain_validator_spec.rb
+++ b/spec/validators/email_domain_validator_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe EmailDomainValidator do
+  let(:subject) { FromAddress.new(params) }
+  let(:params) do
+    {
+      service_id: SecureRandom.uuid,
+      email: email
+    }
+  end
+  let(:email) { 'buck.rogers@digital.justice.gov.uk' }
+
+  describe '#validate' do
+    before do
+      subject.validate
+    end
+
+    context 'when email is allowed' do
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'when email is not allowed' do
+      let(:email) { 'buck.rogers@gmail.com' }
+
+      it 'is not valid' do
+        expect(subject).to_not be_valid
+      end
+
+      it 'returns the correct error message' do
+        expect(subject.errors.full_messages).to eq([I18n.t(
+          'activemodel.errors.models.from_address.invalid_domain'
+        )])
+      end
+    end
+
+    context 'when email is blank' do
+      let(:email) { '' }
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/uG6KFmbT/2952-from-address-move-justice-and-digitaljustice-domains-into-an-allowlist)

Moved allowed domains into a validator that checks against an allow list. We want to be able to easily add domains to the allow list as the app grows.