### PR TITLE
Show placeholder reference number when reference number is enabled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'maintenance-page'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.17.23'
+gem 'metadata_presenter', '2.17.24'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.23)
+    metadata_presenter (2.17.24)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -459,7 +459,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.17.23)
+  metadata_presenter (= 2.17.24)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,4 +71,18 @@ class ApplicationController < ActionController::Base
       end
     end
   end
+
+  def show_reference_number
+    I18n.t('default_values.reference_number')
+  end
+  helper_method :show_reference_number
+
+  def reference_number_enabled?
+    reference_number_config.present?
+  end
+  helper_method :reference_number_enabled?
+
+  def reference_number_config
+    @reference_number_config ||= ServiceConfiguration.find_by(service_id: service.service_id, name: 'REFERENCE_NUMBER')
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
     branching_title: 'Branching point %{branching_number}'
     confirmation_email_subject: "Your submission to ‘%{service_name}’"
     confirmation_email_body: "Thank you for your submission to ‘%{service_name}’.\n\r\nA copy of the information you provided is attached to this email."
+    reference_number: '123-ABCD-456'
   notification_banners:
     important: Important
     success: Success

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe ApplicationController do
     end
   end
 
-  describe '#reference`_number_enabled?' do
+  describe '#reference_number_enabled?' do
     before do
       allow(controller).to receive(:service).and_return(service)
       allow(ServiceConfiguration).to receive(:find_by).and_return(service_configuration)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -161,4 +161,34 @@ RSpec.describe ApplicationController do
       end
     end
   end
+
+  describe '#reference`_number_enabled?' do
+    before do
+      allow(controller).to receive(:service).and_return(service)
+      allow(ServiceConfiguration).to receive(:find_by).and_return(service_configuration)
+    end
+
+    context 'when REFERENCE_NUMBER is enabled' do
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :dev,
+          :reference_number,
+          service_id: service.service_id
+        )
+      end
+
+      it 'returns true' do
+        expect(controller.reference_number_enabled?).to be_truthy
+      end
+    end
+
+    context 'when REFERENCE_NUMBER is disabled' do
+      let!(:service_configuration) { nil }
+
+      it 'returns false' do
+        expect(controller.reference_number_enabled?).to be_falsey
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Show placeholder when reference number is enabled
When in the Editor or in preview mode, and reference number is enabled, we want to show a placeholder reference number.
This is done through the methods `show_reference_number` and `reference_number_enabled?`.

### Bump to presenter 2.17.24

This version of the presenter has the new confirmation email template that includes reference numbers.


![Screenshot 2022-11-25 at 13 14 33](https://user-images.githubusercontent.com/29227502/203993404-218bd019-dfd9-428e-afe5-61d2a0c19ff0.png)