### PR TITLE
Add definition list component for settings screens

### DIFF
--- a/app/components/moj_forms/definition_list_component.rb
+++ b/app/components/moj_forms/definition_list_component.rb
@@ -1,5 +1,6 @@
 module MojForms
   class DefinitionListComponent < GovukComponent::Base
+    renders_many :items, DefinitionListItemComponent
 
     def initialize(classes: [], html_attributes: {})
       super(classes: classes, html_attributes: html_attributes)
@@ -7,14 +8,18 @@ module MojForms
 
     def call
       tag.dl(**html_attributes) do
-        content
+        if items?
+          safe_join(items.collect { |item| item })
+        else
+          content
+        end
       end
     end
 
     private
 
     def default_attributes
-      { class: %w[mojf-definition-list]}
+      { class: %w[mojf-definition-list] }
     end
   end
 end

--- a/app/components/moj_forms/definition_list_component.rb
+++ b/app/components/moj_forms/definition_list_component.rb
@@ -1,0 +1,20 @@
+module MojForms
+  class DefinitionListComponent < GovukComponent::Base
+
+    def initialize(classes: [], html_attributes: {})
+      super(classes: classes, html_attributes: html_attributes)
+    end
+
+    def call
+      tag.dl(**html_attributes) do
+        content
+      end
+    end
+
+    private
+
+    def default_attributes
+      { class: %w[mojf-definition-list]}
+    end
+  end
+end

--- a/app/components/moj_forms/definition_list_item_component.rb
+++ b/app/components/moj_forms/definition_list_item_component.rb
@@ -1,0 +1,34 @@
+module MojForms
+  class DefinitionListItemComponent < GovukComponent::Base
+    include GovukLinkHelper
+
+    attr_reader :title, :href, :description
+
+    def initialize(title: , href: , description: , classes: [], html_attributes: {} )
+      @title = title
+      @href = href
+      @description = description
+      super(classes:classes, html_attributes: html_attributes)
+    end
+
+    def call
+      tag.div(**html_attributes) do
+       safe_join([dt, dd])
+      end
+    end
+
+    private
+
+    def dt
+      tag.dt govuk_link_to(title, href)
+    end
+
+    def dd
+      tag.dd description, class: 'govuk-hint'
+    end
+
+    def default_attributes
+      { class: %w[mojf-definition-list__item]}
+    end
+  end
+end

--- a/app/components/moj_forms/definition_list_item_component.rb
+++ b/app/components/moj_forms/definition_list_item_component.rb
@@ -4,16 +4,21 @@ module MojForms
 
     attr_reader :title, :href, :description
 
-    def initialize(title: , href: , description: , classes: [], html_attributes: {} )
+    def initialize(title:, href:, description:, display: true, classes: [], html_attributes: {})
       @title = title
       @href = href
       @description = description
-      super(classes:classes, html_attributes: html_attributes)
+      @display = display
+      super(classes: classes, html_attributes: html_attributes)
+    end
+
+    def render?
+      @display
     end
 
     def call
       tag.div(**html_attributes) do
-       safe_join([dt, dd])
+        safe_join([dt, dd])
       end
     end
 
@@ -28,7 +33,7 @@ module MojForms
     end
 
     def default_attributes
-      { class: %w[mojf-definition-list__item]}
+      { class: %w[mojf-definition-list__item] }
     end
   end
 end

--- a/app/helpers/moj_forms_components_helper.rb
+++ b/app/helpers/moj_forms_components_helper.rb
@@ -2,6 +2,8 @@ module MojFormsComponentsHelper
   {
     mojf_settings_screen: 'MojForms::SettingsScreenComponent',
     mojf_back_link: 'MojForms::BackLinkComnponent',
+    mojf_definition_list: 'MojForms::DefinitionListComponent',
+    mojf_definition_list_item: 'MojForms::DefinitionListItemComponent',
   }.each do |name, klass|
     define_method(name) do |*args, **kwargs, &block|
       capture do

--- a/app/helpers/moj_forms_components_helper.rb
+++ b/app/helpers/moj_forms_components_helper.rb
@@ -1,7 +1,7 @@
 module MojFormsComponentsHelper
   {
     mojf_settings_screen: 'MojForms::SettingsScreenComponent',
-    mojf_back_link: 'MojForms::BackLinkComnponent'
+    mojf_back_link: 'MojForms::BackLinkComnponent',
   }.each do |name, klass|
     define_method(name) do |*args, **kwargs, &block|
       capture do

