### PR TITLE
Reinstate continuous deployment to Live

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,13 +388,9 @@ workflows:
       - acceptance_tests_eks:
           requires:
             - deploy_to_test_eks
-      - confirm_live_deploy:
-          type: approval
-          requires:
-          - acceptance_tests_eks
       - deploy_to_live_eks:
           requires:
-            - confirm_live_deploy
+            - acceptance_tests_eks
   deploy_testable_branch:
     jobs:
       - build:


### PR DESCRIPTION
### Reinstate continuous deployment to Live
Now that we have tested the publishing mechanism, we can remove the manual gate and allow continuous deployment to live.