### PR TITLE
Update publishing warnings

### DIFF
--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -32,7 +32,8 @@ feature 'Publishing' do
 
       then_I_should_see_the_no_service_output_message
       then_the_publish_button_should_be_enabled
-
+      then_I_click_the_collecting_information_by_email_link
+      then_I_should_be_on_collecting_information_by_email_page
       when_I_enable_the_submission_settings
 
       when_I_visit_the_publishing_page
@@ -152,6 +153,14 @@ feature 'Publishing' do
   def then_I_should_see_the_no_service_output_message
     message = environment_section.find(:css, '.govuk-warning-text__text').text
     expect(message).to include(I18n.t('publish.service_output.message', href_collection_information_by_email: I18n.t('publish.service_output.link') ))
+  end
+
+  def then_I_click_the_collecting_information_by_email_link
+    environment_section.find(:css,'.govuk-link').click
+  end
+
+  def then_I_should_be_on_collecting_information_by_email_page
+    expect(page).to have_content(I18n.t('settings.collection_email.heading'))
   end
 
   def then_I_should_see_the_publish_button

--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -21,11 +21,9 @@ feature 'Publishing' do
 
   shared_examples 'a publishing page environment' do
     let(:exit_url) { 'exit' }
-    let(:warning_both) { I18n.t("warnings.submission_pages.#{environment}.both_pages") }
-    let(:warning_cya) { I18n.t("warnings.submission_pages.#{environment}.cya_page") }
-    let(:warning_confirmation) { I18n.t("warnings.submission_pages.#{environment}.confirmation_page") }
+
     let(:button_class) { '.govuk-button.fb-govuk-button.DialogActivator' }
-    let(:autocomplete_warning_message) {I18n.t("publish.autocomplete_items.#{environment}.message", title: 'Question') }
+    let(:autocomplete_warning_message) { I18n.t("publish.autocomplete_items.#{environment}.message", title: 'Question') }
     let(:upload_button) { I18n.t('dialogs.autocomplete.button') }
     let(:valid_csv_one_column) { './spec/fixtures/autocomplete/valid_one_column.csv' }
 
@@ -118,6 +116,9 @@ feature 'Publishing' do
     let(:environment) { 'dev' }
     let(:publish_button) { I18n.t('publish.dev.button') }
     let(:button_disabled) { '' } # aria-disabled is not set when button is enabled
+    let(:warning_both){ 'it is missing a check answers page and confirmation page' }
+    let(:warning_cya){ 'it is missing a check answers page' }
+    let(:warning_confirmation){ 'it is missing a confirmation page'}
 
     it_behaves_like 'a publishing page environment'
   end
@@ -126,6 +127,9 @@ feature 'Publishing' do
     let(:environment) { 'production' }
     let(:publish_button) { I18n.t('publish.production.button') }
     let(:button_disabled) { 'true' }
+    let(:warning_both){ 'add a check answers page and confirmation page' }
+    let(:warning_cya){ 'add a check answers page' }
+    let(:warning_confirmation){ 'add a confirmation page'}
 
     it_behaves_like 'a publishing page environment'
   end
@@ -147,7 +151,7 @@ feature 'Publishing' do
 
   def then_I_should_see_the_no_service_output_message
     message = environment_section.find(:css, '.govuk-warning-text__text').text
-    expect(message).to include(I18n.t('publish.service_output.message', href_collection_information_by_email: t('publish.service_output.link') ))
+    expect(message).to include(I18n.t('publish.service_output.message', href_collection_information_by_email: I18n.t('publish.service_output.link') ))
   end
 
   def then_I_should_see_the_publish_button

--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -147,7 +147,7 @@ feature 'Publishing' do
 
   def then_I_should_see_the_no_service_output_message
     message = environment_section.find(:css, '.govuk-warning-text__text').text
-    expect(message).to include(I18n.t('publish.service_output.message'))
+    expect(message).to include(I18n.t('publish.service_output.message', href_collection_information_by_email: t('publish.service_output.link') ))
   end
 
   def then_I_should_see_the_publish_button

--- a/app/presenters/autocomplete_items_presenter.rb
+++ b/app/presenters/autocomplete_items_presenter.rb
@@ -25,19 +25,6 @@ class AutocompleteItemsPresenter
   end
 
   def messages
-    @messages ||=
-      pages_with_autocomplete_component.each_with_object([]) do |page, arry|
-        page.components.each do |component|
-          next unless component.uuid.in?(component_uuids_without_items)
-
-          arry.push(
-            { component_title: component.humanised_title, page_uuid: page.uuid }
-          )
-        end
-      end
-  end
-
-  def message
     env = ENV['RAILS_ENV'] == 'development' ? 'dev' : ENV['RAILS_ENV']
     pages_with_autocomplete_component.each_with_object([]) do |page, arry|
       page.components.each do |component|
