### PR TITLE
Add Controller to add Expander to send by email settings page

### DIFF
--- a/app/javascript/src/controller_collection_email.js
+++ b/app/javascript/src/controller_collection_email.js
@@ -1,0 +1,37 @@
+const DefaultController = require('./controller_default');
+const Expander = require('./component_expander');
+
+class CollectionEmailController extends DefaultController {
+  constructor(app) {
+    super(app);
+
+    switch(app.page.action) {
+      case 'create':
+      case 'index':
+        this.#index();
+      break;
+    }
+  }
+
+  #index() {
+    this.#addExpanderEnhancement();
+  }
+
+  #addExpanderEnhancement() {
+    $(".collect-info-environment-config").each(function(index) {
+      var $this = $(this);
+      var $checkbox = $("input[type=checkbox]", $this);
+      var expander = new Expander($("details", $this), {
+        auto_open: $(".govuk-form-group--error", $this).length
+      });
+
+      $checkbox.on("click", function() {
+        if(this.checked && !expander.isOpen()) {
+          expander.open();
+        }
+      });
+    });
+  }
+}
+
+module.exports = CollectionEmailController;

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -6,8 +6,9 @@ const PublishController = require('./controller_publish');
 const BranchesController = require('./controller_branches');
 const FormAnalyticsController = require('./controller_form_analytics');
 const FromAddressController = require('./controller_from_address');
+const CollectionEmailController = require('./controller_collection_email');
 const {
-  snakeToPascalCase, 
+  snakeToPascalCase,
 } = require('./utilities');
 
 // Determine the controller we need to use
@@ -71,6 +72,11 @@ switch(controllerAndAction()) {
   case "FromAddressController#index":
   case "FromAddressController#create":
       Controller = FromAddressController;
+  break;
+
+  case "EmailController#index":
+  case "EmailController#create":
+      Controller = CollectionEmailController;
   break;
 
   default:

--- a/app/views/settings/email/index.html.erb
+++ b/app/views/settings/email/index.html.erb
@@ -4,7 +4,7 @@
 
   <%= form_for @email_settings_dev,
     url: settings_email_index_path(service.service_id),
-    html: { id: 'email-submission-dev' } do |f| %>
+    html: { id: 'email-submission-dev', class: 'collect-info-environment-config' } do |f| %>
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -32,7 +32,7 @@
 
   <%= form_for @email_settings_production,
     url: settings_email_index_path(service.service_id),
-    html: { id: 'email-submission-production' } do |f| %>
+    html: { id: 'email-submission-production', class: 'collect-info-environment-config' } do |f| %>
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">


### PR DESCRIPTION
Adds the expander component to the `Send data by email` settings page.

This adds the functionlality to open the following configuration block when the 'Send by email on test/live' checkbox is checked (if it is not already open).

If the page is saved with errors then the configuration block with errors in will open automatically on page load, allowing the user to see and resolve the issues.