### PR TITLE
Re-send email verification link for From Address 

### DIFF
--- a/app/controllers/api/from_address_controller.rb
+++ b/app/controllers/api/from_address_controller.rb
@@ -1,14 +1,10 @@
 module Api
   class FromAddressController < ApiController
+    include FromAddressObjects
+
     before_action :assign_from_address
 
     def resend_validation
-      from_address_creation = FromAddressCreation.new(
-        from_address: @from_address,
-        from_address_params: {},
-        email_service: email_service
-      )
-
       if from_address_creation.resend_validation
         head :ok
       else
@@ -16,18 +12,8 @@ module Api
       end
     end
 
-    private
-
-    def assign_from_address
-      @from_address = FromAddress.find_or_initialize_by(service_id: service.service_id)
-    end
-
-    def email_service
-      @email_service ||= if Rails.env.production?
-                           EmailService::Adapters::AwsSesClient.new
-                         else
-                           EmailService::Adapters::Local.new
-                         end
+    def from_address_params
+      {}
     end
   end
 end

--- a/app/controllers/api/from_address_controller.rb
+++ b/app/controllers/api/from_address_controller.rb
@@ -1,7 +1,33 @@
 module Api
   class FromAddressController < ApiController
+    before_action :assign_from_address
+
     def resend_validation
-      head :ok
+      from_address_creation = FromAddressCreation.new(
+        from_address: @from_address,
+        from_address_params: {},
+        email_service: email_service
+      )
+
+      if from_address_creation.resend_validation
+        head :ok
+      else
+        head :bad_request
+      end
+    end
+
+    private
+
+    def assign_from_address
+      @from_address = FromAddress.find_or_initialize_by(service_id: service.service_id)
+    end
+
+    def email_service
+      @email_service ||= if Rails.env.production?
+                           EmailService::Adapters::AwsSesClient.new
+                         else
+                           EmailService::Adapters::Local.new
+                         end
     end
   end
 end

--- a/app/controllers/settings/from_address_controller.rb
+++ b/app/controllers/settings/from_address_controller.rb
@@ -30,10 +30,10 @@ class Settings::FromAddressController < FormController
   end
 
   def email_service
-    @email_service ||= if Rails.env.development?
-                         EmailService::Adapters::Local.new
-                       else
+    @email_service ||= if Rails.env.production?
                          EmailService::Adapters::AwsSesClient.new
+                       else
+                         EmailService::Adapters::Local.new
                        end
   end
 end

--- a/app/controllers/settings/from_address_controller.rb
+++ b/app/controllers/settings/from_address_controller.rb
@@ -1,15 +1,11 @@
 class Settings::FromAddressController < FormController
-  before_action :assign_from_address
+  include FromAddressObjects
+
+  before_action :assign_from_address, :assign_from_address_presenter
 
   def index; end
 
   def create
-    from_address_creation = FromAddressCreation.new(
-      from_address: @from_address,
-      from_address_params: from_address_params,
-      email_service: email_service
-    )
-
     if from_address_creation.save
       redirect_to settings_from_address_index_path(service.service_id)
     else
@@ -23,17 +19,7 @@ class Settings::FromAddressController < FormController
 
   private
 
-  def assign_from_address
-    # initialize for those forms that were created before FromAddress records existed
-    @from_address = FromAddress.find_or_initialize_by(service_id: service.service_id)
+  def assign_from_address_presenter
     @presenter = FromAddressPresenter.new(@from_address)
-  end
-
-  def email_service
-    @email_service ||= if Rails.env.production?
-                         EmailService::Adapters::AwsSesClient.new
-                       else
-                         EmailService::Adapters::Local.new
-                       end
   end
 end

--- a/app/models/from_address_objects.rb
+++ b/app/models/from_address_objects.rb
@@ -1,0 +1,22 @@
+module FromAddressObjects
+  def from_address_creation
+    @from_address_creation ||= FromAddressCreation.new(
+      from_address: @from_address,
+      from_address_params: from_address_params,
+      email_service: email_service
+    )
+  end
+
+  def assign_from_address
+    # initialize for those forms that were created before FromAddress records existed
+    @from_address = FromAddress.find_or_initialize_by(service_id: service.service_id)
+  end
+
+  def email_service
+    @email_service ||= if Rails.env.production?
+                         EmailService::Adapters::AwsSesClient.new
+                       else
+                         EmailService::Adapters::Local.new
+                       end
+  end
+end

