### PR TITLE
Rake task to update default from address email

### DIFF
--- a/lib/tasks/from_address.rake
+++ b/lib/tasks/from_address.rake
@@ -5,4 +5,17 @@ namespace 'from_address' do
   rescue StandardError => e
     Sentry.capture_exception(e)
   end
+
+  desc "Update default email to 'no-reply-moj-forms'"
+  task update_email: [:environment, 'db:load_config'] do
+    FromAddress.all.each do |record|
+      if record.email_address == 'moj-forms@digital.justice.gov.uk'
+        record.email = ''
+        record.save!
+      end
+    end
+
+  rescue StandardError => e
+    Sentry.capture_exception(e)
+  end
 end


### PR DESCRIPTION
With the release of From Address, old forms will have the old 'moj-forms' default email. We want to update these to use the new 'no-reply-moj-forms' email. This task will be run manually as it will only need to be done once.

The email is saved as an empty string in the rake task as the `FromAddress` model allows this and will update and encrypt records accordingly.