### PR TITLE
Confirmation email blocking modals

### DIFF
--- a/app/models/destroy_question_modal.rb
+++ b/app/models/destroy_question_modal.rb
@@ -6,6 +6,7 @@ class DestroyQuestionModal
 
   def to_partial_path
     return 'api/questions/cannot_delete_modal' if can_not_be_deleted?
+    return 'api/questions/cannot_delete_confirmation_email_modal' if used_in_confirmation_email?
 
     'api/questions/destroy_message_modal'
   end
@@ -14,5 +15,18 @@ class DestroyQuestionModal
 
   def can_not_be_deleted?
     expressions.map(&:component).include?(question.uuid)
+  end
+
+  def used_in_confirmation_email?
+    return if confirmation_email_component_id.nil?
+
+    confirmation_email_component_id.decrypt_value.include?(question.id)
+  end
+
+  def confirmation_email_component_id
+    @confirmation_email_component_id ||= ServiceConfiguration.find_by(
+      service_id: service.service_id,
+      name: 'CONFIRMATION_EMAIL_COMPONENT_ID'
+    )
   end
 end

--- a/app/views/api/pages/_delete_page_used_for_confirmation_email_modal.html.erb
+++ b/app/views/api/pages/_delete_page_used_for_confirmation_email_modal.html.erb
@@ -1,0 +1,19 @@
+<div class="component component-dialog component-dialog-api-request dialog-delete"
+     data-component="DialogApiRequest">
+
+  <h3 data-node="heading" class="govuk-label govuk-label--m">
+    <%= t('pages.delete_modal.can_not_delete_email_page_heading') %>
+  </h3>
+  <p data-node="content">
+    <%= t('pages.delete_modal.can_not_delete_email_page_message') %>
+  </p>
+
+  <div class="govuk-button-group">
+    <%= link_to t('pages.delete_modal.go_to_email_settings'),
+      settings_confirmation_email_index_path(service.service_id),
+      class: "govuk-button fb-govuk-button"%>
+
+    <button class="govuk-button govuk-button--secondary ui-button"><%= t('dialogs.button_cancel') %></button>
+  </div>
+</div>
+

--- a/app/views/api/questions/_cannot_delete_confirmation_email_modal.html.erb
+++ b/app/views/api/questions/_cannot_delete_confirmation_email_modal.html.erb
@@ -1,0 +1,16 @@
+<div class="component component-dialog component-dialog-delete" id="dialog-confirmation-delete">
+  <h3 data-node="heading" class="govuk-label govuk-label--m">
+    <%= t('questions.delete_modal.can_not_delete_heading') %>
+  </h3>
+  <p data-node="content">
+    <%= t('questions.delete_modal.can_not_delete_message_confirmation_email') %>
+  </p>
+
+  <div class="govuk-button-group">
+    <%= link_to t('pages.delete_modal.go_to_email_settings'),
+    settings_confirmation_email_index_path(service.service_id),
+    class: "govuk-button fb-govuk-button"%>
+
+    <button class="govuk-button govuk-button--secondary ui-button"><%= t('dialogs.button_cancel') %></button>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,6 +220,9 @@ en:
       you_cannot_delete_this_page: 'You cannot delete this page yet'
       delete_page_used_for_branching_not_supported_message: 'You cannot delete this page because it is used in a branching condition. Update the branching point first, then try again.'
       stack_branches_not_supported_message: 'Deleting this page would result in 2 branching points in a row, which is not currently possible. Try combining your branching rules into 1 branching point.'
+      can_not_delete_email_page_heading: 'You cannot delete this page yet'
+      can_not_delete_email_page_message: 'You cannot delete this page because it is used by the confirmation email. Update the email settings first.'
+      go_to_email_settings: 'Go to email settings'
     destination:
       heading: 'Change destination'
       lede: 'Update this connection to lead to the following page:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,6 +195,7 @@ en:
     delete_modal:
       can_not_delete_heading: 'You cannot delete this question yet'
       can_not_delete_message: 'You cannot delete this question because it is used in a branching condition. Update the branching point first, then try again.'
