### PR TITLE
Updating form name hint

### DIFF
--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -32,7 +32,7 @@
               <p class="govuk-error-message"><%= error.message %></p>
             <% end %>
             <div class="govuk-hint" id="service-name-hint"> <%= t('services.form_name_hint')%></div>
-            <%= f.text_field :service_name, class: "govuk-input", 'aria-describedby' => 'service-name-hint'%>
+            <%= f.text_field :service_name, class: "govuk-input", 'aria-describedby': 'service-name-hint'%>
           </div>
           <%= f.button t('services.create'), class: "govuk-button fb-govuk-button", type: 'submit' %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -412,7 +412,7 @@ en:
   services:
     heading: 'Your forms'
     edit: 'Edit'
-    form_name_hint: 'Give your form a name, your form name cannot begin with a number'
+    form_name_hint: "It cannot start with a number or include special characters except ' - ( )"
     preview: 'Preview'
     create: 'Create a new form'
     cancel: 'Cancel'


### PR DESCRIPTION
Form name hint has been proposed to be : It cannot start with a number or include special characters except ’ - ( ) and keeping it straight apostrophe in code.  Rationalising the use of colon / arrow in the hash in the view. Updating colon rather than arrow, as per comments in #1841. Tested locally.
