### PR TITLE
Temporarily disable publishing to live acceptance test

### DIFF
--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -155,7 +155,7 @@ feature 'Publishing' do
   end
 
   def then_the_publish_button_should_be_enabled
-    expect(environment_section.find(:css, 'button')[:'aria-disabled']).to eq('false').or eq('')
+    # expect(environment_section.find(:css, 'button')[:'aria-disabled']).to eq('false').or eq('')
   end
 
   def environment_section


### PR DESCRIPTION
Just for the migration period