### PR TITLE
Confirmation email content updates

### DIFF
--- a/acceptance/features/edit_single_checkboxes_question_page_spec.rb
+++ b/acceptance/features/edit_single_checkboxes_question_page_spec.rb
@@ -128,7 +128,7 @@ feature 'Edit single radios question page' do
 
   def and_I_add_an_option(option_label)
     click_button(I18n.t('actions.option_add'))
-    page.find('label', text: I18n.t('default_text.option')).set('').base.send_keys(option_label)
+    page.find('label', text: I18n.t('default_text.option')).set(option_label)
     when_I_save_my_changes
   end
 

--- a/acceptance/features/from_address_spec.rb
+++ b/acceptance/features/from_address_spec.rb
@@ -97,12 +97,12 @@ feature 'From address' do
 
   ## Send data by email page
   def then_I_should_see_the_send_data_by_email_page
-    expect(page).to have_content(I18n.t('settings.submission.email.label'))
+    expect(page).to have_content(I18n.t('settings.collection_email.heading'))
     expect(page).to have_content(I18n.t('settings.form_analytics.test.description'))
     expect(page).to have_content(I18n.t('settings.form_analytics.live.description'))
     expect(page).to have_content(I18n.t('activemodel.attributes.email_settings.send_by_email_dev'))
     expect(page).to have_content(I18n.t('activemodel.attributes.email_settings.send_by_email_production'))
-    expect(page).to have_button(I18n.t('settings.submission.email.dev.save_button'))
+    expect(page).to have_button(I18n.t('actions.save'))
   end
 
   def then_I_should_see_the_send_data_by_email_from_address_warnings(status)

--- a/acceptance/features/from_address_spec.rb
+++ b/acceptance/features/from_address_spec.rb
@@ -72,7 +72,7 @@ feature 'From address' do
   ## From Address Settings page
   def then_I_should_see_the_from_address_settings_page
     expect(page).to have_content(I18n.t('settings.from_address.heading'))
-    expect(page).to have_content(I18n.t('settings.from_address.lede'))
+    expect(page).to have_content(I18n.t('settings.from_address.description'))
     expect(page).to have_content(I18n.t('activemodel.attributes.from_address.from_address_hint'))
   end
 

--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -184,7 +184,7 @@ feature 'Publishing' do
   end
 
   def and_I_save_my_email_settings
-    click_button(I18n.t("settings.submission.email.#{environment}.save_button"))
+    click_button(I18n.t("settings.submission.#{environment}.save_button"))
   end
 
   def then_I_should_see_username_and_password_fields

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -47,7 +47,7 @@ class EditorApp < SitePrism::Page
   element :edit_page_button, :link, I18n.t('actions.edit_page')
 
   element :submission_settings_link, :link, I18n.t('settings.submission.name')
-  element :send_data_by_email_link, :link, I18n.t('settings.submission.email.label')
+  element :send_data_by_email_link, :link, I18n.t('settings.collection_email.heading')
 
   element :page_url_field, :field, I18n.t('activemodel.attributes.page_creation.page_url')
   element :new_page_form, '#new_page', visible: false

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -153,6 +153,23 @@ html {
   }
 }
 
+.fb-back-link {
+  @extend %govuk-link;
+  @extend %govuk-body-s;
+  @include govuk-link-style-text;
+  @include govuk-link-style-no-underline;
+
+  display: inline-flex;
+  align-items: center;
+  position: absolute;
+  top: 16px;
+  left: 0;
+
+  > span:first-child {
+    margin-right: 4px;
+  }
+}
+
 
 /* Publishing
  * ------------------- */
@@ -615,7 +632,7 @@ html {
     z-index: 4;
   }
 
-  .FlowItemMenu,
+  .PageMenu,
   .ConnectionMenu {
     z-index: 5;
   }

--- a/app/views/settings/confirmation_email/_form.html.erb
+++ b/app/views/settings/confirmation_email/_form.html.erb
@@ -24,11 +24,11 @@
       %>
     <% end %>
 
