### PR TITLE
Ensure confirmation email modal is prioritised over branching modals

### DIFF
--- a/app/models/destroy_page_modal.rb
+++ b/app/models/destroy_page_modal.rb
@@ -7,11 +7,11 @@ class DestroyPageModal
   delegate :expressions, :branches, to: :service
 
   PARTIALS = {
+    delete_page_used_for_confirmation_email?: 'delete_page_used_for_confirmation_email',
     potential_stacked_branches?: 'stack_branches_not_supported',
     delete_page_used_for_branching?: 'delete_page_used_for_branching_not_supported',
     branch_destination_with_default_next?: 'delete_branch_destination_page',
     branch_destination_no_default_next?: 'delete_branch_destination_page_no_default_next',
-    delete_page_used_for_confirmation_email?: 'delete_page_used_for_confirmation_email',
     default?: 'delete'
   }.freeze
 

--- a/spec/models/destroy_page_modal_spec.rb
+++ b/spec/models/destroy_page_modal_spec.rb
@@ -148,6 +148,38 @@ RSpec.describe DestroyPageModal do
         end
       end
 
+      context 'when confirmation email is used as a branching destination' do
+        let(:environment) { 'dev' }
+        let(:service_metadata) { metadata_fixture(:branching_12) }
+        let(:page) { service.find_page_by_url('email') }
+
+        context 'and the component is used on the page' do
+          let(:value) { 'email_email_1' }
+
+          before do
+            create(:submission_setting, :dev, :send_confirmation_email, service_id: service.service_id)
+            allow(destroy_page_modal).to receive(:confirmation_email_component_ids).and_return([service_configuration])
+          end
+
+          it 'returns delete_page_used_for_confirmation_email' do
+            expect(partial).to eq('api/pages/delete_page_used_for_confirmation_email_modal')
+          end
+        end
+
+        context 'and the component is not used on the page' do
+          let(:value) { 'email_not_used' }
+
+          before do
+            create(:submission_setting, :dev, :send_confirmation_email, service_id: service.service_id)
+            allow(destroy_page_modal).to receive(:confirmation_email_component_ids).and_return([service_configuration])
+          end
+
+          it 'returns deleting branch destination page partial' do
+            expect(partial).to eq('api/pages/delete_branch_destination_page_modal')
+          end
+        end
+      end
+
       context 'when deleting a page without any consequences' do
         it 'returns the default delete partial' do
           expect(partial).to eq(default_delete_partial)


### PR DESCRIPTION
[Trello](https://trello.com/c/0xsnJd78/3069-confirmation-email-no-warning-model-when-deleting-a-branching-destination-page)
Currently, when a user tries to delete a page that has an email component used in confirmation email and is a destination of a branch, the user is presented with the delete destination page modal. This modal allows the user to delete the page, this is not what we want, instead we want the confirmation email modal to appear as this blocks the user from deleting the page until they have changed their confirmation email settings.
This commit implements this change.

Note: We do not need to change the behaviour on the question level as the branching modals will only trigger for  radio or checkbox options and the confirmation email modals will only trigger on email components on a multiple question page.