### PR TITLE
Fix missing arrow condition

### DIFF
--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -571,11 +571,12 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
 
   constructor(points, config) {
     super(points, config);
+
     var dimensions = {
       forward1: Math.round(this.points.via_x - CURVE_SPACING),
       down: Math.round(utilities.difference(this.points.from_y, config.bottom) - (CURVE_SPACING * 2)),
       backward: Math.round(utilities.difference(this.points.from_x + this.points.via_x, this.points.to_x)),
-      up: Math.round(utilities.difference(config.bottom, this.points.from_y) + utilities.difference(this.points.from_y, this.points.to_y) - (CURVE_SPACING * 2)),
+      up: Math.round( utilities.difference(config.bottom, this.points.to_y) - (CURVE_SPACING * 2)),
       forward2: 0
     }
 

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -576,7 +576,7 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
       forward1: Math.round(this.points.via_x - CURVE_SPACING),
       down: Math.round(utilities.difference(this.points.from_y, config.bottom) - (CURVE_SPACING * 2)),
       backward: Math.round(utilities.difference(this.points.from_x + this.points.via_x, this.points.to_x)),
-      up: Math.round( utilities.difference(config.bottom, this.points.to_y) - (CURVE_SPACING * 2)),
+      up: Math.round(utilities.difference(config.bottom, this.points.from_y) + utilities.difference(this.points.from_y, this.points.to_y, false) - (CURVE_SPACING * 2)),
       forward2: 0
     }
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -553,6 +553,7 @@ function applyPageFlowConnectorPaths(view, $overview) {
     var fromY = $item.position().top + (rowHeight / 4);
     var $next = $("[data-fb-id=" + next + "]", $overview);
 
+
     try {
       var toX = $next.position().left - 1; // - 1 for design spacing
       var toY = $next.position().top + (rowHeight / 4);
@@ -889,9 +890,7 @@ function calculateAndCreatePageFlowConnectorPath(points, config) {
       }
     }
     else {
-      if(up) {
-        new ConnectorPath.ForwardDownBackwardUpPath(points, config);
-      }
+      new ConnectorPath.ForwardDownBackwardUpPath(points, config);
     }
   }
 }

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -281,12 +281,14 @@ function maxWidth($collection) {
 
 
 /* Get the difference between two numbers
+ * defaults to returning an absolute value
  **/
-function difference(a, b) {
-  if(a > b)
+function difference(a, b, abs=true) {
+  if(abs) {
+    return Math.abs(a - b);
+  } else {
     return a - b;
-  else
-    return b - a;
+  }
 }
 
 

--- a/test/utilities/difference_test.js
+++ b/test/utilities/difference_test.js
@@ -10,4 +10,8 @@ describe('utilities.difference', function() {
   it("should return b - a when b is greater", function() {
     expect(utilities.difference(7, 12)).to.equal(5);
   });
+
+  it("should return negative number when abs is false", function() {
+    expect(utilities.difference(7,12, false)).to.equal(-5);
+  })
 });


### PR DESCRIPTION
This is a fix for a missing arrow discovered on the DDaT Assessment Eligibility form.



**Before:**
![Screenshot 2022-11-23 at 09 43 50](https://user-images.githubusercontent.com/595564/203515457-8d8a38fc-2815-44d2-96fe-52f722be545d.png)

**After:**
![image](https://user-images.githubusercontent.com/595564/203523985-31d41baf-7b64-4743-bc80-6b151c3d47c6.png)




