### PR TITLE
Send by email from address formatting

### DIFF
--- a/app/views/settings/email/_email_fieldset.html.erb
+++ b/app/views/settings/email/_email_fieldset.html.erb
@@ -12,8 +12,10 @@
         <%= govuk_link_to(t('activemodel.attributes.email_settings.from_address.pending_link'),
           settings_from_address_index_path(service.service_id), class: 'govuk-!-margin-left-8')%>
       <% else %>
-        <%= govuk_link_to(t('activemodel.attributes.email_settings.from_address.link'),
-          settings_from_address_index_path(service.service_id))%>
+        <p class="govuk-!-margin-top-2">
+          <%= govuk_link_to(t('activemodel.attributes.email_settings.from_address.link'),
+            settings_from_address_index_path(service.service_id))%>
+        </p>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
Small change to format link when email address is verified.

### Before
<img width="722" alt="Screenshot 2022-10-14 at 12 33 56" src="https://user-images.githubusercontent.com/29227502/195838532-a060484e-2c69-4b5c-8c56-0b7f658f9b4e.png">

### After
<img width="770" alt="Screenshot 2022-10-14 at 12 35 34" src="https://user-images.githubusercontent.com/29227502/195838544-f82493ae-3370-4de4-a04b-781e92c3012d.png">