@@ -51,5 +38,10 @@ class AutocompleteItemsPresenter
         arry.push(msg)
       end
     end
+  end
+
+  def message
+    # because submission warnings presenter expect presenter to have methods message
+    messages
   end
 end

--- a/app/presenters/autocomplete_items_presenter.rb
+++ b/app/presenters/autocomplete_items_presenter.rb
@@ -1,11 +1,12 @@
 class AutocompleteItemsPresenter
   include ActionView::Helpers
   include GovukLinkHelper
-  attr_reader :autocomplete_items, :service
+  attr_reader :autocomplete_items, :service, :deployment_environment
 
-  def initialize(service, autocomplete_items)
+  def initialize(service, autocomplete_items, deployment_environment)
     @service = service
     @autocomplete_items = autocomplete_items
+    @deployment_environment = deployment_environment
   end
 
   def autocomplete_component_uuids
@@ -25,14 +26,13 @@ class AutocompleteItemsPresenter
   end
 
   def messages
-    env = ENV['RAILS_ENV'] == 'development' ? 'dev' : ENV['RAILS_ENV']
     pages_with_autocomplete_component.each_with_object([]) do |page, arry|
       page.components.each do |component|
         next unless component.uuid.in?(component_uuids_without_items)
 
         link = govuk_link_to(component.humanised_title, Rails.application.routes.url_helpers.edit_page_path(service.service_id, page.uuid))
 
-        description = I18n.t("publish.autocomplete_items.#{env}.message", title: link)
+        description = I18n.t("publish.autocomplete_items.#{deployment_environment}.message", title: link)
 
         msg = description.html_safe
         arry.push(msg)

--- a/app/presenters/autocomplete_items_presenter.rb
+++ b/app/presenters/autocomplete_items_presenter.rb
@@ -1,4 +1,6 @@
 class AutocompleteItemsPresenter
+  include ActionView::Helpers
+  include GovukLinkHelper
   attr_reader :autocomplete_items, :service
 
   def initialize(service, autocomplete_items)
@@ -33,5 +35,21 @@ class AutocompleteItemsPresenter
           )
         end
       end
+  end
+
+  def message
+    env = ENV['RAILS_ENV'] == 'development' ? 'dev' : ENV['RAILS_ENV']
+    pages_with_autocomplete_component.each_with_object([]) do |page, arry|
+      page.components.each do |component|
+        next unless component.uuid.in?(component_uuids_without_items)
+
+        link = govuk_link_to(component.humanised_title, Rails.application.routes.url_helpers.edit_page_path(service.service_id, page.uuid))
+
+        description = I18n.t("publish.autocomplete_items.#{env}.message", title: link)
+
+        msg = description.html_safe
+        arry.push(msg)
+      end
+    end
   end
 end

--- a/app/presenters/autocomplete_items_presenter.rb
+++ b/app/presenters/autocomplete_items_presenter.rb
@@ -30,18 +30,20 @@ class AutocompleteItemsPresenter
       page.components.each do |component|
         next unless component.uuid.in?(component_uuids_without_items)
 
-        link = govuk_link_to(component.humanised_title, Rails.application.routes.url_helpers.edit_page_path(service.service_id, page.uuid))
-
-        description = I18n.t("publish.autocomplete_items.#{deployment_environment}.message", title: link)
-
-        msg = description.html_safe
+        msg = I18n.t("publish.autocomplete_items.#{deployment_environment}.message", title: link(component, page)).html_safe
         arry.push(msg)
       end
     end
   end
 
+  # the method message is required by the submission warning presenter
   def message
-    # because submission warnings presenter expect presenter to have methods message
     messages
+  end
+
+  private
+
+  def link(component, page)
+    govuk_link_to(component.humanised_title, Rails.application.routes.url_helpers.edit_page_path(service.service_id, page.uuid))
   end
 end

--- a/app/presenters/autocomplete_items_presenter.rb
+++ b/app/presenters/autocomplete_items_presenter.rb
@@ -26,20 +26,18 @@ class AutocompleteItemsPresenter
   end
 
   def messages
-    pages_with_autocomplete_component.each_with_object([]) do |page, arry|
-      page.components.each do |component|
-        next unless component.uuid.in?(component_uuids_without_items)
+    @messages ||=
+      pages_with_autocomplete_component.each_with_object([]) do |page, arry|
+        page.components.each do |component|
+          next unless component.uuid.in?(component_uuids_without_items)
 
-        msg = I18n.t("publish.autocomplete_items.#{deployment_environment}.message", title: link(component, page)).html_safe
-        arry.push(msg)
+          msg = I18n.t("publish.autocomplete_items.#{deployment_environment}.message", title: link(component, page)).html_safe
+          arry.push(msg)
+        end
       end
-    end
   end
 
-  # the method message is required by the submission warning presenter
-  def message
-    messages
-  end
+  alias_method :message, :messages
 
   private
 

