### PR TITLE
Do not build testable editor workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,21 +131,6 @@ jobs:
           fail_only: true
           failure_message: ":facepalm:  Failed job ${CIRCLE_JOB} for ${CIRCLE_BRANCH}  :homer-disappear:"
           include_job_number_field: false
-  build_workers_testable_branch:
-    working_directory: ~/circle/git/fb-editor
-    docker: *ecr_image
-    steps:
-      - checkout
-      - setup_remote_docker: *remote_docker
-      - run: *build_sha
-      - run: *deploy_scripts
-      - run:
-          name: build testable editor workers docker images
-          environment:
-            ENVIRONMENT_NAME: test
-            IMAGE_TYPE: workers
-          command: './deploy-scripts/bin/build'
-      - slack/status: *testable_slack_status
   deploy_testable_branch:
     working_directory: ~/circle/git/fb-editor
     docker: *ecr_image
@@ -427,22 +412,10 @@ workflows:
             branches:
               only:
                 - /testable-.*/
-      - build_workers_testable_branch:
-          context: *context
-          requires:
-            - lint
-            - security
-            - rspec_test
-            - js_test
-          filters:
-            branches:
-              only:
-                - /testable-.*/
       - deploy_testable_branch:
           context: *context
           requires:
             - build_web_testable_branch
-            - build_workers_testable_branch
       - testable_branch_acceptance_tests:
           context: *context
           requires:

--- a/app/services/testable_editor_remover.rb
+++ b/app/services/testable_editor_remover.rb
@@ -1,10 +1,8 @@
 class TestableEditorRemover
   WEB = '-web-test'.freeze
-  WORKERS = '-workers-test'.freeze
   CONFIGURATIONS = [
     { type: 'configmap', append: '-config-map' },
     { type: 'deployment', append: WEB },
-    { type: 'deployment', append: WORKERS },
     { type: 'hpa', append: WEB },
     { type: 'ingress', append: '-ing-test' },
     { type: 'service', append: '-svc-test' },
@@ -48,7 +46,7 @@ class TestableEditorRemover
   def unique_testable_deployments
     deployments = kubernetes_deployments.split("\n").map do |deployment|
       if deployment.include?(TESTABLE)
-        deployment.split(' ')[0].gsub(/#{WEB}|#{WORKERS}/, '')
+        deployment.split(' ')[0].gsub(/#{WEB}/, '')
       end
     end
     deployments.compact.uniq

--- a/deploy-eks/fb-editor-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-editor-chart/templates/deployment.yaml
@@ -152,8 +152,11 @@ spec:
       volumes:
         - name: tmp-files
           emptyDir: {}
----
+
 # workers
+# Only build workers for the main branch editor
+{{- if eq .Values.app_name "fb-editor" }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -294,3 +297,4 @@ spec:
       volumes:
         - name: tmp-files
           emptyDir: {}
+{{- end }}

--- a/spec/services/testable_editor_remover_spec.rb
+++ b/spec/services/testable_editor_remover_spec.rb
@@ -6,13 +6,12 @@ RSpec.describe TestableEditorRemover do
       "origin/HEAD -> origin/main\n  origin/acceptance-test/delete-component-multi-question\n  origin/main\n  origin/test-create-form\n  origin/testable-editor-to-keep"
     end
     let(:kubernetes_deployments) do
-      "NAME                                                              READY   UP-TO-DATE   AVAILABLE   AGE\ntestable-editor-to-keep-web-test                                2/2     2            2           134d\ntestable-editor-to-keep-workers-test                           2/2     2            2           134d\nfb-metadata-api-test                                              2/2     2            2           245d\ntestable-editor-to-remove-web-test       2/2     2            2           2d3h\ntestable-editor-to-remove-workers-test   2/2     2            2           2d3h"
+      "NAME                                                              READY   UP-TO-DATE   AVAILABLE   AGE\ntestable-editor-to-keep-web-test                                2/2     2            2           134d\nfb-metadata-api-test                                              2/2     2            2           245d\ntestable-editor-to-remove-web-test       2/2     2            2           2d3h"
     end
     let(:expected_targets) do
       [
         { config: 'configmap', name: 'testable-editor-to-remove-config-map' },
         { config: 'deployment', name: 'testable-editor-to-remove-web-test' },
-        { config: 'deployment', name: 'testable-editor-to-remove-workers-test' },
         { config: 'hpa', name: 'testable-editor-to-remove-web-test' },
         { config: 'ingress', name: 'testable-editor-to-remove-ing-test' },
         { config: 'service', name: 'testable-editor-to-remove-svc-test' },


### PR DESCRIPTION
This change will stop any testable editors creating corresponding worker deployments.

Having several sets of different code bases all reading off of the same delayed job queue causes uncecessary behavioural disparities.