### PR TITLE
Update modal focus() to allow for links or buttons.

### DIFF
--- a/app/javascript/src/component_dialog.js
+++ b/app/javascript/src/component_dialog.js
@@ -10,7 +10,7 @@
 * not use the native jQuery UI dialog buttons.
 *
 * These dialogs are intended to be used with a static template (always) present
-* in the page, that does not contain the text content. 
+* in the page, that does not contain the text content.
 *
 * When the dialog is required the open method is called with the desired
 * content, which is then injected into the template and the dialog opened and
@@ -22,16 +22,16 @@
 * property (type) [default value]:
 *
 *  - activator ($node | boolean) [false]
-*    Either an existing node that will trigger the dialog, or a boolean value 
+*    Either an existing node that will trigger the dialog, or a boolean value
 *    indicating whether or not to create an activator
 *
 *  - autoOpen (boolean) [false]
 *    Open the dialog on creation.
 *
-*  - classes (object) [{}] 
+*  - classes (object) [{}]
 *    An object of jQuery ui classes that will be applied to the UI dialog
 *    elements
-*  
+*
 *  - closeOnClickSelector (string) [button:not([data-node="confirm"])]
 *    jQuery selector string for elements that will close the dialog when
 *    clicked.  Should *not* include the confirmation element.
@@ -40,7 +40,7 @@
 *    jQuery selector string for the 'confirmation' action for the dialog.
 *    bin
 *
-*  - onOpen (function(dialog)) 
+*  - onOpen (function(dialog))
 *    Callable that will be called when the dialog is opened. Recieves the
 *    Dialog class instance as an argument
 *
@@ -56,11 +56,11 @@
 *    Callable that will be called when the dialog has been instantiated and all
 *    event listeners / JS enhancements have been applied. Recieves the
 *    Dialog class instance as an argument
-*    
+*
 * Setters
 * =======
 * As the dialog is initialised on a template node and reused with different
-* injected content for many actions within the app, the following setters are 
+* injected content for many actions within the app, the following setters are
 * provided to override the global config.
 *
 * content(text)