--- a/app/presenters/publishing_page_presenter.rb
+++ b/app/presenters/publishing_page_presenter.rb
@@ -59,6 +59,10 @@ class PublishingPagePresenter
   end
 
   def submission_warning_presenters
-    [submission_pages_presenter, from_address_presenter]
+    [
+      submission_pages_presenter,
+      autocomplete_warning,
+      from_address_presenter
+    ]
   end
 end

--- a/app/presenters/publishing_page_presenter.rb
+++ b/app/presenters/publishing_page_presenter.rb
@@ -27,7 +27,7 @@ class PublishingPagePresenter
   end
 
   def autocomplete_warning
-    @autocomplete_warning ||= AutocompleteItemsPresenter.new(service, service_autocomplete_items)
+    @autocomplete_warning ||= AutocompleteItemsPresenter.new(service, service_autocomplete_items, deployment_environment)
   end
 
   def publish_button_disabled?

--- a/app/presenters/publishing_page_presenter.rb
+++ b/app/presenters/publishing_page_presenter.rb
@@ -59,10 +59,10 @@ class PublishingPagePresenter
   end
 
   def submission_warning_presenters
-    [
-      submission_pages_presenter,
-      autocomplete_warning,
-      from_address_presenter
-    ]
+    presenters = [submission_pages_presenter, from_address_presenter]
+
+    return presenters if deployment_environment == 'dev'
+
+    presenters.push(autocomplete_warning)
   end
 end

--- a/app/presenters/submission_pages_presenter.rb
+++ b/app/presenters/submission_pages_presenter.rb
@@ -29,14 +29,9 @@ class SubmissionPagesPresenter
     name_link = I18n.t("warnings.submission_pages.link.#{pages_with_warnings}")
     govuk_link_to(
       name_link,
-      I18n.t('partials.header.user_guide_url')
+      I18n.t('partials.header.user_guide_check_confirm_url'),
+      target: :_blank
     )
-  end
-
-  def adding_guide_link(pages_with_warnings)
-    name_link = I18n.t("warnings.submission_pages.link.#{pages_with_warnings}")
-    link = govuk_link_to(name_link, I18n.t('partials.header.user_guide_url'))
-    warning_message.gsub('%{href}', link).html_safe
   end
 
   def submitting_pages_not_present_message

--- a/app/presenters/submission_pages_presenter.rb
+++ b/app/presenters/submission_pages_presenter.rb
@@ -1,4 +1,6 @@
 class SubmissionPagesPresenter
+  include ActionView::Helpers
+  include GovukLinkHelper
   attr_reader :messages, :service
 
   def initialize(service, messages)
@@ -23,21 +25,35 @@ class SubmissionPagesPresenter
 
   private
 
+  def link(pages_with_warnings)
+    name_link = I18n.t("warnings.submission_pages.link.#{pages_with_warnings}")
+    govuk_link_to(
+      name_link,
+      I18n.t('partials.header.user_guide_url')
+    )
+  end
+
+  def adding_guide_link(pages_with_warnings)
+    name_link = I18n.t("warnings.submission_pages.link.#{pages_with_warnings}")
+    link = govuk_link_to(name_link, I18n.t('partials.header.user_guide_url'))
+    warning_message.gsub('%{href}', link).html_safe
+  end
+
   def submitting_pages_not_present_message
     if cya_and_confirmation_missing?
-      messages[:both_pages]
+      messages[:both_pages].gsub('%{href}', link('both_pages')).html_safe
     end
   end
 
   def cya_page_not_present_message
     if !checkanswers_in_main_flow? && confirmation_in_main_flow?
-      messages[:cya_page]
+      messages[:cya_page].gsub('%{href}', link('cya_page')).html_safe
     end
   end
 
   def confirmation_page_not_present_message
     if checkanswers_in_main_flow? && !confirmation_in_main_flow?
-      messages[:confirmation_page]
+      messages[:confirmation_page].gsub('%{href}', link('confirmation_page')).html_safe
     end
   end
 

--- a/app/presenters/submission_warnings_presenter.rb
+++ b/app/presenters/submission_warnings_presenter.rb
@@ -15,6 +15,6 @@ class SubmissionWarningsPresenter
   end
 
   def messages
-    presenters.map(&:message).compact
+    presenters.map(&:message).compact.flatten
   end
 end

--- a/app/views/publish/_autocomplete_warning.html.erb
+++ b/app/views/publish/_autocomplete_warning.html.erb
@@ -1,0 +1,7 @@
+<% autocomplete_warning.messages.each do |message| %>
+  <%= govuk_warning_text(
+    text: message.html_safe,
+    icon_fallback_text: t("publish.autocomplete_items.#{environment}.icon_fallback"),
+    classes: environment == 'production' ? 'govuk-warning-text--error' : ''
+  ) %>
+<% end %>

