### PR TITLE
Hint form name

### DIFF
--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -27,15 +27,14 @@
            data-component="FormCreateDialog">
         <%= form_for(@service_creation, url: services_path) do |f| %>
           <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
-            <div id="hint">Give your form a name, your form name cannot begin with a number</div>
             <%= f.label :service_name, class: "govuk-label govuk-label--m" %>
             <% f.object.errors.each do |error|  %>
               <p class="govuk-error-message"><%= error.message %></p>
               <div id="hint">Give your form a name, your form name cannot begin with a number</div>
             <% end %>
+            <div class="govuk-hint" id="hint">Give your form a name, your form name cannot begin with a number</div>
             <%= f.text_field :service_name, class: "govuk-input", 'aria-describedby' => 'hint'%>
           </div>
-
           <%= f.button t('services.create'), class: "govuk-button fb-govuk-button", type: 'submit' %>
           <%# f.button t('actions.cancel'), class: "govuk-button govuk-button--secondary", type: 'button' %>
         <% end %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -35,7 +35,6 @@
             <%= f.text_field :service_name, class: "govuk-input", 'aria-describedby' => 'service-name-hint'%>
           </div>
           <%= f.button t('services.create'), class: "govuk-button fb-govuk-button", type: 'submit' %>
-          <%# f.button t('actions.cancel'), class: "govuk-button govuk-button--secondary", type: 'button' %>
         <% end %>
       </div>
     </div>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -31,6 +31,7 @@
             <%= f.label :service_name, class: "govuk-label govuk-label--m" %>
             <% f.object.errors.each do |error|  %>
               <p class="govuk-error-message"><%= error.message %></p>
+              <div id="hint">Give your form a name, your form name cannot begin with a number</div>
             <% end %>
             <%= f.text_field :service_name, class: "govuk-input", 'aria-describedby' => 'hint'%>
           </div>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -30,10 +30,9 @@
             <%= f.label :service_name, class: "govuk-label govuk-label--m" %>
             <% f.object.errors.each do |error|  %>
               <p class="govuk-error-message"><%= error.message %></p>
-              <div id="hint">Give your form a name, your form name cannot begin with a number</div>
             <% end %>
-            <div class="govuk-hint" id="hint">Give your form a name, your form name cannot begin with a number</div>
-            <%= f.text_field :service_name, class: "govuk-input", 'aria-describedby' => 'hint'%>
+            <div class="govuk-hint" id="service-name-hint">Give your form a name, your form name cannot begin with a number</div>
+            <%= f.text_field :service_name, class: "govuk-input", 'aria-describedby' => 'service-name-hint'%>
           </div>
           <%= f.button t('services.create'), class: "govuk-button fb-govuk-button", type: 'submit' %>
           <%# f.button t('actions.cancel'), class: "govuk-button govuk-button--secondary", type: 'button' %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -31,7 +31,7 @@
             <% f.object.errors.each do |error|  %>
               <p class="govuk-error-message"><%= error.message %></p>
             <% end %>
-            <div class="govuk-hint" id="service-name-hint">Give your form a name, your form name cannot begin with a number</div>
+            <div class="govuk-hint" id="service-name-hint"> <%= t('services.form_name_hint')%></div>
             <%= f.text_field :service_name, class: "govuk-input", 'aria-describedby' => 'service-name-hint'%>
           </div>
           <%= f.button t('services.create'), class: "govuk-button fb-govuk-button", type: 'submit' %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -27,11 +27,12 @@
            data-component="FormCreateDialog">
         <%= form_for(@service_creation, url: services_path) do |f| %>
           <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
+            <div id="hint">Give your form a name, your form name cannot begin with a number</div>
             <%= f.label :service_name, class: "govuk-label govuk-label--m" %>
             <% f.object.errors.each do |error|  %>
               <p class="govuk-error-message"><%= error.message %></p>
             <% end %>
-            <%= f.text_field :service_name, class: "govuk-input" %>
+            <%= f.text_field :service_name, class: "govuk-input", 'aria-describedby' => 'hint'%>
           </div>
 
           <%= f.button t('services.create'), class: "govuk-button fb-govuk-button", type: 'submit' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -412,6 +412,7 @@ en:
   services:
     heading: 'Your forms'
     edit: 'Edit'
+    form_name_hint: 'Give your form a name, your form name cannot begin with a number'
     preview: 'Preview'
     create: 'Create a new form'
     cancel: 'Cancel'


### PR DESCRIPTION
## Context
Following PR #1838 solving the issue of service names to avoid deployment issues for Kubernetes ingress controllers names having to follow DNS labels standard defined in RFC1035. We raised the error for starting a form name with numbers is default and not specific. To follow up on that, we want to suggest to the user with a hint to the prohibition to use numeric characters.

## Implementation 
Adding hint with "aria-describedby". It is placed between the label name and the text field. Adding also a class "govuk-hint” to display in grey.

## Tests
Manual tests were performed and hint is displayed as this:
<img width="769" alt="Screenshot 2022-10-28 at 14 25 48" src="https://user-images.githubusercontent.com/26165112/198631423-5c5e7486-bf57-456c-8c30-0bdba25a192e.png">