-    <%= govuk_details(summary_text: t("settings.submission.email.#{deployment_environment}.config_details_summary").html_safe, classes: "configure-#{deployment_environment}") do %>
+    <%= govuk_details(summary_text: t("settings.submission.#{deployment_environment}.config_details_summary").html_safe, classes: "configure-#{deployment_environment}") do %>
       <%= render "email_fields", f: f, deployment_environment: deployment_environment %>
     <% end %>
 
     <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
-      <%= t("settings.submission.email.#{deployment_environment}.save_button") %>
+      <%= t("settings.submission.#{deployment_environment}.save_button") %>
     </button>
   <% end %>

--- a/app/views/settings/confirmation_email/index.html.erb
+++ b/app/views/settings/confirmation_email/index.html.erb
@@ -1,6 +1,6 @@
 <%= editor_settings_screen(settings_submission_index_path) do %>
-  <h1 class="govuk-heading-xl"><%= t('settings.confirmation_email.email.label') %></h1>
-  <p><%= t('settings.confirmation_email.email.help') %></p>
+  <h1 class="govuk-heading-xl"><%= t('settings.confirmation_email.heading') %></h1>
+  <p><%= t('settings.confirmation_email.description') %></p>
 
   <% if @email_components.present? %>
     <% content_for :forms do %>

--- a/app/views/settings/email/_form.html.erb
+++ b/app/views/settings/email/_form.html.erb
@@ -24,13 +24,13 @@
       %>
     <% end %>
 
-    <%= govuk_details(summary_text: t("settings.submission.email.#{deployment_environment}.config_details_summary").html_safe, classes: "configure-#{deployment_environment}") do %>
+    <%= govuk_details(summary_text: t("settings.submission.#{deployment_environment}.config_details_summary").html_safe, classes: "configure-#{deployment_environment}") do %>
       <%= render "email_fieldset", f: f, deployment_environment: deployment_environment %>
       <%= render "pdf_fieldset",   f: f, deployment_environment: deployment_environment %>
       <%= render "csv_fieldset",   f: f, deployment_environment: deployment_environment %>
     <% end %>
 
     <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
-      <%= t("settings.submission.email.#{deployment_environment}.save_button") %>
+      <%= t("settings.submission.#{deployment_environment}.save_button") %>
     </button>
   <% end %>

--- a/app/views/settings/email/index.html.erb
+++ b/app/views/settings/email/index.html.erb
@@ -1,6 +1,6 @@
 <%= editor_settings_screen(settings_submission_index_path) do %>
-  <h1 class="govuk-heading-xl"><%= t('settings.submission.email.label') %></h1>
-  <p><%= t('settings.submission.email.help') %></p>
+  <h1 class="govuk-heading-xl"><%= t('settings.collection_email.heading') %></h1>
+  <p><%= t('settings.collection_email.lede') %></p>
 
   <% content_for :forms do %>
     <%= render 'form', object: @email_settings_dev, deployment_environment: 'dev' %>

--- a/app/views/settings/email/index.html.erb
+++ b/app/views/settings/email/index.html.erb
@@ -1,6 +1,6 @@
 <%= editor_settings_screen(settings_submission_index_path) do %>
   <h1 class="govuk-heading-xl"><%= t('settings.collection_email.heading') %></h1>
-  <p><%= t('settings.collection_email.lede') %></p>
+  <p><%= t('settings.collection_email.description') %></p>
 
   <% content_for :forms do %>
     <%= render 'form', object: @email_settings_dev, deployment_environment: 'dev' %>

--- a/app/views/settings/from_address/index.html.erb
+++ b/app/views/settings/from_address/index.html.erb
@@ -35,7 +35,7 @@
 
     <h1 class="govuk-heading-xl"><%= t('settings.from_address.heading') %></h1>
 
-    <p class="govuk-!-margin-bottom-7"><%= t('settings.from_address.lede') %></p>
+    <p class="govuk-!-margin-bottom-7"><%= t('settings.from_address.description') %></p>
 
     <%= f.govuk_text_field :email,
       label: { text:  t('activemodel.attributes.from_address.email') },

