### PR TITLE
Cater for autoclosing Configure summary link

### DIFF
--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -169,9 +169,16 @@ feature 'Publishing' do
     editor.find(:css, '#email_settings_send_by_email_dev', visible: false).set(value)
   end
 
-  def and_I_set_the_email_field
+  # This is terrible
+  # For some reason the summary click opens the section, but then it is auto closed
+  # again therefore the test is unable to find the field.
+  # In those instance rescue and try one more time
+  def and_I_set_the_email_field(value = 'paul@atreides.com')
     editor.find(:css, '#configure-dev').click
-    editor.find(:css, '#service_email_output_dev').set('paul@atreides.com')
+    editor.find(:css, '#service_email_output_dev').set(value)
+  rescue Capybara::ElementNotFound
+    editor.find(:css, '#configure-dev').click
+    editor.find(:css, '#service_email_output_dev').set(value)
   end
 
   def and_I_save_my_email_settings
@@ -275,8 +282,7 @@ feature 'Publishing' do
     # will have been deleted by the Metadata API as it cleans up after acceptance
     # test runs.
     and_I_click_the_submission_settings_link
-    editor.find(:css, '#configure-dev').click
-    editor.find(:css, '#service_email_output_dev').set('')
+    and_I_set_the_email_field('')
     and_I_save_my_email_settings
   end
 


### PR DESCRIPTION
In the publishing page acceptance spec we go to the email settings page in order to configure the service email output address. Clicking on 'Configure' opens the form, but then it closes it again.

Therefore when the test was unable to find the field it needed it failed. The terrible solution we implemented will capture the Capybara exception and try one more time.

This is not a great solution and does increase the test time significantly.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>