### PR TITLE
Add JS tests for SubmitHandler class

### DIFF
--- a/app/javascript/src/submit_handler.js
+++ b/app/javascript/src/submit_handler.js
@@ -41,9 +41,10 @@ class SubmitHandler {
     
     this.$form = $form;
     this.$button = this.$form.find(this.#config.buttonSelector);
-    this.text = this.#config.text;
     this.$buttonDescription = this.$form.find('#'+this.$button.attr('aria-describedby'));
     
+    this.#submitEnabled = true;
+
     this.$form.on('submit', (event) => this.#handleSubmit(event));
     this.$button.on('click', (event) => this.#handleClick(event));
   }
@@ -128,11 +129,10 @@ class SubmitHandler {
   }
 
   #setButtonText(text) {
-    if(this.$button.is('button')) {
+    if(this.$button.is('button[type="submit"]')) {
       this.$button.text(text);
-    }
-
-    if(this.$button.is('input')) {
+    } 
+    else if(this.$button.is('input[type="submit"]')) {
       this.$button.val(text);
     }
   }

--- a/test/handlers/submit_handler/behaviours_test.js
+++ b/test/handlers/submit_handler/behaviours_test.js
@@ -1,0 +1,133 @@
+require('../../setup.js');
+
+describe('SubmitHandler', function() {
+
+  const helpers = require('./helpers.js');
+  const c  = helpers.constants;
+  const COMPONENT_ID = 'submit-handler-behaviours-test';
+
+  describe('Behaviours', function() {
+    describe('with input[type="submit"]', function() {
+      var created;
+
+      before( function() {
+        helpers.setupView(COMPONENT_ID);
+        created = helpers.createSubmitHandler(COMPONENT_ID);
+        // sinon.spy(created.handler);
+      })
+
+      after(function(){
+        helpers.teardownView(COMPONENT_ID);
+        // sinon.restore();
+      }) 
+
+      it("should have the default text initially", function() {
+        expect( created.handler.$button.val() ).to.eql(c.DEFAULT_TEXT);
+      });
+
+      it('should have the unsubmitted text when enabled', function() {
+        created.handler.submittable = true
+        expect( created.handler.$button.val() ).to.eql(c.UNSUBMITTED_TEXT);
+      })
+
+      it('should reset the description text when enabled', function() {
+        created.handler.submittable = true
+        expect( created.handler.$buttonDescription.text() ).to.eql('');
+      });
+
+      it('should set aria-dsibaled to false when enabled', function() { 
+        created.handler.submittable = true
+        expect( created.handler.$button.attr('aria-disabled')).to.eql('false')
+      });
+
+      it('should have the submitted text when disabled', function() {
+        created.handler.submittable = false; 
+        expect( created.handler.$button.val() ).to.eql(c.SUBMITTED_TEXT);
+      });
+      
+      it('should set the description text when disabled', function() {
+        created.handler.submittable = false
+        expect( created.handler.$buttonDescription.text() ).to.eql(c.DESCRIPTION_TEXT);
+      });
+
+      it('should set aria-disabled to true when disabled', function() {
+
+        created.handler.submittable = false
+        expect( created.handler.$button.attr('aria-disabled')).to.eql('true')
+      })
+
+      it('should have the submitting text when button is clicked', function() {
+        created.handler.submittable = true;
+
+        created.$form.on('submit', (e) => e.preventDefault()  );
+
+        created.handler.$button.click();
+
+        expect( created.handler.$button.val() ).to.eql(c.SUBMITTING_TEXT);
+      });
+
+      it('should prevent submit when disabled', function() {
+        var submitted = false;
+        created.handler.submittable = false;
+        created.$form.on('submit', () => submitted = true);
+        
+        created.handler.$button.click();
+
+        expect(submitted).to.be.false;
+      });
+
+      it('should allow submit when enabled', function() {
+        var submitted = false;
+        created.handler.submittable = true;
+        created.$form.on('submit', () => submitted = true);
+        
+        created.handler.$button.click();
+
+        expect(submitted).to.be.true;
+      });
+      
+    });
+
+    describe('with button[type="submit"]', function() {
+
+      var created;
+
+      before( function() {
+        helpers.setupView(COMPONENT_ID, true);
+        created = helpers.createSubmitHandler(COMPONENT_ID);
+        // sinon.spy(created.handler);
+      })
+
+      after(function(){
+        helpers.teardownView(COMPONENT_ID);
+        // sinon.restore();
+      }) 
+
+      it("should have the default text initially", function() {
+        expect( created.handler.$button.text() ).to.eql(c.DEFAULT_TEXT);
+      });
+
+      it('should have the unsubmitted text when enabled', function() {
+        created.handler.submittable = true
+        expect( created.handler.$button.text() ).to.eql(c.UNSUBMITTED_TEXT);
+      })
+
+      it('should have the submitted text when disabled', function() {
+        created.handler.submittable = false; 
+        expect( created.handler.$button.text() ).to.eql(c.SUBMITTED_TEXT);
+      })
+
+      it('should have the submitting text when button is clicked', function() {
+        created.handler.submittable = true;
+
+        created.$form.on('submit', (e) => e.preventDefault()  );
+
+        created.handler.$button.click();
+
+        expect( created.handler.$button.text() ).to.eql(c.SUBMITTING_TEXT);
+      });
+    });
+
+
+  });
+});

--- a/test/handlers/submit_handler/helpers.js
+++ b/test/handlers/submit_handler/helpers.js
@@ -1,0 +1,60 @@
+const SubmitHandler = require('../../../app/javascript/src/submit_handler.js');
+const GlobalHelpers = require('../../helpers.js');
+
+const constants = {
+  BUTTON_CLASS: 'submit-handler-btn',
+  BUTTON_DESCRIPTION_ID: 'button-description',
+  DEFAULT_TEXT: 'Click Me',
+  SUBMITTED_TEXT: 'Saved',
+  SUBMITTING_TEXT: 'Saving',
+  UNSUBMITTED_TEXT: 'Save',
+  DESCRIPTION_TEXT: 'No Changes',
+}
+
+function setupView(id, useButton=false) {
+  var form = `<form id="${id}" >
+              </form>`;
+  var button;
+
+  if(useButton) {
+    button = `<button class="${constants.BUTTON_CLASS}" type="submit" aria-describedby="btn-description">${constants.DEFAULT_TEXT}</button>`;
+  } else {
+    button = `<input class="${constants.BUTTON_CLASS}" type="submit" value="${constants.DEFAULT_TEXT}" aria-describedby="${constants.BUTTON_DESCRIPTION_ID}"/>`;
+  }
+
+  $('body').append(form);
+  var $form =  $('body').find('#'+id);
+  $form.append(button);
+  $form.append(`<span id="${constants.BUTTON_DESCRIPTION_ID}"></span>`);
+
+}
+
+function createSubmitHandler(id, config={}) {
+  var $form = $('#'+id);
+  
+  var conf = GlobalHelpers.mergeConfig({
+    text: {
+      submitted: constants.SUBMITTED_TEXT,
+      unsubmitted: constants.UNSUBMITTED_TEXT,
+      submitting: constants.SUBMITTING_TEXT,
+      description: constants.DESCRIPTION_TEXT,
+    }
+  }, config);
+
+  return {
+    $form: $form,
+    handler: new SubmitHandler($form, conf),
+  }
+}
+
+
+function teardownView(id) {
+  $("#"+ id).remove();
+}
+
+module.exports = {
+  constants: constants,
+  setupView: setupView,
+  teardownView: teardownView,
+  createSubmitHandler: createSubmitHandler
+}

--- a/test/handlers/submit_handler/methods_test.js
+++ b/test/handlers/submit_handler/methods_test.js
@@ -1,0 +1,44 @@
+require('../../setup.js');
+
+describe('SubmitHandler', function() {
+
+  const helpers = require('./helpers.js');
+  const c  = helpers.constants;
+  const COMPONENT_ID = 'submit-handler-methods-test';
+
+  describe('Methods', function() {
+    var created;
+
+    before( function() {
+      helpers.setupView(COMPONENT_ID);
+      created = helpers.createSubmitHandler(COMPONENT_ID);
+    })
+
+    after(function(){
+      helpers.teardownView(COMPONENT_ID);
+    }) 
+
+    it('should have a setter for submittable property', function() {
+      expect(created.handler.submittable).to.be.true;
+
+      created.handler.submittable = false;
+      expect(created.handler.submittable).to.be.false;
+
+      created.handler.submittable = true;
+      expect(created.handler.submittable).to.be.true;
+    });
+
+    it('should submit if #submitEnabled is false', function() {
+      var submitted = false;
+      created.$form.on('submit', (event) => submitted = true );
+
+      created.handler.submittable = false;
+      created.handler.submit();
+
+      expect(submitted).to.be.true;
+
+    })
+
+  });
+
+});

--- a/test/handlers/submit_handler/properties_test.js
+++ b/test/handlers/submit_handler/properties_test.js
@@ -1,0 +1,50 @@
+require('../../setup.js');
+
+describe('SubmitHandler', function() {
+
+  const helpers = require('./helpers.js');
+  const c  = helpers.constants;
+  const COMPONENT_ID = 'submit-handler-properties-test';
+
+  describe('Properties', function() {
+    var created;
+
+    before( function() {
+      helpers.setupView(COMPONENT_ID);
+      created = helpers.createSubmitHandler(COMPONENT_ID);
+    })
+
+    after(function(){
+      helpers.teardownView(COMPONENT_ID);
+    }) 
+
+    it("should have a public submittable property", function() {
+       expect( created.handler.submittable ).to.be.true
+    });
+
+    it("should make the form public", function() {
+      $form = $('#'+COMPONENT_ID);
+
+      expect(created.handler.$form).to.exist;
+      expect(created.handler.$form.length).to.eq(1);
+      expect(created.handler.$form.get(0)).to.eq($form.get(0));
+    })
+
+    it("should make the button public", function() {
+      $button = $('#'+COMPONENT_ID).find(':submit');
+
+      expect(created.handler.$button).to.exist;
+      expect(created.handler.$button.length).to.eq(1);
+      expect(created.handler.$button.get(0)).to.eq($button.get(0));
+    });
+
+    it("should make the button description public", function() {
+      $buttonDescription = $('#'+c.BUTTON_DESCRIPTION_ID);
+
+      expect(created.handler.$buttonDescription).to.exist;
+      expect(created.handler.$buttonDescription.length).to.eq(1);
+      expect(created.handler.$buttonDescription.get(0)).to.eq($buttonDescription.get(0));
+    })
+
+  });
+});


### PR DESCRIPTION
Adds in test for SubmitHandler class.

Does not test page unloading behaviour as it is all private/intgernal to the class, so not easy to observe and test the behaviour.

This is probably better enforced with e2e tests, which will be able to observe the alert dialog and interact with it.

