### PR TITLE
Add expanders to confirmation email settings page

### DIFF
--- a/app/javascript/src/controller_confirmation_email.js
+++ b/app/javascript/src/controller_confirmation_email.js
@@ -1,0 +1,37 @@
+const DefaultController = require('./controller_default');
+const Expander = require('./component_expander');
+
+class ConfirmationEmailController extends DefaultController {
+  constructor(app) {
+    super(app);
+
+    switch(app.page.action) {
+      case 'create':
+      case 'index':
+        this.#index();
+      break;
+    }
+  }
+
+  #index() {
+    this.#addExpanderEnhancement();
+  }
+
+  #addExpanderEnhancement() {
+    $(".collect-info-environment-config").each(function(index) {
+      var $this = $(this);
+      var $checkbox = $("input[type=checkbox]", $this);
+      var expander = new Expander($("details", $this), {
+        auto_open: $(".govuk-form-group--error", $this).length
+      });
+
+      $checkbox.on("click", function() {
+        if(this.checked && !expander.isOpen()) {
+          expander.open();
+        }
+      });
+    });
+  }
+}
+
+module.exports = ConfirmationEmailController;

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -7,6 +7,7 @@ const BranchesController = require('./controller_branches');
 const FormAnalyticsController = require('./controller_form_analytics');
 const FromAddressController = require('./controller_from_address');
 const CollectionEmailController = require('./controller_collection_email');
+const ConfirmationEmailController = require('./controller_confirmation_email');
 const {
   snakeToPascalCase,
 } = require('./utilities');
@@ -78,6 +79,11 @@ switch(controllerAndAction()) {
   case "EmailController#create":
       Controller = CollectionEmailController;
   break;
+
+  case "ConfirmationEmailController#index":
+  case "ConfirmationEmailController#create":
+    Controller = ConfirmationEmailController;
+    break;
 
   default:
        console.log(controllerAndAction());


### PR DESCRIPTION
Adds in the functionality to expand the configure blocks when the 'enable' checkboxes are checked in either test or live environments.

Trello Ticket: https://trello.com/c/yTexNZli/3034-expand-config-with-checkbox-confirmation-email-settings

I had initially started refactoring the way this was implemented - but I'll leave that to another PR - this gets the functionality in and working! 