### PR TITLE
Use correct email default values when reference number is enabled/disabled

### DIFF
--- a/acceptance/features/confirmation_email_spec.rb
+++ b/acceptance/features/confirmation_email_spec.rb
@@ -7,8 +7,9 @@ feature 'Confirmation email' do
   let(:question) { 'New Email Component' }
   # Capybara strips out the carriage return `\r`
   let(:message_body) {
-    "Thank you for your submission to ‘#{service_name}’.\n\nA copy of the information you provided is attached to this email."
+    "Thank you for your submission to ‘#{service_name}’. \n\nA copy of the information you provided is attached to this email."
   }
+  let(:message_subject) { "Your submission to ‘#{service_name}’ " }
   let(:multiple_question_page) { 'Title' }
   let(:email_question) { 'Email address question' }
   let(:text_component_question) { 'Question' }
@@ -145,13 +146,7 @@ feature 'Confirmation email' do
     expect(page).to have_content(I18n.t('default_values.service_email_from'))
     expect(page).to have_content(I18n.t('warnings.email_settings.default'))
     expect(page).to have_content(I18n.t('activemodel.attributes.email_settings.from_address.link'))
-    expect(page).to have_field(
-      'Subject',
-      with: I18n.t(
-        'default_values.confirmation_email_subject',
-        service_name: service_name
-      )
-    )
+    expect(page.find(:css, "input#confirmation-email-settings-confirmation-email-subject-#{environment}-field").value).to have_content(message_subject)
     expect(page).to have_content(message_body)
   end
 

--- a/app/controllers/settings/reference_number_controller.rb
+++ b/app/controllers/settings/reference_number_controller.rb
@@ -13,7 +13,7 @@ class Settings::ReferenceNumberController < FormController
     if @reference_number.valid?
       ReferenceNumberUpdater.new(
         reference_number_settings: @reference_number,
-        service_id: service.service_id
+        service: service
       ).create_or_update!
 
       redirect_to settings_reference_number_index_path(service_id: service.service_id)

--- a/app/controllers/settings/reference_number_controller.rb
+++ b/app/controllers/settings/reference_number_controller.rb
@@ -16,11 +16,6 @@ class Settings::ReferenceNumberController < FormController
         service_id: service.service_id
       ).create_or_update!
 
-      ReferenceNumberUpdater.new(
-        reference_number_settings: @reference_number,
-        service_id: service.service_id
-      ).create_or_update!
-
       redirect_to settings_reference_number_index_path(service_id: service.service_id)
     else
       render :index, status: :unprocessable_entity

--- a/app/helpers/content_substitutor_helper.rb
+++ b/app/helpers/content_substitutor_helper.rb
@@ -1,0 +1,15 @@
+module ContentSubstitutorHelper
+  def content_substitutor
+    @content_substitutor ||= ContentSubstitutor.new(
+      service_name: service.service_name,
+      reference_number_enabled: reference_number_enabled
+    )
+  end
+
+  def reference_number_enabled
+    ServiceConfiguration.where(
+      service_id: service.service_id,
+      name: 'REFERENCE_NUMBER'
+    ).present?
+  end
+end

--- a/app/models/base_email_settings.rb
+++ b/app/models/base_email_settings.rb
@@ -1,5 +1,6 @@
 class BaseEmailSettings
   include ActiveModel::Model
+  include ContentSubstitutorHelper
 
   def settings_for(setting_name)
     params(setting_name).presence ||
@@ -16,6 +17,10 @@ class BaseEmailSettings
   end
 
   def default_value(setting_name)
+    initial_value = content_substitutor.assign(setting_name)
+
+    return initial_value if initial_value.present?
+
     I18n.t("default_values.#{setting_name}", service_name: service.service_name)
   end
 

--- a/app/models/content_substitutor.rb
+++ b/app/models/content_substitutor.rb
@@ -73,14 +73,20 @@ class ContentSubstitutor
     )
   end
 
+  def assign(setting)
+    public_send(setting)
+  rescue NoMethodError
+    nil
+  end
+
   private
 
   def subject_content
-    I18n.t('default_values.reference_number_subject')
+    @subject_content ||= I18n.t('default_values.reference_number_subject')
   end
 
   def body_content
-    I18n.t('default_values.reference_number_sentence')
+    @body_content ||= I18n.t('default_values.reference_number_sentence')
   end
 
   def insert_placeholder_sentence(setting, placeholder, content)