--- a/app/views/publish/_autocomplete_warning.html.erb
+++ b/app/views/publish/_autocomplete_warning.html.erb
@@ -1,9 +1,0 @@
-<% autocomplete_warning.messages.each do |message| %>
-  <%= govuk_warning_text(
-    text: t("publish.autocomplete_items.#{environment}.message",
-            title: govuk_link_to(message[:component_title],
-            edit_page_path(service.service_id, message[:page_uuid]))).html_safe,
-    icon_fallback_text: t("publish.autocomplete_items.#{environment}.icon_fallback"),
-    classes: environment == 'production' ? 'govuk-warning-text--error' : ''
-  ) %>
-<% end %>

--- a/app/views/publish/_publish_environment.html.erb
+++ b/app/views/publish/_publish_environment.html.erb
@@ -7,8 +7,15 @@
   <% end %>
 
   <% if presenter.no_service_output? %>
-    <%= govuk_warning_text(
-        text: t('publish.service_output.message'),
+    <%= govuk_warning_text( text:
+      t(
+        'publish.service_output.message',
+        href_collection_information_by_email:
+          govuk_link_to(
+            t('publish.service_output.link'),
+            settings_email_index_path(service.service_id)
+          )
+        ).html_safe,
         icon_fallback_text: t('publish.service_output.icon_fallback'),
       ) %>
   <% else %>

--- a/app/views/publish/_publish_environment.html.erb
+++ b/app/views/publish/_publish_environment.html.erb
@@ -20,6 +20,9 @@
       ) %>
   <% else %>
     <%= render 'submission_warning', submission_presenter: presenter.submission_warnings, environment: environment %>
+    <% if environment == 'dev' %>
+      <%= render 'autocomplete_warning', autocomplete_warning: presenter.autocomplete_warning, environment: environment %>
+    <% end %>
   <% end %>
 
   <button class="govuk-button fb-govuk-button"

--- a/app/views/publish/_publish_environment.html.erb
+++ b/app/views/publish/_publish_environment.html.erb
@@ -13,7 +13,6 @@
       ) %>
   <% else %>
     <%= render 'submission_warning', submission_presenter: presenter.submission_warnings, environment: environment %>
-    <%= render 'autocomplete_warning', autocomplete_warning: presenter.autocomplete_warning, environment: environment %>
   <% end %>
 
   <button class="govuk-button fb-govuk-button"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,6 +120,7 @@ en:
       sign_out: Sign out %{user_name}
       user_guide: "User guide"
       user_guide_url: "https://moj-forms.service.justice.gov.uk/user-guide/"
+      user_guide_check_confirm_url: 'https://moj-forms.service.justice.gov.uk/building-and-editing/#check-confirm'
   home:
     show:
       title: MoJ Forms

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -347,8 +347,8 @@ en:
           pending: 'You have not validated your %{href} for emails'
           default: 'You have not set a %{href} for emails'
         production:
-          pending: 'You need to validate your %{href} for emails'
-          default: 'You need to set a %{href} for emails'
+          pending: 'validate your %{href} for emails'
+          default: 'set a %{href} for emails'
     confirmation_email:
       message: 'Your form must include an email question to enable a %{href}.'
       link_text: confirmation email
@@ -373,12 +373,12 @@ en:
     publish:
       dev:
         icon_fallback: 'Warning'
-        heading: 'You will not receive any responses from this form because:'
+        heading: 'Your form will not send any user submissions because:'
       production:
         icon_fallback: 'Error'
-        heading: 'Your form has issue(s) preventing submissions from being sent. Publishing to Live won’t be possible until they are resolved'
+        heading: 'Before you can publish to Live you must:'
     email_settings:
-      default: set and validate a team email address.
+      default: You need to set and validate a team email address.
       pending: You need to validate this email address.
   publish:
     name: 'Publishing'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -343,24 +343,24 @@ en:
       publishing:
         link: ‘from’ address
         dev:
-          pending: 'You have not validated your %{href} for emails'
-          default: 'You have not set a %{href} for emails'
+          pending: 'you have not validated your %{href} for emails'
+          default: 'you have not set a %{href} for emails'
         production:
-          pending: 'You need to validate your %{href} for emails'
-          default: 'You need to set a %{href} for emails'
+          pending: 'you need to validate your %{href} for emails'
+          default: 'you need to set a %{href} for emails'
     confirmation_email:
       message: 'Your form must include an email question to enable a %{href}.'
       link_text: confirmation email
       link_url: 'https://moj-forms.service.justice.gov.uk/settings/#confirmation-email'
     submission_pages:
       dev:
-        both_pages: 'Your form has no check answers page or confirmation page'
-        cya_page: 'Your form has no check answers page'
-        confirmation_page: 'Your form has no confirmation page'
+        both_pages: 'add a check answers page and a confirmation page'
+        cya_page: 'add a check answers page'
+        confirmation_page: 'add a confirmation page'
       production:
