### PR TITLE
Add from address email to send by email page

### DIFF
--- a/app/controllers/settings/email_controller.rb
+++ b/app/controllers/settings/email_controller.rb
@@ -1,9 +1,9 @@
 class Settings::EmailController < FormController
-  before_action :assign_form_objects
+  before_action :assign_form_objects, :assign_from_address_presenter
 
   def create
     @email_settings = EmailSettings.new(
-      email_settings_params.merge(service: service)
+      email_settings_params.merge(service: service, from_address: from_address)
     )
 
     if @email_settings.valid?
@@ -51,11 +51,21 @@ class Settings::EmailController < FormController
   def assign_form_objects
     @email_settings_dev = EmailSettings.new(
       service: service,
-      deployment_environment: 'dev'
+      deployment_environment: 'dev',
+      from_address: from_address
     )
     @email_settings_production = EmailSettings.new(
       service: service,
-      deployment_environment: 'production'
+      deployment_environment: 'production',
+      from_address: from_address
     )
+  end
+
+  def assign_from_address_presenter
+    @from_address_presenter = FromAddressPresenter.new(from_address, :email)
+  end
+
+  def from_address
+    @from_address ||= FromAddress.find_or_initialize_by(service_id: service.service_id)
   end
 end

--- a/app/models/email_settings.rb
+++ b/app/models/email_settings.rb
@@ -2,9 +2,9 @@ class EmailSettings
   include ActiveModel::Model
   attr_accessor :deployment_environment,
                 :service,
+                :from_address,
                 :send_by_email,
                 :service_email_output,
-                :service_email_from,
                 :service_email_subject,
                 :service_email_body,
                 :service_email_pdf_heading,
@@ -17,8 +17,7 @@ class EmailSettings
 
   validates :service_email_output, presence: true, if: :send_by_email?
 
-  validates :service_email_output, format: { with: URI::MailTo::EMAIL_REGEXP },
-                                   allow_blank: true
+  validates :service_email_output, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
 
   def send_by_email_checked?
     send_by_email? || SubmissionSetting.find_by(
@@ -36,7 +35,7 @@ class EmailSettings
   end
 
   def service_email_from
-    settings_for(:service_email_from)
+    from_address.email_address
   end
 
   def service_email_subject

--- a/app/presenters/from_address_presenter.rb
+++ b/app/presenters/from_address_presenter.rb
@@ -14,6 +14,10 @@ class FromAddressPresenter
       verified: I18n.t('publish.from_address.messages.verified'),
       pending: I18n.t('publish.from_address.messages.pending'),
       default: I18n.t('publish.from_address.messages.default')
+    },
+    email: {
+      pending: I18n.t('activemodel.attributes.email_settings.from_address.pending'),
+      default: I18n.t('activemodel.attributes.email_settings.from_address.default')
     }
   }.freeze
 

--- a/app/views/settings/email/_form.html.erb
+++ b/app/views/settings/email/_form.html.erb
@@ -11,6 +11,25 @@
       </h3>
     </legend>
 
+  <% if ENV['FROM_ADDRESS'] == 'enabled' %>
+    <div class="govuk-form-group">
+      <%= f.object.class.human_attribute_name :service_email_from %>
+      <strong><%= f.object.service_email_from %></strong>
+
+      <% unless @from_address.verified? %>
+        <%= govuk_warning_text(text: @from_address_presenter.message[:text]) %>
+      <% end %>
+
+      <% if @from_address.pending? %>
+        <%= link_to(t('activemodel.attributes.email_settings.from_address.pending_link'),
+          settings_from_address_index_path(service.service_id))%>
+      <% else %>
+        <%= link_to(t('activemodel.attributes.email_settings.from_address.link'),
+          settings_from_address_index_path(service.service_id))%>
+      <% end %>
+    </div>
+  <% end %>
+
     <div class="govuk-form-group <%= !f.object.errors[:service_email_output].empty? ? 'govuk-form-group--error' : '' %> ">
       <% f.object.errors[:service_email_output].each do |message| %>
         <p class="govuk-error-message"><%= message %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -394,6 +394,7 @@ en:
         send_by_email_dev: Send by email on Test
         send_by_email_production: Send by email on Live
         service_email_output: Send email to