--- a/app/helpers/moj_forms_components_helper.rb
+++ b/app/helpers/moj_forms_components_helper.rb
@@ -3,7 +3,7 @@ module MojFormsComponentsHelper
     mojf_settings_screen: 'MojForms::SettingsScreenComponent',
     mojf_back_link: 'MojForms::BackLinkComnponent',
     mojf_definition_list: 'MojForms::DefinitionListComponent',
-    mojf_definition_list_item: 'MojForms::DefinitionListItemComponent',
+    mojf_definition_list_item: 'MojForms::DefinitionListItemComponent'
   }.each do |name, klass|
     define_method(name) do |*args, **kwargs, &block|
       capture do

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -1190,20 +1190,5 @@ html {
   }
 }
 
-dl {
-  @extend %govuk-list
-}
 
-dl dt {
-  margin-bottom: govuk-spacing(2);
-}
-
-dl dd {
-  margin: 0;
-}
-
-dl > dt:not(:first-of-type),
-dl > div:not(:first-of-type){
-  margin-top: govuk-spacing(7);
-}
 

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -24,6 +24,7 @@
 @import "./component_status_message";
 @import "components/settings-screen";
 @import "components/back-link";
+@import "components/definition-list";
 @import "./shared/content";
 @import "./index";
 @import "./admin"

--- a/app/javascript/styles/components/definition-list.scss
+++ b/app/javascript/styles/components/definition-list.scss
@@ -1,0 +1,16 @@
+dl {
+  @extend %govuk-list
+}
+
+dl dt {
+  margin-bottom: govuk-spacing(2);
+}
+
+dl dd {
+  margin: 0;
+}
+
+dl > dt:not(:first-of-type),
+dl > div:not(:first-of-type){
+  margin-top: govuk-spacing(7);
+}

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,18 +1,23 @@
 <%= mojf_settings_screen(heading:t('settings.name')) do |c| %>
   <nav class="govuk-navigation" aria-labelledby="page-heading">
