### PR TITLE
Fix issues with save button tests

### DIFF
--- a/acceptance/features/edit_multiple_questions_page_spec.rb
+++ b/acceptance/features/edit_multiple_questions_page_spec.rb
@@ -116,6 +116,15 @@ feature 'Edit multiple questions page' do
     end
   end
 
+  def when_I_save_my_changes
+    # click outside of fields that will make save button re-enable
+    editor.service_name.click
+    expect(editor.save_page_button['aria-disabled']).to eq('false')
+    editor.save_page_button.click
+    expect(editor.save_page_button['aria-disabled']).to eq('true')
+  end
+
+
   def then_I_add_a_content_component(content:)
     and_I_add_a_component
     and_I_add_a_content_area

--- a/acceptance/features/edit_single_question_page_spec.rb
+++ b/acceptance/features/edit_single_question_page_spec.rb
@@ -129,6 +129,14 @@ feature 'Edit single question page' do
     end
   end
 
+  def when_I_save_my_changes
+    # click outside of fields that will make save button re-enable
+    editor.service_name.click
+    expect(editor.save_page_button['aria-disabled']).to eq('false')
+    editor.save_page_button.click
+    expect(editor.save_page_button['aria-disabled']).to eq('true')
+  end
+
   def when_I_update_the_question_name
     and_I_edit_the_question
     then_I_should_be_warned_when_leaving_page
@@ -191,6 +199,6 @@ feature 'Edit single question page' do
     expect(page).to have_content(I18n.t('default_text.section_heading'))
   end
 
-  
+
 end
 

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -244,9 +244,7 @@ module CommonSteps
   def when_I_save_my_changes
     # click outside of fields that will make save button re-enable
     editor.service_name.click
-    expect(editor.save_page_button['aria-disabled']).to eq('false')
     editor.save_page_button.click
-    expect(editor.save_page_button['aria-disabled']).to eq('true')
   end
 
   def then_the_save_button_should_be_disabled


### PR DESCRIPTION
Original deploy for this had issues where it was expecting dynaimic save button behaviour on the branching page.

Updated the tests so the dynamic behaviour is only tested on the eidt question pages.