### PR TITLE
Publish warning messages for From Address

### DIFF
--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -1,5 +1,5 @@
 class PublishController < FormController
-  before_action :assign_form_objects, :assign_autocomplete_warning
+  before_action :assign_form_objects, :assign_autocomplete_warning, :assign_from_address_presenter
 
   def index
     @published_dev = published?(service.service_id, 'dev')
@@ -53,6 +53,14 @@ class PublishController < FormController
 
   def assign_autocomplete_warning
     @autocomplete_warning = AutocompleteItemsPresenter.new(service, service_autocomplete_items)
+  end
+
+  def assign_from_address_presenter
+    @from_address_presenter = FromAddressPresenter.new(from_address, :publish)
+  end
+
+  def from_address
+    @from_address ||= FromAddress.find_or_initialize_by(service_id: service.service_id)
   end
 
   def published?(service_id, environment)

--- a/app/controllers/settings/from_address_controller.rb
+++ b/app/controllers/settings/from_address_controller.rb
@@ -20,6 +20,6 @@ class Settings::FromAddressController < FormController
   private
 
   def assign_from_address_presenter
-    @presenter = FromAddressPresenter.new(@from_address)
+    @presenter = FromAddressPresenter.new(@from_address, :from_address)
   end
 end

--- a/app/presenters/from_address_presenter.rb
+++ b/app/presenters/from_address_presenter.rb
@@ -1,22 +1,32 @@
 class FromAddressPresenter
-  def initialize(from_address)
+  def initialize(from_address, controller)
     @from_address = from_address
