### PR TITLE
Update settings screen to use components for consistency

### DIFF
--- a/app/components/moj_forms.rb
+++ b/app/components/moj_forms.rb
@@ -1,1 +1,0 @@
-module MojForms; end

--- a/app/components/moj_forms.rb
+++ b/app/components/moj_forms.rb
@@ -1,0 +1,1 @@
+module MojForms; end

--- a/app/components/moj_forms/back_link_component.rb
+++ b/app/components/moj_forms/back_link_component.rb
@@ -1,29 +1,31 @@
-class MojForms::BackLinkComponent < GovukComponent::Base
-  attr_reader :text, :href
+module MojForms
+  class BackLinkComponent < GovukComponent::Base
+    attr_reader :text, :href
 
-  def initialize(href:, text: t('actions.back'), classes: [], html_attributes: {})
-    @href = href
-    @text = text
+    def initialize(href:, text: t('actions.back'), classes: [], html_attributes: {})
+      @href = href
+      @text = text
 
-    super(classes: classes, html_attributes: html_attributes)
-  end
+      super(classes: classes, html_attributes: html_attributes)
+    end
 
-  def call
-    link_to href, **html_attributes do
-      concat tag.span '<svg width="7" height="12" viewBox="0 0 7 12" fill="none" role="image" aria-hidden="true">
+    def call
+      link_to href, **html_attributes do
+        concat tag.span '<svg width="7" height="12" viewBox="0 0 7 12" fill="none" role="image" aria-hidden="true">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M5.75345 0L6.46045 0.706L1.41445 5.753L6.46045 10.799L5.75345 11.507L0.000449181 5.753L5.75345 0Z" fill="currentColor"/>
         </svg>'.html_safe
-      concat tag.span link_content
+        concat tag.span link_content
+      end
     end
-  end
 
-  private
+    private
 
-  def link_content
-    content || text || raise(ArgumentError, 'no text or content')
-  end
+    def link_content
+      content || text || raise(ArgumentError, 'no text or content')
+    end
 
-  def default_attributes
-    { class: %w[mojf-back-link] }
+    def default_attributes
+      { class: %w[mojf-back-link] }
+    end
   end
 end

--- a/app/components/moj_forms/back_link_component.rb
+++ b/app/components/moj_forms/back_link_component.rb
@@ -1,0 +1,29 @@
+class MojForms::BackLinkComponent < GovukComponent::Base
+  attr_reader :text, :href
+
+  def initialize(href:, text: t('actions.back'), classes: [], html_attributes: {})
+    @href = href
+    @text = text
+
+    super(classes: classes, html_attributes: html_attributes)
+  end
+
+  def call
+    link_to href, **html_attributes do
+      concat tag.span '<svg width="7" height="12" viewBox="0 0 7 12" fill="none" role="image" aria-hidden="true">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M5.75345 0L6.46045 0.706L1.41445 5.753L6.46045 10.799L5.75345 11.507L0.000449181 5.753L5.75345 0Z" fill="currentColor"/>
+        </svg>'.html_safe
+      concat tag.span link_content
+    end
+  end
+
+  private
+
+  def link_content
+    content || text || raise(ArgumentError, 'no text or content')
+  end
+
+  def default_attributes
+    { class: %w[mojf-back-link] }
+  end
+end

--- a/app/components/moj_forms/settings_screen_component.html.erb
+++ b/app/components/moj_forms/settings_screen_component.html.erb
@@ -1,0 +1,20 @@
+<%= tag.div(**html_attributes) do %>
+  <div class="govuk-grid-row">
+    <section class="govuk-grid-column-two-thirds" aria-labelledby="page-heading">
+      <%= back_link if back_link? %>
+
+      <%= notification if notification? %>
+
+      <header class="<%= @header_classes -%>">
+        <% if @heading %>
+          <h1 id="page-heading" class="govuk-heading-xl"><%= @heading %></h1>
+        <% end %>
+        <% if @description %>
+          <p class="mojf-settings-screen__description"><%= @description %></p>
+        <% end %>
+      </header>
+
+      <%= content %>
+    </div>
+  </div>
+<% end %>

