### PR TITLE
reinstate .fb-link-button class

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -1,4 +1,4 @@
-/* Note:
+/*fNote:
  * These styles rely on some sass code from the govuk design files.
  * Specific customisations for the MOJ form builder Editor.
  **/
@@ -132,6 +132,10 @@ html {
 
 .fb-govuk-button--inline {
   width: auto;
+}
+
+.fb-link-button {
+  @include button_as_link;
 }
 
 .fb-govuk-button-inverted {


### PR DESCRIPTION
Fix for this bug: https://trello.com/c/KH0rtWs9/3040-bug-add-another-branch-button-styling

Looks like the .fb-link-button class got removed somewhere in the undo/redo functionlaity.

It's confusing becasue we have 2 mixins now `button_as_link` and `button_type_link` may need to do a bit of investigation and refactoring to try and tidy up / make things a bit more explict