### PR TITLE
Keep unsuccessful cronjobs for logging

### DIFF
--- a/deploy-eks/fb-editor-chart/templates/from_address.yaml
+++ b/deploy-eks/fb-editor-chart/templates/from_address.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 spec:
   schedule: "*/2 * * * *"
-  successfulJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
       template:

--- a/deploy-eks/fb-editor-chart/templates/sessions_trim.yaml
+++ b/deploy-eks/fb-editor-chart/templates/sessions_trim.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   schedule: "*/30 * * * *"
   successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
If a cronjob fails we want to be able to see more of the error and log outputs for a few different runs.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>