--- a/app/components/moj_forms/settings_screen_component.rb
+++ b/app/components/moj_forms/settings_screen_component.rb
@@ -1,0 +1,19 @@
+class MojForms::SettingsScreenComponent < GovukComponent::Base
+  renders_one :back_link, MojForms::BackLinkComponent
+  renders_one :notification
+
+  def initialize(heading:, description: '', classes: [], html_attributes: {})
+    @heading = heading
+    @description = description
+
+    @header_classes = @description ? 'with-description' : ''
+
+    super(classes: classes, html_attributes: html_attributes)
+  end
+
+  private
+
+  def default_attributes
+    { class: %w[mojf-settings-screen] }
+  end
+end

--- a/app/components/moj_forms/settings_screen_component.rb
+++ b/app/components/moj_forms/settings_screen_component.rb
@@ -1,19 +1,21 @@
-class MojForms::SettingsScreenComponent < GovukComponent::Base
-  renders_one :back_link, MojForms::BackLinkComponent
-  renders_one :notification
+module MojForms
+  class SettingsScreenComponent < GovukComponent::Base
+    renders_one :back_link, MojForms::BackLinkComponent
+    renders_one :notification
 
-  def initialize(heading:, description: '', classes: [], html_attributes: {})
-    @heading = heading
-    @description = description
+    def initialize(heading:, description: '', classes: [], html_attributes: {})
+      @heading = heading
+      @description = description
 
-    @header_classes = @description ? 'with-description' : ''
+      @header_classes = @description ? 'with-description' : ''
 
-    super(classes: classes, html_attributes: html_attributes)
-  end
+      super(classes: classes, html_attributes: html_attributes)
+    end
 
-  private
+    private
 
-  def default_attributes
-    { class: %w[mojf-settings-screen] }
+    def default_attributes
+      { class: %w[mojf-settings-screen] }
+    end
   end
 end

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -147,28 +147,6 @@ html {
   box-shadow: none; // 0 1px 0 #002d18;
 }
 