-        both_pages: 'You need to add a check answers page and a confirmation page'
-        cya_page: 'You need to add a check answers page'
-        confirmation_page: 'You need to add a confirmation page'
+        both_pages: 'add a check answers page and a confirmation page'
+        cya_page: 'add a check answers page'
+        confirmation_page: 'add a confirmation page'
     pages_flow:
       both_pages: 'You won’t receive any user data without a check answers page and a confirmation page'
       cya_page: 'You won’t receive any user data without a check answers page'
@@ -368,12 +368,12 @@ en:
     publish:
       dev:
         icon_fallback: 'Warning'
-        heading: 'Your form has issue(s) preventing submissions from being sent'
+        heading: 'You will not receive any responses from this form because: '
       production:
         icon_fallback: 'Error'
         heading: 'Your form has issue(s) preventing submissions from being sent. Publishing to Live won’t be possible until they are resolved'
     email_settings:
-      default: You need to set and validate a team email address.
+      default: set and validate a team email address.
       pending: You need to validate this email address.
   publish:
     name: 'Publishing'
@@ -381,16 +381,16 @@ en:
     autocomplete_items:
       dev:
         icon_fallback: 'Warning'
-        message: '“%{title}” has no autocomplete options and cannot be answered.'
+        message: 'upload some autocomplete options for “%{title}”'
       production:
         icon_fallback: 'Error'
-        message: 'You need to upload some autocomplete options for “%{title}”'
+        message: 'upload some autocomplete options for “%{title}”'
     environment:
       dev: Test
       production: Live
     service_output:
       icon_fallback: Warning
-      message: "No submission method is enabled, you will not receive any response"
+      message: "You have not set your form to collect information and will not receive any responses."
     dialog:
       heading: Publish to Test?
       option_1: Allow anyone with the link to view

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -343,24 +343,28 @@ en:
       publishing:
         link: ‘from’ address
         dev:
-          pending: 'you have not validated your %{href} for emails'
-          default: 'you have not set a %{href} for emails'
+          pending: 'You have not validated your %{href} for emails'
+          default: 'You have not set a %{href} for emails'
         production:
-          pending: 'you need to validate your %{href} for emails'
-          default: 'you need to set a %{href} for emails'
+          pending: 'You need to validate your %{href} for emails'
+          default: 'You need to set a %{href} for emails'
     confirmation_email:
       message: 'Your form must include an email question to enable a %{href}.'
       link_text: confirmation email
       link_url: 'https://moj-forms.service.justice.gov.uk/settings/#confirmation-email'
     submission_pages:
       dev:
-        both_pages: 'add a check answers page and a confirmation page'
-        cya_page: 'add a check answers page'
-        confirmation_page: 'add a confirmation page'
+        both_pages: 'it is missing a %{href}'
+        cya_page: 'it is missing a %{href}'
+        confirmation_page: ' it is missing a %{href}'
       production:
-        both_pages: 'add a check answers page and a confirmation page'
-        cya_page: 'add a check answers page'
-        confirmation_page: 'add a confirmation page'
+        both_pages: 'add a %{href}'
+        cya_page: 'add a %{href}'
+        confirmation_page: 'add a %{href}'
+      link:
+        both_pages: 'check answers page and confirmation page'
+        cya_page: 'check answers page'
+        confirmation_page: 'confirmation page'
     pages_flow:
       both_pages: 'You won’t receive any user data without a check answers page and a confirmation page'
       cya_page: 'You won’t receive any user data without a check answers page'
@@ -368,7 +372,7 @@ en:
     publish:
       dev:
         icon_fallback: 'Warning'
-        heading: 'You will not receive any responses from this form because: '
+        heading: 'You will not receive any responses from this form because:'
       production:
         icon_fallback: 'Error'
         heading: 'Your form has issue(s) preventing submissions from being sent. Publishing to Live won’t be possible until they are resolved'
@@ -381,7 +385,7 @@ en:
     autocomplete_items:
       dev:
         icon_fallback: 'Warning'
-        message: 'upload some autocomplete options for “%{title}”'
+        message: '“%{title}” has no autocomplete options and cannot be answered.'
       production:
         icon_fallback: 'Error'
         message: 'upload some autocomplete options for “%{title}”'
@@ -390,7 +394,8 @@ en:
       production: Live
     service_output:
       icon_fallback: Warning
-      message: "You have not set your form to collect information and will not receive any responses."
+      message: 'Your form will not send any user submissions until you enable %{href_collection_information_by_email}.'
+      link: collecting information by email
     dialog:
       heading: Publish to Test?
       option_1: Allow anyone with the link to view

--- a/spec/presenters/autocomplete_items_presenter_spec.rb
+++ b/spec/presenters/autocomplete_items_presenter_spec.rb
@@ -1,17 +1,11 @@
 RSpec.describe AutocompleteItemsPresenter do
   subject(:autocomplete_items_presenter) { described_class.new(service, autocomplete_items) }
