### PR TITLE
Fix arrow overlap issues

### DIFF
--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -571,11 +571,12 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
 
   constructor(points, config) {
     super(points, config);
+
     var dimensions = {
       forward1: Math.round(this.points.via_x - CURVE_SPACING),
       down: Math.round(utilities.difference(this.points.from_y, config.bottom) - (CURVE_SPACING * 2)),
       backward: Math.round(utilities.difference(this.points.from_x + this.points.via_x, this.points.to_x)),
-      up: Math.round(utilities.difference(config.bottom, this.points.from_y) + utilities.difference(this.points.from_y, this.points.to_y) - (CURVE_SPACING * 2)),
+      up: Math.round( utilities.difference(config.bottom, this.points.to_y) - (CURVE_SPACING * 2)),
       forward2: 0
     }
 

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -576,7 +576,7 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
       forward1: Math.round(this.points.via_x - CURVE_SPACING),
       down: Math.round(utilities.difference(this.points.from_y, config.bottom) - (CURVE_SPACING * 2)),
       backward: Math.round(utilities.difference(this.points.from_x + this.points.via_x, this.points.to_x)),
-      up: Math.round( utilities.difference(config.bottom, this.points.to_y) - (CURVE_SPACING * 2)),
+      up: Math.round(utilities.difference(config.bottom, this.points.from_y) + utilities.difference(this.points.from_y, this.points.to_y, false) - (CURVE_SPACING * 2)),
       forward2: 0
     }
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -553,6 +553,7 @@ function applyPageFlowConnectorPaths(view, $overview) {
     var fromY = $item.position().top + (rowHeight / 4);
     var $next = $("[data-fb-id=" + next + "]", $overview);
 
+
     try {
       var toX = $next.position().left - 1; // - 1 for design spacing
       var toY = $next.position().top + (rowHeight / 4);
@@ -889,9 +890,7 @@ function calculateAndCreatePageFlowConnectorPath(points, config) {
       }
     }
     else {
-      if(up) {
-        new ConnectorPath.ForwardDownBackwardUpPath(points, config);
-      }
+      new ConnectorPath.ForwardDownBackwardUpPath(points, config);
     }
   }
 }

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -811,8 +811,7 @@ function adjustOverlappingFlowConnectorPaths($overview) {
       $paths.each(function() { // or $paths.not($path).each
         var $current = $(this);
         var current = $current.data("instance");
-
-        if(path.id != current.id) {
+        if(path.prop('id') != current.prop('id')) {
 
           // Call the overlap avoidance functionality and register
           // if anything was moved (reported by its return value).

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -281,12 +281,14 @@ function maxWidth($collection) {
 
 
 /* Get the difference between two numbers
+ * defaults to returning an absolute value
  **/
-function difference(a, b) {
-  if(a > b)
+function difference(a, b, abs=true) {
+  if(abs) {
+    return Math.abs(a - b);
+  } else {
     return a - b;
-  else
-    return b - a;
+  }
 }
 
 

--- a/test/utilities/difference_test.js
+++ b/test/utilities/difference_test.js
@@ -10,4 +10,8 @@ describe('utilities.difference', function() {
   it("should return b - a when b is greater", function() {
     expect(utilities.difference(7, 12)).to.equal(5);
   });
+
+  it("should return negative number when abs is false", function() {
+    expect(utilities.difference(7,12, false)).to.equal(-5);
+  })
 });


### PR DESCRIPTION
This PR fixes the fact that line overlapping was broken.

It appears that during test-writing changes were made to the implementation of the `FlowConnectorPath` class that made the `id` property private.

A public `prop` accessor function was made available (not entirely sure at this point why standard getters weren't used.)

It seems that the code in `adjustOverlappingFlowConnectorPaths()` was not updated to use the `prop` accessor.  As such `path.id` and `current.id` were returning `undefined` - this was meaning no lines were being compared for overlaps.

This went unnoticed, as the 'undefined' variables didn't trigger any errors, just prevented an essential function call.

Strike this up as a reason for using Typescript 😉

**Before:**
![Screenshot 2022-11-23 at 10 23 44](https://user-images.githubusercontent.com/595564/203577658-29284c13-1fca-49db-8d3e-704f30388394.png)

**After:**
![image](https://user-images.githubusercontent.com/595564/203577731-4d56b88f-0eb2-4e40-a172-90fcf2814882.png)


There is still an outstanding bug / rendering issue that I can see: nudged lines at the top of the flow viewport get cut off.  Don't know if this was an existing bug, or if it is new....

![image](https://user-images.githubusercontent.com/595564/203577878-89fdc021-a672-456a-bda2-8ffba957e650.png)