-.fb-settings-screen {
-  h1 {
-    margin-top: govuk-spacing(6);
-  }
-}
-
-.fb-back-link {
-  @extend %govuk-link;
-  @extend %govuk-body-s;
-  @include govuk-link-style-text;
-  @include govuk-link-style-no-underline;
-
-  display: inline-flex;
-  align-items: center;
-  position: absolute;
-  top: 16px;
-  left: 0;
-
-  > span:first-child {
-    margin-right: 4px;
-  }
-}
 
 
 /* Publishing

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -22,5 +22,7 @@
 @import "./component_expander";
 @import "./component_warning_text";
 @import "./component_status_message";
+@import "components/settings-screen";
+@import "components/back-link";
 @import "./shared/content";
 @import "./index";

--- a/app/javascript/styles/components/back-link.scss
+++ b/app/javascript/styles/components/back-link.scss
@@ -1,0 +1,16 @@
+.mojf-back-link {
+  @extend %govuk-link;
+  @extend %govuk-body-s;
+  @include govuk-link-style-text;
+  @include govuk-link-style-no-underline;
+
+  display: inline-flex;
+  align-items: center;
+  position: absolute;
+  top: 16px;
+  left: 0;
+
+  > span:first-child {
+    margin-right: 4px;
+  }
+}

--- a/app/javascript/styles/components/settings-screen.scss
+++ b/app/javascript/styles/components/settings-screen.scss
@@ -1,0 +1,17 @@
+.mojf-settings-screen {
+
+  h1 {
+    margin-top: govuk-spacing(6);
+  }
+
+  header.with-description {
+    h1 {
+      margin-bottom: 0;
+    }
+  }
+
+  &__description {
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(8);
+  }
+}

--- a/app/views/settings/confirmation_email/index.html.erb
+++ b/app/views/settings/confirmation_email/index.html.erb
@@ -1,6 +1,9 @@
-<%= editor_settings_screen(settings_submission_index_path) do %>
-  <h1 class="govuk-heading-xl"><%= t('settings.confirmation_email.heading') %></h1>
-  <p><%= t('settings.confirmation_email.description') %></p>
+<%= render MojForms::SettingsScreenComponent.new(
+  heading:t('settings.confirmation_email.heading'),
+  description: t('settings.confirmation_email.description')
+  ) do |c| %>
+
+  <% c.with_back_link(href: settings_submission_index_path) %>
 
   <% if @email_components.present? %>
     <% content_for :forms do %>

--- a/app/views/settings/email/index.html.erb
+++ b/app/views/settings/email/index.html.erb
@@ -1,6 +1,9 @@
-<%= editor_settings_screen(settings_submission_index_path) do %>
-  <h1 class="govuk-heading-xl"><%= t('settings.collection_email.heading') %></h1>
-  <p><%= t('settings.collection_email.description') %></p>
+<%= render MojForms::SettingsScreenComponent.new(
+  heading:t('settings.collection_email.heading'),
+  description: t('settings.collection_email.description')
+  ) do |c| %>
+
+  <% c.with_back_link(href: settings_submission_index_path) %>
 
   <% content_for :forms do %>
     <%= render 'form', object: @email_settings_dev, deployment_environment: 'dev' %>

--- a/app/views/settings/form_analytics/index.html.erb
+++ b/app/views/settings/form_analytics/index.html.erb
@@ -1,17 +1,21 @@
-<%= editor_settings_screen(settings_path) do %>
-    <h1 class="govuk-heading-xl"><%= t('settings.form_analytics.name') %></h1>
-    <p class="govuk-body"><%= t('settings.form_analytics.intro') %></p>
-    <%= form_for @form_analytics, url: settings_form_analytics_path(service.service_id),
-      html: { id: 'form-analytics-settings' },
-      builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+<%= render MojForms::SettingsScreenComponent.new(
+  heading:t('settings.form_analytics.heading'),
+  description: t('settings.form_analytics.description')
+  ) do |c| %>
 
-      <%= f.govuk_error_summary %>
+  <% c.with_back_link(href: settings_path) %>
 
-      <%= render partial: 'form', locals: { f: f, environment: 'test' } %>
-      <%= render partial: 'form', locals: { f: f, environment: 'live' } %>
+  <%= form_for @form_analytics, url: settings_form_analytics_path(service.service_id),
+    html: { id: 'form-analytics-settings' },
+    builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
 
-      <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
-        <%= t('actions.save') %>
-      </button>
+    <%= f.govuk_error_summary %>
+
+    <%= render partial: 'form', locals: { f: f, environment: 'test' } %>
+    <%= render partial: 'form', locals: { f: f, environment: 'live' } %>
+
+    <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
+      <%= t('actions.save') %>
+    </button>
   <% end %>
 <% end %>

--- a/app/views/settings/form_information/index.html.erb
+++ b/app/views/settings/form_information/index.html.erb
@@ -1,5 +1,9 @@
-<%= editor_settings_screen(settings_path) do %>
-  <h1 class="govuk-heading-xl"><%= t('settings.form_information.name') %></h1>
+<%= render MojForms::SettingsScreenComponent.new(
+  heading:t('settings.form_information.heading'),
+  description: t('settings.form_information.description')
+) do |c| %>
+
+  <% c .with_back_link(href: settings_path) %>
 
   <%= form_for @settings, as: :service, url: settings_form_information_index_path(service.service_id) do |f| %>
     <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">

--- a/app/views/settings/from_address/_contact_us.html.erb
+++ b/app/views/settings/from_address/_contact_us.html.erb
@@ -1,0 +1,6 @@
+<%= t('warnings.from_address.settings.contact_us').html_safe %>
+<p>
+  <%= link_to t('settings.from_address.link_contact_us'),
+    t('settings.from_address.contact_url'),
+    class: 'fb-link-button' %>
+</p>

--- a/app/views/settings/from_address/_resend_validation_link.html.erb
+++ b/app/views/settings/from_address/_resend_validation_link.html.erb
@@ -1,0 +1,11 @@
+<p>
+  <span role="alert"></span>
+  <%= tag.button t('settings.from_address.resend_link_text'),
+    class: 'fb-link-button',
+    data: {
+      remote: true,
+      method: 'post',
+      url: api_service_settings_from_address_resend_path(service.service_id),
+      success: t('settings.from_address.link_resent_success')
+    } %>
+</p>

--- a/app/views/settings/from_address/index.html.erb
+++ b/app/views/settings/from_address/index.html.erb
@@ -1,41 +1,31 @@
-<%= editor_settings_screen(settings_submission_index_path) do %>
-  <%= form_for @from_address,
+<%= form_for @from_address,
     method: :post,
     url: settings_from_address_index_path(service.service_id),
     html: { class: (@from_address.errors.any? ? 'with-errors' : '') },
     builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
 
+<%= render MojForms::SettingsScreenComponent.new(
+  heading:t('settings.from_address.heading'),
+  description: t('settings.from_address.description')
+  ) do |c| %>
+
+  <% c.with_back_link(href: settings_submission_index_path) %>
+
+  <% c.with_notification do %>
     <%= f.govuk_error_summary link_base_errors_to: :email, class: "govuk-!-margin-bottom-6 govuk-!-margin-top-6" %>
 
     <% if @from_address.pending? && @from_address.errors.blank? %>
       <%= govuk_notification_banner(title_text: t('notification_banners.important'), classes: "govuk-!-margin-top-6") do %>
         <% if @from_address.allowed_domain? %>
           <%= @presenter.message.html_safe %>
-            <p>
-              <span role="alert"></span>
-              <%= tag.button t('settings.from_address.resend_link_text'),
-                class: 'fb-link-button',
-                data: {
-                  remote: true,
-                  method: 'post',
-                  url: api_service_settings_from_address_resend_path(service.service_id),
-                  success: t('settings.from_address.link_resent_success')
-                } %>
-            </p>
+          <%= render "resend_validation_link" %>
         <% else %>
-          <%= t('warnings.from_address.settings.contact_us').html_safe %>
-            <p>
-              <%= link_to t('settings.from_address.link_contact_us'),
-                t('settings.from_address.contact_url'),
-                class: 'fb-link-button' %>
-            </p>
+          <%= render "contact_us" %>
         <% end %>
       <% end %>
     <% end %>
 
-    <h1 class="govuk-heading-xl"><%= t('settings.from_address.heading') %></h1>
-
-    <p class="govuk-!-margin-bottom-7"><%= t('settings.from_address.description') %></p>
+  <% end %>
 
     <%= f.govuk_text_field :email,
       label: { text:  t('activemodel.attributes.from_address.email') },
@@ -58,5 +48,6 @@
       <%= t('actions.save') %>
     </button>
     <span class="sr-only" id="save_description"></span>
+
   <% end %>
 <% end %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,18 +1,17 @@
-<%= editor_settings_screen(false) do %>
-  <h1 id="settings-navigation-heading" class="govuk-heading-xl"><%= t('settings.name') %></h1>
-  <nav class="govuk-navigation" aria-labelledby="settings-navigation-heading">
+<%= render MojForms::SettingsScreenComponent.new(heading:t('settings.name')) do |c| %>
+  <nav class="govuk-navigation" aria-labelledby="page-heading">
     <dl class="fb-settings-list">
       <div>
-        <dt><%= link_to t('settings.form_information.name'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %></dt>
-        <dd class="govuk-hint"><%= t('settings.form_information.description') %></dd>
+        <dt><%= link_to t('settings.form_information.heading'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %></dt>
+        <dd class="govuk-hint"><%= t('settings.form_information.lede') %></dd>
       </div>
       <div>
-        <dt><%= link_to t('settings.form_analytics.name'), settings_form_analytics_path(service.service_id), class: 'govuk-link' %></dt>
-        <dd class="govuk-hint" ><%= t('settings.form_analytics.hint') %></dd>
+        <dt><%= link_to t('settings.form_analytics.heading'), settings_form_analytics_path(service.service_id), class: 'govuk-link' %></dt>
+        <dd class="govuk-hint" ><%= t('settings.form_analytics.lede') %></dd>
       </div>
       <div>
-        <dt><%= link_to t('settings.submission.name'), settings_submission_index_path(service.service_id), class: 'govuk-link' %></dt>
-        <dd class="govuk-hint" ><%= t('settings.submission.hint') %></dd>
+        <dt><%= link_to t('settings.submission.heading'), settings_submission_index_path(service.service_id), class: 'govuk-link' %></dt>
+        <dd class="govuk-hint" ><%= t('settings.submission.lede') %></dd>
       </div>
     </dl>
   </nav>

--- a/app/views/settings/submission/index.html.erb
+++ b/app/views/settings/submission/index.html.erb
@@ -1,6 +1,11 @@
-<%= editor_settings_screen(settings_path) do %>
-  <h1 id="settings-navigation-heading" class="govuk-heading-xl"><%= t('settings.submission.name') %></h1>
-  <nav class="govuk-navigation" aria-labelledby="settings-navigation-heading">
+<%= render MojForms::SettingsScreenComponent.new(
+  heading:t('settings.submission.heading'),
+  description: t('settings.submission.description')
+  ) do |c| %>
+
+  <% c.with_back_link(href: settings_path) %>
+
+  <nav class="govuk-navigation" aria-labelledby="page-heading">
     <dl aria-labelledby="submission-settings-navigation-heading" class="fb-settings">
       <div>
         <dt><%= link_to t('settings.from_address.heading'), settings_from_address_index_path(service.service_id), class: 'govuk-link' %></dt>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
     branching_title: 'Branching point %{branching_number}'
     confirmation_email_subject: "Your submission to ‘%{service_name}’"
     confirmation_email_body: "Thank you for your submission to ‘%{service_name}’.\n\r\nA copy of the information you provided is attached to this email."
-  notifictaion_banners:
+  notification_banners:
     important: Important
     success: Success
   dialogs:
@@ -140,6 +140,7 @@ en:
       heading: You don't have access to that page
       body: Contact the form owner or the MoJ Forms team for help.
   actions:
+    back: 'Back'
     edit: 'Edit'
     save: 'Save'
     saving: 'Saving...'
@@ -281,7 +282,8 @@ en:
   settings:
     name: 'Settings'
     form_information:
-      name: 'Form details'
+      heading: 'Form details'
+      lede: "Set your form's name, URL and phase (e.g. Alpha, Beta)."
       description: "Set your form's name, URL and phase (e.g. Alpha, Beta)."
       form_name:
         label: 'Form name'
@@ -296,9 +298,9 @@ en:
       link_contact_us: Contact us
       contact_url: https://moj-forms.service.justice.gov.uk/contact/
     form_analytics:
-      name: Google Analytics
-      hint:  Monitor your form's performance (requires a Google Analytics account).
-      intro: This inserts tracking code in your form, allowing you to view performance metrics in Google Analytics. It requires your own Google Analytics account and at least one tracking ID.
+      heading: Google Analytics
+      lede:  Monitor your form's performance (requires a Google Analytics account).
+      description: This inserts tracking code in your form, allowing you to view performance metrics in Google Analytics. It requires your own Google Analytics account and at least one tracking ID.
       test:
         heading: Test site
         description: Where you can check your form works and get feedback.
@@ -308,9 +310,9 @@ en:
       details: Configure
       details_hint: 'You can use tracking IDs for any of the following Google products:'
     submission:
-      name: 'Submission settings'
-      hint: 'Set what happens when a user submits their data.'
-      sub_heading: 'Use these settings to control what happens when a user submits the form on Test or Live.'
+      heading: 'Submission settings'
+      lede: 'Set what happens when a user submits their data.'
+      description: 'Use these settings to control what happens when a user submits the form on Test or Live.'
       dev:
         config_details_summary: Configure <span class="sr-only">test settings</span>
         save_button: Save Test settings


### PR DESCRIPTION
Settings screens had incorrect and inconsistent spacings between header, (optional) desciription text and page content.

This PR fixes the spacing issues, and also updates the way the settings screens are rendered.

Previously there was a helper method to handle rednering the settings screen wrapper, and another to render a back link.

These have been migrated to use ViewComponents.  Given that we are using the GovukComponents gem to provide us with consistent components from the GOVUK design system, we can start to build out our own UI components for MOJ Forms.

This has several advantages:
* Ensures consistency - of markup structure, classes and accessibility
* Reduces the need for backend devs to write out HTML
* Encapsulates more of the template logic in ruby classes
* Simplifies view templates
* Gives the potential for these components to be tested (if required)
* Should help break up css into more manageable componentized files

Components have been placed in an `MojForms` namespace, and all inherit from the `GovukComopnent::Base`.

Introduces a new `mojf-` naming convention for MOJ Forms specific css (with an aim to migrate away from the `fb-` prefix), which shoudl help delineate which classes are coming from the design system, and which are unnique to the editor.

**Next Steps:**
It might be nice to introduce a helper pattern similar to GovukComponents to allow for writing `<%= mojforms_settings_screen() %>` instead of `<%= render MojForms::SettingsScreenComponent.new() %>`