-  let(:autocomplete_warning) do
-    I18n.t('publish.autocomplete_items.dev.message')
-  end
   let(:page) { service.find_page_by_url('countries') }
   let(:component_uuid) { page.components.first.uuid }
   let(:component_title) { page.components.first.humanised_title }
   let(:page_uuid) { page.uuid }
-  let(:warning_messages) do
-    [
-      { component_title: component_title, page_uuid: page_uuid }
-    ]
-  end
+  let(:environment) { 'test' }
+  let(:warning_messages) { [I18n.t("publish.autocomplete_items.#{environment}.message")] }
 
   describe '#messages' do
     context 'when all components have items' do

--- a/spec/presenters/autocomplete_items_presenter_spec.rb
+++ b/spec/presenters/autocomplete_items_presenter_spec.rb
@@ -1,11 +1,12 @@
 RSpec.describe AutocompleteItemsPresenter do
-  subject(:autocomplete_items_presenter) { described_class.new(service, autocomplete_items) }
+  subject(:autocomplete_items_presenter) { described_class.new(service, autocomplete_items, environment) }
   let(:page) { service.find_page_by_url('countries') }
   let(:component_uuid) { page.components.first.uuid }
   let(:component_title) { page.components.first.humanised_title }
   let(:page_uuid) { page.uuid }
-  let(:environment) { 'test' }
-  let(:warning_messages) { [I18n.t("publish.autocomplete_items.#{environment}.message")] }
+  let(:environment) { 'dev' }
+  let(:warning_messages) { I18n.t("publish.autocomplete_items.#{environment}.message", title: component_title) }
+  let(:url) { "/services/#{service.service_id}/pages/#{page_uuid}/edit" }
 
   describe '#messages' do
     context 'when all components have items' do
@@ -28,7 +29,11 @@ RSpec.describe AutocompleteItemsPresenter do
       end
 
       it 'should return an array with warning messages' do
-        expect(autocomplete_items_presenter.messages).to eq(warning_messages)
+        expect(strip_tags(autocomplete_items_presenter.messages.first)).to eq(warning_messages)
+      end
+
+      it 'should link to the correct page of the service' do
+        expect(autocomplete_items_presenter.messages.first).to include(url)
       end
     end
 
@@ -36,8 +41,12 @@ RSpec.describe AutocompleteItemsPresenter do
       let(:autocomplete_items) { double(metadata: { 'items' => {} }) }
 
       it 'it should return an array with warning messages' do
-        expect(autocomplete_items_presenter.messages).to eq(warning_messages)
+        expect(strip_tags(autocomplete_items_presenter.messages.first)).to eq(warning_messages)
       end
+    end
+
+    def strip_tags(string)
+      ActionController::Base.helpers.strip_tags(string)
     end
   end
 end

--- a/spec/presenters/publishing_page_presenter_spec.rb
+++ b/spec/presenters/publishing_page_presenter_spec.rb
@@ -73,63 +73,97 @@ RSpec.describe PublishingPagePresenter do
   end
 
   describe '#publish_button_disabled?' do
-    RSpec.shared_examples 'a publishing button' do
-      let(:deployment_environment) { 'production' }
-
-      before do
-        allow_any_instance_of(PublishServiceCreation).to receive(:no_service_output?).and_return(false)
-      end
-
-      context 'when there are submission warnings' do
-        before do
-          allow_any_instance_of(SubmissionWarningsPresenter).to receive(:messages).and_return(['Some messages'])
-        end
-
-        it 'returns truthy' do
-          expect(subject.publish_button_disabled?).to be_truthy
-        end
-      end
-
-      context 'when there are autocomplete warnings' do
-        before do
-          allow_any_instance_of(AutocompleteItemsPresenter).to receive(:messages).and_return(['Some messages'])
-        end
-
-        it 'returns truthy' do
-          expect(subject.publish_button_disabled?).to be_truthy
-        end
-      end
-
-      context 'when there are no submission or autocomplete warnings' do
-        before do
-          allow_any_instance_of(SubmissionWarningsPresenter).to receive(:messages).and_return([])
-          allow_any_instance_of(AutocompleteItemsPresenter).to receive(:messages).and_return([])
-        end
-
-        it 'returns falsey' do
-          expect(subject.publish_button_disabled?).to be_falsey
-        end
-      end
-    end
-
     context 'service output is disabled' do
+      before do
+        allow_any_instance_of(PublishServiceCreation).to receive(:no_service_output?).and_return(true)
+      end
       it 'returns falsey' do
         expect(subject.publish_button_disabled?).to be_falsey
       end
-    end
-
-    context 'service output is enabled' do
-      it_behaves_like 'a publishing button'
     end
 
     context 'deployment environment is dev' do
