### PR TITLE
Reference number only update default config values

### DIFF
--- a/app/controllers/settings/reference_payment_controller.rb
+++ b/app/controllers/settings/reference_payment_controller.rb
@@ -1,5 +1,5 @@
 class Settings::ReferencePaymentController < FormController
-  before_action :assign_form_objects
+  before_action :assign_form_objects, only: :index
 
   def index
     @reference_payment = ReferencePaymentSettings.new(service_id: service.service_id)

--- a/app/models/reference_payment_updater.rb
+++ b/app/models/reference_payment_updater.rb
@@ -4,6 +4,13 @@ class ReferencePaymentUpdater
   attr_reader :service, :reference_payment_settings
 
   CONFIGS = %w[REFERENCE_NUMBER].freeze
+  CONFIG_WITH_DEFAULTS = %w[
+    CONFIRMATION_EMAIL_SUBJECT
+    CONFIRMATION_EMAIL_BODY
+    SERVICE_EMAIL_SUBJECT
+    SERVICE_EMAIL_BODY
+    SERVICE_EMAIL_PDF_HEADING
+  ].freeze
 
   def initialize(service:, reference_payment_settings:)
     @service = service
@@ -13,8 +20,11 @@ class ReferencePaymentUpdater
   def create_or_update!
     ActiveRecord::Base.transaction do
       save_config
+      save_config_with_defaults
     end
   end
+
+  private
 
   def save_config
     CONFIGS.each do |config|
@@ -25,7 +35,6 @@ class ReferencePaymentUpdater
         remove_service_configuration(config, 'dev')
         remove_service_configuration(config, 'production')
       end
-      save_config_with_defaults
     end
   end
 
@@ -49,52 +58,18 @@ class ReferencePaymentUpdater
   end
 
   def save_config_with_defaults
-    email_settings.each do |settings|
-      EmailSettingsUpdater.new(
-        email_settings: settings,
-        service: service
-      ).create_or_update!
-    end
-
-    confirmation_emails_settings.each do |settings|
-      ConfirmationEmailSettingsUpdater.new(
-        confirmation_email_settings: settings,
-        service: service
-      ).create_or_update!
+    %w[dev production].each do |environment|
+      CONFIG_WITH_DEFAULTS.each do |config|
+        create_or_update_service_configuration(
+          config: config,
+          deployment_environment: environment,
+          value: content_substitutor.public_send(config.downcase)
+        )
+      end
     end
   end
-
-  private
 
   def reference_number
     @reference_number ||= reference_payment_settings.reference_number
-  end
-
-  def confirmation_emails_settings
-    [
-      assign_confirmation_email_settings('dev'),
-      assign_confirmation_email_settings('production')
-    ]
-  end
-
-  def email_settings
-    [assign_email_settings('dev'), assign_email_settings('production')]
-  end
-
-  def assign_email_settings(deployment_environment)
-    EmailSettings.new(
-      deployment_environment: deployment_environment,
-      service_email_subject: content_substitutor.service_email_subject,
-      service_email_body: content_substitutor.service_email_body,
-      service_email_pdf_heading: content_substitutor.service_email_pdf_heading
-    )
-  end
-
-  def assign_confirmation_email_settings(deployment_environment)
-    ConfirmationEmailSettings.new(
-      deployment_environment: deployment_environment,
-      confirmation_email_subject: content_substitutor.confirmation_email_subject,
-      confirmation_email_body: content_substitutor.confirmation_email_body
-    )
   end
 end


### PR DESCRIPTION
When the reference number is enabled or disabled we only want to update
the following service configurations:

- CONFIRMATION_EMAIL_SUBJECT
- CONFIRMATION_EMAIL_BODY
- SERVICE_EMAIL_SUBJECT
- SERVICE_EMAIL_BODY
- SERVICE_EMAIL_PDF_HEADING

Submission settings and any other service configuration records should
be left alone.

By using the EmailSettingsUpdater and the
ConfirmationEmailSettingsUpdater models all other settings and configs
were being removed as their attributes would have been nil at the time
of saving.