@@ -184,7 +184,7 @@ class Dialog {
   close(callback) {
     const dialog = this;
 
-    this.focusActivator(); 
+    this.focusActivator();
 
     this.$node.dialog('close');
     this.#state = 'closed';
@@ -198,7 +198,7 @@ class Dialog {
   }
 
   focus() {
-    const el = this.$node.find('button:not([type="disabled"]):not([data-method="delete"])').eq(0);
+    const el = this.$node.find('.govuk-button:not([type="disabled"]):not([data-method="delete"])').eq(0);
     if(el){
       el.focus();
     }
@@ -225,7 +225,7 @@ class Dialog {
 
   #build() {
     var dialog = this;
-    
+
     // this.activator is true || $node setup a DialogActivator
     if(this.activator) {
       this.#addActivator();
@@ -239,7 +239,7 @@ class Dialog {
       modal: true,
       resizable: false,
     });
-    
+
     this.$container = dialog.$node.parents(".ui-dialog");
     this.$container.addClass(dialog.#className);
     this.$node.data("instance", dialog);
@@ -289,18 +289,18 @@ class Dialog {
       $buttons.on("click", function() {
         dialog.close();
       });
-    } 
+    }
   }
 
   #setupConfirmButton() {
     const dialog = this;
     const $button = $(this.#config.confirmOnClickSelector, this.$container).first();
     $button.on("click", function(e) {
-      e.preventDefault(); 
+      e.preventDefault();
       dialog.close(dialog.#config.onConfirm);
     });
   }
-  
+
   #addActivator() {
     var $marker = $("<span></span>");
 

--- a/app/javascript/src/component_dialog_api_request.js
+++ b/app/javascript/src/component_dialog_api_request.js
@@ -11,8 +11,8 @@
 * These dialogs are ephemeral - they are created on a successful API request,
 * and removed entirely from the DOM once closed.
 *
-* While it is possible to pass in buttons for jQuery UI to use within the config 
-* options, it is recommended to have the controlling buttons included within the 
+* While it is possible to pass in buttons for jQuery UI to use within the config
+* options, it is recommended to have the controlling buttons included within the
 * markup in the returned template.
 *
 * Configuration
@@ -21,7 +21,7 @@
 * property (type) [default value]:
 *
 *  - activator ($node | boolean) [false]
-*    Either an existing node that will trigger the dialog, or a boolean value 
+*    Either an existing node that will trigger the dialog, or a boolean value
 *    indicating whether or not to create an activator
 *
 *  - autoOpen (boolean) [false]
@@ -35,20 +35,20 @@
 *            {
 *               text: "This is used for button text",
 *               click: function(dialog) {
-*                 // an action to run on click that receives the DialogApiRequest 
+*                 // an action to run on click that receives the DialogApiRequest
 *                 // instance as an argument.
 *               }
 *            }
 *
-*  - classes (object) [{}] 
+*  - classes (object) [{}]
 *    An object of jQuery ui classes that will be applied to the UI dialog
 *    elements
-*  
+*
 *  - closeOnClickSelector (string) ['']
 *    jQuery selector string for elements that will close the dialog when
-*    clicked. Use this option if you do not pass in buttons. 
+*    clicked. Use this option if you do not pass in buttons.
 *
-*  - onOpen (function(dialog)) 
+*  - onOpen (function(dialog))
 *    Callable that will be called when the dialog is opened. Recieves the
 *    Dialog class instance as an argument
 *
@@ -59,7 +59,7 @@
 *  - onLoad (function(dialog))
 *    Callable that will be called when the response from the server is
 *    successfully recieved, but before the jQuery dialog is initialized or any
-*    enhancements ahve been applied to the repsonse. Recieves the Dialog class 
+*    enhancements ahve been applied to the repsonse. Recieves the Dialog class
 *    instance as an argument
 *
 *  - onReady (function(dialog))
@@ -84,7 +84,7 @@ class DialogApiRequest {
   /**
   * @param {string} url - The url to request the template from
   * @param {Object} config - config key/value pairs
-  */ 
+  */
   constructor(url, config) {
     this.#config = mergeObjects({
       activator: false,
@@ -126,7 +126,7 @@ class DialogApiRequest {
 
     this.$node.dialog("open");
     safelyActivateFunction(this.#config.onOpen, dialog);
-    
+
     queueMicrotask(() => {
       dialog.focus();
     });
@@ -140,7 +140,7 @@ class DialogApiRequest {
   }
 
   focus() {
-    const el = this.$node.find('button:not([type="disabled"]):not([data-method="delete"])').eq(0);
+    const el = this.$node.find('.govuk-button:not([type="disabled"]):not([data-method="delete"])').eq(0);
     if(el){
       el.focus();
     }
@@ -172,7 +172,7 @@ class DialogApiRequest {
 
   #build() {
     const dialog = this;
-    
+
     // this.activator is true || $node setup a DialogActivator
     if(this.activator) {
       this.#addActivator();
@@ -186,9 +186,9 @@ class DialogApiRequest {
       modal: true,
       resizable: false,
       open: function() { dialog.#state = "open" },
-      close: function() { 
-        dialog.#state = "closed"; 
-        dialog.focusActivator(); 
+      close: function() {
+        dialog.#state = "closed";
+        dialog.focusActivator();
         dialog.#destroy();
       }
     });
@@ -247,7 +247,7 @@ class DialogApiRequest {
 
   #destroy() {
     if(this.$node.dialog('instance')) {
-      this.$node.dialog('destroy'); 
+      this.$node.dialog('destroy');
     }
     this.$node.remove();
   }

--- a/app/javascript/src/component_dialog_form.js
+++ b/app/javascript/src/component_dialog_form.js
@@ -9,7 +9,7 @@
 * the page, or an HTML teplate recieved via an API request.
 *
 * This class is effectively a combination of the Dialog and DialogApiRequest
-* classes with added functionality to handle forms.  
+* classes with added functionality to handle forms.
 *
 * The form within the dialog can either be submitted synchronoously or
 * asynchronously.
@@ -20,22 +20,22 @@
 * property (type) [default value]:
 *
 *  - activator ($node | boolean) [false]
-*    Either an existing node that will trigger the dialog, or a boolean value 
+*    Either an existing node that will trigger the dialog, or a boolean value
 *    indicating whether or not to create an activator
 *
 *  - autoOpen (boolean) [false]
 *    Open the dialog on creation.
 *
-*  - classes (object) [{}] 
+*  - classes (object) [{}]
 *    An object of jQuery ui classes that will be applied to the UI dialog
 *    elements
-*  
+*
 *  - closeOnClickSelector (string) ['button[type="button]']
 *    jQuery selector string for elements that will close the dialog when
 *    clicked.
 *
 *  - submitOnClickSelector (string) ['button[type="submit"]']
-*    jQuery selector string for the button that will submit the form wihtin the 
+*    jQuery selector string for the button that will submit the form wihtin the
 *    dialog when clicked.
 *
 *  - remote (boolean) [false]
@@ -45,7 +45,7 @@
 *    Only used when remote is true.  If a string is provided, the submit button
 *    will be disabled on submit, and its label set to the value of this option.
 *
-*  - onOpen (function(dialog)) 
+*  - onOpen (function(dialog))
 *    Callable that will be called when the dialog is opened. Recieves the
 *    Dialog class instance as an argument
 *
@@ -56,7 +56,7 @@
 *  - onLoad (function(dialog))
 *    Callable that will be called when the response from the server is
 *    successfully recieved, but before the jQuery dialog is initialized or any
-*    enhancements ahve been applied to the repsonse. Recieves the Dialog class 
+*    enhancements ahve been applied to the repsonse. Recieves the Dialog class
 *    instance as an argument
 *
 *  - onReady (function(dialog))
@@ -81,7 +81,7 @@
 
 const {
 mergeObjects,
-safelyActivateFunction, 
+safelyActivateFunction,
 } = require('./utilities');
 
 const DialogActivator = require('./component_dialog_activator');
@@ -93,9 +93,9 @@ class DialogForm {
   #state;
 
   /**
-  * @param {string|jQuery} source - Either a url to request html from or jQuery node 
+  * @param {string|jQuery} source - Either a url to request html from or jQuery node
   * @param {Object} config - config key/value pairs
-  */ 
+  */
   constructor(source, config) {
     this.#config = mergeObjects({
       activator: false,
@@ -113,7 +113,7 @@ class DialogForm {
       onOpen: function(dialog) {},
       onClose: function(dialog) {},
     }, config);
-   
+
     this.#remoteSource = false;
     this.#state = "closed";
     this.$node = $(); // Should be overwritten once intialised
@@ -180,7 +180,7 @@ class DialogForm {
   focus() {
     var el = this.$node.parent().find('input[aria-invalid]').get(0);
     if(!el) {
-      el = this.$node.parent().find('input:not([type="hidden"], [type="disabled"]), button:not([type="disabled"])').not(".ui-dialog-titlebar-close").eq(0);
+      el = this.$node.parent().find('input:not([type="hidden"], [type="disabled"]), .govuk-button:not([type="disabled"])').not(".ui-dialog-titlebar-close").eq(0);
     }
     if(el){
       el.focus();
@@ -194,10 +194,10 @@ class DialogForm {
     }
   }
 
-  /* 
-  * simply a function alias for better readability / nicer api 
-  * expected to be called if the dialog html is changed dynamically 
-  * will re-enhance the html to add the required functionality 
+  /*
+  * simply a function alias for better readability / nicer api
+  * expected to be called if the dialog html is changed dynamically
+  * will re-enhance the html to add the required functionality
   * */
   refresh() {
     this.#enhance();
@@ -211,15 +211,15 @@ class DialogForm {
       $.get(source)
       .done((response) => {
         this.$node = $(response);
-        this.#build(); 
-        // Allow a function to be specified in dialog config 
+        this.#build();
+        // Allow a function to be specified in dialog config
         safelyActivateFunction(dialog.#config.onLoad, dialog);
         this.#enhance();
         if(this.#config.autoOpen) {
           this.open();
         }
       })
-    } else { 
+    } else {
       this.$node = source;
 
       this.#build();
@@ -234,7 +234,7 @@ class DialogForm {
 
   #build() {
     var dialog = this;
-    
+
     // this.activator is true || $node setup a DialogActivator
     if(this.activator) {
       this.#addActivator();
@@ -248,7 +248,7 @@ class DialogForm {
       modal: true,
       resizable: false,
     });
-    
+
     this.$container = dialog.$node.parents(".ui-dialog");
     this.$container.addClass(dialog.#className);
     this.$node.data("instance", dialog);
@@ -278,7 +278,7 @@ class DialogForm {
       $buttons.on("click", function() {
         dialog.close();
       });
-    } 
+    }
   }
 
   /* add event listeners to configured submit button */
@@ -286,7 +286,7 @@ class DialogForm {
     var dialog = this;
     let $button = $(this.#config.submitOnClickSelector, this.$container).first();
     $button.on("click", function(e) {
-      e.preventDefault(); 
+      e.preventDefault();
       if(dialog.#config.remote && dialog.#config.disableOnSubmit) {
         $button.text(dialog.#config.disableOnSubmit);
         $button.attr('disabled', 'disabled');
@@ -299,7 +299,7 @@ class DialogForm {
   #submitRemote() {
     var dialog = this;
 
-    $.ajax({ 
+    $.ajax({
       type: 'POST',
       url: dialog.$form.attr('action'),
       data: new FormData(dialog.$form.get(0)),
@@ -318,7 +318,7 @@ class DialogForm {
 
   #destroy() {
     if(this.$node.dialog('instance')) {
-      this.$node.dialog('destroy'); 
+      this.$node.dialog('destroy');
     }
     this.$node.remove();
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -199,8 +199,8 @@ en:
   questions:
     delete_modal:
       can_not_delete_heading: 'You cannot delete this question yet'
-      can_not_delete_message: 'You cannot delete this question because it is used in a branching condition. Update the branching point first, then try again.'
-      can_not_delete_message_confirmation_email: 'You cannot delete this question because it is used by the confirmation email. Update the email settings.'
+      can_not_delete_message: 'You cannot delete this question because it is used in a branching condition. Update the branching point first.'
+      can_not_delete_message_confirmation_email: 'You cannot delete this question because it is required by the confirmation email. Update the email settings first.'
   question_items:
     delete_modal:
       can_not_delete_heading: 'You cannot delete this option yet'
@@ -224,10 +224,10 @@ en:
       delete_branch_destination_page_no_default_next_message: 'You cannot leave a branch without any pages. Either edit the branching point or add another page to the branch first.'
       delete_and_update_branching: 'Delete and update branching'
       you_cannot_delete_this_page: 'You cannot delete this page yet'
-      delete_page_used_for_branching_not_supported_message: 'You cannot delete this page because it is used in a branching condition. Update the branching point first, then try again.'
+      delete_page_used_for_branching_not_supported_message: 'You cannot delete this page because it is used in a branching condition. Update the branching point first.'
       stack_branches_not_supported_message: 'Deleting this page would result in 2 branching points in a row, which is not currently possible. Try combining your branching rules into 1 branching point.'
       can_not_delete_email_page_heading: 'You cannot delete this page yet'
-      can_not_delete_email_page_message: 'You cannot delete this page because it is used by the confirmation email. Update the email settings first.'
+      can_not_delete_email_page_message: 'You cannot delete this page because it is required by the confirmation email. Update the email settings first.'
       go_to_email_settings: 'Go to email settings'
     destination:
       heading: 'Change destination'


### PR DESCRIPTION
The confirmation email question deletion modal has its confirmation button as a link to the settings page, so this change allows that button to correctly gain focus on opening the modal.

Also includes a small change to the wording in the modal, and a change to the wording in a similar branching modal for consistency.

N.B. Sorry for all the trailing whitespace noise.  Now have my editor set to remove it on save, so when editing an older file from when I didn't it all gets removed! 

**Before**
![image](https://user-images.githubusercontent.com/595564/198591778-1620a1bb-a217-4b01-935a-7078a2d69a37.png)

**After**
![image](https://user-images.githubusercontent.com/595564/198591463-9bb42b15-efc3-4fd5-853f-7158e2d32dfd.png)