-      it 'returns falsey' do
-        expect(subject.publish_button_disabled?).to be_falsey
+      context 'when the service output is enabled' do
+        let(:deployment_environment) { 'dev' }
+
+        before do
+          allow_any_instance_of(PublishServiceCreation).to receive(:no_service_output?).and_return(false)
+        end
+
+        context 'when there are submission warnings' do
+          before do
+            allow_any_instance_of(SubmissionWarningsPresenter).to receive(:messages).and_return(['Some messages'])
+          end
+
+          it 'returns falsey' do
+            expect(subject.publish_button_disabled?).to be_falsey
+          end
+        end
+
+        context 'when there are autocomplete warnings' do
+          before do
+            allow_any_instance_of(AutocompleteItemsPresenter).to receive(:messages).and_return(['Some messages'])
+            allow_any_instance_of(AutocompleteItemsPresenter).to receive(:component_uuids_without_items).and_return(['Some components uuids'])
+          end
+
+          it 'returns falsey' do
+            expect(subject.publish_button_disabled?).to be_falsey
+          end
+        end
+
+        context 'when there are no submission or autocomplete warnings' do
+          before do
+            allow_any_instance_of(SubmissionWarningsPresenter).to receive(:messages).and_return([])
+            allow_any_instance_of(AutocompleteItemsPresenter).to receive(:messages).and_return([])
+          end
+
+          it 'returns falsey' do
+            expect(subject.publish_button_disabled?).to be_falsey
+          end
+        end
       end
     end
 
-    context 'deployment environment is production' do
-      it_behaves_like 'a publishing button'
+    context 'deployment environment is live' do
+      context 'when the service output is enabled' do
+        let(:deployment_environment) { 'production' }
+
+        before do
+          allow_any_instance_of(PublishServiceCreation).to receive(:no_service_output?).and_return(false)
+        end
+
+        context 'when there are submission warnings' do
+          before do
+            allow_any_instance_of(SubmissionWarningsPresenter).to receive(:messages).and_return(['Some messages'])
+          end
+
+          it 'returns truthy' do
+            expect(subject.publish_button_disabled?).to be_truthy
+          end
+        end
+
+        context 'when there are autocomplete warnings' do
+          before do
+            allow_any_instance_of(AutocompleteItemsPresenter).to receive(:messages).and_return(['Some messages'])
+            allow_any_instance_of(AutocompleteItemsPresenter).to receive(:component_uuids_without_items).and_return(['Some components uuids'])
+          end
+
+          it 'returns truthy' do
+            expect(subject.publish_button_disabled?).to be_truthy
+          end
+        end
+
+        context 'when there are no submission or autocomplete warnings' do
+          before do
+            allow_any_instance_of(SubmissionWarningsPresenter).to receive(:messages).and_return([])
+            allow_any_instance_of(AutocompleteItemsPresenter).to receive(:messages).and_return([])
+          end
+
+          it 'returns falsey' do
+            expect(subject.publish_button_disabled?).to be_falsey
+          end
+        end
+      end
     end
   end
 end

--- a/spec/presenters/publishing_page_presenter_spec.rb
+++ b/spec/presenters/publishing_page_presenter_spec.rb
@@ -32,11 +32,14 @@ RSpec.describe PublishingPagePresenter do
       expect(subject.submission_warnings).to be_a SubmissionWarningsPresenter
     end
 
-    context 'submission warning presenters' do
+    context 'submission warning presenters in production' do
+      let(:deployment_environment) { 'production' }
       let(:presenters) do
-        [submission_pages_presenter,
-         autocomplete_warning,
-         from_address_presenter]
+        [
+          submission_pages_presenter,
+          autocomplete_warning,
+          from_address_presenter
+        ]
       end
       let(:submission_pages_presenter) { double }
       let(:autocomplete_warning) { double }
@@ -45,6 +48,21 @@ RSpec.describe PublishingPagePresenter do
       before do
         allow(subject).to receive(:submission_pages_presenter).and_return(submission_pages_presenter)
         allow(subject).to receive(:autocomplete_warning).and_return(autocomplete_warning)
+        allow(subject).to receive(:from_address_presenter).and_return(from_address_presenter)
+      end
+
+      it 'returns the expected presenters' do
+        expect(subject.submission_warnings.presenters).to match_array(presenters)
+      end
+    end
+
+    context 'submission warning presenters in dev' do
+      let(:presenters) { [submission_pages_presenter, from_address_presenter] }
+      let(:submission_pages_presenter) { double }
+      let(:from_address_presenter) { double }
+
+      before do
+        allow(subject).to receive(:submission_pages_presenter).and_return(submission_pages_presenter)
         allow(subject).to receive(:from_address_presenter).and_return(from_address_presenter)
       end
 

--- a/spec/presenters/publishing_page_presenter_spec.rb
+++ b/spec/presenters/publishing_page_presenter_spec.rb
@@ -34,13 +34,17 @@ RSpec.describe PublishingPagePresenter do
 
     context 'submission warning presenters' do
       let(:presenters) do