-    @messages = {
+    @controller = controller
+  end
+
+  MESSAGES = {
+    from_address: {
       verified: I18n.t('settings.from_address.messages.verified'),
       pending: I18n.t('settings.from_address.messages.pending'),
       default: I18n.t('settings.from_address.messages.default')
+    },
+    publish: {
+      verified: I18n.t('publish.from_address.messages.verified'),
+      pending: I18n.t('publish.from_address.messages.pending'),
+      default: I18n.t('publish.from_address.messages.default')
     }
-  end
+  }.freeze
 
   def message
     key = from_address.status&.to_sym || :default
+
     {
-      text: messages[key],
+      text: MESSAGES[@controller][key],
       status: from_address.status
     }
   end
 
   private
 
-  attr_reader :from_address, :messages
+  attr_reader :from_address
 end

--- a/app/services/publish_service_creation.rb
+++ b/app/services/publish_service_creation.rb
@@ -76,6 +76,8 @@ class PublishServiceCreation
     send_by_email.blank? || (send_by_email.present? && service_email_output.blank?)
   end
 
+  delegate :verified?, to: :from_address, prefix: true
+
   private
 
   def create_publish_service
@@ -172,6 +174,10 @@ class PublishServiceCreation
   end
 
   def from_address_email
-    FromAddress.find_or_initialize_by(service_id: service_id).email_address
+    from_address.email_address
+  end
+
+  def from_address
+    @from_address ||= FromAddress.find_or_initialize_by(service_id: service_id)
   end
 end

--- a/app/views/publish/index.html.erb
+++ b/app/views/publish/index.html.erb
@@ -32,9 +32,13 @@
 
     <%= render 'autocomplete_warning', environment: t('publish.environment.test'), text: 'publish.warning.autocomplete_items' %>
 
+    <% if !@publish_service_creation_dev.from_address_verified? %>
+      <%= govuk_warning_text(text: @from_address_presenter.message[:text]) %>
+    <% end %>
+
     <button class="govuk-button fb-govuk-button"
         data-module="govuk-button"
-        type="button" 
+        type="button"
         data-fb-action="publish"
         hidden >
         <%= t('actions.publish_to_test') %>
@@ -80,9 +84,13 @@
 
     <%= render 'autocomplete_warning', environment: t('publish.environment.live'), text: 'publish.error.autocomplete_items' %>
 
+    <% if !@publish_service_creation_dev.from_address_verified? %>
+      <%= govuk_warning_text(text: @from_address_presenter.message[:text]) %>
+    <% end %>
+
     <button class="govuk-button fb-govuk-button"
             data-module="govuk-button"
-            type="button" 
+            type="button"
             aria-disabled="<%= @autocomplete_warning.messages.blank? ? 'false' : 'true' %>"
             data-fb-action="publish"
             hidden >

--- a/app/views/settings/from_address/index.html.erb
+++ b/app/views/settings/from_address/index.html.erb
@@ -10,6 +10,7 @@
     <% if @presenter.message[:status] == 'pending' && @from_address.errors.blank? %>
       <%= govuk_notification_banner(title_text: t('notification_banners.important'), classes: "govuk-!-margin-top-6") do %>
         <%= @presenter.message[:text].html_safe %>
+
         <p>
           <span role="alert"></span>
           <%= tag.button t('settings.from_address.resend_link_text'),
@@ -47,7 +48,7 @@
 
     <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button" aria-describedby="save_description">
       <%= t('actions.save') %>
-    </button> 
+    </button>
     <span class="sr-only" id="save_description"></span>
   <% end %>
 <% end %>

--- a/brakeman.ignore
+++ b/brakeman.ignore
@@ -26,19 +26,19 @@
     {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "62b97237b5296e61b21dccc5d3df3549d75931c8cc7a459843d9109432b60a22",
+      "fingerprint": "8cde876c3a74d83f589dbdc13368f0699ac1aacaa5f27c98218c14b84fb4f85b",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/settings/from_address/index.html.erb",
-      "line": 13,
+      "line": 12,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "FromAddressPresenter.new(FromAddress.find_or_initialize_by(:service_id => service.service_id)).message[:text]",
+      "code": "FromAddressPresenter.new(FromAddress.find_or_initialize_by(:service_id => service.service_id), :from_address).message[:text]",
       "render_path": [
         {
           "type": "controller",
           "class": "Settings::FromAddressController",
           "method": "index",
-          "line": 5,
+          "line": 7,
           "file": "app/controllers/settings/from_address_controller.rb",
           "rendered": {
             "name": "settings/from_address/index",
@@ -138,6 +138,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-09-16 09:32:34 +0100",
+  "updated": "2022-09-27 09:30:48 +0100",
   "brakeman_version": "5.3.1"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -287,7 +287,7 @@ en:
         pending: <strong>Now check the email you set for a validation link</strong><br /><br />The email will come from <b>Amazon Web Services</b>. The link is valid for 24 hours.
         verified: This email address has been validated.
       resend_link_text: Resend validation link
-      link_resent_success: Link resent - now check your email 
+      link_resent_success: Link resent - now check your email
     form_analytics:
       name: Google Analytics
       hint:  Monitor your form's performance (requires a Google Analytics account).
@@ -331,6 +331,11 @@ en:
       warning: Warning
       message: "Your %{environment} site %{href} are incomplete - you will not receive any emails."
       link: submission settings
+    from_address:
+      messages:
+        verified: 'Your from address has been validated'
+        pending: 'You need to validate your from address'
+        default: 'You need to set a from address'
     dialog:
       heading: Publish to Test?
       option_1: Allow anyone with the link to view

--- a/spec/presenters/from_address_presenter_spec.rb
+++ b/spec/presenters/from_address_presenter_spec.rb
@@ -1,52 +1,97 @@
 RSpec.describe FromAddressPresenter do
-  subject(:from_address_presenter) { described_class.new(from_address) }
+  subject(:from_address_presenter) { described_class.new(from_address, controller) }
   let(:service_id) { SecureRandom.uuid }
   let(:from_address) { FromAddress.find_by(service_id: service_id) }
 
   describe '#message' do
     let(:expected_message) do
       {
-        text: message,
+        text: text,
         status: status
       }
     end
 
-    context 'when from address is verified' do
-      let(:message) { I18n.t('settings.from_address.messages.verified') }
-      let(:status) { 'verified' }
+    context 'when from address page' do
+      let(:controller) { :from_address }
+      context 'when from address is verified' do
+        let(:text) { I18n.t('settings.from_address.messages.verified') }
+        let(:status) { 'verified' }
 
-      before do
-        create(:from_address, :verified, service_id: service_id)
+        before do
+          create(:from_address, :verified, service_id: service_id)
+        end
+
+        it 'returns the verified message' do
+          expect(from_address_presenter.message).to eq(expected_message)
+        end
       end
 
-      it 'returns the verified message' do
-        expect(from_address_presenter.message).to eq(expected_message)
+      context 'when from address is pending' do
+        let(:text) { I18n.t('settings.from_address.messages.pending') }
+        let(:status) { 'pending' }
+
+        before do
+          create(:from_address, :pending, service_id: service_id)
+        end
+
+        it 'returns the pending message' do
+          expect(from_address_presenter.message).to eq(expected_message)
+        end
+      end
+
+      context 'when from address is default' do
+        let(:text) { I18n.t('settings.from_address.messages.default') }
+        let(:status) { 'default' }
+
+        before do
+          create(:from_address, :default, service_id: service_id)
+        end
+
+        it 'returns the default message' do
+          expect(from_address_presenter.message).to eq(expected_message)
+        end
       end
     end
 
-    context 'when from address is pending' do
-      let(:message) { I18n.t('settings.from_address.messages.pending') }
-      let(:status) { 'pending' }
+    context 'when publishing page' do
+      let(:controller) { :publish }
+      context 'when from address is verified' do
+        let(:text) { I18n.t('publish.from_address.messages.verified') }
+        let(:status) { 'verified' }
 
-      before do
-        create(:from_address, :pending, service_id: service_id)
+        before do
+          create(:from_address, :verified, service_id: service_id)
+        end
+
+        it 'returns the verified message' do
+          expect(from_address_presenter.message).to eq(expected_message)
+        end
       end
 
-      it 'returns the pending message' do
-        expect(from_address_presenter.message).to eq(expected_message)
+      context 'when from address is pending' do
+        let(:text) { I18n.t('publish.from_address.messages.pending') }
+        let(:status) { 'pending' }
+
+        before do
+          create(:from_address, :pending, service_id: service_id)
+        end
+
+        it 'returns the pending message' do
+          expect(from_address_presenter.message).to eq(expected_message)
+        end
       end
-    end
 
-    context 'when from address is default' do
-      let(:message) { I18n.t('settings.from_address.messages.default') }
-      let(:status) { 'default' }
+      context 'when from address is default' do
+        let(:text) { I18n.t('publish.from_address.messages.default') }
+        let(:status) { 'default' }
 
-      before do
-        create(:from_address, :default, service_id: service_id)
-      end
+        before do
+          create(:from_address, :default, service_id: service_id)
+        end
 
-      it 'returns the default message' do
-        expect(from_address_presenter.message).to eq(expected_message)
+        it 'returns the default message' do
+          expect(from_address_presenter.message).to eq(expected_message)
+        end
       end
     end
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/PFcpcgAo/2956-from-address-publish-warnings-object)
### Publish warning messages for From Address
For the Publish page to know which warnings are required, it needs to know whether an email has been set and verified, and which messages to show.

We already have an existing `FromAddressPresenter`, this commit refactors the presenter's messages object to allow us to pass the correct message according to which controller is being presented to the user.

### Add to brakeman report
This is for an existing warning that is already being ignored. Have amended the report as we now pass a second argument into the `FromAddressPresenter`.