--- a/app/models/content_substitutor.rb
+++ b/app/models/content_substitutor.rb
@@ -1,0 +1,101 @@
+class ContentSubstitutor
+  attr_accessor :service_name, :reference_number_enabled
+
+  REFERENCE_NUMBER_PLACEHOLDER = '{{reference_number_placeholder}}'.freeze
+
+  def initialize(service_name:, reference_number_enabled:)
+    @service_name = service_name
+    @reference_number_enabled = reference_number_enabled
+  end
+
+  def confirmation_email_subject
+    setting = I18n.t(
+      'default_values.confirmation_email_subject',
+      service_name: service_name
+    )
+
+    substitute_placeholder(
+      setting: setting,
+      placeholder: REFERENCE_NUMBER_PLACEHOLDER,
+      content: subject_content
+    )
+  end
+
+  def confirmation_email_body
+    setting = I18n.t(
+      'default_values.confirmation_email_body',
+      service_name: service_name
+    )
+
+    substitute_placeholder(
+      setting: setting,
+      placeholder: REFERENCE_NUMBER_PLACEHOLDER,
+      content: body_content
+    )
+  end
+
+  def service_email_subject
+    setting = I18n.t(
+      'default_values.service_email_subject',
+      service_name: service_name
+    )
+
+    substitute_placeholder(
+      setting: setting,
+      placeholder: REFERENCE_NUMBER_PLACEHOLDER,
+      content: subject_content
+    )
+  end
+
+  def service_email_body
+    setting = I18n.t(
+      'default_values.service_email_body',
+      service_name: service_name
+    )
+
+    substitute_placeholder(
+      setting: setting,
+      placeholder: REFERENCE_NUMBER_PLACEHOLDER,
+      content: body_content
+    )
+  end
+
+  def service_email_pdf_heading
+    setting = I18n.t(
+      'default_values.service_email_pdf_heading',
+      service_name: service_name
+    )
+
+    substitute_placeholder(
+      setting: setting,
+      placeholder: REFERENCE_NUMBER_PLACEHOLDER,
+      content: subject_content
+    )
+  end
+
+  private
+
+  def subject_content
+    I18n.t('default_values.reference_number_subject')
+  end
+
+  def body_content
+    I18n.t('default_values.reference_number_sentence')
+  end
+
+  def insert_placeholder_sentence(setting, placeholder, content)
+    setting.gsub(placeholder, content)
+  end
+
+  def remove_placeholder_sentence(setting, placeholder)
+    setting.gsub(placeholder, '')
+  end
+
+  def substitute_placeholder(setting:, placeholder:, content:)
+    if reference_number_enabled
+      insert_placeholder_sentence(setting, placeholder, content)
+    else
+      remove_placeholder_sentence(setting, placeholder)
+    end
+  end
+end

--- a/app/models/reference_number_updater.rb
+++ b/app/models/reference_number_updater.rb
@@ -1,4 +1,6 @@
 class ReferenceNumberUpdater
+  include ContentSubstitutorHelper
+
   attr_reader :service, :reference_number_settings
 
   CONFIGS = %w[REFERENCE_NUMBER].freeze
@@ -82,32 +84,17 @@ class ReferenceNumberUpdater
   def assign_email_settings(deployment_environment)
     EmailSettings.new(
       deployment_environment: deployment_environment,
-      service_email_subject: content_substitutor(deployment_environment).service_email_subject,
-      service_email_body: content_substitutor(deployment_environment).service_email_body,
-      service_email_pdf_heading: content_substitutor(deployment_environment).service_email_pdf_heading
+      service_email_subject: content_substitutor.service_email_subject,
+      service_email_body: content_substitutor.service_email_body,
+      service_email_pdf_heading: content_substitutor.service_email_pdf_heading
     )
   end
 
   def assign_confirmation_email_settings(deployment_environment)
     ConfirmationEmailSettings.new(
       deployment_environment: deployment_environment,
-      confirmation_email_subject: content_substitutor(deployment_environment).confirmation_email_subject,
-      confirmation_email_body: content_substitutor(deployment_environment).confirmation_email_body
+      confirmation_email_subject: content_substitutor.confirmation_email_subject,
+      confirmation_email_body: content_substitutor.confirmation_email_body
     )
-  end
-
-  def content_substitutor(deployment_environment)
-    @content_substitutor ||= ContentSubstitutor.new(
-      service_name: service.service_name,
-      reference_number_enabled: reference_number_enabled(deployment_environment)
-    )
-  end
-
-  def reference_number_enabled(deployment_environment)
-    ServiceConfiguration.find_by(
-      service_id: service.service_id,
-      deployment_environment: deployment_environment,
-      name: 'REFERENCE_NUMBER'
-    ).present?
   end
 end

--- a/app/models/reference_number_updater.rb
+++ b/app/models/reference_number_updater.rb
@@ -1,10 +1,10 @@
 class ReferenceNumberUpdater
-  attr_reader :service_id, :reference_number_settings
+  attr_reader :service, :reference_number_settings
 
   CONFIGS = %w[REFERENCE_NUMBER].freeze
 
-  def initialize(service_id:, reference_number_settings:)
-    @service_id = service_id
+  def initialize(service:, reference_number_settings:)
+    @service = service
     @reference_number_settings = reference_number_settings
   end
 
@@ -16,32 +16,98 @@ class ReferenceNumberUpdater
 
   def save_config
     CONFIGS.each do |config|
-      if reference_number_settings.enabled? && config.present?
-        create_or_update_the_service_configuration(config, 'dev')
-        create_or_update_the_service_configuration(config, 'production')
+      if reference_number_settings.enabled?
+        create_or_update_service_configuration(config: config, deployment_environment: 'dev')
+        create_or_update_service_configuration(config: config, deployment_environment: 'production')
       else
-        remove_the_service_configuration(config, 'dev')
-        remove_the_service_configuration(config, 'production')
+        remove_service_configuration(config, 'dev')
+        remove_service_configuration(config, 'production')
       end
+      save_config_with_defaults
     end
   end
 
-  def create_or_update_the_service_configuration(config, deployment_environment)
+  def create_or_update_service_configuration(config:, deployment_environment:, value: reference_number)
     setting = find_or_initialize_setting(config, deployment_environment)
-    setting.value = reference_number_settings.reference_number
+    setting.value = value
     setting.save!
   end
 
   def find_or_initialize_setting(config, deployment_environment)
     ServiceConfiguration.find_or_initialize_by(
-      service_id: service_id,
+      service_id: service.service_id,
       deployment_environment: deployment_environment,
       name: config
     )
   end
 