-        [submission_pages_presenter, from_address_presenter]
+        [submission_pages_presenter,
+         autocomplete_warning,
+         from_address_presenter]
       end
       let(:submission_pages_presenter) { double }
+      let(:autocomplete_warning) { double }
       let(:from_address_presenter) { double }
 
       before do
         allow(subject).to receive(:submission_pages_presenter).and_return(submission_pages_presenter)
+        allow(subject).to receive(:autocomplete_warning).and_return(autocomplete_warning)
         allow(subject).to receive(:from_address_presenter).and_return(from_address_presenter)
       end
 

--- a/spec/presenters/submission_pages_presenter_spec.rb
+++ b/spec/presenters/submission_pages_presenter_spec.rb
@@ -1,12 +1,15 @@
 RSpec.describe SubmissionPagesPresenter do
-  let(:publish_warning_both_pages) do
-    I18n.t('warnings.submission_pages.dev.both_pages')
+  let(:link) do
+    "<a class=\"govuk-link\" href=\"https://moj-forms.service.justice.gov.uk/user-guide/\">#{warning_text}</a>"
   end
-  let(:publish_warning_cya_page) do
-    I18n.t('warnings.submission_pages.dev.cya_page')
+  let(:warning_text) do
+    I18n.t("warnings.submission_pages.link.#{page_with_warning}")
   end
-  let(:publish_warning_confirmation_page) do
-    I18n.t('warnings.submission_pages.dev.confirmation_page')
+  let(:publish_warning) do
+    I18n.t(
+      "warnings.submission_pages.dev.#{page_with_warning}",
+      href: link
+    )
   end
   let(:confirmation_uuid) { '778e364b-9a7f-4829-8eb2-510e08f156a3' }
   let(:checkanswers_uuid) { 'e337070b-f636-49a3-a65c-f506675265f0' }
@@ -41,8 +44,9 @@ RSpec.describe SubmissionPagesPresenter do
           MetadataPresenter::Service.new(metadata_fixture(:exit_only_service))
         end
 
+        let(:page_with_warning) { 'both_pages' }
         it 'returns the correct warning' do
-          expect(presenter.message).to eq(publish_warning_both_pages)
+          expect(presenter.message).to eq(publish_warning)
         end
       end
     end
@@ -62,9 +66,10 @@ RSpec.describe SubmissionPagesPresenter do
           end
           metadata
         end
+        let(:page_with_warning) { 'cya_page' }
 
         it 'returns the correct warning' do
-          expect(presenter.message).to eq(publish_warning_cya_page)
+          expect(presenter.message).to eq(publish_warning)
         end
       end
 
@@ -75,9 +80,10 @@ RSpec.describe SubmissionPagesPresenter do
           arnold_wrong_answers['next']['default'] = confirmation_uuid
           metadata
         end
+        let(:page_with_warning) { 'cya_page' }
 
         it 'returns the correct message' do
-          expect(presenter.message).to eq(publish_warning_cya_page)
+          expect(presenter.message).to eq(publish_warning)
         end
       end
     end
@@ -96,8 +102,10 @@ RSpec.describe SubmissionPagesPresenter do
           metadata
         end
 
+        let(:page_with_warning) { 'confirmation_page' }
+
         it 'returns the correct warning' do
-          expect(presenter.message).to eq(publish_warning_confirmation_page)
+          expect(presenter.message).to eq(publish_warning)
         end
       end
 
@@ -106,9 +114,10 @@ RSpec.describe SubmissionPagesPresenter do
           checkanswers_page['next']['default'] = ''
           metadata
         end
+        let(:page_with_warning) { 'confirmation_page' }
 
         it 'returns the correct warning' do
-          expect(presenter.message).to eq(publish_warning_confirmation_page)
+          expect(presenter.message).to eq(publish_warning)
         end
       end
     end

--- a/spec/presenters/submission_pages_presenter_spec.rb
+++ b/spec/presenters/submission_pages_presenter_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe SubmissionPagesPresenter do
   let(:link) do
-    "<a class=\"govuk-link\" href=\"https://moj-forms.service.justice.gov.uk/user-guide/\">#{warning_text}</a>"
+    "<a target=\"_blank\" class=\"govuk-link\" href=\"https://moj-forms.service.justice.gov.uk/building-and-editing/#check-confirm\">#{warning_text}</a>"
   end
   let(:warning_text) do
     I18n.t("warnings.submission_pages.link.#{page_with_warning}")


### PR DESCRIPTION
## Context
Publishing warnings are being updated. Some of the content has to be changed but also the display of autocomplete warnings with the other warnings.

## Implementation
In order to change the content it is a simple update of the translation file en.yml. In order to have the publishing warnings for autocomplete uniform with the rest, we add the publish them in the list if presenters for the publishing page presenter and remove them from the publish environment view.

## Tests
Unit tests and publishing acceptance tests have been updated. Local testing with manual observation performed.