### PR TITLE
Adding the JAC domain to both the mail to and auth allow lists

### DIFF
--- a/app/models/from_address.rb
+++ b/app/models/from_address.rb
@@ -2,7 +2,8 @@ class FromAddress < ApplicationRecord
   ALLOWED_DOMAINS = [
     'justice.gov.uk',
     'digital.justice.gov.uk',
-    'cica.gov.uk'
+    'cica.gov.uk',
+    'judicialappointments.gov.uk'
   ].freeze
 
   before_save :encrypt_email

--- a/app/services/auth0_user_session.rb
+++ b/app/services/auth0_user_session.rb
@@ -6,7 +6,8 @@ class Auth0UserSession
   VALID_EMAIL_DOMAINS = [
     'justice.gov.uk',
     'cps.gov.uk',
-    'cica.gov.uk'
+    'cica.gov.uk',
+    'judicialappointments.gov.uk'
   ].freeze
 
   attr_accessor :user_info, :user_id, :created_at, :new_user


### PR DESCRIPTION
The JAC are being given the ability to log into the editor using their own domain. The judicialappointments.gov.uk uses the DOM1 Azure AD (same as justice). Adding this will allow access to the editor.

https://trello.com/c/JazRQJZK