### PR TITLE
Add payment link attributes to reference payment model

### DIFF
--- a/app/models/reference_payment_settings.rb
+++ b/app/models/reference_payment_settings.rb
@@ -3,6 +3,8 @@ class ReferencePaymentSettings
 
   attr_accessor :service_id,
                 :reference_number,
+                :payment_link,
+                :payment_link_url,
                 :deployment_environment
 
   validates :service_id, presence: true


### PR DESCRIPTION
These attributes are now being passed into the reference payment model from the controller so need to have accessors