### PR TITLE
Wait for intial delay before running rake task in cronjobs

### DIFF
--- a/deploy-eks/fb-editor-chart/templates/from_address.yaml
+++ b/deploy-eks/fb-editor-chart/templates/from_address.yaml
@@ -20,6 +20,7 @@ spec:
             args:
             - /bin/sh
             - -c
+            - /bin/sleep {{ .Values.readinessProbe.web.initialDelaySeconds }}
             - bundle exec rake from_address:sync
             securityContext:
               runAsUser: 1001

--- a/deploy-eks/fb-editor-chart/templates/remove_test_services_configs.yaml
+++ b/deploy-eks/fb-editor-chart/templates/remove_test_services_configs.yaml
@@ -21,6 +21,7 @@ spec:
             args:
             - /bin/sh
             - -c
+            - /bin/sleep {{ .Values.readinessProbe.web.initialDelaySeconds }}
             - bundle exec rake remove:test_services_configs
             securityContext:
               runAsUser: 1001

--- a/deploy-eks/fb-editor-chart/templates/sessions_trim.yaml
+++ b/deploy-eks/fb-editor-chart/templates/sessions_trim.yaml
@@ -20,6 +20,7 @@ spec:
             args:
             - /bin/sh
             - -c
+            - /bin/sleep {{ .Values.readinessProbe.web.initialDelaySeconds }}
             - rake db:sessions:trim
             securityContext:
               runAsUser: 1001

--- a/deploy-eks/fb-editor-chart/templates/unpublish_test_services.yaml
+++ b/deploy-eks/fb-editor-chart/templates/unpublish_test_services.yaml
@@ -21,6 +21,7 @@ spec:
             args:
             - /bin/sh
             - -c
+            - /bin/sleep {{ .Values.readinessProbe.web.initialDelaySeconds }}
             - bundle exec rake unpublish:test_services
             securityContext:
               runAsUser: 1001


### PR DESCRIPTION
We have been getting a number of connection errors to the DB when the cronjob task containers are spinning up.

Add a wait time before running the task to see if this helps