+        service_email_from: 'From:'
         service_email_subject: Email subject
         service_email_body: Email text
         service_email_pdf_heading: Heading
@@ -407,6 +408,11 @@ en:
         csv_hint: A comma-separated values (CSV) lists all the answers in plain text, separated by commas. It can be imported into spreadsheets and other applications.
         csv_sample: See sample CSV
         csv_checkbox: Send a separate email with answers in a CSV
+        from_address:
+          default: You need to set and validate a team email address.
+          pending: You need to validate this email address.
+          pending_link: Get validation link
+          link: Change ’from’ address
       page_creation:
         page_url: "Give your page a short name"
         page_url_hint: "This will form the page’s URL so should be in lower case with no spaces"

--- a/spec/models/email_settings_spec.rb
+++ b/spec/models/email_settings_spec.rb
@@ -1,10 +1,11 @@
 RSpec.describe EmailSettings do
   subject(:email_settings) do
     described_class.new(
-      params.merge(service: service)
+      params.merge(service: service, from_address: from_address)
     )
   end
   let(:params) { {} }
+  let(:from_address) { create(:from_address, :default, service_id: service.service_id) }
 
   describe '#valid?' do
     context 'when send by email is ticked' do
@@ -71,47 +72,6 @@ RSpec.describe EmailSettings do
 
     context 'when user submits a value' do
       let(:params) do
-        {
-          deployment_environment: 'dev',
-          service_email_output: 'han.solo@milleniumfalcon.uk'
-        }
-      end
-
-      it 'shows the submitted value' do
-        expect(
-          email_settings.service_email_output
-        ).to eq('han.solo@milleniumfalcon.uk')
-      end
-    end
-
-    context 'when a value already exists in the db' do
-      let(:params) { { deployment_environment: 'dev' } }
-      let!(:service_configuration) do
-        create(
-          :service_configuration,
-          :dev,
-          :service_email_output,
-          service_id: service.service_id
-        )
-      end
-
-      it 'shows the value in the db' do
-        expect(
-          email_settings.service_email_output
-        ).to eq(service_configuration.decrypt_value)
-      end
-    end
-  end
-
-  describe '#service_email_output' do
-    context 'when email is empty' do
-      it 'returns nil' do
-        expect(email_settings.service_email_output).to eq('')
-      end
-    end
-
-    context 'when user submits a value' do
-      let(:params) do
         { deployment_environment: 'production',
           service_email_output: 'han.solo@milleniumfalcon.uk' }
       end
@@ -139,6 +99,12 @@ RSpec.describe EmailSettings do
           email_settings.service_email_output
         ).to eq(service_configuration.decrypt_value)
       end
+    end
+  end
+
+  describe '#service_email_from' do
+    it 'returns the from address value' do
+      expect(email_settings.service_email_from).to eq(from_address.email_address)
     end
   end
 

--- a/spec/presenters/from_address_presenter_spec.rb
+++ b/spec/presenters/from_address_presenter_spec.rb
@@ -94,5 +94,35 @@ RSpec.describe FromAddressPresenter do
         end
       end
     end
+
+    context 'when send by email page' do
+      let(:controller) { :email }
+
+      context 'when from address is pending' do
+        let(:text) { I18n.t('activemodel.attributes.email_settings.from_address.pending') }
+        let(:status) { 'pending' }
+
+        before do
+          create(:from_address, :pending, service_id: service_id)
+        end
+
+        it 'returns the pending message' do
+          expect(from_address_presenter.message).to eq(expected_message)
+        end
+      end
+
+      context 'when from address is default' do
+        let(:text) { I18n.t('activemodel.attributes.email_settings.from_address.default') }
+        let(:status) { 'default' }
+
+        before do
+          create(:from_address, :default, service_id: service_id)
+        end
+
+        it 'returns the default message' do
+          expect(from_address_presenter.message).to eq(expected_message)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/l3YsIX7S/2929-send-by-email-from-address)

### Add from address email to send by email page
Since this will be the first time users will be able to change their from address email, we will need to surface this email in the Send data by Email page.

We want to allow users to see the from address email that will be used when the form is next published rather than what is currently set as the `servce_email_from` value for the particular environment. This means we want to provide the email address that is in the `FromAddress` table, rather than the `service_email_from` address in the `ServiceConfiguration` table.