### PR TITLE
Fix acceptance tests

### DIFF
--- a/acceptance/features/form_analytics_spec.rb
+++ b/acceptance/features/form_analytics_spec.rb
@@ -92,8 +92,8 @@ feature 'Form analytics configuration' do
   def when_I_visit_the_form_analytics_page
     page.find(:css, '#main-content', visible: true)
     editor.click_link(I18n.t('settings.name'))
-    expect(page).to have_content(I18n.t('settings.form_analytics.hint'))
-    editor.click_link(I18n.t('settings.form_analytics.name'))
+    expect(page).to have_content(I18n.t('settings.form_analytics.lede'))
+    editor.click_link(I18n.t('settings.form_analytics.heading'))
   end
 
   def when_I_enable_the_analytics(environment)
@@ -110,8 +110,8 @@ feature 'Form analytics configuration' do
   end
 
   def then_I_should_see_the_settings_configuration
-    expect(page).to have_content(I18n.t('settings.form_analytics.name'))
-    expect(page).to have_content(I18n.t('settings.form_analytics.intro'))
+    expect(page).to have_content(I18n.t('settings.form_analytics.heading'))
+    expect(page).to have_content(I18n.t('settings.form_analytics.description'))
     expect(page).to have_content(I18n.t('settings.form_analytics.test.heading'))
     expect(page).to have_content(I18n.t('settings.form_analytics.test.description'))
     expect(page).to have_content(I18n.t('settings.form_analytics.live.heading'))

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -46,7 +46,7 @@ class EditorApp < SitePrism::Page
   element :preview_form_button, :link, I18n.t('actions.preview_form')
   element :edit_page_button, :link, I18n.t('actions.edit_page')
 
-  element :submission_settings_link, :link, I18n.t('settings.submission.name')
+  element :submission_settings_link, :link, I18n.t('settings.submission.heading')
   element :send_data_by_email_link, :link, I18n.t('settings.collection_email.heading')
 
   element :page_url_field, :field, I18n.t('activemodel.attributes.page_creation.page_url')

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -502,7 +502,7 @@ module CommonSteps
   def when_I_visit_the_from_address_settings_page
     page.find(:css, '#main-content', visible: true)
     editor.click_link(I18n.t('settings.name'))
-    editor.click_link(I18n.t('settings.submission.name'))
+    editor.click_link(I18n.t('settings.submission.heading'))
     expect(page).to have_content(I18n.t('settings.from_address.heading'))
     editor.click_link(I18n.t('settings.from_address.heading'))
   end

--- a/app/views/api/branches/destroy_message.html.erb
+++ b/app/views/api/branches/destroy_message.html.erb
@@ -20,7 +20,7 @@
 
     <div class="govuk-button-group">
       <%= f.button t('branches.delete_modal.submit'), class: 'govuk-button govuk-button--warning', data: { method: "delete" } %>
-      <button type="button" class="govuk-button govuk-button--secondary ui-button"><%= t('dialogs.cancel') %></button>
+      <button type="button" class="govuk-button govuk-button--secondary ui-button"><%= t('dialogs.button_cancel') %></button>
     </div>
   <% end %>
 </div>

--- a/app/views/api/component_validations/_string_length_validation.html.erb
+++ b/app/views/api/component_validations/_string_length_validation.html.erb
@@ -21,7 +21,7 @@
                  type="radio" value="<%= @component_validation.characters_radio_value %>"
                  <%= ((!@component_validation.select_characters? && !@component_validation.select_words?) || @component_validation.select_characters?) ? 'checked' : '' %>>
           <label class="govuk-label govuk-radios__label" for="component_validation_characters">
-            <%= t('activemodel.component_validations.string.characters') %>
+            <%= t('dialogs.component_validations.string.characters') %>
           </label>
         </div>
         <div class="govuk-radios__item govuk-!-margin-bottom-0">
@@ -29,7 +29,7 @@
                  type="radio" value="<%= @component_validation.words_radio_value %>"
                  <%= @component_validation.select_words? ? 'checked' : '' %>>
           <label class="govuk-label govuk-radios__label" for="component_validation_words">
-            <%= t('activemodel.component_validations.string.words') %>
+            <%= t('dialogs.component_validations.string.words') %>
           </label>
         </div>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,6 +146,7 @@ en:
     saving: 'Saving...'
     saved: 'Saved'
     continue: 'Continue'
+    cancel: 'Cancel'
     publish_to_test: 'Publish to Test'
     publish_to_live: 'Publish to Live'
     add_branch: 'Add branching'


### PR DESCRIPTION
This fixes the boken acceptance tests after the previous merge to sort out and tidy up the settigns screens

It also corrects test that were failing after enabling the config setting to fail if a translation is missing.

