### PR TITLE
Fix focus issue on activated menus after modal trigger

### DIFF
--- a/app/javascript/src/components/menus/activated_menu.js
+++ b/app/javascript/src/components/menus/activated_menu.js
@@ -6,7 +6,7 @@
  * button to open the menu.
  *
  * This class does the following:
- *  - Takes the provided jQuery <ul> node and wraps it in an 
+ *  - Takes the provided jQuery <ul> node and wraps it in an
  *    ActvatedMenuContainer
  *  - If an activator node is not provided, creates and inserts an
  *    ActavtedMenuActivator button \
@@ -20,16 +20,16 @@
  *  - activator_classname (string) class(es) to be added to the created activator
  *  - activator_text (string) accessible label for the created activator element
  *  - container_id (string) an HTML id attribute to be applied to the generated
- *                          ActivatedMenuContainer element.  If none is provided 
+ *                          ActivatedMenuContainer element.  If none is provided
  *                          a unique id will be generated.
  *  - container_classname (string) class(es) to be applied to the generated menu
  *                                 container element
- *  - menu (object) 
+ *  - menu (object)
  *  - prevent_default (bool) prevent the default event on item nodes
  *                           (<a>,<button>)
- *  - selection_event (string) if provided, in addition to the  `menuselect` event 
- *                             on the <ul> the component will trigger this event 
- *                             on the `document` allowing external components to 
+ *  - selection_event (string) if provided, in addition to the  `menuselect` event
+ *                             on the <ul> the component will trigger this event
+ *                             on the `document` allowing external components to
  *                             listen for menu events.
  *
  *
@@ -41,8 +41,8 @@
  * References:
  *  - https://www.w3.org/TR/wai-aria-practices/#menu for implemented keyboard
  * behaviours.
- *  - https://api.jqueryui.com/position/ 
- * 
+ *  - https://api.jqueryui.com/position/
+ *
  *
  **/
 
@@ -188,7 +188,7 @@ class ActivatedMenu {
       }
     } else {
       this.#currentFocusIndex = index;
-      $item.focus();
+      $item[0].focus();
       this.$node.attr('aria-activedescendant', $item.attr('id'));
     }
   }