-    <dl class="fb-settings-list">
-      <div>
-        <dt><%= link_to t('settings.form_information.heading'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %></dt>
-        <dd class="govuk-hint"><%= t('settings.form_information.lede') %></dd>
-      </div>
-      <div>
-        <dt><%= link_to t('settings.form_analytics.heading'), settings_form_analytics_path(service.service_id), class: 'govuk-link' %></dt>
-        <dd class="govuk-hint" ><%= t('settings.form_analytics.lede') %></dd>
-      </div>
-      <div>
-        <dt><%= link_to t('settings.submission.heading'), settings_submission_index_path(service.service_id), class: 'govuk-link' %></dt>
-        <dd class="govuk-hint" ><%= t('settings.submission.lede') %></dd>
-      </div>
-    </dl>
+    <%= mojf_definition_list do %>
+      <%= mojf_definition_list_item(
+        title: t('settings.form_information.heading'),
+        href: settings_form_information_index_path(service.service_id),
+        description: t('settings.form_information.lede')
+      ) %>
+
+      <%= mojf_definition_list_item(
+        title: t('settings.form_analytics.heading'),
+        href: settings_form_analytics_path(service.service_id),
+        description: t('settings.form_analytics.lede')
+      ) %>
+
+      <%= mojf_definition_list_item(
+        title: t('settings.submission.heading'),
+        href: settings_submission_index_path(service.service_id),
+        description: t('settings.submission.lede')
+      ) %>
+    <% end %>
   </nav>
 <% end %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,23 +1,23 @@
 <%= mojf_settings_screen(heading:t('settings.name')) do |c| %>
   <nav class="govuk-navigation" aria-labelledby="page-heading">
-    <%= mojf_definition_list do %>
-      <%= mojf_definition_list_item(
+    <%= mojf_definition_list do |c| %>
+      <% c.with_items([
+      {
         title: t('settings.form_information.heading'),
         href: settings_form_information_index_path(service.service_id),
         description: t('settings.form_information.lede')
-      ) %>
-
-      <%= mojf_definition_list_item(
+      },
+      {
         title: t('settings.form_analytics.heading'),
         href: settings_form_analytics_path(service.service_id),
         description: t('settings.form_analytics.lede')
-      ) %>
-
-      <%= mojf_definition_list_item(
+      },
+      {
         title: t('settings.submission.heading'),
         href: settings_submission_index_path(service.service_id),
         description: t('settings.submission.lede')
-      ) %>
+      }
+      ]) %>
     <% end %>
   </nav>
 <% end %>

--- a/app/views/settings/submission/index.html.erb
+++ b/app/views/settings/submission/index.html.erb
@@ -5,19 +5,25 @@
   <% c.with_back_link(href: settings_path) %>
 
   <nav class="govuk-navigation" aria-labelledby="page-heading">
-    <dl aria-labelledby="submission-settings-navigation-heading" class="fb-settings">
-      <div>
-        <dt><%= link_to t('settings.from_address.heading'), settings_from_address_index_path(service.service_id), class: 'govuk-link' %></dt>
-        <dd class="govuk-hint"><%= t('settings.from_address.lede') %></dd>
-      </div>
-      <div>
-        <dt><%= link_to t('settings.collection_email.heading'), settings_email_index_path(service.service_id), class: 'govuk-link' %></dt>
-        <dd class="govuk-hint"><%= t('settings.collection_email.lede') %></dd>
-      </div>
-        <div>
-          <dt><%= link_to t('settings.confirmation_email.heading'), settings_confirmation_email_index_path(service.service_id), class: 'govuk-link' %></dt>
-          <dd class="govuk-hint" ><%= t('settings.confirmation_email.lede') %></dd>
-        </div>
-    </dl>
+    <%= mojf_definition_list do |c| %>
+      <% c.with_items([
+        {
+          title: t('settings.from_address.heading'),
+          href: settings_from_address_index_path(service.service_id),
+          description: t('settings.from_address.lede')
+        },
+        {
+          title: t('settings.collection_email.heading'),
+          href: settings_email_index_path(service.service_id),
+          description: t('settings.collection_email.lede')
+        },
+        {
+          title: t('settings.confirmation_email.heading'),
+          href: settings_confirmation_email_index_path(service.service_id),
+          description: t('settings.confirmation_email.lede'),
+          display: ENV['CONFIRMATION_EMAIL'] == 'enabled'
+        }
+      ]) %>
+    <% end %>
   </nav>
 <% end %>


### PR DESCRIPTION
This PR adds a new component to make rendering lists for settings screens easier / more consistent.

Instead of this:
```
<dl class="fb-settings-list">
  <div>
    <dt><%= link_to t('settings.form_information.heading'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %></dt>
    <dd class="govuk-hint"><%= t('settings.form_information.lede') %></dd>
  </div>
  ...
</dl>
```

we can write this:
```
<%= mojf_definition_list do |c| %>
  <% c.with_items([
      {
        title: t('settings.form_information.heading'),
        href: settings_form_information_index_path(service.service_id),
        description: t('settings.form_information.lede')
      },
      ...
]) %>
<% end %>
```

Instead of using `with_items` it is also possible to use standard block content within the `DefinitionListComponent` and manually render `DefinitionListItemComponent`s e.g.

```
<%= mojf_definition_list do |c| %>
  <%= mojf_definition_list_item(
    title: 'Title',
    href: 'http://google.com',
    description: 'A description of the list item')
  %>
<% end %>
```

The `DefinitionListItemComponent` also takes a `display` parameter, giving the ability to hide settings items that are behind feature flags:

```
<%= mojf_definition_list_item(
    title: 'Title',
    href: 'http://google.com',
    description: 'A description of the list item'),
    display: ENV('feature') == 'enabled'
  %>
```

### Questions:

1) Is this an improvement?
2) Does this make writing the UI templates easier from a backend perspective?
3) There are two methods of writing templates for ViewComponents - either an inline template within the component class or a separate `html.erb` template - which is our preference?

```
def call
  tag.dl(**html_attributes) do
    if items?
      safe_join( items.collect { |item| item } )
    else
      content
    end
  end
end
```
or a separate html template:
```
#app/components/mojf/definition_list_component.html.erb
<%= tag.dl(**html_attributes) do %>
  <% if items? %>
    <% items.each do |item| %>
      <%= item %>
    <% end %>
  <% else %>
    <%= content %>
  <% end %>
<% end %>
```

I have opted for the inline method here (mostly for brevity and simplicity) is this the preferred method?  Is it easier to understand / reaosn about having it in a more ruby style? Or would we prefer a more 'classic' `html.erb` template?