-  def remove_the_service_configuration(config, deployment_environment)
+  def remove_service_configuration(config, deployment_environment)
     setting = find_or_initialize_setting(config, deployment_environment)
     setting.destroy!
+  end
+
+  def save_config_with_defaults
+    email_settings.each do |settings|
+      EmailSettingsUpdater.new(
+        email_settings: settings,
+        service: service
+      ).create_or_update!
+    end
+
+    confirmation_emails_settings.each do |settings|
+      ConfirmationEmailSettingsUpdater.new(
+        confirmation_email_settings: settings,
+        service: service
+      ).create_or_update!
+    end
+  end
+
+  private
+
+  def reference_number
+    @reference_number ||= reference_number_settings.reference_number
+  end
+
+  def confirmation_emails_settings
+    [
+      assign_confirmation_email_settings('dev'),
+      assign_confirmation_email_settings('production')
+    ]
+  end
+
+  def email_settings
+    [assign_email_settings('dev'), assign_email_settings('production')]
+  end
+
+  def assign_email_settings(deployment_environment)
+    EmailSettings.new(
+      deployment_environment: deployment_environment,
+      service_email_subject: content_substitutor(deployment_environment).service_email_subject,
+      service_email_body: content_substitutor(deployment_environment).service_email_body,
+      service_email_pdf_heading: content_substitutor(deployment_environment).service_email_pdf_heading
+    )
+  end
+
+  def assign_confirmation_email_settings(deployment_environment)
+    ConfirmationEmailSettings.new(
+      deployment_environment: deployment_environment,
+      confirmation_email_subject: content_substitutor(deployment_environment).confirmation_email_subject,
+      confirmation_email_body: content_substitutor(deployment_environment).confirmation_email_body
+    )
+  end
+
+  def content_substitutor(deployment_environment)
+    @content_substitutor ||= ContentSubstitutor.new(
+      service_name: service.service_name,
+      reference_number_enabled: reference_number_enabled(deployment_environment)
+    )
+  end
+
+  def reference_number_enabled(deployment_environment)
+    ServiceConfiguration.find_by(
+      service_id: service.service_id,
+      deployment_environment: deployment_environment,
+      name: 'REFERENCE_NUMBER'
+    ).present?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,13 +27,15 @@ en:
   default_values:
     service_email_output: ''
     service_email_from: 'no-reply-moj-forms@digital.justice.gov.uk'
-    service_email_subject: 'Submission from %{service_name}'
-    service_email_body: 'Please find attached a submission sent from %{service_name}'
-    service_email_pdf_heading: 'Submission for %{service_name}'
+    service_email_subject: 'Submission from %{service_name} {{reference_number_placeholder}}'
+    service_email_body: 'Please find attached a submission sent from %{service_name}. {{reference_number_placeholder}}'
+    service_email_pdf_heading: 'Submission for %{service_name} {{reference_number_placeholder}}'
     service_email_pdf_subheading: ''
     branching_title: 'Branching point %{branching_number}'
-    confirmation_email_subject: "Your submission to ‘%{service_name}’"
-    confirmation_email_body: "Thank you for your submission to ‘%{service_name}’.\n\r\nA copy of the information you provided is attached to this email."
+    confirmation_email_subject: "Your submission to ‘%{service_name}’ {{reference_number_placeholder}}"
+    confirmation_email_body: "Thank you for your submission to ‘%{service_name}’. {{reference_number_placeholder}}\n\r\nA copy of the information you provided is attached to this email."
+    reference_number_sentence: "Your reference number is {{reference_number}}."
+    reference_number_subject: "Reference number: {{reference_number}}."
     reference_number: '123-ABCD-456'
   notification_banners:
     important: Important

--- a/spec/models/confirmation_email_settings_spec.rb
+++ b/spec/models/confirmation_email_settings_spec.rb
@@ -6,18 +6,8 @@ RSpec.describe ConfirmationEmailSettings do
   end
   let(:params) { {} }
   let(:from_address) { create(:from_address, :default, service_id: service.service_id) }
-  let(:default_body) do
-    I18n.t(
-      'default_values.confirmation_email_body',
-      service_name: service.service_name
-    )
-  end
-  let(:default_subject) do
-    I18n.t(
-      'default_values.confirmation_email_subject',
-      service_name: service.service_name
-    )
-  end
+  let(:confirmation_email_subject) { I18n.t('default_values.confirmation_email_subject', service_name: service.service_name) }
+  let(:confirmation_email_body) { I18n.t('default_values.confirmation_email_body', service_name: service.service_name) }
 
   describe '#valid?' do
     context 'when send by confirmation email is ticked' do
@@ -57,7 +47,7 @@ RSpec.describe ConfirmationEmailSettings do
 
       context 'when subject is empty' do
         it 'shows the default value' do
-          expect(confirmation_email_settings.confirmation_email_subject).to eq(default_subject)
+          expect(confirmation_email_settings.confirmation_email_subject).to eq(confirmation_email_subject)
         end
       end
 
@@ -107,7 +97,7 @@ RSpec.describe ConfirmationEmailSettings do
 
       context 'when body is empty' do
         it 'shows the default value' do
-          expect(confirmation_email_settings.confirmation_email_body).to eq(default_body)
+          expect(confirmation_email_settings.confirmation_email_body).to eq(confirmation_email_body)
         end
       end
 

