### PR TITLE
Fix position with branching diamond page menu

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -769,7 +769,7 @@ html {
     }
   }
 
-  .FlowItemMenuActivator {
+  .PageMenuActivator {
     bottom: 10px;
     left: 82px;
     top: calc(125px - 45px);


### PR DESCRIPTION
Trello: https://trello.com/c/G97XXlKj/3041-bug-branching-point-page-menu-position

The branching point menu activator had deserted its post and gone AWOL
This very small change brings it back into line!

**Before**
![image](https://user-images.githubusercontent.com/595564/198685936-14424475-a0b7-4cc0-9060-a50433a77b5f.png)

**After**
![image](https://user-images.githubusercontent.com/595564/198686196-3b556622-6a32-4abb-88c4-b4db3b7a5ce6.png)

