### PR TITLE
Add components helpers and use them

### DIFF
--- a/app/helpers/moj_forms_components_helper.rb
+++ b/app/helpers/moj_forms_components_helper.rb
@@ -1,0 +1,14 @@
+module MojFormsComponentsHelper
+  {
+    mojf_settings_screen: 'MojForms::SettingsScreenComponent',
+    mojf_back_link: 'MojForms::BackLinkComnponent'
+  }.each do |name, klass|
+    define_method(name) do |*args, **kwargs, &block|
+      capture do
+        render(klass.constantize.new(*args, **kwargs)) do |com|
+          block.call(com) if block.present?
+        end
+      end
+    end
+  end
+end

--- a/app/views/settings/confirmation_email/index.html.erb
+++ b/app/views/settings/confirmation_email/index.html.erb
@@ -1,4 +1,4 @@
-<%= render MojForms::SettingsScreenComponent.new(
+<%= mojf_settings_screen(
   heading:t('settings.confirmation_email.heading'),
   description: t('settings.confirmation_email.description')
   ) do |c| %>

--- a/app/views/settings/email/index.html.erb
+++ b/app/views/settings/email/index.html.erb
@@ -1,4 +1,4 @@
-<%= render MojForms::SettingsScreenComponent.new(
+<%= mojf_settings_screen(
   heading:t('settings.collection_email.heading'),
   description: t('settings.collection_email.description')
   ) do |c| %>

--- a/app/views/settings/form_analytics/index.html.erb
+++ b/app/views/settings/form_analytics/index.html.erb
@@ -1,4 +1,4 @@
-<%= render MojForms::SettingsScreenComponent.new(
+<%= mojf_settings_screen(
   heading:t('settings.form_analytics.heading'),
   description: t('settings.form_analytics.description')
   ) do |c| %>

--- a/app/views/settings/form_information/index.html.erb
+++ b/app/views/settings/form_information/index.html.erb
@@ -1,4 +1,4 @@
-<%= render MojForms::SettingsScreenComponent.new(
+<%= mojf_settings_screen(
   heading:t('settings.form_information.heading'),
   description: t('settings.form_information.description')
 ) do |c| %>

--- a/app/views/settings/from_address/index.html.erb
+++ b/app/views/settings/from_address/index.html.erb
@@ -4,7 +4,7 @@
     html: { class: (@from_address.errors.any? ? 'with-errors' : '') },
     builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
 
-<%= render MojForms::SettingsScreenComponent.new(
+<%= mojf_settings_screen(
   heading:t('settings.from_address.heading'),
   description: t('settings.from_address.description')
   ) do |c| %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,4 +1,4 @@
-<%= render MojForms::SettingsScreenComponent.new(heading:t('settings.name')) do |c| %>
+<%= mojf_settings_screen(heading:t('settings.name')) do |c| %>
   <nav class="govuk-navigation" aria-labelledby="page-heading">
     <dl class="fb-settings-list">
       <div>

--- a/app/views/settings/submission/index.html.erb
+++ b/app/views/settings/submission/index.html.erb
@@ -1,4 +1,4 @@
-<%= render MojForms::SettingsScreenComponent.new(
+<%= mojf_settings_screen(
   heading:t('settings.submission.heading'),
   ) do |c| %>
 


### PR DESCRIPTION
This PR replicates the view helper from the GOVUK Components gem for MOJ Forms Components.

Allows us to write:
`<%= mojf_settings_screen(heading: 'Page title') do %>` instead of 
`<%= render MOJForms::SettingsScreenComponent.new(heeading: 'Page Title') do %>`
More convenient and easier to read 🙂