--- a/spec/models/confirmation_email_settings_spec.rb
+++ b/spec/models/confirmation_email_settings_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe ConfirmationEmailSettings do
   end
   let(:params) { {} }
   let(:from_address) { create(:from_address, :default, service_id: service.service_id) }
-  let(:confirmation_email_subject) { I18n.t('default_values.confirmation_email_subject', service_name: service.service_name) }
-  let(:confirmation_email_body) { I18n.t('default_values.confirmation_email_body', service_name: service.service_name) }
+  let(:confirmation_email_subject) { confirmation_email_settings.default_value('confirmation_email_subject') }
+  let(:confirmation_email_body) { confirmation_email_settings.default_value('confirmation_email_body') }
 
   describe '#valid?' do
     context 'when send by confirmation email is ticked' do

--- a/spec/models/confirmation_email_settings_updater_spec.rb
+++ b/spec/models/confirmation_email_settings_updater_spec.rb
@@ -11,17 +11,11 @@ RSpec.describe ConfirmationEmailSettingsUpdater do
     )
   end
   let(:params) { {} }
-  let(:default_body) do
-    I18n.t(
-      'default_values.confirmation_email_body',
-      service_name: service.service_name
-    )
+  let(:default_email_subject) do
+    confirmation_email_settings_updater.confirmation_email_settings.default_value('confirmation_email_subject')
   end
-  let(:default_subject) do
-    I18n.t(
-      'default_values.confirmation_email_subject',
-      service_name: service.service_name
-    )
+  let(:default_email_body) do
+    confirmation_email_settings_updater.confirmation_email_settings.default_value('confirmation_email_body')
   end
 
   describe '#create_or_update' do
@@ -118,7 +112,7 @@ RSpec.describe ConfirmationEmailSettingsUpdater do
             service_configuration.reload
             expect(
               service_configuration.decrypt_value
-            ).to eq(default_subject)
+            ).to eq(default_email_subject)
           end
         end
       end
@@ -162,7 +156,7 @@ RSpec.describe ConfirmationEmailSettingsUpdater do
             expect(service_configuration).to be_persisted
             expect(
               service_configuration.decrypt_value
-            ).to eq(default_subject)
+            ).to eq(default_email_subject)
           end
         end
       end
@@ -207,7 +201,7 @@ RSpec.describe ConfirmationEmailSettingsUpdater do
             service_configuration.reload
             expect(
               service_configuration.decrypt_value
-            ).to eq(default_body)
+            ).to eq(default_email_body)
           end
         end
       end
@@ -251,7 +245,7 @@ RSpec.describe ConfirmationEmailSettingsUpdater do
             expect(service_configuration).to be_persisted
             expect(
               service_configuration.decrypt_value
-            ).to eq(default_body)
+            ).to eq(default_email_body)
           end
         end
       end

--- a/spec/models/content_substitutor_spec.rb
+++ b/spec/models/content_substitutor_spec.rb
@@ -1,0 +1,115 @@
+RSpec.describe ContentSubstitutor do
+  subject(:content_substitutor) do
+    described_class.new(
+      reference_number_enabled: reference_number_enabled,
+      service_name: service_name
+    )
+  end
+  let(:reference_number_enabled) { true }
+  let(:service_name) { 'The Substitutor!' }
+
+  describe '#confirmation_email_subject' do
+    context 'when reference number is enabled' do
+      let(:content) do
+        I18n.t('default_values.reference_number_subject')
+      end
+
+      it 'returns the correct content' do
+        expect(content_substitutor.confirmation_email_subject).to include(content)
+      end
+    end
+
+    context 'when reference number is disabled' do
+      let(:reference_number_enabled) { false }
+      let(:content) { '{{reference_number_placeholder}}' }
+
+      it 'returns the correct content' do
+        expect(content_substitutor.confirmation_email_subject).to_not include(content)
+      end
+    end
+  end
+
+  describe '#confirmation_email_body' do
+    context 'when reference number is enabled' do
+      let(:content) do
+        I18n.t('default_values.reference_number_sentence')
+      end
+
+      it 'returns the correct content' do
+        expect(content_substitutor.confirmation_email_body).to include(content)
+      end
+    end
+
+    context 'when reference number is disabled' do
+      let(:reference_number_enabled) { false }
+      let(:content) { '{{reference_number_placeholder}}' }
+
+      it 'returns the correct content' do
+        expect(content_substitutor.confirmation_email_body).to_not include(content)
+      end
+    end
+  end
+
+  describe '#service_email_subject' do
+    context 'when reference number is enabled' do
+      let(:content) do
+        I18n.t('default_values.reference_number_subject')
+      end
+
+      it 'returns the correct content' do
+        expect(content_substitutor.service_email_subject).to include(content)
+      end
+    end
+
+    context 'when reference number is disabled' do
+      let(:reference_number_enabled) { false }
+      let(:content) { '{{reference_number_placeholder}}' }
+
+      it 'returns the correct content' do
+        expect(content_substitutor.service_email_subject).to_not include(content)
+      end
+    end
+  end
+
+  describe '#service_email_body' do
+    context 'when reference number is enabled' do
+      let(:content) do
+        I18n.t('default_values.reference_number_sentence')
+      end
+
+      it 'returns the correct content' do
+        expect(content_substitutor.service_email_body).to include(content)
+      end
+    end
+
+    context 'when reference number is disabled' do
+      let(:reference_number_enabled) { false }
+      let(:content) { '{{reference_number_placeholder}}' }
+
+      it 'returns the correct content' do
+        expect(content_substitutor.service_email_body).to_not include(content)
+      end
+    end
+  end
+
+  describe '#service_email_pdf_heading' do
+    context 'when reference number is enabled' do
+      let(:content) do
+        I18n.t('default_values.reference_number_subject')
+      end
+
+      it 'returns the correct content' do
+        expect(content_substitutor.service_email_pdf_heading).to include(content)
+      end
+    end
+
+    context 'when reference number is disabled' do
+      let(:reference_number_enabled) { false }
+      let(:content) { '{{reference_number_placeholder}}' }
+
+      it 'returns the correct content' do
+        expect(content_substitutor.service_email_pdf_heading).to_not include(content)
+      end
+    end
+  end
+end

