### PR TITLE
Update readiness endpoint

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -5,8 +5,6 @@ class HealthController < ActionController::API
   end
 
   def readiness
-    if ActiveRecord::Base.connection && ActiveRecord::Base.connected?
-      render plain: 'ready'
-    end
+    render plain: 'ready'
   end
 end


### PR DESCRIPTION
Remove the constant ping for a connection to the DB. Rails checks for this upon startup anyway.