### PR TITLE
Add Sentry logging to frontend

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,12 @@
 require("jquery")
 require("jquery-ui")
 require("showdown")
+const Sentry = require('@sentry/browser');
+Sentry.init({
+  dsn: 'https://5c37dde874b24d8988f04157fade6015@o345774.ingest.sentry.io/5684540',
+})
+window.Sentry = Sentry;
+
 require("../src/index")
 
 // Entry point for fb-editor stylesheets

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,12 +8,6 @@
 require("jquery")
 require("jquery-ui")
 require("showdown")
-const Sentry = require('@sentry/browser');
-Sentry.init({
-  dsn: 'https://5c37dde874b24d8988f04157fade6015@o345774.ingest.sentry.io/5684540',
-})
-window.Sentry = Sentry;
-
 require("../src/index")
 
 // Entry point for fb-editor stylesheets

--- a/app/javascript/src/controller_default.js
+++ b/app/javascript/src/controller_default.js
@@ -15,6 +15,7 @@
 
 
 const Dialog = require('./component_dialog');
+const SentryLogger=  require('./sentry_logger');
 const post = require('./utilities').post;
 
 
@@ -24,6 +25,7 @@ class DefaultController {
     var $document = $(document);
     this.type = $(".fb-main-grid-wrapper").data("fb-pagetype");
     this.features = app.features;
+    this.sentry = new SentryLogger();
     this.page = app.page;
     this.text = app.text;
     this.dialog = createDialog.call(this);

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -557,7 +557,7 @@ function applyPageFlowConnectorPaths(view, $overview) {
       var toX = $next.position().left - 1; // - 1 for design spacing
       var toY = $next.position().top + (rowHeight / 4);
     } catch(err) {
-      window.SentryLogger.send(err);
+      view.sentry.send(err);
     }
 
     if( fromX && fromY && toX && toY) {

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -553,11 +553,11 @@ function applyPageFlowConnectorPaths(view, $overview) {
     var fromY = $item.position().top + (rowHeight / 4);
     var $next = $("[data-fb-id=" + next + "]", $overview);
 
-    if($next.length) {
+    try {
       var toX = $next.position().left - 1; // - 1 for design spacing
       var toY = $next.position().top + (rowHeight / 4);
-    } else {
-      // TODO - notify Dev team of issue
+    } catch(err) {
+      Sentry.captureException(err);
     }
 
     if( fromX && fromY && toX && toY) {

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -557,7 +557,7 @@ function applyPageFlowConnectorPaths(view, $overview) {
       var toX = $next.position().left - 1; // - 1 for design spacing
       var toY = $next.position().top + (rowHeight / 4);
     } catch(err) {
-      SentryLogger.send(err);
+      window.SentryLogger.send(err);
     }
 
     if( fromX && fromY && toX && toY) {

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -67,7 +67,7 @@ ServicesController.edit = function() {
   }
 
   if(view.$flowDetached.length) {
-    layoutDetachedItemsOveriew(view);
+    layoutDetachedItemsOverview(view);
   }
 
   addServicesContentScrollContainer(view);
@@ -192,7 +192,7 @@ function layoutFormFlowOverview(view) {
  *            appear to position correctly with the noticed exception of
  *            the line type mentioned earlier. Double call is quickfix.
 **/
-function layoutDetachedItemsOveriew(view) {
+function layoutDetachedItemsOverview(view) {
   var $container = view.$flowDetached;
   var expander = $container.find('.Expander').data("instance"); // Element is set as an Expander Component.
 
@@ -557,7 +557,7 @@ function applyPageFlowConnectorPaths(view, $overview) {
       var toX = $next.position().left - 1; // - 1 for design spacing
       var toY = $next.position().top + (rowHeight / 4);
     } catch(err) {
-      Sentry.captureException(err);
+      SentryLogger.send(err);
     }
 
     if( fromX && fromY && toX && toY) {

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -93,7 +93,4 @@ switch(controllerAndAction()) {
        Controller = DefaultController;
 }
 
-$(document).ready( () => {
-  window.SentryLogger = new SentryLogger(app);
-  new Controller(app);
-});
+$(document).ready( () =>  new Controller(app) );

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -8,7 +8,6 @@ const FormAnalyticsController = require('./controller_form_analytics');
 const FromAddressController = require('./controller_from_address');
 const CollectionEmailController = require('./controller_collection_email');
 const ConfirmationEmailController = require('./controller_confirmation_email');
-const SentryLogger = require('./sentry_logger');
 
 const {
   snakeToPascalCase,

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -13,6 +13,7 @@ const {
   snakeToPascalCase,
 } = require('./utilities');
 
+
 // Determine the controller we need to use
 function controllerAndAction() {
   var controller = snakeToPascalCase(app.page.controller);

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -8,6 +8,7 @@ const FormAnalyticsController = require('./controller_form_analytics');
 const FromAddressController = require('./controller_from_address');
 const CollectionEmailController = require('./controller_collection_email');
 const ConfirmationEmailController = require('./controller_confirmation_email');
+
 const {
   snakeToPascalCase,
 } = require('./utilities');

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -8,6 +8,7 @@ const FormAnalyticsController = require('./controller_form_analytics');
 const FromAddressController = require('./controller_from_address');
 const CollectionEmailController = require('./controller_collection_email');
 const ConfirmationEmailController = require('./controller_confirmation_email');
+const SentryLogger = require('./sentry_logger');
 
 const {
   snakeToPascalCase,
@@ -92,4 +93,7 @@ switch(controllerAndAction()) {
        Controller = DefaultController;
 }
 
-$(document).ready( () => new Controller(app) );
+$(document).ready( () => {
+  window.SentryLogger = new SentryLogger(app);
+  new Controller(app);
+});

--- a/app/javascript/src/sentry_logger.js
+++ b/app/javascript/src/sentry_logger.js
@@ -1,0 +1,39 @@
+/**
+ * This is a wrapper class for Sentry Logging
+ *
+ * It will initialize Sentry with the correct DSN for the environment
+ * injected by webpack.
+ *
+ * This module gets initialized and 'provided' by webpack to the whole
+ * application.
+ *
+ * This means that anywhere in the code we can call SentryLogger.send() to
+ * log an error to sentry.
+ *
+ * Errors will not be sent in the development environment
+ *
+ **/
+
+const Sentry = require('@sentry/browser');
+
+class SentryLogger {
+  constructor() {
+    Sentry.init({
+      dsn: ''+SENTRY_DSN+'',
+    });
+
+    this.sentry = Sentry;
+  }
+
+  send(details) {
+    if(NODE_ENV != 'development') {
+      if(typeof details == 'string') {
+        this.sentry.captureMessage(details);
+      } else {
+        this.sentry.captureException(details);
+      }
+    }
+  }
+}
+
+module.exports = new SentryLogger

--- a/app/javascript/src/sentry_logger.js
+++ b/app/javascript/src/sentry_logger.js
@@ -17,7 +17,7 @@
 const Sentry = require('@sentry/browser');
 
 class SentryLogger {
-  constructor() {
+  constructor(app) {
     Sentry.init({
       dsn: ''+app.sentry_dsn+'',
     });
@@ -36,4 +36,4 @@ class SentryLogger {
   }
 }
 
-module.exports = new SentryLogger
+module.exports = SentryLogger

--- a/app/javascript/src/sentry_logger.js
+++ b/app/javascript/src/sentry_logger.js
@@ -17,16 +17,18 @@
 const Sentry = require('@sentry/browser');
 
 class SentryLogger {
-  constructor(app) {
+  constructor() {
+
     Sentry.init({
-      dsn: ''+app.sentry_dsn+'',
+      dsn: window.SENTRY_DSN,
     });
 
+    this.env = window.PLATFORM_ENV;
     this.sentry = Sentry;
   }
 
   send(details) {
-    if(app.platform_env != 'local') {
+    if(this.env != 'local') {
       if(typeof details == 'string') {
         this.sentry.captureMessage(details);
       } else {

--- a/app/javascript/src/sentry_logger.js
+++ b/app/javascript/src/sentry_logger.js
@@ -19,14 +19,14 @@ const Sentry = require('@sentry/browser');
 class SentryLogger {
   constructor() {
     Sentry.init({
-      dsn: ''+SENTRY_DSN+'',
+      dsn: ''+app.sentry_dsn+'',
     });
 
     this.sentry = Sentry;
   }
 
   send(details) {
-    if(NODE_ENV != 'development') {
+    if(app.platform_env != 'local') {
       if(typeof details == 'string') {
         this.sentry.captureMessage(details);
       } else {

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -1,7 +1,7 @@
 <script>
+  var SENTRY_DSN = "<%= ENV['SENTRY_DSN'] %>";
+  var PLATFORM_ENV =  "<%= ENV['PLATFORM_ENV'] %>";
   var app = {
-    sentry_dsn: "<%= ENV['SENTRY_DSN'] %>",
-    platform_env: "<%= ENV['PLATFORM_ENV'] %>",
     api: {
       // FE terminology    | BE terminology
       // --------------------------------------------------------

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -1,5 +1,7 @@
 <script>
   var app = {
+    sentry_dsn: <%= ENV['SENTRY_DSN'] %>,
+    platform_env: <%= ENV['PLATFORM_ENV'] %>,
     api: {
       // FE terminology    | BE terminology
       // --------------------------------------------------------

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -1,7 +1,7 @@
 <script>
   var app = {
-    sentry_dsn: <%= ENV['SENTRY_DSN'] %>,
-    platform_env: <%= ENV['PLATFORM_ENV'] %>,
+    sentry_dsn: "<%= ENV['SENTRY_DSN'] %>",
+    platform_env: "<%= ENV['PLATFORM_ENV'] %>",
     api: {
       // FE terminology    | BE terminology
       // --------------------------------------------------------

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,10 +1,19 @@
 const { environment } = require('@rails/webpacker')
 const webpack = require('webpack')
+const path = require("path");
 
 environment.plugins.prepend('Provide',
   new webpack.ProvidePlugin({
     $: 'jquery',
-    jQuery: 'jquery'
+    jQuery: 'jquery',
+    SentryLogger: 'sentry-logger',
+  })
+);
+
+environment.plugins.prepend('env',
+  new webpack.DefinePlugin({
+    'NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+    'SENTRY_DSN': (JSON.stringify(process.env.NODE_ENV) == 'production' ?  JSON.stringify('https://5c37dde874b24d8988f04157fade6015@o345774.ingest.sentry.io/5684540') : JSON.stringify('https://e7caecf8f1a54fbe99a50a4801237625@o345774.ingest.sentry.io/5671754')),
   })
 );
 
@@ -23,7 +32,11 @@ if (!Array.isArray(nodeModulesLoader.exclude)) {
 }
 nodeModulesLoader.exclude.push(/sanitize-html/);
 
-const aliasConfig = { 'jquery': 'jquery/src/jquery', 'jquery-ui': 'jquery-ui-dist/jquery-ui.js' };
+const aliasConfig = {
+  'jquery': 'jquery/src/jquery',
+  'jquery-ui': 'jquery-ui-dist/jquery-ui.js',
+  'sentry-logger': path.resolve(__dirname, '../../app/javascript/src/sentry_logger'),
+};
 environment.config.set('resolve.alias', aliasConfig);
 
 module.exports = environment

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,19 +1,10 @@
 const { environment } = require('@rails/webpacker')
 const webpack = require('webpack')
-const path = require("path");
 
 environment.plugins.prepend('Provide',
   new webpack.ProvidePlugin({
     $: 'jquery',
     jQuery: 'jquery',
-    SentryLogger: 'sentry-logger',
-  })
-);
-
-environment.plugins.prepend('env',
-  new webpack.DefinePlugin({
-    'NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-    'SENTRY_DSN': (JSON.stringify(process.env.NODE_ENV) == 'production' ?  JSON.stringify('https://5c37dde874b24d8988f04157fade6015@o345774.ingest.sentry.io/5684540') : JSON.stringify('https://e7caecf8f1a54fbe99a50a4801237625@o345774.ingest.sentry.io/5671754')),
   })
 );
 
@@ -35,7 +26,6 @@ nodeModulesLoader.exclude.push(/sanitize-html/);
 const aliasConfig = {
   'jquery': 'jquery/src/jquery',
   'jquery-ui': 'jquery-ui-dist/jquery-ui.js',
-  'sentry-logger': path.resolve(__dirname, '../../app/javascript/src/sentry_logger'),
 };
 environment.config.set('resolve.alias', aliasConfig);
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@rails/activestorage": "^7.0.4",
     "@rails/ujs": "^7.0.4",
     "@rails/webpacker": "^5.4.3",
+    "@sentry/browser": "^7.17.2",
     "accessible-autocomplete": "^2.0.4",
     "govuk-frontend": "4.3.1",
     "jquery": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "version": "0.1.0",
   "devDependencies": {
+    "@sentry/webpack-plugin": "^1.19.1",
     "chai": "^4.3.6",
     "form-data": "^4.0.0",
     "jquery-ui": "^1.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,6 +1030,38 @@
     webpack-cli "^3.3.12"
     webpack-sources "^1.4.3"
 
+"@sentry/browser@^7.17.2":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.17.2.tgz#624c2c371c9d771311672c484fe24666a92bdbdd"
+  integrity sha512-LICJvwnES+Jp7ShN7zkmTFYIQB9jWOg/s9U58CQWfwrkMTwE4zKylojF3OTtyNaMmekVv/y/1JjeS5KAK3IrHQ==
+  dependencies:
+    "@sentry/core" "7.17.2"
+    "@sentry/types" "7.17.2"
+    "@sentry/utils" "7.17.2"
+    tslib "^1.9.3"
+
+"@sentry/core@7.17.2":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.17.2.tgz#0d3b5f0155f3ecefb7ddb2f050c25bf0fb69e0fb"
+  integrity sha512-mBFjngWJPN3V1A/tz/qa1jkQvmZtU07hhlWg+kmajD0nFulPHUWEvZhsi8NFveGcxMxc/wmaSSLcEOpKq5L29g==
+  dependencies:
+    "@sentry/types" "7.17.2"
+    "@sentry/utils" "7.17.2"
+    tslib "^1.9.3"
+
+"@sentry/types@7.17.2":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.17.2.tgz#49dee17896e3814d0ce6dae1b7efead5f1af8c8c"
+  integrity sha512-zxhNQ8Xt/hfP8bFZEV66ovJZK7aUqok5w1wjsHgkUz/S6/gkiMrDYT3OtRCRuY3mfQu9KmeBniM0xZkaxREJ1w==
+
+"@sentry/utils@7.17.2":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.17.2.tgz#934f900715dacc51699b44e8e61df8c7fbdd0b5f"
+  integrity sha512-l8t6qzyi+UUzD0a/oOYn4i+Eii+Ei29/TVwj/+9ogfJzBk6dSwSLvXievsyCRpcN3tftpWP0cHREcbZN64ZOWw==
+  dependencies:
+    "@sentry/types" "7.17.2"
+    tslib "^1.9.3"
+
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -6509,6 +6541,11 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
+
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tty-browserify@0.0.0:
   version "0.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,6 +1040,19 @@
     "@sentry/utils" "7.17.2"
     tslib "^1.9.3"
 
+"@sentry/cli@^1.74.4":
+  version "1.74.6"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.74.6.tgz#c4f276e52c6f5e8c8d692845a965988068ebc6f5"
+  integrity sha512-pJ7JJgozyjKZSTjOGi86chIngZMLUlYt2HOog+OJn+WGvqEkVymu8m462j1DiXAnex9NspB4zLLNuZ/R6rTQHg==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    mkdirp "^0.5.5"
+    node-fetch "^2.6.7"
+    npmlog "^4.1.2"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+    which "^2.0.2"
+
 "@sentry/core@7.17.2":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.17.2.tgz#0d3b5f0155f3ecefb7ddb2f050c25bf0fb69e0fb"
@@ -1061,6 +1074,14 @@
   dependencies:
     "@sentry/types" "7.17.2"
     tslib "^1.9.3"
+
+"@sentry/webpack-plugin@^1.19.1":
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.19.1.tgz#0be3261c4ad9fe373dd169ca75cee1a7ee2b001f"
+  integrity sha512-8/zsByYBczQMayFMRV0oWuCI2+bsMAbkgh1Sr72nLPLt3FNVVicXFns3PbVL6W+fObLkREkg99+xBfjgQEaGzA==
+  dependencies:
+    "@sentry/cli" "^1.74.4"
+    webpack-sources "^2.0.0 || ^3.0.0"
 
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
   version "1.8.3"
@@ -1363,6 +1384,11 @@ ansi-colors@4.1.1:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
+
 ansi-regex@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
@@ -1403,10 +1429,18 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-aproba@^1.1.1:
+aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+
+are-we-there-yet@~1.1.2:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz#b15474a932adab4ff8a50d9adfa7e4e926f21146"
+  integrity sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^2.0.6"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -2011,6 +2045,11 @@ coa@^2.0.2:
     chalk "^2.4.1"
     q "^1.1.2"
 
+code-point-at@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+  integrity sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -2116,6 +2155,11 @@ console-browserify@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
+
+console-control-strings@^1.0.0, console-control-strings@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+  integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
 constants-browserify@^1.0.0:
   version "1.0.0"
@@ -2540,6 +2584,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+  integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
 
 des.js@^1.0.0:
   version "1.0.1"
@@ -3101,6 +3150,20 @@ functions-have-names@^1.2.2:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
+gauge@~2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+  integrity sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==
+  dependencies:
+    aproba "^1.0.3"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.0"
+    object-assign "^4.1.0"
+    signal-exit "^3.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wide-align "^1.1.0"
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -3250,6 +3313,11 @@ has-tostringtag@^1.0.0:
   dependencies:
     has-symbols "^1.0.2"
 
+has-unicode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+  integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
+
 has-value@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
@@ -3372,7 +3440,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@^5.0.1:
+https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
@@ -3656,6 +3724,13 @@ is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+
+is-fullwidth-code-point@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  integrity sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==
+  dependencies:
+    number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
@@ -4301,7 +4376,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
+mkdirp@^0.5, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -4420,6 +4495,13 @@ nise@^5.1.1:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-libs-browser@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
@@ -4486,6 +4568,16 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
+npmlog@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.7.3"
+    set-blocking "~2.0.0"
+
 nth-check@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
@@ -4497,6 +4589,11 @@ num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
   integrity sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=
+
+number-is-nan@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+  integrity sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==
 
 nwsapi@^2.2.2:
   version "2.2.2"
@@ -5513,10 +5610,20 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 prr@~1.0.1:
   version "1.0.1"
@@ -5630,7 +5737,7 @@ read-cache@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -5998,7 +6105,7 @@ serialize-javascript@^5.0.1:
   dependencies:
     randombytes "^2.1.0"
 
-set-blocking@^2.0.0:
+set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -6053,6 +6160,11 @@ side-channel@^1.0.4:
     call-bind "^1.0.0"
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
+
+signal-exit@^3.0.0:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -6245,6 +6357,24 @@ strict-uri-encode@^1.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
+string-width@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  integrity sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
@@ -6253,15 +6383,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
-
-string-width@^4.1.0, string-width@^4.2.0:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string.prototype.trimend@^1.0.5:
   version "1.0.5"
@@ -6294,6 +6415,13 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
+  dependencies:
+    ansi-regex "^2.0.0"
 
 strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
@@ -6537,6 +6665,11 @@ tr46@^3.0.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -6761,6 +6894,11 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
@@ -6803,6 +6941,11 @@ webpack-sources@^1.0.0, webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+"webpack-sources@^2.0.0 || ^3.0.0":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
+  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@^4.46.0:
   version "4.46.0"
@@ -6853,6 +6996,14 @@ whatwg-url@^11.0.0:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
 
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
@@ -6875,6 +7026,20 @@ which@^1.2.14, which@^1.2.9, which@^1.3.1:
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
+
+which@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
+wide-align@^1.1.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
+  integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
+  dependencies:
+    string-width "^1.0.2 || 2 || 3 || 4"
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Ticket: https://trello.com/c/zO2GeDb2/3042-flow-view-blank-screen-property-and-affairs-upfront-notification-application-v2

**Adding Sentry**
So in addition to the above fix, this PR adds Sentry logging into the frontend of the app.  This was not as straightforward as itcould be `cos Webpack.

We want a solution that:
* Makes Sentry logging available globally in any JS file 
* Only logs in test & production environments, not dev
* Logs to the correct Sentry project `fb-editor-live` or `fb-editor-test` respectively.

This is achieved using `webpack.definePlugin` to provide the `NODE_ENV` and appropriate `SENTRY_DSN` and then using `webpack.providePlugin` to provide a `SentryLogger` class globally to the app.

the `SentryLogger` class is a simple wrapper around the `@sentry/browser` module.  It defines a `send` method, which will send the provided details to sentry if not in the development environment.