--- a/spec/models/content_substitutor_spec.rb
+++ b/spec/models/content_substitutor_spec.rb
@@ -112,4 +112,29 @@ RSpec.describe ContentSubstitutor do
       end
     end
   end
+
+  describe '#assign' do
+    context 'when setting exists' do
+      let(:content) { I18n.t('default_values.reference_number_subject') }
+      context 'when reference number is enabled' do
+        it 'returns the correct content' do
+          expect(content_substitutor.assign('confirmation_email_subject')).to include(content)
+        end
+      end
+
+      context 'when reference number is disabled' do
+        let(:reference_number_enabled) { false }
+
+        it 'returns the correct content' do
+          expect(content_substitutor.assign('confirmation_email_subject')).to_not include(content)
+        end
+      end
+    end
+
+    context 'when setting does not exist' do
+      it 'returns nil' do
+        expect(content_substitutor.assign('blah_blah')).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/email_settings_spec.rb
+++ b/spec/models/email_settings_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe EmailSettings do
   end
   let(:params) { {} }
   let(:from_address) { create(:from_address, :default, service_id: service.service_id) }
+  let(:default_subject) { I18n.t('default_values.service_email_subject', service_name: service.service_name) }
+  let(:default_body) { I18n.t('default_values.service_email_body', service_name: service.service_name) }
+  let(:default_pdf_heading) { I18n.t('default_values.service_email_pdf_heading', service_name: service.service_name) }
 
   describe '#valid?' do
     context 'when send by email is ticked' do
@@ -109,340 +112,204 @@ RSpec.describe EmailSettings do
   end
 
   describe '#service_email_subject' do
-    context 'when subject is empty' do
-      it 'shows the default value' do
-        expect(email_settings.service_email_subject).to eq(
-          "Submission from #{service.service_name}"
-        )
+    RSpec.shared_examples 'service email subject' do
+      let(:deployment_environment) { 'dev' }
+
+      context 'when subject is empty' do
+        it 'shows the default value' do
+          expect(email_settings.service_email_subject).to eq(default_subject)
+        end
+      end
+
+      context 'when user submits a value' do
+        let(:params) do
+          {
+            deployment_environment: deployment_environment,
+            service_email_subject: 'Never tell me the odds.'
+          }
+        end
+
+        it 'shows the submitted value' do
+          expect(
+            email_settings.service_email_subject
+          ).to eq('Never tell me the odds.')
+        end
+      end
+
+      context 'when a value already exists in the db' do
+        let(:params) { { deployment_environment: 'dev' } }
+
+        let!(:service_configuration) do
+          create(
+            :service_configuration,
+            :service_email_subject,
+            deployment_environment: deployment_environment,
+            service_id: service.service_id
+          )
+        end
+
+        it 'shows the value in the db' do
+          expect(
+            email_settings.service_email_subject
+          ).to eq(service_configuration.decrypt_value)
+        end
       end
     end
 
-    context 'when user submits a value' do
-      let(:params) do
-        {
-          deployment_environment: 'dev',
-          service_email_subject: 'Never tell me the odds.'
-        }
-      end
-
-      it 'shows the submitted value' do
-        expect(
-          email_settings.service_email_subject
-        ).to eq('Never tell me the odds.')
-      end
-    end
-
-    context 'when a value already exists in the db' do
-      let(:params) { { deployment_environment: 'dev' } }
-      let!(:service_configuration) do
-        create(
-          :service_configuration,
-          :dev,
-          :service_email_subject,
-          service_id: service.service_id
-        )
-      end
-
-      it 'shows the value in the db' do
-        expect(
-          email_settings.service_email_subject
-        ).to eq(service_configuration.decrypt_value)
-      end
-    end
-  end
-
-  describe '#service_email_subject' do
-    context 'when subject is empty' do
-      it 'shows the default value' do
-        expect(email_settings.service_email_subject).to eq(
-          "Submission from #{service.service_name}"
-        )
-      end
-    end
-
-    context 'when user submits a value' do
-      let(:params) do
-        { deployment_environment: 'production',
-          service_email_subject: 'Never tell me the odds.' }
-      end
-
-      it 'shows the submitted value' do
-        expect(
-          email_settings.service_email_subject
-        ).to eq('Never tell me the odds.')
-      end
-    end
-
-    context 'when a value already exists in the db' do
-      let(:params) { { deployment_environment: 'production' } }
-      let!(:service_configuration) do
-        create(
-          :service_configuration,
-          :production,
-          :service_email_subject,
-          service_id: service.service_id
-        )
-      end
-
-      it 'shows the value in the db' do
-        expect(
-          email_settings.service_email_subject
-        ).to eq(service_configuration.decrypt_value)
-      end
+    context 'in production environment' do
+      let(:deployment_environment) { 'production' }
+      it_behaves_like 'service email subject'
     end
   end
 
   describe '#service_email_body' do