--- a/app/services/email_service/adapters/local.rb
+++ b/app/services/email_service/adapters/local.rb
@@ -14,7 +14,7 @@ module EmailService
       end
 
       def delete_email_identity(_identity)
-        {}
+        OpenStruct.new(successful?: true)
       end
     end
   end

--- a/app/services/from_address_creation.rb
+++ b/app/services/from_address_creation.rb
@@ -34,6 +34,24 @@ class FromAddressCreation
     end
   end
 
+  def resend_validation
+    response = email_service.delete_email_identity(@from_address.decrypt_email)
+
+    if response.successful?
+      Rails.logger.info("Creating email identity for service #{from_address.service_id}")
+
+      email_service.create_email_identity(@from_address.decrypt_email)
+    else
+      Rails.logger.info("Delete email identity unsuccessful for service #{from_address.service_id}")
+
+      nil
+    end
+  rescue EmailServiceError
+    Rails.logger.info("Resend Validation unsuccessful for service #{from_address.service_id}")
+
+    nil
+  end
+
   def all_identities
     email_service.list_email_identities.email_identities
   end

--- a/app/views/settings/from_address/index.html.erb
+++ b/app/views/settings/from_address/index.html.erb
@@ -10,7 +10,7 @@
       <%= govuk_notification_banner(title_text: t('notification_banners.important')) do %>
         <%= @presenter.message[:text].html_safe %>
         <p>
-          <span role="alert"></span> 
+          <span role="alert"></span>
           <%= tag.button t('settings.from_address.resend_link_text'),
             class: 'fb-link-button',
             data: {

--- a/spec/requests/api/from_address_spec.rb
+++ b/spec/requests/api/from_address_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe 'From Address spec', type: :request do
+  let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+  let(:latest_metadata) { metadata_fixture(:version) }
+
+  before do
+    allow_any_instance_of(
+      Api::FromAddressController
+    ).to receive(:require_user!).and_return(true)
+
+    allow_any_instance_of(
+      Api::FromAddressController
+    ).to receive(:service).and_return(service)
+
+    allow_any_instance_of(
+      FromAddressCreation
+    ).to receive(:email_service).and_return(email_service)
+
+    create(:from_address, :pending, service_id: service_id, email: email)
+  end
+
+  describe 'POST /api/services/:service_id/settings/from_address/resend' do
+    let(:request) do
+      post "/api/services/#{service_id}/settings/from_address/resend"
+    end
+    let(:email) { 'bob@digital.justice.gov.uk' }
+    let(:service_id) { service.service_id }
+    let(:email_service) { double }
+
+    context 'context when resending validation' do
+      before do
+        allow(email_service).to receive(:create_email_identity)
+      end
+
+      it 'makes AWS call to delete identity' do
+        expect(email_service).to receive(:delete_email_identity).with(email).and_return(double(successful?: true))
+
+        request
+      end
+    end
+
+    context 'when call to delete identity is successful' do
+      before do
+        allow(email_service).to receive(:delete_email_identity).with(email).and_return(double(successful?: true))
+      end
+
+      it 'makes create identity call' do
+        expect(email_service).to receive(:create_email_identity).with(email)
+
+        request
+      end
+    end
+
+    context 'when call to delete identity is unsuccessful' do
+      before do
+        allow(email_service).to receive(:delete_email_identity).and_raise(EmailServiceError)
+
+        request
+      end
+
+      it 'raises an EmailServiceError' do
+        expect(response.status).to eq(400)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/uazpEFwF/2923-from-address-re-send-email-verification-link)
### Re-send verification link for FromAddress
When a user is unable to verify their email in time, we need to be able to re-send this email. AWS does not have a 're-send' API endpoint as such we need to first delete and then create the email identity again, this will trigger the AWS verification email.

### Move shared FromAddress methods into a FromAddressObjects module
These methods are now used in two controllers. Move the common methods out into a shared module to dry up the code.