### PR TITLE
Remove submissions settings description and add fullstops

### DIFF
--- a/app/views/settings/submission/index.html.erb
+++ b/app/views/settings/submission/index.html.erb
@@ -1,6 +1,5 @@
 <%= render MojForms::SettingsScreenComponent.new(
   heading:t('settings.submission.heading'),
-  description: t('settings.submission.description')
   ) do |c| %>
 
   <% c.with_back_link(href: settings_path) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,7 +292,7 @@ en:
         warning_message: 'We are making some changes in this area. In the meantime, <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/contact/">contact&nbsp;us</a> to change your form’s name.'
     from_address:
       heading: "‘From’ address"
-      lede: Emails sent by your form will come from this address
+      lede: Emails sent by your form will come from this address.
       description: Emails sent by your form, either to you or to people filling it in, will come from this address
       resend_link_text: Resend validation link
       link_resent_success: Link resent - now check your email
@@ -326,7 +326,7 @@ en:
       description: 'Receive your form data in PDF and CSV attached to emails.'
     confirmation_email:
       heading: 'Send a confirmation email'
-      lede: Send the people who complete your form a copy of their data
+      lede: Send the people who complete your form a copy of their data.
       description: Send the people completing your form a confirmation email with their information attached in a PDF.
   warnings:
     from_address:


### PR DESCRIPTION
Fixes the last couple of content tweaks.
* Remove unneeded description
* Add full stops at the end of the item descriptions