### PR TITLE
Fix confirmation page blocking modals

### DIFF
--- a/app/helpers/confirmation_email_modal_helper.rb
+++ b/app/helpers/confirmation_email_modal_helper.rb
@@ -1,0 +1,53 @@
+module ConfirmationEmailModalHelper
+  def confirmation_email_setting_checked?
+    confirmation_email_checked_in_dev? || confirmation_email_checked_in_production?
+  end
+
+  def confirmation_email_component_ids
+    if confirmation_email_checked_in_both?
+      [confirmation_email_component_id_dev.decrypt_value].push(
+        confirmation_email_component_id_production.decrypt_value
+      )
+    elsif confirmation_email_checked_in_dev?
+      [confirmation_email_component_id_dev.decrypt_value]
+    else
+      [confirmation_email_component_id_production.decrypt_value]
+    end
+  end
+
+  def confirmation_email_checked_in_both?
+    confirmation_email_checked_in_dev? && confirmation_email_checked_in_production?
+  end
+
+  def confirmation_email_component_id_dev
+    @confirmation_email_component_id_dev ||= ServiceConfiguration.find_by(
+      service_id: service.service_id,
+      deployment_environment: 'dev',
+      name: 'CONFIRMATION_EMAIL_COMPONENT_ID'
+    )
+  end
+
+  def confirmation_email_component_id_production
+    @confirmation_email_component_id_production ||= ServiceConfiguration.find_by(
+      service_id: service.service_id,
+      deployment_environment: 'production',
+      name: 'CONFIRMATION_EMAIL_COMPONENT_ID'
+    )
+  end
+
+  def confirmation_email_checked_in_dev?
+    @confirmation_email_checked_in_dev ||=
+      SubmissionSetting.where(
+        service_id: service.service_id,
+        deployment_environment: 'dev'
+      ).pick(:send_confirmation_email)
+  end
+
+  def confirmation_email_checked_in_production?
+    @confirmation_email_checked_in_production ||=
+      SubmissionSetting.where(
+        service_id: service.service_id,
+        deployment_environment: 'production'
+      ).pick(:send_confirmation_email)
+  end
+end

--- a/app/models/destroy_question_modal.rb
+++ b/app/models/destroy_question_modal.rb
@@ -1,5 +1,7 @@
 class DestroyQuestionModal
   include ActiveModel::Model
+  include ConfirmationEmailModalHelper
+
   attr_accessor :service, :page, :question
 
   delegate :expressions, :conditionals, to: :service
@@ -18,15 +20,8 @@ class DestroyQuestionModal
   end
 
   def used_in_confirmation_email?
-    return if confirmation_email_component_id.nil?
+    return unless confirmation_email_setting_checked?
 
-    confirmation_email_component_id.decrypt_value.include?(question.id)
-  end
-
-  def confirmation_email_component_id
-    @confirmation_email_component_id ||= ServiceConfiguration.find_by(
-      service_id: service.service_id,
-      name: 'CONFIRMATION_EMAIL_COMPONENT_ID'
-    )
+    question.id.in?(confirmation_email_component_ids)
   end
 end

--- a/spec/factories/submission_settings.rb
+++ b/spec/factories/submission_settings.rb
@@ -21,5 +21,9 @@ FactoryBot.define do
     trait :service_csv_output do
       service_csv_output { true }
     end
+
+    trait :send_confirmation_email do
+      send_confirmation_email { true }
+    end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/R1YDi5hs/3032-bug-confirmation-email-delete-modals-appear-when-form-is-not-checked)

Previously, we were only checking whether a `CONFIRMATION_EMAIL_COMPONENT_ID` had been set in either 'dev' or 'production'. This is not enough as we can have these set but then have the `send_confirmation_email` config SubmissionSetting as 'false'.

This commit rectifies this issue and checks for:
- Whether the `send_confirmation_email` is true in either environment
- If so, whether the `CONFIRMATION_EMAIL_COMPONENT_ID` is the same as the component_id of the page/question being deleted.

Unfortunately, these configs need to be checked for both 'dev' and 'production' environments.