### PR TITLE
Stop using the beta versions of kubernetes ingress controllers

### DIFF
--- a/config/publisher/cloud_platform/ingress.yaml.erb
+++ b/config/publisher/cloud_platform/ingress.yaml.erb
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: <%= service_slug %>-ingress
@@ -25,6 +25,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: <%= service_slug %>
-          servicePort: <%= container_port %>
+          service:
+            name: <%= service_slug %>
+            port:
+              number: <%= container_port %>

--- a/spec/fixtures/kubernetes_configuration/ingress.yaml
+++ b/spec/fixtures/kubernetes_configuration/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: acceptance-tests-date-ingress
@@ -25,6 +25,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: acceptance-tests-date
-          servicePort: 3000
+          service:
+            name: acceptance-tests-date
+            port:
+              number: 3000


### PR DESCRIPTION
All beta Ingress API versions such as extensions/v1beta1 and networking.k8s.io/v1beta1 have been deprecated and are not available in Kubernetes v1.22 or the new nginx-ingress-controller v1.2

Change the apiVersion to networking.k8s.io/v1

Add pathType: ImplementationSpecific after path: /

For serviceName, rename -backend.serviceName to -backend.service.name

For String servicePort, rename -backend.servicePort to -backend.service.port.name

For Numeric servicePort, rename -backend.servicePort to -backend.service.port.number