### PR TITLE
Resend validation always returns 200 status

### DIFF
--- a/app/controllers/api/from_address_controller.rb
+++ b/app/controllers/api/from_address_controller.rb
@@ -5,11 +5,9 @@ module Api
     before_action :assign_from_address
 
     def resend_validation
-      if from_address_creation.resend_validation
-        head :ok
-      else
-        head :bad_request
-      end
+      from_address_creation.resend_validation
+
+      head :ok
     end
 
     def from_address_params

--- a/spec/requests/api/from_address_spec.rb
+++ b/spec/requests/api/from_address_spec.rb
@@ -56,10 +56,6 @@ RSpec.describe 'From Address spec', type: :request do
 
         request
       end
-
-      it 'raises an EmailServiceError' do
-        expect(response.status).to eq(400)
-      end
     end
   end
 end


### PR DESCRIPTION
### Resend validation always returns 200 status
We have decided to always return a 200 status.
We won't be able to do much when we can not reach AWS except have the user try the link again.
The link comes back on page reload, so in the event a user does not receive a validation email from AWS, they will be able to access the resend link and try again.
Have discussed with product and design who are happy with this behaviour.