### PR TITLE
Fix Test Services Configs Remover

### DIFF
--- a/app/services/test_services_configs_remover.rb
+++ b/app/services/test_services_configs_remover.rb
@@ -14,7 +14,7 @@ class TestServicesConfigsRemover
   private
 
   def moj_forms_team_service_ids
-    @moj_forms_team_service_ids ||= team_services.map(&:id).reject { |id| id.in?(RUNNER_ACCEPTANCE_TEST_FORMS) }
+    @moj_forms_team_service_ids ||= team_services.map(&:id) + RUNNER_ACCEPTANCE_TEST_FORMS
   end
 
   def team_services


### PR DESCRIPTION
We want to include the service ids of the Runner Acceptance tests.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>