-    context 'when body is empty' do
-      it 'shows the default value' do
-        expect(email_settings.service_email_body).to eq(
-          "Please find attached a submission sent from #{service.service_name}"
-        )
+    RSpec.shared_examples 'service email body' do
+      let(:deployment_environment) { 'dev' }
+
+      context 'when body is empty' do
+        it 'shows the default value' do
+          expect(email_settings.service_email_body).to eq(default_body)
+        end
+      end
+
+      context 'when user submits a value' do
+        let(:params) do
+          {
+            deployment_environment: deployment_environment,
+            service_email_body: 'Please find attached the Death star plans'
+          }
+        end
+
+        it 'shows the submitted value' do
+          expect(
+            email_settings.service_email_body
+          ).to eq('Please find attached the Death star plans')
+        end
+      end
+
+      context 'when a value already exists in the db' do
+        let(:params) { { deployment_environment: 'dev' } }
+        let!(:service_configuration) do
+          create(
+            :service_configuration,
+            :service_email_body,
+            deployment_environment: deployment_environment,
+            service_id: service.service_id
+          )
+        end
+
+        it 'shows the value in the db' do
+          expect(
+            email_settings.service_email_body
+          ).to eq(service_configuration.decrypt_value)
+        end
       end
     end
 
-    context 'when user submits a value' do
-      let(:params) do
-        {
-          deployment_environment: 'dev',
-          service_email_body: 'Please find attached the Death star plans'
-        }
-      end
-
-      it 'shows the submitted value' do
-        expect(
-          email_settings.service_email_body
-        ).to eq('Please find attached the Death star plans')
-      end
-    end
-
-    context 'when a value already exists in the db' do
-      let(:params) { { deployment_environment: 'dev' } }
-      let!(:service_configuration) do
-        create(
-          :service_configuration,
-          :dev,
-          :service_email_body,
-          service_id: service.service_id
-        )
-      end
-
-      it 'shows the value in the db' do
-        expect(
-          email_settings.service_email_body
-        ).to eq(service_configuration.decrypt_value)
-      end
-    end
-  end
-
-  describe '#service_email_body' do
-    context 'when body is empty' do
-      it 'shows the default value' do
-        expect(email_settings.service_email_body).to eq(
-          "Please find attached a submission sent from #{service.service_name}"
-        )
-      end
-    end
-
-    context 'when user submits a value' do
-      let(:params) do
-        {
-          deployment_environment: 'production',
-          service_email_body: 'Please find attached the Death star plans'
-        }
-      end
-
-      it 'shows the submitted value' do
-        expect(
-          email_settings.service_email_body
-        ).to eq('Please find attached the Death star plans')
-      end
-    end
-
-    context 'when a value already exists in the db' do
-      let(:params) { { deployment_environment: 'production' } }
-      let!(:service_configuration) do
-        create(
-          :service_configuration,
-          :production,
-          :service_email_body,
-          service_id: service.service_id
-        )
-      end
-
-      it 'shows the value in the db' do
-        expect(
-          email_settings.service_email_body
-        ).to eq(service_configuration.decrypt_value)
-      end
+    context 'in production environment' do
+      let(:deployment_environment) { 'production' }
+      it_behaves_like 'service email body'
     end
   end
 
   describe '#service_email_pdf_heading' do
-    context 'when body is empty' do
-      it 'shows the default value' do
-        expect(email_settings.service_email_pdf_heading).to eq(
-          "Submission for #{service.service_name}"
-        )
+    RSpec.shared_examples 'service email pdf heading' do
+      let(:deployment_environment) { 'dev' }
+
+      context 'when body is empty' do
+        it 'shows the default value' do
+          expect(email_settings.service_email_pdf_heading).to eq(default_pdf_heading)
+        end
+      end
+
+      context 'when user submits a value' do
+        let(:params) do
+          {
+            deployment_environment: deployment_environment,
+            service_email_pdf_heading: 'Death star plans'
+          }
+        end
+
+        it 'shows the submitted value' do
+          expect(
+            email_settings.service_email_pdf_heading
+          ).to eq('Death star plans')
+        end
+      end
+
+      context 'when a value already exists in the db' do
+        let(:params) { { deployment_environment: deployment_environment } }
+        let!(:service_configuration) do
+          create(
+            :service_configuration,
+            :service_email_pdf_heading,
+            deployment_environment: deployment_environment,
+            service_id: service.service_id
+          )
+        end
+
+        it 'shows the value in the db' do
+          expect(
+            email_settings.service_email_pdf_heading
+          ).to eq(service_configuration.decrypt_value)
+        end
       end
     end
 
