### PR TITLE
Do not reject service email from configuration

### DIFF
--- a/app/models/service_configuration.rb
+++ b/app/models/service_configuration.rb
@@ -16,7 +16,6 @@ class ServiceConfiguration < ApplicationRecord
   ].freeze
   CONFIRMATION_EMAIL = %w[
     CONFIRMATION_EMAIL_COMPONENT_ID
-    SERVICE_EMAIL_FROM
     CONFIRMATION_EMAIL_SUBJECT
     CONFIRMATION_EMAIL_BODY
   ].freeze

--- a/spec/services/publisher/service_provisioner_spec.rb
+++ b/spec/services/publisher/service_provisioner_spec.rb
@@ -184,6 +184,29 @@ RSpec.describe Publisher::ServiceProvisioner do
     end
   end
 
+  describe '#config_map' do
+    let(:attributes) do
+      {
+        service_id: service_id,
+        platform_environment: 'test',
+        deployment_environment: 'dev',
+        service_configuration: [
+          build(:service_configuration, :service_email_from, service_id: service_id, name: 'SERVICE_EMAIL_FROM', deployment_environment: 'dev')
+        ]
+      }
+    end
+
+    let(:service_id) { SecureRandom.uuid }
+
+    before do
+      SubmissionSetting.create(service_id: service_id, deployment_environment: 'dev', send_email: true)
+    end
+
+    it 'should have a email from' do
+      expect(service_provisioner.config_map.map(&:name)).to include('SERVICE_EMAIL_FROM')
+    end
+  end
+
   describe '#strategy_max_surge' do
     it 'returns the max surge configuration' do
       expect(service_provisioner.strategy_max_surge).to eq('200%')


### PR DESCRIPTION
When a user has enabled send by email but not enabled confirmation email. We want to make that the service email from is still injected in the form container.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>