### PR TITLE
Fix Test Services Configs remover

### DIFF
--- a/app/services/test_services_configs_remover.rb
+++ b/app/services/test_services_configs_remover.rb
@@ -16,7 +16,7 @@ class TestServicesConfigsRemover
   end
 
   def user_ids
-    User.all.select { |user| user.id if user.email.in?(team_emails) }.compact
+    User.all.map { |user| user.id if user.email.in?(team_emails) }.compact
   end
 
   def team_emails


### PR DESCRIPTION
`select` returns the User objects. We want to return just the IDs so use `map`. Doh.