### PR TITLE
Unpublish services in the Test environment

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class ServicesController < Admin::ApplicationController
+    include MetadataVersionHelper
+
     def index
       response = MetadataApiClient::Service.all_services(
         page: page,
@@ -121,25 +123,6 @@ module Admin
       User.find_by(id: user_id)
     end
 
-    def latest_version(service_id)
-      MetadataApiClient::Service.latest_version(service_id)
-    end
-
-    def get_version_metadata(publish_service)
-      # get the latest version of the metadata because if the version id is missing
-      # then the latest version would have been the one published before the
-      # version_id column was added to the DB
-      if publish_service.version_id.blank?
-        return latest_version(publish_service.service_id)
-      end
-
-      version = MetadataApiClient::Version.find(
-        service_id: publish_service.service_id,
-        version_id: publish_service.version_id
-      )
-      version.metadata
-    end
-
     def duplicate_attributes(service_creation)
       {
         'service_name' => service_creation.service_name,
@@ -173,11 +156,6 @@ module Admin
         service_id: @service.service_id,
         deployment_environment: environment
       ).last&.unpublished?
-    end
-
-    def service_slug(version_metadata)
-      service = MetadataPresenter::Service.new(version_metadata, editor: true)
-      service.service_slug
     end
   end
 end

--- a/app/helpers/metadata_version_helper.rb
+++ b/app/helpers/metadata_version_helper.rb
@@ -1,0 +1,25 @@
+module MetadataVersionHelper
+  def get_version_metadata(publish_service)
+    # get the latest version of the metadata because if the version id is missing
+    # then the latest version would have been the one published before the
+    # version_id column was added to the DB
+    if publish_service.version_id.blank?
+      return latest_version(publish_service.service_id)
+    end
+
+    version = MetadataApiClient::Version.find(
+      service_id: publish_service.service_id,
+      version_id: publish_service.version_id
+    )
+    version.metadata
+  end
+
+  def latest_version(service_id)
+    MetadataApiClient::Service.latest_version(service_id)
+  end
+
+  def service_slug(version_metadata)
+    service = MetadataPresenter::Service.new(version_metadata, editor: true)
+    service.service_slug
+  end
+end

--- a/app/services/unpublish_test_services.rb
+++ b/app/services/unpublish_test_services.rb
@@ -1,0 +1,39 @@
+class UnpublishTestServices
+  include MetadataVersionHelper
+
+  ACCEPTANCE_TEST_SERVICES = [
+    'cd75ad76-1d4b-4ce5-8a9e-035262cd2683', # New Runner Service
+    'e68dca75-20b8-468e-9436-e97791a914c5'  # Branching Fixture 10 Service
+  ].freeze
+  ENVIRONMENTS = %i[dev production].freeze
+  SELECT_LATEST_PUBLISH_SERVICE_RECORD = 'SELECT DISTINCT ON (service_id) * FROM publish_services ORDER BY service_id, created_at DESC'.freeze
+
+  def call
+    ENVIRONMENTS.each do |environment|
+      send(environment).each do |publish_service|
+        version_metadata = get_version_metadata(publish_service)
+        UnpublishServiceJob.perform_later(
+          publish_service_id: publish_service.id,
+          service_slug: service_slug(version_metadata)
+        )
+      end
+    end
+  end
+
+  private
+
+  def published_services
+    @published_services ||=
+      PublishService.find_by_sql(SELECT_LATEST_PUBLISH_SERVICE_RECORD)
+                    .reject { |ps| ps.service_id.in?(ACCEPTANCE_TEST_SERVICES) }
+                    .select(&:completed?)
+  end
+
+  def dev
+    published_services.select { |ps| ps.status == 'dev' }
+  end
+
+  def production
+    published_services.select { |ps| ps.status == 'production' }
+  end
+end

--- a/deploy-eks/fb-editor-chart/templates/remove_test_services_configs.yaml
+++ b/deploy-eks/fb-editor-chart/templates/remove_test_services_configs.yaml
@@ -49,16 +49,6 @@ spec:
                   secretKeyRef:
                     name: {{ .Values.bearer_token }}
                     key: token
-              - name: AWS_SES_ACCESS_KEY_ID
-                valueFrom:
-                  secretKeyRef:
-                    name: fb-editor-secrets-{{ .Values.environmentName }}
-                    key: aws_ses_access_key_id
-              - name: AWS_SES_SECRET_ACCESS_KEY
-                valueFrom:
-                  secretKeyRef:
-                    name: fb-editor-secrets-{{ .Values.environmentName }}
-                    key: aws_ses_secret_access_key
               - name: ENCRYPTION_KEY
                 valueFrom:
                   secretKeyRef:

--- a/deploy-eks/fb-editor-chart/templates/unpublish_test_services.yaml
+++ b/deploy-eks/fb-editor-chart/templates/unpublish_test_services.yaml
@@ -49,16 +49,6 @@ spec:
                   secretKeyRef:
                     name: {{ .Values.bearer_token }}
                     key: token
-              - name: AWS_SES_ACCESS_KEY_ID
-                valueFrom:
-                  secretKeyRef:
-                    name: fb-editor-secrets-{{ .Values.environmentName }}
-                    key: aws_ses_access_key_id
-              - name: AWS_SES_SECRET_ACCESS_KEY
-                valueFrom:
-                  secretKeyRef:
-                    name: fb-editor-secrets-{{ .Values.environmentName }}
-                    key: aws_ses_secret_access_key
               - name: ENCRYPTION_KEY
                 valueFrom:
                   secretKeyRef:

--- a/deploy-eks/fb-editor-chart/templates/unpublish_test_services.yaml
+++ b/deploy-eks/fb-editor-chart/templates/unpublish_test_services.yaml
@@ -1,0 +1,73 @@
+{{- if eq .Values.environmentName "test" }}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: fb-editor-cron-unpublish-test-services-{{ .Values.environmentName }}
+  namespace: formbuilder-saas-{{ .Values.environmentName }}
+spec:
+  schedule: "0 20 * * FRI"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            from-address: cronjob
+        spec:
+          containers:
+          - name: "fb-editor-workers-{{ .Values.environmentName }}"
+            image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-editor-workers:{{ .Values.circleSha1 }}"
+            args:
+            - /bin/sh
+            - -c
+            - bundle exec rake unpublish:test_services
+            securityContext:
+              runAsUser: 1001
+            imagePullPolicy: Always
+            envFrom:
+              - configMapRef:
+                  name: fb-editor-config-map
+            env:
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: sentry_dsn
+              - name: SECRET_KEY_BASE
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: secret_key_base
+              - name: DATABASE_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: rds-instance-formbuilder-editor-{{ .Values.environmentName }}
+                    key: url
+              - name: EDITOR_SERVICE_ACCOUNT_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.bearer_token }}
+                    key: token
+              - name: AWS_SES_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: aws_ses_access_key_id
+              - name: AWS_SES_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: aws_ses_secret_access_key
+              - name: ENCRYPTION_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: encryption_key
+              - name: ENCRYPTION_SALT
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: encryption_salt
+          restartPolicy: Never
+{{- end }}

