### PR TITLE
Add aria describedby attirbute and update content

### DIFF
--- a/app/views/settings/reference_number/_form.html.erb
+++ b/app/views/settings/reference_number/_form.html.erb
@@ -1,11 +1,14 @@
 <%= f.govuk_check_boxes_fieldset :"reference_number",
       multiple: false,
-      legend: { text: t('settings.reference_number.heading'), size: 'l'} do %>
+      legend: { text: t('settings.reference_number.legend'), size: 'l'} do %>
       <div class="govuk-hint" id="reference_number_hint"><%= t('settings.reference_number.hint') %></div>
       <%= f.govuk_check_box :"reference_number", 1, 0,
         multiple: false,
         link_errors: true,
         label: { text: t('settings.reference_number.label') },
-        checked: f.object.reference_number_checked?
+        checked: f.object.reference_number_checked?,
+        aria: {
+            describedby: 'reference_number_hint reference_number_warning'
+          }
       %>
 <% end %>

--- a/app/views/settings/reference_number/index.html.erb
+++ b/app/views/settings/reference_number/index.html.erb
@@ -9,7 +9,7 @@
 
   <% c.with_back_link(href: settings_path) %>
 
-  <%= govuk_warning_text(text: t('settings.reference_number.warning')) %>
+  <%= govuk_warning_text(text: t('settings.reference_number.warning'), html_attributes: { id: 'reference_number_warning' }) %>
 
     <%= form_for @reference_number, url: settings_reference_number_index_path(service.service_id),
     html: { id: 'reference-number-settings' },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -313,12 +313,13 @@ en:
       details_hint: 'You can use tracking IDs for any of the following Google products:'
     reference_number:
       link: Reference numbers
-      heading: Reference Number
-      lede: Generates a unique reference number for each submission.
-      hint: This inserts a reference number in the confirmation page, confirmation email, submission email and submission attachments
+      heading: Reference numbers
+      lede: Generate a unique reference number for each submission.
       description: Generate and provide your users with a unique reference number with each submission. (For details, see the %{href}.)
-      href: <a class="govuk-link" href="%{url}" target="_blank">user guide</a>
+      href: <a class="govuk-link" href="%{url}" target="_blank" rel="noopener noreferrer">user guide</a>
       warning: Updating these settings will reset the confirmation and submission emails and any changes you have made to the subjects and messages will be lost.
+      legend: Reference numbers
+      hint: This inserts a reference number in the confirmation page, confirmation email, submission email and submission attachments
       label: Enable reference numbers
     submission:
       heading: 'Submission settings'


### PR DESCRIPTION
Makes a couple of tweaks to the reference number templates. 

* Adds the hint text into the aria-describedby attribute of the input
* Adds the warning text into the aria-describedby attribute of the input - feels like this is important enought that we want them to know it if all they do is focus the input.
* Separates out the 'heading' text string into 'heading' and 'legend' as they will be different when we do pay
* Add `rel="noopener noferrer"` to the `target="_blank"` link - required for security
* Tweak capitalisation of headings, and ensure 'Reference numbers' is always plural (as per figma)