### PR TITLE
Remove From address update email rake task

### DIFF
--- a/lib/tasks/from_address.rake
+++ b/lib/tasks/from_address.rake
@@ -5,17 +5,4 @@ namespace 'from_address' do
   rescue StandardError => e
     Sentry.capture_exception(e)
   end
-
-  desc "Update default email to 'no-reply-moj-forms'"
-  task update_email: [:environment, 'db:load_config'] do
-    FromAddress.all.each do |record|
-      if record.email_address == 'moj-forms@digital.justice.gov.uk'
-        record.email = ''
-        record.save!
-      end
-    end
-
-  rescue StandardError => e
-    Sentry.capture_exception(e)
-  end
 end


### PR DESCRIPTION
This rake task was used to update any forms that were created before From Address was released. Now that from address has been released and all forms have been been updated with the new default email address, we no longer require this rake task.