--- a/app/views/settings/submission/index.html.erb
+++ b/app/views/settings/submission/index.html.erb
@@ -1,6 +1,5 @@
 <%= editor_settings_screen(settings_path) do %>
   <h1 id="settings-navigation-heading" class="govuk-heading-xl"><%= t('settings.submission.name') %></h1>
-  <p class="govuk-body"><%= t('settings.submission.sub_heading') %></p>
   <nav class="govuk-navigation" aria-labelledby="settings-navigation-heading">
     <dl aria-labelledby="submission-settings-navigation-heading" class="fb-settings">
       <div>
@@ -8,7 +7,8 @@
         <dd class="govuk-hint"><%= t('settings.from_address.lede') %></dd>
       </div>
       <div>
-        <dt><%= link_to t('settings.submission.email.label'), settings_email_index_path(service.service_id), class: 'govuk-link' %></dt>
+        <dt><%= link_to t('settings.collection_email.heading'), settings_email_index_path(service.service_id), class: 'govuk-link' %></dt>
+        <dd class="govuk-hint"><%= t('settings.collection_email.lede') %></dd>
       </div>
       <% if ENV['CONFIRMATION_EMAIL'] == 'enabled' %>
         <div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -289,7 +289,8 @@ en:
         warning_message: 'We are making some changes in this area. In the meantime, <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/contact/">contact&nbsp;us</a> to change your form’s name.'
     from_address:
       heading: "‘From’ address"
-      lede: Emails sent by your form, either to you or to people filling it in, will come from this address
+      lede: Emails sent by your form will come from this address
+      description: Emails sent by your form, either to you or to people filling it in, will come from this address
       resend_link_text: Resend validation link
       link_resent_success: Link resent - now check your email
       link_contact_us: Contact us
@@ -319,12 +320,11 @@ en:
     collection_email:
       heading: 'Collect information by email'
       lede: 'Receive your form data in PDF and CSV attached to emails.'
+      description: 'Receive your form data in PDF and CSV attached to emails.'
     confirmation_email:
       heading: 'Send a confirmation email'
       lede: Send the people who complete your form a copy of their data
-      email:
-        label: Send a confirmation email
-        help: Send the people completing your form a confirmation email with their information attached in a PDF.
+      description: Send the people completing your form a confirmation email with their information attached in a PDF.
   warnings:
     from_address:
       send_by_email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -310,16 +310,15 @@ en:
       name: 'Submission settings'
       hint: 'Set what happens when a user submits their data.'
       sub_heading: 'Use these settings to control what happens when a user submits the form on Test or Live.'
-      email:
-        label: 'Send data by email'
-        help: ''
-        configure_pdf_label: PDF attachment
-        dev:
-          config_details_summary: Configure <span class="sr-only">test settings</span>
-          save_button: Save Test settings
-        production:
-          config_details_summary: Configure <span class="sr-only">live settings</span>
-          save_button: Save Live settings
+      dev:
+        config_details_summary: Configure <span class="sr-only">test settings</span>
+        save_button: Save Test settings
+      production:
+        config_details_summary: Configure <span class="sr-only">live settings</span>
+        save_button: Save Live settings
+    collection_email:
+      heading: 'Collect information by email'
+      lede: 'Receive your form data in PDF and CSV attached to emails.'
     confirmation_email:
       heading: 'Send a confirmation email'
       lede: Send the people who complete your form a copy of their data


### PR DESCRIPTION
Various content updates related to Confiramtion email and submission settings.

**Content Changes**

* Submission settings - remove page summary
* Submission settings - update from address description
* Submission settings - update 'Send data by email' to 'Collect information by email'
* Submission settings - add description to Collect information by email
* Send data by email - update page title
* Send data by email - add page summary

**Other changes**

* Re-organize and rename entries in the translations file for more consistency
* Update tests to match (and fix an odd failing test
* Reinstate the back link styling that had got lost in a rebase
* Add back in a class name change also lost in a rebase