@@ -361,15 +361,15 @@ class ActivatedMenu {
   /*
    * Removes any position values that have occurred as a result of
    * calling the setMenuOpenPosition() function.
-   * Note: This assumes that no external JS script is trying to 
+   * Note: This assumes that no external JS script is trying to
    * set values independently of the ActivatedMenu class functionality.
    * Clearing the values is required to stop jQueryUI position()
    * functionality adding to existing, each time it's called.
-   * An alternative might be to set position once, and not on each 
+   * An alternative might be to set position once, and not on each
    * ActivatedMenu.open call. There is a minor performance gain that
-   * could be claimed, but it would also be less flexible, if the 
+   * could be claimed, but it would also be less flexible, if the
    * activators (used for position reference) need to be dynamically
-   * moved for any enhance or future design improvements. 
+   * moved for any enhance or future design improvements.
    **/
   #resetMenuOpenPosition() {
     var node = this.container.$node.get(0);

--- a/app/javascript/src/components/menus/activated_menu_item.js
+++ b/app/javascript/src/components/menus/activated_menu_item.js
@@ -17,7 +17,7 @@ const ActivatedMenuSubmenu =require('./activated_menu_submenu');
 class ActivatedMenuItem {
 
   /*
-   * @param $node (jQuery) a jQuery wrapped node 
+   * @param $node (jQuery) a jQuery wrapped node
    * @param menu (ActivatedMenu) the top-level ActivatedMenu
    **/
   constructor($node, menu) {
@@ -61,7 +61,7 @@ class ActivatedMenuItem {
     }
   }
 
-  #bindEventHandlers() {  
+  #bindEventHandlers() {
     var item = this;
 
     this.$node.on("click", (event) => {
@@ -72,9 +72,9 @@ class ActivatedMenuItem {
     this.$node.on("mouseenter", (event) => {
       if(this.hasSubmenu()) {
         setTimeout(function(e) {
-          item.submenu.open(); 
+          item.submenu.open();
         }, 50);
-      } 
+      }
     });
 
     this.$node.on("mouseout", (event) => {
@@ -82,7 +82,7 @@ class ActivatedMenuItem {
         if( this.submenu.isOpen() ) {
           if(!$.contains(event.currentTarget, event.relatedTarget)) {
             setTimeout(function(e) {
-              item.submenu.close(); 
+              item.submenu.close();
             }, 50);
           }
         }
@@ -99,12 +99,12 @@ class ActivatedMenuItem {
             event.preventDefault();
             event.stopImmediatePropagation();
             if( this.hasSubmenu ) {
-              this.submenu.open(); 
+              this.submenu.open();
               this.submenu.focus();
-            } 
+            }
             break;
           case 'Enter':
-          case 'Space': 
+          case 'Space':
             event.preventDefault();
             if( this.hasSubmenu() ) {
               this.submenu.open();

--- a/app/javascript/src/controller_default.js
+++ b/app/javascript/src/controller_default.js
@@ -21,7 +21,6 @@ const post = require('./utilities').post;
 
 class DefaultController {
   constructor(app) {
-    var view = this;
     var $document = $(document);
     this.type = $(".fb-main-grid-wrapper").data("fb-pagetype");
     this.features = app.features;
@@ -39,30 +38,6 @@ class DefaultController {
     }
 
     isolatedMethodDeleteLinks();
-
-    // To support keyboard navigation, try to set focus
-    // for tabbing back to last important point.
-    $document.on("DialogClose ActivatedDialogClose", function() {
-      view.$lastPoint.focus();
-      view.$lastPoint = $(); // Reset in case it was never used after any setting.
-    });
-  }
-
-  /* We have difficulty supporting keyboard tabbing because some components
-   * need to interact with others thus, jumping the tab focus around the
-   * actual DOM. Some components also have their own keyboard tabbing handling,
-   * such as the jQueryUI Dialogs, which makes it even harder to keep track.
-   * To compensate, we use a variable on the view called $lastPoint. This is
-   * expected to be a jQuery node, set by the last point (node) we want to
-   * come back to after a Dialog has closed, for instance (shifting focus back).
-   *
-   * Register the activator node  as a possible last point for tab focus support.
-   **/
-  addLastPointHandler($node) {
-    var view = this;
-    $node.on("keydown", function() {
-      view.$lastPoint = $node;
-    });
   }
 
   /* General actions to happen when called by a view that is ready.

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -538,50 +538,46 @@ function enhanceContent(view) {
  **/
 function enhanceQuestions(view) {
   view.$editable.filter("[data-fb-content-type=text], [data-fb-content-type=email], [data-fb-content-type=number], [data-fb-content-type=upload]").each(function(i, node) {
-    var question = new TextQuestion($(this), {
+    new TextQuestion($(this), {
       form: view.submitHandler.$form,
       text: {
         default_content: view.text.defaults.content,
         optionalFlag: view.text.question_optional_flag
       }
     });
-    view.addLastPointHandler(question.menu.activator.$node);
   });
 
   view.$editable.filter("[data-fb-content-type=autocomplete]").each(function(i, node) {
-    var question = new AutocompleteQuestion($(this), {
+    new AutocompleteQuestion($(this), {
       form: view.submitHandler.$form,
       text: {
         default_content: view.text.defaults.content,
         optionalFlag: view.text.question_optional_flag
       }
     });
-    view.addLastPointHandler(question.menu.activator.$node);
   });
 
 
   view.$editable.filter("[data-fb-content-type=date]").each(function(i, node) {
-    var question = new DateQuestion($(this), {
+    new DateQuestion($(this), {
       form: view.submitHandler.$form,
       text: {
         optionalFlag: view.text.question_optional_flag
       }
     });
-    view.addLastPointHandler(question.menu.activator.$node);
   });
 
   view.$editable.filter("[data-fb-content-type=textarea]").each(function(i, node) {
-    var question = new TextareaQuestion($(this), {
+    new TextareaQuestion($(this), {
       form: view.submitHandler.$form,
       text: {
         optionalFlag: view.text.question_optional_flag
       }
     });
-    view.addLastPointHandler(question.menu.activator.$node);
   });
 
   view.$editable.filter("[data-fb-content-type=checkboxes]").each(function(i, node) {
-    var question = new CheckboxesQuestion($(this), {
+    new CheckboxesQuestion($(this), {
       form: view.submitHandler.$form,
       view: view,
       text: {
@@ -608,11 +604,10 @@ function enhanceQuestions(view) {
         });
       }
     });
-    view.addLastPointHandler(question.menu.activator.$node);
   });
 
   view.$editable.filter("[data-fb-content-type=radios]").each(function(i, node) {
-    var question = new RadiosQuestion($(this), {
+    new RadiosQuestion($(this), {
       form: view.submitHandler.$form,
       view: view,
       text: {
@@ -641,7 +636,6 @@ function enhanceQuestions(view) {
 
 
     });
-    view.addLastPointHandler(question.menu.activator.$node);
   });
 }
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -104,8 +104,8 @@ function createPageAdditionDialog(view) {
  * Create the context menus for each flow item within an overview layout.
  **/
 function createPageMenus(view) {
-  $("[data-component='ItemActionMenu']").each((i, el) => {
-    var menu = new PageMenu($(el), {
+  $("[data-component='ItemActionMenu']").each((_, el) => {
+    new PageMenu($(el), {
       view: view,
       preventDefault: true, // Stops the default action of triggering element.
       menu: {
@@ -115,8 +115,6 @@ function createPageMenus(view) {
         }
       }
     });
-
-    view.addLastPointHandler(menu.activator.$node);
   });
 }
 /* VIEW SETUP FUNCTION:
@@ -124,8 +122,8 @@ function createPageMenus(view) {
  * Create the connection menus for each flow item within an overview layout.
  **/
 function createConnectionMenus(view) {
-  $("[data-component='ConnectionMenu']").each((i, el) => {
-    var menu = new ConnectionMenu($(el), {
+  $("[data-component='ConnectionMenu']").each((_, el) => {
+    new ConnectionMenu($(el), {
       view: view,
       preventDefault: true, // Stops the default action of triggering element.
       menu: {
@@ -135,8 +133,6 @@ function createConnectionMenus(view) {
         }
       }
     });
-
-    view.addLastPointHandler(menu.activator.$node);
   });
 }
 
@@ -336,7 +332,7 @@ function adjustOverviewHeight($overview) {
   var topNumbers = [];
   var top, bottom, topOverlap, height;
 
-  $items.each(function(index) {
+  $items.each(function() {
     var $item = $(this);
     // jquery.offset() always returns 0,0 in Safari for scg elements
     // so we use native getBoundingClientRect instead which returns correct values

--- a/app/views/services/_flow_page_menu.html.erb
+++ b/app/views/services/_flow_page_menu.html.erb
@@ -12,7 +12,9 @@
     <li data-action="preview">
       <%= link_to t('actions.preview_page'),
       File.join(preview_service_path(service.service_id), item[:url]),
-      target: '_blank' %>
+      target: '_blank',
+      rel: 'noreferrer nofollow'
+    %>
     </li>
   <% end %>
 


### PR DESCRIPTION
Bugfix for: https://trello.com/c/fypC35DH/3105-vertical-keyboard-navigation-in-dropdown-is-broken-after-opening-closing-a-modal

Activated menu items that triggered a modal, would no longer corectly show focus afttre the modal had opened. Using the arrow keys would update ActiveDescendant, but the item would not be highlighted (focus styles not applied)

I suspect this is somehow related to jQuery UI dialog, however the fix appears to be to call focus() on the html node itself rather then on the jQuery $node.

This commit also removes some legacy focus management code that is no longer needed.

Also lots of trailing whitespace automatically removed (sorry for the noisy diff)