-    context 'when user submits a value' do
-      let(:params) do
-        {
-          deployment_environment: 'dev',
-          service_email_pdf_heading: 'Death star plans'
-        }
-      end
-
-      it 'shows the submitted value' do
-        expect(
-          email_settings.service_email_pdf_heading
-        ).to eq('Death star plans')
-      end
-    end
-
-    context 'when a value already exists in the db' do
-      let(:params) { { deployment_environment: 'dev' } }
-      let!(:service_configuration) do
-        create(
-          :service_configuration,
-          :dev,
-          :service_email_pdf_heading,
-          service_id: service.service_id
-        )
-      end
-
-      it 'shows the value in the db' do
-        expect(
-          email_settings.service_email_pdf_heading
-        ).to eq(service_configuration.decrypt_value)
-      end
-    end
-  end
-
-  describe '#service_email_pdf_heading' do
-    context 'when body is empty' do
-      it 'shows the default value' do
-        expect(email_settings.service_email_pdf_heading).to eq(
-          "Submission for #{service.service_name}"
-        )
-      end
-    end
-
-    context 'when user submits a value' do
-      let(:params) do
-        {
-          deployment_environment: 'production',
-          service_email_pdf_heading: 'Death star plans'
-        }
-      end
-
-      it 'shows the submitted value' do
-        expect(
-          email_settings.service_email_pdf_heading
-        ).to eq('Death star plans')
-      end
-    end
-
-    context 'when a value already exists in the db' do
-      let(:params) { { deployment_environment: 'production' } }
-      let!(:service_configuration) do
-        create(
-          :service_configuration,
-          :production,
-          :service_email_pdf_heading,
-          service_id: service.service_id
-        )
-      end
-
-      it 'shows the value in the db' do
-        expect(
-          email_settings.service_email_pdf_heading
-        ).to eq(service_configuration.decrypt_value)
-      end
+    context 'in production environment' do
+      let(:deployment_environment) { 'production' }
+      it_behaves_like 'service email pdf heading'
     end
   end
 
   describe '#service_email_pdf_subheading' do
-    context 'when body is empty' do
-      it 'shows the default value' do
-        expect(email_settings.service_email_pdf_subheading).to eq('')
+    RSpec.shared_examples 'service email pdf subheading' do
+      let(:deployment_environment) { 'dev' }
+
+      context 'when body is empty' do
+        it 'shows the default value' do
+          expect(email_settings.service_email_pdf_subheading).to eq('')
+        end
+      end
+
+      context 'when user submits a value' do
+        let(:params) do
+          {
+            deployment_environment: deployment_environment,
+            service_email_pdf_subheading: 'Rebellion ships'
+          }
+        end
+
+        it 'shows the submitted value' do
+          expect(
+            email_settings.service_email_pdf_subheading
+          ).to eq('Rebellion ships')
+        end
+      end
+
+      context 'when a value already exists in the db' do
+        let(:params) { { deployment_environment: deployment_environment } }
+        let!(:service_configuration) do
+          create(
+            :service_configuration,
+            :dev,
+            :service_email_pdf_subheading,
+            deployment_environment: deployment_environment,
+            service_id: service.service_id
+          )
+        end
+
+        it 'shows the value in the db' do
+          expect(
+            email_settings.service_email_pdf_subheading
+          ).to eq(service_configuration.decrypt_value)
+        end
       end
     end
 
-    context 'when user submits a value' do
-      let(:params) do
-        {
-          deployment_environment: 'dev',
-          service_email_pdf_subheading: 'Rebellion ships'
-        }
-      end
-
-      it 'shows the submitted value' do
-        expect(
-          email_settings.service_email_pdf_subheading
-        ).to eq('Rebellion ships')
-      end
-    end
-
-    context 'when a value already exists in the db' do
-      let(:params) { { deployment_environment: 'dev' } }
-      let!(:service_configuration) do
-        create(
-          :service_configuration,
-          :dev,
-          :service_email_pdf_subheading,
-          service_id: service.service_id
-        )
-      end
-
-      it 'shows the value in the db' do
-        expect(
-          email_settings.service_email_pdf_subheading
-        ).to eq(service_configuration.decrypt_value)
-      end
-    end
-  end
-
-  describe '#service_email_pdf_subheading' do
-    context 'when body is empty' do
-      it 'shows the default value' do
-        expect(email_settings.service_email_pdf_subheading).to eq('')
-      end
-    end
-
-    context 'when user submits a value' do
-      let(:params) do
-        {
-          deployment_environment: 'production',
-          service_email_pdf_subheading: 'Rebellion ships'
-        }
-      end
-
-      it 'shows the submitted value' do
-        expect(
-          email_settings.service_email_pdf_subheading
-        ).to eq('Rebellion ships')
-      end
-    end
-
-    context 'when a value already exists in the db' do
-      let(:params) { { deployment_environment: 'production' } }
-      let!(:service_configuration) do
-        create(
-          :service_configuration,
-          :production,
-          :service_email_pdf_subheading,
-          service_id: service.service_id
-        )
-      end
-
-      it 'shows the value in the db' do
-        expect(
-          email_settings.service_email_pdf_subheading
-        ).to eq(service_configuration.decrypt_value)
-      end
+    context 'in production environment' do
+      let(:deployment_environment) { 'production' }
+      it_behaves_like 'service email pdf subheading'
     end
   end
 

--- a/spec/models/email_settings_spec.rb
+++ b/spec/models/email_settings_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe EmailSettings do
   end
   let(:params) { {} }
   let(:from_address) { create(:from_address, :default, service_id: service.service_id) }
-  let(:default_subject) { I18n.t('default_values.service_email_subject', service_name: service.service_name) }
-  let(:default_body) { I18n.t('default_values.service_email_body', service_name: service.service_name) }
-  let(:default_pdf_heading) { I18n.t('default_values.service_email_pdf_heading', service_name: service.service_name) }
+  let(:default_subject) { email_settings.default_value('service_email_subject') }
+  let(:default_body) { email_settings.default_value('service_email_body') }
+  let(:default_pdf_heading) { email_settings.default_value('service_email_pdf_heading') }
 
   describe '#valid?' do
     context 'when send by email is ticked' do