+      can_not_delete_message_confirmation_email: 'You cannot delete this question because it is used by the confirmation email. Update the email settings.'
   question_items:
     delete_modal:
       can_not_delete_heading: 'You cannot delete this option yet'

--- a/spec/models/destroy_page_modal_spec.rb
+++ b/spec/models/destroy_page_modal_spec.rb
@@ -10,50 +10,87 @@ RSpec.describe DestroyPageModal do
   describe '#to_partial_path' do
     subject(:partial) { destroy_page_modal.to_partial_path }
 
-    # branch destinations
-    context 'when after branch' do
-      context 'when there is no branch sequentially after the page' do
-        context 'when the destination has a default next' do
-          let(:page) { service.find_page_by_url('page-c') }
+    context 'branching' do
+      # branch destinations
+      context 'when after branch' do
+        context 'when there is no branch sequentially after the page' do
+          context 'when the destination has a default next' do
+            let(:page) { service.find_page_by_url('page-c') }
+
+            it 'returns deleting branch destination page partial' do
+              expect(partial).to eq('api/pages/delete_branch_destination_page_modal')
+            end
+          end
+        end
+
+        context 'when the destination has no default next' do
+          let(:service_metadata) { metadata_fixture(:branching_7) }
+          let(:page) { service.find_page_by_url('page-g') }
 
           it 'returns deleting branch destination page partial' do
-            expect(partial).to eq('api/pages/delete_branch_destination_page_modal')
+            expect(partial).to eq('api/pages/delete_branch_destination_page_no_default_next_modal')
+          end
+        end
+
+        context 'when there is a branch sequentially after the page' do
+          let(:page) { service.find_page_by_url('page-j') }
+
+          it 'returns not supported stack branches partial' do
+            expect(partial).to eq('api/pages/stack_branches_not_supported_modal')
           end
         end
       end
 
-      context 'when the destination has no default next' do
-        let(:service_metadata) { metadata_fixture(:branching_7) }
-        let(:page) { service.find_page_by_url('page-g') }
+      # used for branch conditionals
+      context 'when there is a branch that depends on the page' do
+        let(:page) { service.find_page_by_url('page-b') }
 
-        it 'returns deleting branch destination page partial' do
-          expect(partial).to eq('api/pages/delete_branch_destination_page_no_default_next_modal')
-        end
-      end
-
-      context 'when there is a branch sequentially after the page' do
-        let(:page) { service.find_page_by_url('page-j') }
-
-        it 'returns not supported stack branches partial' do
-          expect(partial).to eq('api/pages/stack_branches_not_supported_modal')
+        it 'returns delete page used for branching not supported' do
+          expect(partial).to eq('api/pages/delete_page_used_for_branching_not_supported_modal')
         end
       end
     end
 
-    # used for branch conditionals
-    context 'when there is a branch that depends on the page' do
-      let(:page) { service.find_page_by_url('page-b') }
+    context 'confirmation email' do
+      context 'when there is a confirmation email that depends on the page' do
+        let(:service_configuration) do
+          create(
+            :service_configuration,
+            name: 'CONFIRMATION_EMAIL_COMPONENT_ID',
+            value: 'email-address_email_1',
+            deployment_environment: 'dev'
+          )
+        end
+        let(:service_metadata) { metadata_fixture(:version) }
+        let(:page) { service.find_page_by_url('email-address') }
 
-      it 'returns delete page used for branching not supported' do
-        expect(partial).to eq('api/pages/delete_page_used_for_branching_not_supported_modal')
+        before do
+          allow(destroy_page_modal).to receive(:confirmation_email_component_id).and_return(service_configuration)
+        end
+
+        it 'returns delete_page_used_for_confirmation_email' do
+          expect(partial).to eq('api/pages/delete_page_used_for_confirmation_email_modal')
+        end
       end
-    end
 
-    context 'when deleting a page without any consequences' do
-      let(:page) { service.find_page_by_url('page-h') }
+      context 'when deleting a page without any consequences' do
+        let(:page) { service.find_page_by_url('page-h') }
 
