### PR TITLE
Update confirmation email user guide link

### DIFF
--- a/app/views/settings/confirmation_email/index.html.erb
+++ b/app/views/settings/confirmation_email/index.html.erb
@@ -15,9 +15,10 @@
       text: t('warnings.confirmation_email.message',
       href:
         govuk_link_to(
-          t('warnings.confirmation_email.link'),
-          t('partials.header.user_guide_url'),
-          target: :_blank
+          t('warnings.confirmation_email.link_text'),
+          t('warnings.confirmation_email.link_url'),
+          target: :_blank,
+          rel: 'nofollow noreferrer'
         )
       ).html_safe
     ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,7 +348,8 @@ en:
           default: 'You need to set a %{href} for emails'
     confirmation_email:
       message: 'Your form must include an email question to enable a %{href}.'
-      link: confirmation email
+      link_text: confirmation email
+      link_url: 'https://moj-forms.service.justice.gov.uk/settings/#confirmation-email'
     submission_pages:
       dev:
         both_pages: 'Your form has no check answers page or confirmation page'


### PR DESCRIPTION
Updates the link to the user guide in the warning if the user has no email components in their form.