--- a/spec/models/email_settings_updater_spec.rb
+++ b/spec/models/email_settings_updater_spec.rb
@@ -11,9 +11,15 @@ RSpec.describe EmailSettingsUpdater do
     )
   end
   let(:params) { {} }
-  let(:default_email_subject) { I18n.t('default_values.service_email_subject', service_name: service.service_name) }
-  let(:default_email_body) { I18n.t('default_values.service_email_body', service_name: service.service_name) }
-  let(:default_email_pdf_heading) { I18n.t('default_values.service_email_pdf_heading', service_name: service.service_name) }
+  let(:default_email_subject) do
+    email_settings_updater.email_settings.default_value('service_email_subject')
+  end
+  let(:default_email_body) do
+    email_settings_updater.email_settings.default_value('service_email_body')
+  end
+  let(:default_email_pdf_heading) do
+    email_settings_updater.email_settings.default_value('service_email_pdf_heading')
+  end
 
   describe '#create_or_update' do
     context 'email output' do

--- a/spec/models/email_settings_updater_spec.rb
+++ b/spec/models/email_settings_updater_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe EmailSettingsUpdater do
     )
   end
   let(:params) { {} }
+  let(:default_email_subject) { I18n.t('default_values.service_email_subject', service_name: service.service_name) }
+  let(:default_email_body) { I18n.t('default_values.service_email_body', service_name: service.service_name) }
+  let(:default_email_pdf_heading) { I18n.t('default_values.service_email_pdf_heading', service_name: service.service_name) }
 
   describe '#create_or_update' do
     context 'email output' do
@@ -305,7 +308,7 @@ RSpec.describe EmailSettingsUpdater do
             service_configuration.reload
             expect(
               service_configuration.decrypt_value
-            ).to eq("Submission from #{service.service_name}")
+            ).to eq(default_email_subject)
           end
         end
       end
@@ -349,7 +352,7 @@ RSpec.describe EmailSettingsUpdater do
             expect(service_configuration).to be_persisted
             expect(
               service_configuration.decrypt_value
-            ).to eq("Submission from #{service.service_name}")
+            ).to eq(default_email_subject)
           end
         end
       end
@@ -394,7 +397,7 @@ RSpec.describe EmailSettingsUpdater do
             service_configuration.reload
             expect(
               service_configuration.decrypt_value
-            ).to eq("Please find attached a submission sent from #{service.service_name}")
+            ).to eq(default_email_body)
           end
         end
       end
@@ -438,7 +441,7 @@ RSpec.describe EmailSettingsUpdater do
             expect(service_configuration).to be_persisted
             expect(
               service_configuration.decrypt_value
-            ).to eq("Please find attached a submission sent from #{service.service_name}")
+            ).to eq(default_email_body)
           end
         end
       end
@@ -483,7 +486,7 @@ RSpec.describe EmailSettingsUpdater do
             service_configuration.reload
             expect(
               service_configuration.decrypt_value
-            ).to eq("Submission for #{service.service_name}")
+            ).to eq(default_email_pdf_heading)
           end
         end
       end
@@ -527,7 +530,7 @@ RSpec.describe EmailSettingsUpdater do
             expect(service_configuration).to be_persisted
             expect(
               service_configuration.decrypt_value
-            ).to eq("Submission for #{service.service_name}")
+            ).to eq(default_email_pdf_heading)
           end
         end
       end
@@ -574,7 +577,7 @@ RSpec.describe EmailSettingsUpdater do
             service_configuration.reload
             expect(
               service_configuration.decrypt_value
-            ).to eq("Please find attached a submission sent from #{service.service_name}")
+            ).to eq(default_email_body)
           end
         end
       end
@@ -616,11 +619,11 @@ RSpec.describe EmailSettingsUpdater do
           end
           before { email_settings_updater.create_or_update! }
 
-          it 'shows the default subject' do
+          it 'shows the default body' do
             expect(service_configuration).to be_persisted
             expect(
               service_configuration.decrypt_value
-            ).to eq("Please find attached a submission sent from #{service.service_name}")
+            ).to eq(default_email_body)
           end
         end
       end
@@ -667,7 +670,7 @@ RSpec.describe EmailSettingsUpdater do
             service_configuration.reload
             expect(
               service_configuration.decrypt_value
-            ).to eq("Submission for #{service.service_name}")
+            ).to eq(default_email_pdf_heading)
           end
         end
       end
@@ -713,7 +716,7 @@ RSpec.describe EmailSettingsUpdater do
             expect(service_configuration).to be_persisted
             expect(
               service_configuration.decrypt_value
-            ).to eq("Submission for #{service.service_name}")
+            ).to eq(default_email_pdf_heading)
           end
         end
       end


### PR DESCRIPTION
### Introduce `ContentSubstitutor` class to substitute placeholder text
This class is responsible for finding the `{{reference_number_placeholder}}` and replacing it with either `''` or the default reference number sentence/subject which is found in the locales.
We decided to create this class as we know there will be future features that will require a similar mechanism of substitution.

We have also used the `EmailSettingsUpdater` and `ConfirmationEmailSettingsUpdater` classes in the `ReferenceNumberUpdater` as a way to leverage the `create_or_update!` methods in these classes to make sure we save any changes to the service configurations to the database.