### PR TITLE
From Address Publish mechanism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,9 +388,13 @@ workflows:
       - acceptance_tests_eks:
           requires:
             - deploy_to_test_eks
+      - confirm_live_deploy:
+          type: approval
+          requires:
+          - acceptance_tests_eks
       - deploy_to_live_eks:
           requires:
-            - acceptance_tests_eks
+            - confirm_live_deploy
   deploy_testable_branch:
     jobs:
       - build:

--- a/app/controllers/settings/email_controller.rb
+++ b/app/controllers/settings/email_controller.rb
@@ -28,7 +28,6 @@ class Settings::EmailController < FormController
       :deployment_environment,
       :send_by_email,
       :service_email_output,
-      :service_email_from,
       :service_email_subject,
       :service_email_body,
       :service_email_pdf_heading,

--- a/app/models/email_settings_updater.rb
+++ b/app/models/email_settings_updater.rb
@@ -12,7 +12,6 @@ class EmailSettingsUpdater
     SERVICE_EMAIL_SUBJECT
     SERVICE_EMAIL_BODY
     SERVICE_EMAIL_PDF_HEADING
-    SERVICE_EMAIL_FROM
   ].freeze
 
   def initialize(email_settings:, service:)

--- a/app/services/publish_service_creation.rb
+++ b/app/services/publish_service_creation.rb
@@ -40,6 +40,7 @@ class PublishServiceCreation
 
     ActiveRecord::Base.transaction do
       create_publish_service
+      assign_service_email_from
 
       if require_authentication?
         create_service_configurations
@@ -162,5 +163,15 @@ class PublishServiceCreation
       service_id: service_id,
       deployment_environment: deployment_environment
     ).try(:service_csv_output?)
+  end
+
+  def assign_service_email_from
+    create_or_update_configuration(
+      name: 'SERVICE_EMAIL_FROM', value: from_address_email
+    )
+  end
+
+  def from_address_email
+    FromAddress.find_or_initialize_by(service_id: service_id).email_address
   end
 end

--- a/spec/factories/service_configurations.rb
+++ b/spec/factories/service_configurations.rb
@@ -64,5 +64,10 @@ FactoryBot.define do
       name { 'SERVICE_CSV_OUTPUT' }
       value { 'true' }
     end
+
+    trait :service_email_from do
+      name { 'SERVICE_EMAIL_FROM' }
+      value { 'luke.piewalker@digital.justice.gov.uk' }
+    end
   end
 end

--- a/spec/models/email_settings_updater_spec.rb
+++ b/spec/models/email_settings_updater_spec.rb
@@ -266,23 +266,6 @@ RSpec.describe EmailSettingsUpdater do
       end
     end
 
-    context 'email from' do
-      let(:service_configuration) do
-        ServiceConfiguration.find_by(
-          service_id: service.service_id,
-          name: 'SERVICE_EMAIL_FROM'
-        )
-      end
-
-      before { email_settings_updater.create_or_update! }
-      it 'uses the default email from address' do
-        expect(service_configuration).to be_persisted
-        expect(
-          service_configuration.decrypt_value
-        ).to eq('moj-forms@digital.justice.gov.uk')
-      end
-    end
-
     context 'email subject' do
       context 'when email subject exists in the db' do
         let!(:service_configuration) do


### PR DESCRIPTION
[Trello](https://trello.com/c/eG608how/2928-publishing-add-send-from-address)

### Remove service email from from email updater
We no longer need the `SERVICE_EMAIL_FROM` service config here, as we will move this into the `PublishServiceCreation` class.
We need to separate the `SERVICE_EMAIL_FROM` out of the email settings page to be able to surface up to three different emails (ie: if the user has different emails published to Test, Live and saved in the `FromAddress` database) on the email settings page.

### Add service configuration for service email from
Now that we have removed the `SERVICE_EMAIL_FROM` from the `EmailUpdater`, we need to create the `SERVICE_EMAIL_FROM` config in the `PublishServiceCreation`. The `PublishServiceCreation` is only ever instantiated when a user clicks publish for a given service.
If the `SERVICE_EMAIL_FROM` config does not exist for a service, we create one with the existing email in the FromAddress record for that environment.

### Add the manual gate back into the deployment pipeline
This is because we are changing the Publishing mechanism, which we would like to test fully before deploying to Live.
Once we are happy with the behaviours in testing, we can move back to continuous deployment to Live.