### PR TITLE
CircleCI unpin docker setup version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker: &remote_docker
-          version: 20.10.11
           docker_layer_caching: true
       - run: &build_sha
           name: Setup base environment variable


### PR DESCRIPTION
Unpin the Docker version in CircleCI pipeline.

CircleCI will be keeping the Docker executor up to date on a rolling
basis.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>