### PR TITLE
Add forms to user in admin

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,11 +1,18 @@
 module Admin
+  # rubocop:disable Lint/LexicallyScopedActionFilter, Lint/MemoizedInstanceVariableName
   class UsersController < Admin::ApplicationController
+    before_action :assign_user_services, only: :show
+
     def valid_action?(name, resource = resource_class)
       %w[destroy edit new].exclude?(name.to_s) && super
     end
 
     def default_sorting_attribute
       :name
+    end
+
+    def assign_user_services
+      @user_services ||= MetadataApiClient::Service.all(user_id: params[:id])
     end
 
     # Overwrite any of the RESTful controller actions to implement custom behavior
@@ -51,4 +58,5 @@ module Admin
     # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
     # for more information
   end
+  # rubocop:enable Lint/LexicallyScopedActionFilter, Lint/MemoizedInstanceVariableName
 end

--- a/app/views/admin/application/show.html.erb
+++ b/app/views/admin/application/show.html.erb
@@ -33,9 +33,10 @@ as well as a link to its edit page.
 </header>
 
 <section class="main-content__body">
+
   <dl>
     <% page.attributes.each do |attribute| %>
-      <dt class="attribute-label" id="<%= attribute.name %>">
+      <dt class="attribute-label" id="<%= attribute.name %>" style="margin-top: 0;">
       <%= t(
         "helpers.label.#{resource_name}.#{attribute.name}",
         default: page.resource.class.human_attribute_name(attribute.name),
@@ -43,7 +44,26 @@ as well as a link to its edit page.
       </dt>
 
       <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
-          ><%= render_field attribute, page: page %></dd>
+          > <%= render_field attribute, page: page %></dd>
     <% end %>
+
   </dl>
+
+<% if @user_services.present? %>
+
+  <div style="clear: both;">
+    <h2>Forms</h2>
+      <ul class="fb-editor-list fb-editor-form-list">
+          <% @user_services.each do |service| %>
+            <li id="service-<%= service.name.parameterize %>">
+
+              <%= link_to(service.name, admin_service_path(service.id), class: "govuk-link edit") %>
+
+            </li>
+          <% end %>
+        </ul>
+    </div>
+  <% end %>
 </section>
+
+


### PR DESCRIPTION
This change lists the services (forms) under the user details.
The form links to the admin service page for that form.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Chris Pymm <chris.pymm@digital.justice.gov.uk>

