### PR TITLE
Ensure AWS calls are made only if the email is valid

### DIFF
--- a/app/models/from_address_objects.rb
+++ b/app/models/from_address_objects.rb
@@ -2,7 +2,6 @@ module FromAddressObjects
   def from_address_creation
     @from_address_creation ||= FromAddressCreation.new(
       from_address: @from_address,
-      from_address_params: from_address_params,
       email_service: email_service
     )
   end
@@ -10,6 +9,10 @@ module FromAddressObjects
   def assign_from_address
     # initialize for those forms that were created before FromAddress records existed
     @from_address = FromAddress.find_or_initialize_by(service_id: service.service_id)
+
+    if action_name == 'create'
+      @from_address.assign_attributes(from_address_params)
+    end
   end
 
   def email_service

--- a/spec/services/from_address_creation_spec.rb
+++ b/spec/services/from_address_creation_spec.rb
@@ -89,22 +89,6 @@ RSpec.describe FromAddressCreation, type: :model do
       end
     end
 
-    # context 'when sending enabled is false but from address record is verified' do
-    #   let(:email_identity) { double(sending_enabled: false) }
-    #   let(:email) { 'artax@justice.gov.uk' }
-
-    #   before do
-    #     create(:from_address, :verified, service_id: service_id, email: email)
-    #     allow(from_address_creation).to receive(:email_identity).and_return(email_identity)
-    #     allow(email_service).to receive(:get_email_identity).and_return(double)
-    #     from_address_creation.save
-    #   end
-
-    #   it 'sets the from address status to default' do
-    #     expect(from_address.reload.status).to eq('default')
-    #   end
-    # end
-
     context 'when the email is blank' do
       let(:email) { '' }
       it 'saves the default email address to the DB' do


### PR DESCRIPTION
[Trello](https://trello.com/c/C2nWHT9z/2984-from-address-bug-aws-verification-email-is-sent-when-errors-are-triggered)

### Ensure AWS calls are made only if the email is valid
We do not want to call AWS with an invalid email address. This commit passes the `from_address_params` into the `from_address` initialiser which allows us to check whether the email submitted is valid before we attempt to make the AWS requests.

### Remove unnecessary test
This test looks at the scenario when the AWS console shows the email as not verified, but in our database the email is verified.
This can never happen as we cannot change the verification status to be unverified, ie: change the sending_enabled status.
We only have the power to delete or create email identities. Therefore, we can remove this test.