### PR TITLE
Update 500 page to have GOVUK Styles

### DIFF
--- a/public/500.html
+++ b/public/500.html
@@ -39,6 +39,13 @@
       .govuk-visually-hidden{padding:0!important;border:0!important;}
       .govuk-visually-hidden{position:absolute!important;width:1px!important;height:1px!important;margin:0!important;overflow:hidden!important;clip:rect(0 0 0 0)!important;-webkit-clip-path:inset(50%)!important;clip-path:inset(50%)!important;white-space:nowrap!important;}
       #main-content{min-height:55vh;}
+      .govuk-link{font-family:GDS Transport,arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;text-decoration:underline;}
+      .govuk-link:focus{outline:3px solid transparent;background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;text-decoration:none;}
+      .govuk-link:link{color:#1d70b8;}
+      .govuk-link:visited{color:#4c2c92;}
+      .govuk-link:hover{color:#003078;}
+      .govuk-link:active,.govuk-link:focus{color:#0b0c0c;}
+
       @media (min-width:40.0625em){
         .govuk-body-m{font-size:19px;font-size:1.1875rem;line-height:1.3157894737;}
         .govuk-body-m{margin-bottom:20px;}
@@ -87,7 +94,7 @@
         <!-- This file lives in public/500.html -->
         <h1>There is a problem with MoJ Forms</h1>
         <p>Try again later.</p>
-        <p>If the problem persists, email <a href="mailto: moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a></p>
+        <p>If the problem persists, email <a class="govuk-link" href="mailto: moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a></p>
       </main>
     </div>
   </body>

--- a/public/500.html
+++ b/public/500.html
@@ -1,67 +1,94 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <title>There is a problem with MoJ Forms - MoJ Forms</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+  <head>
+    <title>There is a problem with MoJ Forms - MoJ Forms</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <style>
+      /* CSS generated using the UseCSS browser extension: https://chrome.google.com/webstore/detail/css-used/cdopjfddjlonogibjahpnmjpoangjfff/related?hl=en */
+      /* Generated from a live MoJ forms 404 page */
+      .govuk-body-m{color:#0b0c0c;font-family:GDS Transport,arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:400;font-size:16px;font-size:1rem;line-height:1.25;margin-top:0;margin-bottom:15px;}
+      .govuk-main-wrapper{display:block;padding-top:20px;padding-bottom:20px;}
+      .govuk-main-wrapper--auto-spacing:first-child{padding-top:30px;}
+      .govuk-template__body{margin:0;background-color:#fff;}
+      .govuk-width-container{max-width:960px;margin-right:15px;margin-left:15px;}
+      .govuk-header{font-family:GDS Transport,arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:400;font-size:14px;font-size:.875rem;line-height:1.1428571429;border-bottom:10px solid #fff;color:#fff;background:#0b0c0c;}
+      .govuk-header__container{position:relative;margin-bottom:-10px;padding-top:10px;border-bottom:10px solid #1d70b8;}
+      .govuk-header__container:after{content:"";display:block;clear:both;}
+      .govuk-header__logotype{display:inline-block;margin-right:5px;}
+      .govuk-header__logotype:last-child{margin-right:0;}
+      .govuk-header__logotype-crown{position:relative;top:-1px;margin-right:1px;fill:currentcolor;vertical-align:top;}
+      .govuk-header__logotype-crown-fallback-image{width:36px;height:32px;border:0;vertical-align:bottom;}
+      .govuk-header__link{font-family:GDS Transport,arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;text-decoration:none;}
+      .govuk-header__link:link,.govuk-header__link:visited{color:#fff;}
+      .govuk-header__link:active,.govuk-header__link:hover{color:hsla(0,0%,100%,.99);}
+      .govuk-header__link:hover{text-decoration:underline;text-decoration-thickness:3px;text-underline-offset:.1em;}
+      .govuk-header__link:focus{outline:3px solid transparent;color:#0b0c0c;background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;text-decoration:none;}
+      .govuk-header__link--homepage{font-family:GDS Transport,arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:700;display:inline-block;margin-right:10px;font-size:30px;line-height:1;}
+      .govuk-header__link--homepage:link,.govuk-header__link--homepage:visited{text-decoration:none;}
+      .govuk-header__link--homepage:active,.govuk-header__link--homepage:hover{margin-bottom:-3px;border-bottom:3px solid;}
+      .govuk-header__link--homepage:focus{margin-bottom:0;border-bottom:0;}
+      .govuk-header__service-name{display:inline-block;margin-bottom:10px;font-family:GDS Transport,arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:700;font-size:18px;font-size:1.125rem;line-height:1.1111111111;}
+      .govuk-header__content,.govuk-header__logo{box-sizing:border-box;}
+      .govuk-header__logo{margin-bottom:10px;padding-right:50px;}
+      .govuk-skip-link{position:absolute!important;width:1px!important;height:1px!important;margin:0!important;overflow:hidden!important;clip:rect(0 0 0 0)!important;-webkit-clip-path:inset(50%)!important;clip-path:inset(50%)!important;white-space:nowrap!important;font-family:GDS Transport,arial,sans-serif;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;text-decoration:underline;font-size:14px;font-size:.875rem;line-height:1.1428571429;display:block;padding:10px 15px;}
+      .govuk-skip-link:active,.govuk-skip-link:focus{position:static!important;width:auto!important;height:auto!important;margin:inherit!important;overflow:visible!important;clip:auto!important;-webkit-clip-path:none!important;clip-path:none!important;white-space:inherit!important;}
+      .govuk-skip-link:link,.govuk-skip-link:visited{color:#0b0c0c;}
+      .govuk-skip-link:hover{color:rgba(11,12,12,.99);}
+      .govuk-skip-link:active,.govuk-skip-link:focus{color:#0b0c0c;}
+      .govuk-skip-link:focus{outline:3px solid #fd0;outline-offset:0;background-color:#fd0;}
+      .govuk-visually-hidden{padding:0!important;border:0!important;}
+      .govuk-visually-hidden{position:absolute!important;width:1px!important;height:1px!important;margin:0!important;overflow:hidden!important;clip:rect(0 0 0 0)!important;-webkit-clip-path:inset(50%)!important;clip-path:inset(50%)!important;white-space:nowrap!important;}
+      #main-content{min-height:55vh;}
+      @media (min-width:40.0625em){
+        .govuk-body-m{font-size:19px;font-size:1.1875rem;line-height:1.3157894737;}
+        .govuk-body-m{margin-bottom:20px;}
+        .govuk-main-wrapper{padding-top:40px;padding-bottom:40px;}
+        .govuk-main-wrapper--auto-spacing:first-child{padding-top:50px;}
+        .govuk-width-container{margin-right:30px;margin-left:30px;}
+        .govuk-header{font-size:16px;font-size:1rem;line-height:1.25;}
+        .govuk-header__link--homepage{display:inline;}
+        .govuk-header__link--homepage:focus{box-shadow:0 0 #fd0;}
+        .govuk-header__service-name{font-size:24px;font-size:1.5rem;line-height:1.25;}
+        .govuk-header__logo{width:33.33%;padding-right:15px;float:left;vertical-align:top;}
+        .govuk-header__content{width:66.66%;padding-left:15px;float:left;}
+        .govuk-skip-link{font-size:16px;font-size:1rem;line-height:1.25;}
+      }
+      @media (min-width:1020px){
+        .govuk-width-container{margin-right:auto;margin-left:auto;}
+      }
+      @media (forced-colors:active){
+        .govuk-header__logotype{forced-color-adjust:none;color:linktext;}
+      }
+    </style>
+  </head>
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+  <body class="govuk-template__body">
+    <header class="govuk-header" role="banner" data-module="govuk-header">
+      <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+      <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo">
+          <a href="/" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                <image src="{{ params.assetsPath | default('/assets/images') }}/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+              </svg>
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+          </a>
+        </div>
+      </div>
+    </header>
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
-
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <div>
-      <h1>There is a problem with MoJ Forms</h1>
-      <p>Try again later.</p>
+    <div class="govuk-width-container govuk-body-m">
+      <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+        <!-- This file lives in public/500.html -->
+        <h1>There is a problem with MoJ Forms</h1>
+        <p>Try again later.</p>
+        <p>If the problem persists, email <a href="mailto: moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a></p>
+      </main>
     </div>
-    <p>If the problem persists, email <a href="mailto: moj-forms@digital.justice.gov.uk">moj-forms@digital.justice.gov.uk</a></p>
-  </div>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
Updates the 500 page for the editor to have GOVUK styles.

Needs to be fully standalone and cannot rely on editor assets.

Subset of the GOVUK CSS generated using a chrome extenmsion to pull the used styles from one of our live 404 pages. Then tidied up a bit.

**Large screen**
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/595564/205310152-38b0c3bd-248d-4cba-b15c-d1336daedfe5.png">

**Small screen**
<img width="336" alt="image" src="https://user-images.githubusercontent.com/595564/205310213-50e21593-2102-4a96-89d7-0abe6b1c5d6f.png">
