### PR TITLE
Update Kubernetes Ingress API version

### DIFF
--- a/deploy-eks/fb-editor-chart/templates/ingress.yaml
+++ b/deploy-eks/fb-editor-chart/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "{{ .Values.app_name }}-ing-{{ .Values.environmentName }}"
@@ -22,6 +22,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: "{{ .Values.app_name }}-svc-{{ .Values.environmentName }}"
-          servicePort: 80
+          service:
+            name: "{{ .Values.app_name }}-svc-{{ .Values.environmentName }}"
+            port:
+              number: 80


### PR DESCRIPTION
This only changes the Editor ingress itself. The ingress for all published services will be done in a separate PR.

All beta Ingress API versions such as extensions/v1beta1 and networking.k8s.io/v1beta1 have been deprecated and are not available in Kubernetes v1.22 or the new nginx-ingress-controller v1.2

Change the apiVersion to networking.k8s.io/v1

Add pathType: ImplementationSpecific after path: /

For serviceName, rename -backend.serviceName to -backend.service.name

For String servicePort, rename -backend.servicePort to -backend.service.port.name

For Numeric servicePort, rename -backend.servicePort to -backend.service.port.number