### PR TITLE
Update copy on the sign in page

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -11,7 +11,11 @@
     </div>
 
       <div>
-        <p><%= t('.body').html_safe %></p>
+        <p><%= t('.body',
+                 product_site_link: govuk_link_to( t('.product_site_link_text'), 'https://moj-forms.service.justice.gov.uk/'),
+                 user_guide_link: govuk_link_to( t('.user_guide_link_text'), 'https://moj-forms.service.justice.gov.uk/user-guide'),
+                 contact_us_link: govuk_link_to( t('.contact_us_link_text'), 'https://moj-forms.service.justice.gov.uk/contact/')
+                ).html_safe %></p>
       </div>
 
       <div class="govuk-inset-text">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,8 +126,11 @@ en:
     show:
       title: MoJ Forms
       lede: Prototype, test and publish online forms quickly and easily
-      body: To find out more about MoJ Forms, email us at <a class="govuk-link" href="mailto:moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a>, or <a class="govuk-link" href="https://app.slack.com/client/T02DYEB3A/CE26QEL1Z" target="_blank">ask us a question on Slack</a>.
-      callout: You will need a @digital.justice.gov.uk or @justice.gov.uk email address to use MoJ Forms.
+      body: To find out more about MoJ Forms, visit our %{product_site_link}, check out the %{user_guide_link} or %{contact_us_link}</a>.
+      product_site_link_text: product site
+      user_guide_link_text: user guide
+      contact_us_link_text: contact us with a question
+      callout: You will need an @digital.justice.gov.uk, @justice.gov.uk or @cica.org.uk email address to use MoJ Forms.
       sign_in: Sign in
   auth:
     existing_user:


### PR DESCRIPTION
Updates the copy on the signin page, to add the new cica allowed domain, and improve the introductory paragraph.

**Before**
![image](https://user-images.githubusercontent.com/595564/205091582-25bdaecd-c467-47d9-805c-256d645945c8.png)


**After**
![image](https://user-images.githubusercontent.com/595564/205091223-b62d37d6-13ea-4a2b-a47b-b8750fca42dc.png)
