### PR TITLE
Add confirmation email warning to reference no settings page

### DIFF
--- a/app/controllers/settings/reference_payment_controller.rb
+++ b/app/controllers/settings/reference_payment_controller.rb
@@ -1,9 +1,7 @@
 class Settings::ReferencePaymentController < FormController
   before_action :assign_form_objects
 
-  def index
-    @reference_payment = ReferencePaymentSettings.new(service_id: service.service_id)
-  end
+  def index; end
 
   def create
     @reference_payment = ReferencePaymentSettings.new(
@@ -26,6 +24,14 @@ class Settings::ReferencePaymentController < FormController
 
   def assign_form_objects
     @reference_payment = ReferencePaymentSettings.new(service_id: service.service_id)
+    @confirmation_email_enabled = confirmation_email_setting('dev').try(:send_confirmation_email?) && confirmation_email_setting('production').try(:send_confirmation_email?)
+  end
+
+  def confirmation_email_setting(environment)
+    SubmissionSetting.find_by(
+      service_id: service.service_id,
+      deployment_environment: environment
+    )
   end
 
   def reference_payment_params

--- a/app/views/settings/reference_payment/index.html.erb
+++ b/app/views/settings/reference_payment/index.html.erb
@@ -1,24 +1,34 @@
-<%= render MojForms::SettingsScreenComponent.new(
-  heading:t('settings.reference_number.heading'),
-  description: t('settings.reference_number.description',
-                  href: t('settings.reference_number.href',
-                    url: t('partials.header.user_guide_url')
-                  )
-                ).html_safe
-  ) do |c| %>
-
-  <% c.with_back_link(href: settings_path) %>
-
-  <%= govuk_warning_text(text: t('settings.reference_number.warning'), html_attributes: { id: 'reference_number_warning' }) %>
-
-    <%= form_for @reference_payment, url: settings_reference_payment_index_path(service.service_id),
+<%= form_for @reference_payment, url: settings_reference_payment_index_path(service.service_id),
     html: { id: 'reference-payment-settings' },
     builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+
+  <%= render MojForms::SettingsScreenComponent.new(
+    heading:t('settings.reference_number.heading'),
+    description: t('settings.reference_number.description',
+                    href: t('settings.reference_number.href',
+                      url: t('partials.header.user_guide_url')
+                    )
+                  ).html_safe
+    ) do |c| %>
+
+    <% c.with_back_link(href: settings_path) %>
+
+    <% c.with_notification do %>
+      <% if @reference_payment.reference_number_checked? && !@confirmation_email_enabled %>
+        <%= govuk_notification_banner(title_text: t('notification_banners.important'), classes: "govuk-!-margin-top-6") do %>
+          <h3 class="govuk-heading-s"><%= t('settings.reference_number.confirmation_email_warning.title') %></h3>
+          <p><%= t('settings.reference_number.confirmation_email_warning.text') %></p>
+          <p><%= govuk_link_to( t('settings.reference_number.confirmation_email_warning.link_text'), settings_confirmation_email_index_path(service.service_id) ) %></p>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= govuk_warning_text(text: t('settings.reference_number.warning'), html_attributes: { id: 'reference_number_warning' }) %>
 
     <%= render partial: 'form', locals: { f: f } %>
 
     <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
       <%= t('actions.save') %>
     </button>
-    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/settings/reference_payment/index.html.erb
+++ b/app/views/settings/reference_payment/index.html.erb
@@ -6,7 +6,7 @@
     heading:t('settings.reference_number.heading'),
     description: t('settings.reference_number.description',
                     href: t('settings.reference_number.href',
-                      url: t('partials.header.user_guide_url')
+                      url: t('partials.header.user_guide_url')+'settings/#references'
                     )
                   ).html_safe
     ) do |c| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -327,6 +327,10 @@ en:
       legend: Reference numbers
       hint: This inserts a reference number in the confirmation page, confirmation email, submission email and submission attachments
       label: Enable reference numbers
+      confirmation_email_warning:
+        title: Do you also want to send a confirmation email?
+        text: These features work best with a confirmation email, which sends the people completing your form an email with their reference number and payment link.
+        link_text: Send a confirmation email
     payment_link:
       legend: GOV.UK Pay payment links
       hint: This inserts a reference number to a GOV.UK Pay payment link and inserts it in the confirmation page and confirmation email. (Requires a %{href})


### PR DESCRIPTION
Adds the warning block into the reference number settings page if confirmation email is not enabled (in test and live)

![image](https://user-images.githubusercontent.com/595564/205636779-4c529313-0893-463f-abc0-8002060bde74.png)
