### PR TITLE
Fix logic around display of autocomplete warnings

### DIFF
--- a/app/presenters/publishing_page_presenter.rb
+++ b/app/presenters/publishing_page_presenter.rb
@@ -41,8 +41,6 @@ class PublishingPagePresenter
   def publish_button_disabled?
     return if deployment_environment == 'dev'
 
-    return false if no_service_output?
-
     submission_warnings.messages.any? || autocomplete_warning.messages.any?
   end
 
@@ -71,7 +69,7 @@ class PublishingPagePresenter
 
     return presenters if deployment_environment == 'dev'
 
-    presenters.push(from_address_warning)
+    presenters.push(from_address_warning) if service_output_warning.blank?
     presenters.push(autocomplete_warning)
   end
 end

--- a/app/presenters/service_output_warning_presenter.rb
+++ b/app/presenters/service_output_warning_presenter.rb
@@ -15,6 +15,10 @@ class ServiceOutputWarningPresenter
 
   delegate :present?, to: :message
 
+  def blank?
+    !present?
+  end
+
   def message
     key = send_confirmation_email? ? :confirmation_email : :default
 

--- a/app/presenters/service_output_warning_presenter.rb
+++ b/app/presenters/service_output_warning_presenter.rb
@@ -14,10 +14,7 @@ class ServiceOutputWarningPresenter
   delegate :no_service_output?, to: :publish_creation
 
   delegate :present?, to: :message
-
-  def blank?
-    !present?
-  end
+  delegate :blank?, to: :message
 
   def message
     key = send_confirmation_email? ? :confirmation_email : :default

--- a/app/views/publish/_publish_environment.html.erb
+++ b/app/views/publish/_publish_environment.html.erb
@@ -7,12 +7,20 @@
   <% end %>
 
   <% if presenter.service_output_warning.present? %>
-    <%= render 'publish/warnings/service_output', warning: presenter.service_output_warning %>
-  <% else %>
-    <%= render 'publish/warnings/submission', warning: presenter.submission_warnings, environment: environment %>
-    <% if environment == 'dev' %>
+    <%= render('publish/warnings/service_output', warning: presenter.service_output_warning) %>
+  <% end %>
+
+  <% if environment == 'dev' %>
+    <% if presenter.service_output_warning.blank? %>
+      <%= render 'publish/warnings/submission', warning: presenter.submission_warnings, environment: environment %>
       <%= render 'publish/warnings/from_address', warning: presenter.from_address_warning, environment: environment %>
-      <%= render 'publish/warnings/autocomplete', warning: presenter.autocomplete_warning, environment: environment %>
+    <% end %>
+    <%= render 'publish/warnings/autocomplete', warning: presenter.autocomplete_warning, environment: environment %>
+  <% end %>
+
+  <% if environment == 'production' %>
+    <% if presenter.service_output_warning.blank? || presenter.autocomplete_warning.messages.any? %>
+      <%= render('publish/warnings/submission', warning: presenter.submission_warnings, environment: environment)  %>
     <% end %>
   <% end %>
 

--- a/spec/presenters/publishing_page_presenter_spec.rb
+++ b/spec/presenters/publishing_page_presenter_spec.rb
@@ -40,13 +40,7 @@ RSpec.describe PublishingPagePresenter do
 
     context 'submission warning presenters in production' do
       let(:deployment_environment) { 'production' }
-      let(:presenters) do
-        [
-          submission_pages_presenter,
-          autocomplete_warning,
-          from_address_warning
-        ]
-      end
+
       let(:submission_pages_presenter) { double }
       let(:autocomplete_warning) { double }
       let(:from_address_warning) { double }
@@ -55,10 +49,35 @@ RSpec.describe PublishingPagePresenter do
         allow(subject).to receive(:submission_pages_presenter).and_return(submission_pages_presenter)
         allow(subject).to receive(:autocomplete_warning).and_return(autocomplete_warning)
         allow(subject).to receive(:from_address_warning).and_return(from_address_warning)
+        allow(subject).to receive(:service_output_warning).and_return(service_output_warning)
       end
 
-      it 'returns the expected presenters' do
-        expect(subject.submission_warnings.presenters).to match_array(presenters)
+      context 'service output warning present' do
+        let(:service_output_warning) { double(blank?: false) }
+        let(:presenters) do
+          [
+            submission_pages_presenter,
+            autocomplete_warning
+          ]
+        end
+        it 'returns the expected presenters' do
+          expect(subject.submission_warnings.presenters).to match_array(presenters)
+        end
+      end
+
+      context 'service output warning not present' do
+        let(:service_output_warning) { double(blank?: true) }
+        let(:presenters) do
+          [
+            submission_pages_presenter,
+            autocomplete_warning,
+            from_address_warning
+          ]
+        end
+
+        it 'returns the expected presenters' do
+          expect(subject.submission_warnings.presenters).to match_array(presenters)
+        end
       end
     end
 


### PR DESCRIPTION
Fixes some logic around the publishing warnings and how we handle autocomplete issues.

The problem was that both in dev and live, the autocomplete warnings only showed if 'collect information by email' was off.  

In dev the solution is pretty easy, as we can show both of the top-level warnings at the same time.

In live the autocomplete warnings are part of the 'submission warnings' block.

So we need to ensure the submission warnings includes the right warnings (i.e. no from address warnings when collect info by email is off), and gets shown if there are any autocomplete issues.


**Before:**
![image](https://user-images.githubusercontent.com/595564/203961175-54e252c3-28bb-454b-bf81-7f8cf5ad4647.png)
Form has an autocomplete without any options, but the user wouldn't know

**After:**
![image](https://user-images.githubusercontent.com/595564/203961877-53187fc2-5633-4bf7-9cf5-cc2158b825c0.png)
Email warning and autocomplete warnings show, but there are no 'From address' warnings in live due to 'collect info by email' being off

