### PR TITLE
Upload metadata to S3 bucket on publishing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'delayed_job_active_record'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 gem 'metadata_presenter', '2.17.22'
 
+gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,13 @@ GEM
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
       jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.59.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.117.1)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
     aws-sdk-sesv2 (1.29.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
@@ -433,6 +440,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-session_store
   administrate
+  aws-sdk-s3
   aws-sdk-sesv2
   better_errors
   binding_of_caller

--- a/app/services/publisher/adapters/aws_s3_client.rb
+++ b/app/services/publisher/adapters/aws_s3_client.rb
@@ -1,0 +1,37 @@
+require 'aws-sdk-s3'
+
+class Publisher
+  module Adapters
+    class AwsS3Client
+      def initialize(platform_deployment)
+        @platform_deployment = platform_deployment
+      end
+
+      REGION = 'eu-west-2'.freeze
+
+      def upload(object_key, body)
+        Rails.logger.info("Uploading #{object_key} to S3")
+        s3.put_object(
+          body: body,
+          bucket: ENV["AWS_S3_BUCKET_#{platform_deployment}"],
+          key: object_key
+        )
+      end
+
+      private
+
+      attr_reader :platform_deployment
+
+      def s3
+        @s3 ||= Aws::S3::Client.new(region: REGION, credentials: credentials)
+      end
+
+      def credentials
+        Aws::Credentials.new(
+          ENV["AWS_S3_ACCESS_KEY_ID_#{platform_deployment}"],
+          ENV["AWS_S3_SECRET_ACCESS_KEY_#{platform_deployment}"]
+        )
+      end
+    end
+  end
+end

--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -24,11 +24,11 @@ class Publisher
     LIVE_PRODUCTION = 'live-production'.freeze
 
     def service_metadata
-      service.to_json.inspect
+      service.to_json
     end
 
     def autocomplete_items
-      Hash(autocomplete_response['items']).to_json.inspect
+      Hash(autocomplete_response['items']).to_json
     end
 
     def autocomplete_ids
@@ -135,6 +135,22 @@ class Publisher
 
     def secrets
       service_configuration.select(&:secrets?)
+    end
+
+    def aws_s3_access_key_id
+      ENV["AWS_S3_ACCESS_KEY_ID_#{platform_deployment_underscore}"]
+    end
+
+    def aws_s3_secret_access_key
+      ENV["AWS_S3_SECRET_ACCESS_KEY_#{platform_deployment_underscore}"]
+    end
+
+    def aws_s3_bucket_name
+      ENV["AWS_S3_BUCKET_#{platform_deployment_underscore}"]
+    end
+
+    def platform_deployment_underscore
+      @platform_deployment_underscore ||= platform_deployment.underscore.upcase
     end
 
     private

--- a/app/services/publisher/utils/service_metadata_files.rb
+++ b/app/services/publisher/utils/service_metadata_files.rb
@@ -1,0 +1,34 @@
+class Publisher
+  module Utils
+    class ServiceMetadataFiles
+      attr_reader :service_provisioner, :adapter
+
+      def initialize(service_provisioner, adapter)
+        @service_provisioner = service_provisioner
+        @adapter = adapter
+      end
+
+      def upload
+        adapter.upload(
+          service_metadata_key,
+          service_provisioner.service_metadata
+        )
+
+        adapter.upload(
+          autocomplete_items_key,
+          service_provisioner.autocomplete_items
+        )
+      end
+
+      private
+
+      def service_metadata_key
+        "#{service_provisioner.service_id}_metadata.json"
+      end
+
+      def autocomplete_items_key
+        "#{service_provisioner.service_id}_autocomplete_items.json"
+      end
+    end
+  end
+end

--- a/config/publisher/cloud_platform/deployment.yaml.erb
+++ b/config/publisher/cloud_platform/deployment.yaml.erb
@@ -44,18 +44,22 @@ spec:
             value: <%= submission_encryption_key %>
           - name: SERVICE_SLUG
             value: <%= service_slug %>
+          - name: SERVICE_ID
+            value: <%= service_id %>
           - name: PLATFORM_ENV
             value: <%= platform_environment %>
           - name: DEPLOYMENT_ENV
             value: <%= deployment_environment %>
           - name: SECRET_KEY_BASE
             value: <%= secret_key_base %>
-          - name: SERVICE_METADATA
-            value: <%= ERB::Util.json_escape(service_metadata) %>
-          - name: AUTOCOMPLETE_ITEMS
-            value: <%= autocomplete_items %>
           - name: SENTRY_DSN
             value: '<%= service_sentry_dsn %>'
+          - name: ACCESS_KEY_ID
+            value: <%= aws_s3_access_key_id %>
+          - name: SECRET_ACCESS_KEY
+            value: <%= aws_s3_secret_access_key %>
+          - name: BUCKET_NAME
+            value: <%= aws_s3_bucket_name %>
         <% secrets.each do |secret|  %>
           - name: <%= secret.name %>
             valueFrom:
@@ -68,10 +72,10 @@ spec:
         ports:
         - containerPort: <%= container_port %>
         resources:
-           limits:
+          limits:
             cpu: <%= resource_limits_cpu %>
             memory: <%= resource_limits_memory %>
-           requests:
+          requests:
             cpu: <%= resource_requests_cpu %>
             memory: <%= resource_requests_memory %>
         readinessProbe:

--- a/deploy-eks/fb-editor-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-editor-chart/templates/deployment.yaml
@@ -256,6 +256,36 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: slack_publish_webhook
+          - name: AWS_S3_ACCESS_KEY_ID_{{ .Values.environmentName | upper }}_DEV
+            valueFrom:
+              secretKeyRef:
+                name: s3-service-metadata-{{ .Values.environmentName }}
+                key: aws_s3_access_key_id_{{ .Values.environmentName }}_dev
+          - name: AWS_S3_SECRET_ACCESS_KEY_{{ .Values.environmentName | upper }}_DEV
+            valueFrom:
+              secretKeyRef:
+                name: s3-service-metadata-{{ .Values.environmentName }}
+                key: aws_s3_secret_access_key_{{ .Values.environmentName }}_dev
+          - name: AWS_S3_BUCKET_{{ .Values.environmentName | upper }}_DEV
+            valueFrom:
+              secretKeyRef:
+                name: s3-service-metadata-{{ .Values.environmentName }}
+                key: aws_s3_bucket_{{ .Values.environmentName }}_dev
+          - name: AWS_S3_ACCESS_KEY_ID_{{ .Values.environmentName | upper }}_PRODUCTION
+            valueFrom:
+              secretKeyRef:
+                name: s3-service-metadata-{{ .Values.environmentName }}
+                key: aws_s3_access_key_id_{{ .Values.environmentName }}_production
+          - name: AWS_S3_SECRET_ACCESS_KEY_{{ .Values.environmentName | upper }}_PRODUCTION
+            valueFrom:
+              secretKeyRef:
+                name: s3-service-metadata-{{ .Values.environmentName }}
+                key: aws_s3_secret_access_key_{{ .Values.environmentName }}_production
+          - name: AWS_S3_BUCKET_{{ .Values.environmentName | upper }}_PRODUCTION
+            valueFrom:
+              secretKeyRef:
+                name: s3-service-metadata-{{ .Values.environmentName }}
+                key: aws_s3_bucket_{{ .Values.environmentName }}_production
       volumes:
         - name: tmp-files
           emptyDir: {}

--- a/spec/fixtures/kubernetes_configuration/deployment.yaml
+++ b/spec/fixtures/kubernetes_configuration/deployment.yaml
@@ -44,18 +44,22 @@ spec:
             value: 65a27a35-c475-48b9-9a20-30142f14
           - name: SERVICE_SLUG
             value: acceptance-tests-date
+          - name: SERVICE_ID
+            value: 0da69306-cafd-4d32-bbee-fff98cac74ce
           - name: PLATFORM_ENV
             value: test
           - name: DEPLOYMENT_ENV
             value: dev
           - name: SECRET_KEY_BASE
             value: 'fdfdd491d611aa1abef54cbf24a709a1bb31ff881a487f8c58c69399202b08f77019920f481e17b40dd7452361055534b9f91f172719ed98a088498242f96f59'
-          - name: SERVICE_METADATA
-            value: "{\"service_name\":\"acceptance-tests-date\",\"test_escaping\":\"I don't know\"}"
-          - name: AUTOCOMPLETE_ITEMS
-            value: "{\"some-component-uuid\":[{\"text\":\"some text\",\"value\":\"some value\"}]}"
           - name: SENTRY_DSN
             value: 'sentry-dsn-test'
+          - name: ACCESS_KEY_ID
+            value: access-key-id
+          - name: SECRET_ACCESS_KEY
+            value: secret-access-key
+          - name: BUCKET_NAME
+            value: bucket-name
           - name: ENCODED_PRIVATE_KEY
             valueFrom:
               secretKeyRef:
@@ -81,10 +85,10 @@ spec:
         ports:
         - containerPort: 3000
         resources:
-           limits:
+          limits:
             cpu: 150m
             memory: 300Mi
-           requests:
+          requests:
             cpu: 10m
             memory: 128Mi
         readinessProbe:

--- a/spec/services/publisher/adapters/aws_s3_client_spec.rb
+++ b/spec/services/publisher/adapters/aws_s3_client_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Publisher::Adapters::AwsS3Client do
+  subject(:aws_s3_client) do
+    described_class.new(platform_deployment)
+  end
+  let(:platform_deployment) { 'TEST_DEV' }
+
+  describe '#upload' do
+    let(:body) { { foo: 'bar' } }
+    let(:bucket) { 'some-bucket' }
+    let(:object_key) { 'some-object-key' }
+
+    before do
+      allow(ENV).to receive(:[])
+      allow(ENV).to receive(:[]).with("AWS_S3_BUCKET_#{platform_deployment}").and_return(bucket)
+    end
+
+    it 'should upload an object to s3' do
+      expect_any_instance_of(Aws::S3::Client).to receive(:put_object).with(
+        body: body,
+        bucket: bucket,
+        key: object_key
+      )
+      aws_s3_client.upload(object_key, body)
+    end
+  end
+end

--- a/spec/services/publisher/adapters/cloud_platform_spec.rb
+++ b/spec/services/publisher/adapters/cloud_platform_spec.rb
@@ -2,9 +2,10 @@ RSpec.describe Publisher::Adapters::CloudPlatform do
   subject(:cloud_platform) do
     described_class.new(service_provisioner)
   end
+  let(:service_id) { '0da69306-cafd-4d32-bbee-fff98cac74ce' }
   let(:service_provisioner) do
     ::Publisher::ServiceProvisioner.new(
-      service_id: '0da69306-cafd-4d32-bbee-fff98cac74ce',
+      service_id: service_id,
       platform_environment: 'test',
       deployment_environment: 'dev'
     )
@@ -22,10 +23,11 @@ RSpec.describe Publisher::Adapters::CloudPlatform do
   describe '#pre_publishing' do
     let(:response) { :ok }
 
-    it 'generates kubernetes configuration' do
+    it 'uploads metadata files and generates kubernetes configuration' do
+      expect_any_instance_of(Publisher::Utils::ServiceMetadataFiles).to receive(:upload)
       expect_any_instance_of(Publisher::Utils::KubernetesConfiguration).to receive(:generate)
-          .with(destination: config_dir)
-          .and_return(response)
+        .with(destination: config_dir)
+        .and_return(response)
       expect(cloud_platform.pre_publishing).to be(:ok)
     end
   end

--- a/spec/services/publisher/service_provisioner_spec.rb
+++ b/spec/services/publisher/service_provisioner_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Publisher::ServiceProvisioner do
 
     it 'returns slug using the service name' do
       expect(service_provisioner.service_metadata).to eq(
-        JSON.generate(service_metadata).inspect
+        JSON.generate(service_metadata)
       )
     end
   end
@@ -63,7 +63,7 @@ RSpec.describe Publisher::ServiceProvisioner do
 
       it 'generates the correct autocomplete items data structure' do
         expect(service_provisioner.autocomplete_items).to eq(
-          autocomplete_response['items'].to_json.inspect
+          autocomplete_response['items'].to_json
         )
       end
     end
@@ -78,7 +78,7 @@ RSpec.describe Publisher::ServiceProvisioner do
       end
 
       it 'generates the correct empty json string' do
-        expect(service_provisioner.autocomplete_items).to eq('"{}"')
+        expect(service_provisioner.autocomplete_items).to eq('{}')
       end
     end
 
@@ -90,7 +90,7 @@ RSpec.describe Publisher::ServiceProvisioner do
       end
 
       it 'generates the correct empty json string' do
-        expect(service_provisioner.autocomplete_items).to eq('"{}"')
+        expect(service_provisioner.autocomplete_items).to eq('{}')
       end
     end
   end

--- a/spec/services/publisher/utils/kubernetes_configuration_spec.rb
+++ b/spec/services/publisher/utils/kubernetes_configuration_spec.rb
@@ -65,6 +65,15 @@ RSpec.describe Publisher::Utils::KubernetesConfiguration do
     allow(MetadataApiClient::Items).to receive(:all)
       .with(service_id: '0da69306-cafd-4d32-bbee-fff98cac74ce')
       .and_return(MetadataApiClient::Items.new(autocomplete_items))
+    allow(ENV).to receive(:[])
+      .with('AWS_S3_ACCESS_KEY_ID_TEST_DEV')
+      .and_return('access-key-id')
+    allow(ENV).to receive(:[])
+      .with('AWS_S3_SECRET_ACCESS_KEY_TEST_DEV')
+      .and_return('secret-access-key')
+    allow(ENV).to receive(:[])
+      .with('AWS_S3_BUCKET_TEST_DEV')
+      .and_return('bucket-name')
   end
 
   describe '#generate' do

--- a/spec/services/publisher/utils/service_metadata_files_spec.rb
+++ b/spec/services/publisher/utils/service_metadata_files_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe Publisher::Utils::ServiceMetadataFiles do
+  subject(:service_metadata_files) do
+    described_class.new(service_provisioner, adapter)
+  end
+  let(:service_id) { SecureRandom.uuid }
+  let(:service_metadata) { '{}' }
+  let(:autocomplete_items) { '{}' }
+  let(:service_provisioner) do
+    double(
+      service_id: service_id,
+      service_metadata: service_metadata,
+      autocomplete_items: autocomplete_items
+    )
+  end
+  let(:adapter) { double }
+
+  context 'uploading service metadata files' do
+    it 'uploads the service metadata and autocomplete items files' do
+      expect(adapter).to receive(:upload).with(
+        "#{service_id}_metadata.json",
+        service_metadata
+      ).once
+      expect(adapter).to receive(:upload).with(
+        "#{service_id}_autocomplete_items.json",
+        autocomplete_items
+      ).once
+      service_metadata_files.upload
+    end
+  end
+end


### PR DESCRIPTION
We have finally reached the point where the size of the metadata for
forms being injected into containers as an environment variable has
become too large.

To get round this issue, during the pre_publishing step we upload both
the service metadata and any autocomplete items associated with
autocompete components to an S3 bucket in the given platform namespace:

For test environments these are:

- formbuilder-platform-test-dev
- formbuilder-platform-test-production

For live environments these are:

- formbuilder-platform-live-dev
- formbuilder-platform-live-production

Yes these namespace names are confusing.

Currently the credentials for each of these buckects are set manually as
a secret in Kubernetes however they will in the near future be moved
into to match the way other secrets are injected into the Editor.

We have also removed the injection of the service metadata and
autocomplete items into the environment of the form containers entirely.
Each form will make a request to the S3 bucket to retrieve two objects:

- <service_id>_metadata.json
- <service_id>_autocomplete_items.json

<img width="892" alt="Screenshot 2022-11-13 at 18 40 26" src="https://user-images.githubusercontent.com/3466862/201538569-a89818b3-2cce-4e95-a2c0-d65c989df54e.png">
