### PR TITLE
Add the remaining members of the MoJ Forms team

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -18,7 +18,7 @@ module Admin
     before_action :authenticate_admin
 
     def authenticate_admin
-      redirect_to unauthorised_path unless moj_forms_dev? || moj_forms_team?
+      redirect_to unauthorised_path unless moj_forms_dev? || moj_forms_admin?
     end
 
     def published(environment)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -75,10 +75,10 @@ module ApplicationHelper
     end
   end
 
-  def moj_forms_team?
+  def moj_forms_admin?
     return if current_user.blank?
 
-    Rails.application.config.moj_forms_team.include?(current_user.email)
+    Rails.application.config.moj_forms_admin.include?(current_user.email)
   end
 
   def moj_forms_dev?

--- a/app/helpers/authorisation_helper.rb
+++ b/app/helpers/authorisation_helper.rb
@@ -1,6 +1,6 @@
 module AuthorisationHelper
   def authorised_access
-    return if moj_forms_team? || moj_forms_dev?
+    return if moj_forms_admin? || moj_forms_dev?
 
     unless current_user.id == service.created_by
       redirect_to redirect_unauthorised_path

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -20,7 +20,7 @@
           <li>
             <%= link_to t('.user_guide'), t('.user_guide_url'), target: :_blank %>
           </li>
-          <% if moj_forms_dev? || moj_forms_team? %>
+          <% if moj_forms_dev? || moj_forms_admin? %>
             <li>
               <%= link_to t('.admin'), admin_root_path %>
             </li>

--- a/config/initializers/moj_forms_team.rb
+++ b/config/initializers/moj_forms_team.rb
@@ -1,4 +1,4 @@
-MOJ_FORMS_TEAM = [
+MOJ_FORMS_ADMIN = [
   'claire.bowman@digital.justice.gov.uk',
   'sijy.mathew@digital.justice.gov.uk',
   'mark.jefferson@digital.justice.gov.uk'
@@ -13,5 +13,12 @@ MOJ_FORMS_DEVS = [
   'hellema.ibrahim@digital.justice.gov.uk'
 ].freeze
 
-Rails.application.config.moj_forms_team = MOJ_FORMS_TEAM
+MOJ_FORMS_TEAM = [
+  'assma.banaris@digital.justice.gov.uk',
+  'fabien.marry@digital.justice.gov.uk',
+  'howard.davies@digital.justice.gov.uk'
+].freeze
+
+Rails.application.config.moj_forms_admin = MOJ_FORMS_ADMIN
 Rails.application.config.moj_forms_devs = MOJ_FORMS_DEVS
+Rails.application.config.moj_forms_team = MOJ_FORMS_TEAM

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Authorisation spec', type: :request do
   shared_examples 'an authorisation action' do
     context 'when admin user' do
       before do
-        allow_any_instance_of(PermissionsController).to receive(:moj_forms_team?).and_return(true)
+        allow_any_instance_of(PermissionsController).to receive(:moj_forms_admin?).and_return(true)
       end
 
       it 'allows access' do


### PR DESCRIPTION
This could be useful if we create overnight jobs to remove acceptance test configs from the database.

Rename moj_forms_team? to moj_forms_admin?

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>