### PR TITLE
Remove test that triggers a publish

### DIFF
--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -176,17 +176,6 @@ feature 'Publishing' do
     and_I_cancel
   end
 
-  scenario 'publishing for the first time' do
-    when_I_visit_the_publishing_page
-    and_I_want_to_publish('Test')
-    then_I_should_see_publish_to_test_modal
-
-    then_username_and_password_should_be_the_default('dev')
-    when_I_enter_valid_username_and_password('dev', 'Test')
-
-    then_I_should_see_the_first_publish_message
-  end
-
   def then_I_should_see_the_default_no_service_output_warning_message
     expect(environment_section).to have_text(I18n.t('publish.service_output.default', link: I18n.t('publish.service_output.link_text')))
   end
@@ -290,12 +279,6 @@ feature 'Publishing' do
     editor.find('.ui-dialog').find(:button, text: "Publish to #{button_environment.capitalize}").click
   end
 
-  def when_I_enter_valid_username_and_password(environment, button_environment)
-    editor.find("#username_#{environment}").set('longusername')
-    editor.find("#password_#{environment}").set('longpassword')
-    editor.find('.ui-dialog').find(:button, text: "Publish to #{button_environment.capitalize}").click
-  end
-
   def then_I_should_see_an_error_message(environment, button_environment)
     page.find(:css, '#main-content', visible: true)
     errors = editor.all("form#publish-form-#{environment} .govuk-error-message").map(&:text)
@@ -355,13 +338,4 @@ feature 'Publishing' do
     expect(environment_section.text).to_not include(autocomplete_warning_message)
   end
 
-  def then_I_should_see_the_first_publish_message
-    page.find('#main-content')
-    sleep(2)
-    expect(editor.text).to include(I18n.t("publish.first_publish_warning"))
-  end
-
-  def then_I_should_see_the_first_publish_success_message
-    expect(editor.text).to include(I18n.t("publish.first_publish_success"))
-  end
 end


### PR DESCRIPTION
Didn't think things through and worte a test that triggers a publihs when running in circle.

This then causes failed publish jobs due to the length of the form name.

Remove the test - the only way to acceptance test the feature is to publish, so we'll have to go without for now.

