### PR TITLE
Update tests for new save button behaviour

### DIFF
--- a/acceptance/features/edit_multiple_questions_page_spec.rb
+++ b/acceptance/features/edit_multiple_questions_page_spec.rb
@@ -41,12 +41,15 @@ feature 'Edit multiple questions page' do
 
     scenario 'adding and updating components' do
       and_I_edit_the_page(url: page_heading)
+      then_the_save_button_should_be_disabled
       and_I_add_the_component(I18n.t('components.list.text'))
       and_I_add_the_component(I18n.t('components.list.textarea'))
       and_I_add_the_component(I18n.t('components.list.email'))
       and_I_add_the_component(I18n.t('components.list.radios'))
       and_I_add_the_component(I18n.t('components.list.checkboxes'))
+      then_the_save_button_should_be_disabled
       and_I_update_the_components
+      then_I_should_be_warned_when_leaving_page
       when_I_save_my_changes
       and_I_return_to_flow_page
       preview_form = and_I_preview_the_form
@@ -58,6 +61,7 @@ feature 'Edit multiple questions page' do
       and_I_add_the_component(I18n.t('components.list.text'))
       and_I_add_the_component(I18n.t('components.list.textarea'))
       and_I_change_the_text_component(text_component_question)
+      then_I_should_be_warned_when_leaving_page
       when_I_save_my_changes
       when_I_want_to_select_component_properties('h2', text_component_question)
       and_I_want_to_delete_a_component(text_component_question)
@@ -71,6 +75,7 @@ feature 'Edit multiple questions page' do
       and_I_add_the_component(I18n.t('components.list.textarea'))
       and_I_add_the_component(I18n.t('components.list.email'))
       and_I_change_the_email_component(email_component_question)
+      then_I_should_be_warned_when_leaving_page
       when_I_save_my_changes
       when_I_want_to_select_component_properties('h2', email_component_question)
       and_I_want_to_delete_a_component(email_component_question)

--- a/acceptance/features/edit_single_question_page_spec.rb
+++ b/acceptance/features/edit_single_question_page_spec.rb
@@ -21,6 +21,7 @@ feature 'Edit single question page' do
   scenario 'when editing text component' do
     given_I_have_a_single_question_page_with_text
     and_I_have_optional_section_heading_text
+    then_the_save_button_should_be_disabled
     when_I_update_the_question_name
     when_I_update_the_optional_section_heading
     when_I_delete_the_optional_section_heading_text
@@ -31,6 +32,7 @@ feature 'Edit single question page' do
   scenario 'when editing textarea component' do
     given_I_have_a_single_question_page_with_textarea
     and_I_have_optional_section_heading_text
+    then_the_save_button_should_be_disabled
     when_I_update_the_question_name
     when_I_update_the_optional_section_heading
     when_I_delete_the_optional_section_heading_text
@@ -41,6 +43,7 @@ feature 'Edit single question page' do
   scenario 'when editing number component' do
     given_I_have_a_single_question_page_with_number
     and_I_have_optional_section_heading_text
+    then_the_save_button_should_be_disabled
     when_I_update_the_question_name
     when_I_update_the_optional_section_heading
     when_I_delete_the_optional_section_heading_text
@@ -51,6 +54,7 @@ feature 'Edit single question page' do
   scenario 'when editing upload component' do
     given_I_have_a_single_question_page_with_upload
     and_I_have_optional_section_heading_text
+    then_the_save_button_should_be_disabled
     when_I_update_the_question_name
     and_I_return_to_flow_page
     then_I_should_see_my_changes_on_preview
@@ -59,6 +63,7 @@ feature 'Edit single question page' do
   scenario 'when editing date component' do
     given_I_have_a_single_question_page_with_date
     and_I_have_optional_section_heading_text
+    then_the_save_button_should_be_disabled
     when_I_update_the_question_name
     when_I_update_the_optional_section_heading
     when_I_delete_the_optional_section_heading_text
@@ -69,6 +74,7 @@ feature 'Edit single question page' do
   scenario 'when editing email component' do
     given_I_have_a_single_question_page_with_email
     and_I_have_optional_section_heading_text
+    then_the_save_button_should_be_disabled
     when_I_update_the_question_name
     when_I_update_the_optional_section_heading
     when_I_delete_the_optional_section_heading_text
@@ -125,6 +131,7 @@ feature 'Edit single question page' do
 
   def when_I_update_the_question_name
     and_I_edit_the_question
+    then_I_should_be_warned_when_leaving_page
     when_I_save_my_changes
   end
 
@@ -183,4 +190,7 @@ feature 'Edit single question page' do
   def and_I_have_optional_section_heading_text
     expect(page).to have_content(I18n.t('default_text.section_heading'))
   end
+
+  
 end
+

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -177,7 +177,7 @@ module CommonSteps
   end
 
   def and_I_return_to_flow_page
-    accept_alert(wait: 1) { editor.pages_link.click }
+    accept_confirm(wait: 1) { editor.pages_link.click }
     rescue Capybara::ModalNotFound
       editor.pages_link.click
     ensure
@@ -244,8 +244,19 @@ module CommonSteps
   def when_I_save_my_changes
     # click outside of fields that will make save button re-enable
     editor.service_name.click
-    expect(editor.save_page_button).to_not be_disabled
+    expect(editor.save_page_button['aria-disabled']).to eq('false')
     editor.save_page_button.click
+    expect(editor.save_page_button['aria-disabled']).to eq('true')
+  end
+
+  def then_the_save_button_should_be_disabled
+    expect(editor.save_page_button['aria-disabled']).to eq('true')
+  end
+
+  def then_I_should_be_warned_when_leaving_page
+    # click outside of fields that will make save button re-enable
+    editor.service_name.click
+    dismiss_confirm(wait: 1) { editor.pages_link.click }
   end
 
   def when_I_want_to_select_question_properties


### PR DESCRIPTION
The edit page save button has been changed to use `aria-disabled` rather than `disabled` so this PR updates the acceptance tests to actually chack against this.

It also adds in more explicit tests for the page unloading behaviour.  

Having written the JS tests for the save button, it was not possible to easily test the page unload prevention behaviour in JS tests.

Added expectations to excplicitly expect a modal and to dismiss it (i.e. stay on page) 
While there was code that sort of did this previously, it was mostly a slight hack to keeop the tests working by always confirming the modal or rescuing if there was no modal.

Tests will now fail if the page unloading behaviour is not working corrcectly 👍 