### PR TITLE
Update form validation to reject name starting with numerical characters

### DIFF
--- a/app/services/editor/service.rb
+++ b/app/services/editor/service.rb
@@ -5,7 +5,7 @@ module Editor
 
     validates :service_name, presence: true
     validates :service_name, length: { minimum: 3, maximum: 128 }, allow_blank: true
-    validates :service_name, format: { with: /\A[\sa-zA-Z0-9-'’()]*\z/ }, allow_blank: true
+    validates :service_name, format: { with: /\A[a-zA-Z][\sa-zA-Z0-9-'’()]*\z/ }, allow_blank: true
     validates :service_name, legacy_service_name: true
 
     def add_errors(service)

--- a/spec/services/service_creation_spec.rb
+++ b/spec/services/service_creation_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe ServiceCreation do
           ).to include('is already used by another form. Please modify it.')
         end
       end
+
+      context 'when name starts with a number' do
+        let(:attributes) { { service_name: '1st-form' } }
+
+        it 'returns false' do
+          expect(service_creation.create).to be_falsey
+        end
+      end
     end
 
     context 'when is valid' do


### PR DESCRIPTION
## Context 
We had an issue recently where Kubernetes could not deploy a form that begins with a numeric character because it has to respect the DNS label standard as defined in RFC 1035. Solution was to update form name validation.

## Implementation
Update service validation to reject name starting with numerical characters. Currently message is default and not specific : "Your answer for ‘Give your form a name' contains characters that are not allowed."

## Tests
Unit tests and local testing performed.
