### PR TITLE
Add private key to cronjob configs

### DIFF
--- a/deploy-eks/fb-editor-chart/templates/remove_test_services_configs.yaml
+++ b/deploy-eks/fb-editor-chart/templates/remove_test_services_configs.yaml
@@ -49,6 +49,11 @@ spec:
                   secretKeyRef:
                     name: {{ .Values.bearer_token }}
                     key: token
+              - name: ENCODED_PRIVATE_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: encoded_private_key
               - name: ENCRYPTION_KEY
                 valueFrom:
                   secretKeyRef:

--- a/deploy-eks/fb-editor-chart/templates/unpublish_test_services.yaml
+++ b/deploy-eks/fb-editor-chart/templates/unpublish_test_services.yaml
@@ -49,6 +49,11 @@ spec:
                   secretKeyRef:
                     name: {{ .Values.bearer_token }}
                     key: token
+              - name: ENCODED_PRIVATE_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-editor-secrets-{{ .Values.environmentName }}
+                    key: encoded_private_key
               - name: ENCRYPTION_KEY
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
Both the removal of test services configs and the unpublishing of test services require the private key in order to sign the JWT token when sending requests to the Metadata API.