### PR TITLE
From address save button

### DIFF
--- a/app/javascript/src/controller_from_address.js
+++ b/app/javascript/src/controller_from_address.js
@@ -1,18 +1,42 @@
-const DefaultController = require('./controller_default');
 const { meta } = require('./utilities.js');
+const DefaultController = require('./controller_default');
+const SubmitHandler = require('./submit_handler');
 
 class FromAddressController extends DefaultController {
   constructor(app) {
     super(app);
+
     switch(app.page.action) {
       case 'create':
       case 'index':
-        this.index();
+        this.#index();
       break;
     }
+    
+    
   }
 
-  index() {
+  #index() {
+    const view = this;
+    const  $form = $('#edit_from_address_1');
+
+    this.submitHandler = new SubmitHandler($form, {
+      text: {
+        submitted: view.text.actions.saved,
+        unsubmitted: view.text.actions.save,
+        submitting: view.text.actions.saving,
+        description: view.text.aria.disabled_save_description,
+      },
+      buttonSelector: '.fb-govuk-button[type="submit"]',
+      preventUnload: false,
+    });
+
+    // Don't show 'saved' if there are validation errors.
+    if(!$form.hasClass('with-errors')) {
+      this.submitHandler.submittable = false;
+    }
+
+    this.submitHandler.$form.on('change', (event) => { this.submitHandler.submittable = true } );
     this.#enhanceRemoteButtons();
   }
 

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -6,11 +6,13 @@ const PublishController = require('./controller_publish');
 const BranchesController = require('./controller_branches');
 const FormAnalyticsController = require('./controller_form_analytics');
 const FromAddressController = require('./controller_from_address');
-
+const {
+  snakeToPascalCase, 
+} = require('./utilities');
 
 // Determine the controller we need to use
 function controllerAndAction() {
-  var controller = app.page.controller.charAt(0).toUpperCase() + app.page.controller.slice(1);
+  var controller = snakeToPascalCase(app.page.controller);
   return controller + "Controller#" + app.page.action;
 }
 
@@ -61,13 +63,13 @@ switch(controllerAndAction()) {
        Controller = PublishController;
   break;
 
-  case "Form_analyticsController#create":
-  case "Form_analyticsController#index":
+  case "FormAnalyticsController#create":
+  case "FormAnalyticsController#index":
        Controller = FormAnalyticsController;
   break;
 
-  case "From_addressController#index":
-  case "From_addressController#create":
+  case "FromAddressController#index":
+  case "FromAddressController#create":
       Controller = FromAddressController;
   break;
 

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -350,6 +350,15 @@ function filterObject(obj, predicate) {
   );
 }
 
+function snakeToPascalCase( str ){
+    str+='';
+    str = str.split('_');
+    for(var i=0;i<str.length;i++){ 
+        str[i] = str[i].charAt(0).toUpperCase() + str[i].substring(1);
+    }
+    return str.join('');
+}
+
 
 
 
@@ -376,4 +385,5 @@ module.exports  = {
   lowestNumber:lowestNumber,
   highestNumber: highestNumber,
   filterObject: filterObject,
+  snakeToPascalCase: snakeToPascalCase,
 }

--- a/app/views/settings/from_address/index.html.erb
+++ b/app/views/settings/from_address/index.html.erb
@@ -2,12 +2,13 @@
   <%= form_for @from_address,
     method: :post,
     url: settings_from_address_index_path(service.service_id),
+    html: { class: (@from_address.errors.any? ? 'with-errors' : '') },
     builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
 
-    <%= f.govuk_error_summary link_base_errors_to: :email %>
+    <%= f.govuk_error_summary link_base_errors_to: :email, class: "govuk-!-margin-bottom-6 govuk-!-margin-top-6" %>
 
-    <% if @presenter.message[:status] == 'pending' %>
-      <%= govuk_notification_banner(title_text: t('notification_banners.important')) do %>
+    <% if @presenter.message[:status] == 'pending' && !@from_address.errors.any? %>
+      <%= govuk_notification_banner(title_text: t('notification_banners.important'), classes: "govuk-!-margin-top-6") do %>
         <%= @presenter.message[:text].html_safe %>
         <p>
           <span role="alert"></span>
@@ -44,8 +45,9 @@
       </p>
     <% end %>
 
-    <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
+    <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button" aria-describedby="save_description">
       <%= t('actions.save') %>
-    </button>
+    </button> 
+    <span class="sr-only" id="save_description"></span>
   <% end %>
 <% end %>

--- a/app/views/settings/from_address/index.html.erb
+++ b/app/views/settings/from_address/index.html.erb
@@ -7,7 +7,7 @@
 
     <%= f.govuk_error_summary link_base_errors_to: :email, class: "govuk-!-margin-bottom-6 govuk-!-margin-top-6" %>
 
-    <% if @presenter.message[:status] == 'pending' && !@from_address.errors.any? %>
+    <% if @presenter.message[:status] == 'pending' && @from_address.errors.blank? %>
       <%= govuk_notification_banner(title_text: t('notification_banners.important'), classes: "govuk-!-margin-top-6") do %>
         <%= @presenter.message[:text].html_safe %>
         <p>


### PR DESCRIPTION
Adds the dynamic save button behaviour into the from address settings screen:  Button wil show Saved, Saving, Saved according to the state of the user entered data.

![image](https://user-images.githubusercontent.com/595564/192226599-30b51af1-31e9-4701-a39c-2ca948710b6d.png)

This PR also adds a minor change to covert the JS controller/action name to be fully pascal case e.g `FormAnalyticsController#action` instead of `Form_analyticsController#action`  which is just slightly nicer IMO 🙂