--- a/lib/tasks/remove_testable_editors.rake
+++ b/lib/tasks/remove_testable_editors.rake
@@ -8,6 +8,8 @@ namespace 'remove' do
 
   desc 'Removes any non moj forms team test services configurations'
   task test_services_configs: [:environment] do
+    return if ENV['PLATFORM_ENV'] == 'live'
+
     TestServicesConfigsRemover.new.call
   rescue StandardError => e
     Sentry.capture_exception(e)

--- a/lib/tasks/unpublish_test_services.rake
+++ b/lib/tasks/unpublish_test_services.rake
@@ -1,0 +1,8 @@
+namespace 'unpublish' do
+  desc 'Unpublishes services from a given environment'
+  task test_services: [:environment, 'db:load_config'] do
+    UnpublishTestServices.new.call
+  rescue StandardError => e
+    Sentry.capture_exception(e)
+  end
+end

--- a/lib/tasks/unpublish_test_services.rake
+++ b/lib/tasks/unpublish_test_services.rake
@@ -1,6 +1,8 @@
 namespace 'unpublish' do
   desc 'Unpublishes services from a given environment'
   task test_services: [:environment, 'db:load_config'] do
+    return if ENV['PLATFORM_ENV'] == 'live'
+
     UnpublishTestServices.new.call
   rescue StandardError => e
     Sentry.capture_exception(e)


### PR DESCRIPTION
This adds a rake task that will unpublish services in the test-dev and test-production namespaces every Friday at 20:00.

This is simply to stop randome services just sitting there using up resources in our Test environments. Users can republish any time they like.

Move some of the helper methods used by the Admin Services Controller into a Helper module.