-      it 'returns the default delete partial' do
-        expect(partial).to eq('api/pages/delete_modal')
+        it 'returns the default delete partial' do
+          expect(partial).to eq('api/pages/delete_modal')
+        end
+      end
+
+      context 'when confirmation email is not set' do
+        let(:page) { service.find_page_by_url('page-h') }
+
+        before do
+          allow(destroy_page_modal).to receive(:confirmation_email_component_id).and_return(nil)
+        end
+
+        it 'returns the default delete partial' do
+          expect(partial).to eq('api/pages/delete_modal')
+        end
       end
     end
   end

--- a/spec/models/destroy_question_modal_spec.rb
+++ b/spec/models/destroy_question_modal_spec.rb
@@ -14,19 +14,69 @@ RSpec.describe DestroyQuestionModal do
       destroy_question_modal.to_partial_path
     end
 
-    context 'when there is a branch that depends on the question' do
-      let(:page) { service.find_page_by_url('page-b') }
+    context 'branching questions' do
+      before do
+        allow(destroy_question_modal).to receive(:used_in_confirmation_email?).and_return(false)
+      end
 
-      it 'returns can not delete the question modal' do
-        expect(partial).to eq('api/questions/cannot_delete_modal')
+      context 'when there is a branch that depends on the question' do
+        let(:page) { service.find_page_by_url('page-b') }
+
+        it 'returns can not delete the question modal' do
+          expect(partial).to eq('api/questions/cannot_delete_modal')
+        end
+      end
+
+      context 'when there is not a branch that depends on the question' do
+        let(:page) { service.find_page_by_url('page-d') }
+
+        it 'returns default delete question modal' do
+          expect(partial).to eq('api/questions/destroy_message_modal')
+        end
       end
     end
 
-    context 'when there is not a branch that depends on the question' do
-      let(:page) { service.find_page_by_url('page-d') }
+    context 'confirmation email questions' do
+      let(:service_metadata) { metadata_fixture(:branching_12) }
+      let(:service_configuration) do
+        create(
+          :service_configuration,
+          name: 'CONFIRMATION_EMAIL_COMPONENT_ID',
+          value: 'multi2_email_1',
+          deployment_environment: 'dev'
+        )
+      end
 
-      it 'returns default delete question modal' do
-        expect(partial).to eq('api/questions/destroy_message_modal')
+      before do
+        allow(destroy_question_modal).to receive(:confirmation_email_component_id).and_return(service_configuration)
+      end
+
+      context 'when confirmation email depends on a question' do
+        let(:page) { service.find_page_by_url('multi2') }
+
+        it 'returns can not delete the question modal' do
+          expect(partial).to eq('api/questions/cannot_delete_confirmation_email_modal')
+        end
+      end
+
+      context 'when a confirmation email does not depend on a question' do
+        let(:page) { service.find_page_by_url('email') }
+
+        it 'returns default delete question modal' do
+          expect(partial).to eq('api/questions/destroy_message_modal')
+        end
+      end
+
+      context 'when confirmation email has not been set' do
+        let(:page) { service.find_page_by_url('email') }
+
+        before do
+          allow(destroy_question_modal).to receive(:confirmation_email_component_id).and_return(nil)
+        end
+
+        it 'returns default delete question modal' do
+          expect(partial).to eq('api/questions/destroy_message_modal')
+        end
       end
     end
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/M2KMc4f4/3024-confirmation-email-05-block-removing-component-page-if-used)

### Add delete page modal for confirmation email
We need to prevent users from deleting any pages that have an email component that is used as the confirmation email.

<img width="909" alt="Screenshot 2022-10-24 at 15 27 22" src="https://user-images.githubusercontent.com/29227502/197550446-8e32b552-0a53-4d43-8132-8ab88efb7c33.png">

### Add delete modal for email questions
Similar to blocking on a page level, we want to prevent users from deleting the specific email component question on a multiple question page.

Since this modal triggers on a component level rather than a page level, users will be able to delete other components on their multiple question page.

<img width="884" alt="Screenshot 2022-10-24 at 15 27 33" src="https://user-images.githubusercontent.com/29227502/197550502-bb2b5b87-2f1b-43af-ac16-2624fe4af6ae.png">