### PR TITLE
Payment link settings validation

### DIFF
--- a/app/models/reference_payment_settings.rb
+++ b/app/models/reference_payment_settings.rb
@@ -8,20 +8,22 @@ class ReferencePaymentSettings
                 :deployment_environment
 
   validates :service_id, presence: true
+  validates :payment_link_url, presence: true, if: proc { |obj| obj.payment_link == '1' }
+  validates :payment_link, presence: true, if: proc { |obj| obj.reference_number == '1' }
 
   def reference_number_checked?
-    enabled? || ServiceConfiguration.exists?(service_id: service_id, name: 'REFERENCE_NUMBER')
+    reference_number_enabled? || ServiceConfiguration.exists?(service_id: service_id, name: 'REFERENCE_NUMBER')
   end
 
-  def enabled?
+  def reference_number_enabled?
     reference_number == '1'
   end
 
   def payment_link_checked?
-    payment_enabled? || ServiceConfiguration.exists?(service_id: service_id, name: 'PAYMENT_LINK')
+    payment_link_enabled? || ServiceConfiguration.exists?(service_id: service_id, name: 'PAYMENT_LINK')
   end
 
-  def payment_enabled?
-    false
+  def payment_link_enabled?
+    payment_link_url.present?
   end
 end

--- a/app/models/reference_payment_settings.rb
+++ b/app/models/reference_payment_settings.rb
@@ -22,7 +22,11 @@ class ReferencePaymentSettings
     payment_link_url_present? || ServiceConfiguration.exists?(service_id: service_id, name: 'PAYMENT_LINK')
   end
 
-  delegate :present?, to: :payment_link_url, prefix: true
+  # rubocop:disable Rails/Delegate
+  def payment_link_url_present?
+    payment_link_url.present?
+  end
+  # rubocop:enable Rails/Delegate
 
   def payment_link_checked?
     payment_link == '1'

--- a/app/models/reference_payment_settings.rb
+++ b/app/models/reference_payment_settings.rb
@@ -8,8 +8,7 @@ class ReferencePaymentSettings
                 :deployment_environment
 
   validates :service_id, presence: true
-  validates :payment_link_url, presence: true, if: proc { |obj| obj.payment_link == '1' }
-  validates :payment_link, presence: true, if: proc { |obj| obj.reference_number == '1' }
+  validates_with ReferencePaymentValidator
 
   def reference_number_checked?
     reference_number_enabled? || ServiceConfiguration.exists?(service_id: service_id, name: 'REFERENCE_NUMBER')
@@ -19,11 +18,13 @@ class ReferencePaymentSettings
     reference_number == '1'
   end
 
-  def payment_link_checked?
-    payment_link_enabled? || ServiceConfiguration.exists?(service_id: service_id, name: 'PAYMENT_LINK')
+  def payment_link_url_enabled?
+    payment_link_url_present? || ServiceConfiguration.exists?(service_id: service_id, name: 'PAYMENT_LINK')
   end
 
-  def payment_link_enabled?
-    payment_link_url.present?
+  delegate :present?, to: :payment_link_url, prefix: true
+
+  def payment_link_checked?
+    payment_link == '1'
   end
 end

--- a/app/models/reference_payment_updater.rb
+++ b/app/models/reference_payment_updater.rb
@@ -28,7 +28,7 @@ class ReferencePaymentUpdater
 
   def save_config
     CONFIGS.each do |config|
-      if reference_payment_settings.enabled?
+      if reference_payment_settings.reference_number_enabled?
         create_or_update_service_configuration(config: config, deployment_environment: 'dev')
         create_or_update_service_configuration(config: config, deployment_environment: 'production')
       else

--- a/app/validators/reference_payment_validator.rb
+++ b/app/validators/reference_payment_validator.rb
@@ -1,0 +1,19 @@
+class ReferencePaymentValidator < ActiveModel::Validator
+  def validate(record)
+    if !record.reference_number_enabled? && record.payment_link_checked?
+      record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.reference_number_disabled'))
+    end
+
+    if record.reference_number_enabled? && record.payment_link_checked? && !record.payment_link_url_enabled?
+      record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.missing_payment_link'))
+    end
+
+    if record.payment_link_checked? && !record.payment_link_url.start_with?(I18n.t('activemodel.errors.models.reference_payment_settings.link_start_with'))
+      record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.invalid_payment_url'))
+    end
+
+    if record.payment_link_checked? && record.payment_link_url.blank?
+      record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.missing_payment_link'))
+    end
+  end
+end

--- a/app/validators/reference_payment_validator.rb
+++ b/app/validators/reference_payment_validator.rb
@@ -4,16 +4,26 @@ class ReferencePaymentValidator < ActiveModel::Validator
       record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.reference_number_disabled'))
     end
 
-    if record.reference_number_enabled? && record.payment_link_checked? && !record.payment_link_url_enabled?
+    if reference_and_payment_checked_with_url_missing(record) || payment_link_checked_with_url_missing(record)
       record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.missing_payment_link'))
     end
 
-    if record.payment_link_checked? && !record.payment_link_url.start_with?(I18n.t('activemodel.errors.models.reference_payment_settings.link_start_with'))
-      record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.invalid_payment_url'))
+    if record.payment_link_checked? && !record.payment_link_url.start_with?(gov_uk_link)
+      record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.invalid_payment_url', link_start_with: gov_uk_link))
     end
+  end
 
-    if record.payment_link_checked? && record.payment_link_url.blank?
-      record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.missing_payment_link'))
-    end
+  private
+
+  def gov_uk_link
+    I18n.t('activemodel.errors.models.reference_payment_settings.link_start_with')
+  end
+
+  def payment_link_checked_with_url_missing(record)
+    record.payment_link_checked? && record.payment_link_url.blank?
+  end
+
+  def reference_and_payment_checked_with_url_missing(record)
+    record.reference_number_enabled? && record.payment_link_checked? && !record.payment_link_url_enabled?
   end
 end

--- a/app/views/settings/reference_payment/_form.html.erb
+++ b/app/views/settings/reference_payment/_form.html.erb
@@ -1,7 +1,19 @@
 <%= f.govuk_check_boxes_fieldset :"reference_number",
       multiple: false,
       legend: { text: t('settings.reference_number.legend'), size: 'l'} do %>
-      <div class="govuk-hint" id="reference_number_hint"><%= t('settings.reference_number.hint') %></div>
+  <div class="govuk-hint" id="reference_number_hint"><%= t('settings.reference_number.hint') %></div>
+
+    <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.present? ? 'govuk-form-group--error' : 'govuk-details__text' %>">
+      <% if f.object.errors.present? %>
+        <% f.object.errors.full_messages.each_with_index do |error_message, index| %>
+          <% if error_message.include?('reference number') %>
+            <p id="reference_payment_settings-field-error_<%= index %>" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> <%= error_message %>
+            </p>
+          <% end %>
+        <% end %>
+      <% end %>
+
       <%= f.govuk_check_box :"reference_number", 1, 0,
         multiple: false,
         link_errors: true,
@@ -12,7 +24,6 @@
           }
       %>
 <% end %>
-
 
 <% if ENV['PAYMENT_LINK'] == 'enabled' %>
   <%= f.govuk_check_boxes_fieldset :"payment_link",
@@ -29,9 +40,21 @@
           }
       %>
 
+    <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.present? ? 'govuk-form-group--error' : 'govuk-details__text' %>">
+      <% if f.object.errors.present? %>
+        <% f.object.errors.full_messages.each_with_index do |error_message, index| %>
+          <% if !error_message.include?('reference number') %>
+            <p id="reference_payment_settings-field-error_<%=index %>" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> <%= error_message %>
+            </p>
+          <% end %>
+        <% end %>
+      <% end %>
+
       <%= f.text_field :"payment_link_url",
         label: 'GovUK Pay',
         class: "govuk-input width-responsive-two-thirds govuk-input--error",
         value: '' %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/settings/reference_payment/_form.html.erb
+++ b/app/views/settings/reference_payment/_form.html.erb
@@ -28,5 +28,10 @@
             describedby: 'payment_link_hint payment_link_warning'
           }
       %>
+
+      <%= f.text_field :"payment_link_url",
+        label: 'GovUK Pay',
+        class: "govuk-input width-responsive-two-thirds govuk-input--error",
+        value: '' %>
   <% end %>
 <% end %>

--- a/app/views/settings/reference_payment/index.html.erb
+++ b/app/views/settings/reference_payment/index.html.erb
@@ -2,6 +2,27 @@
     html: { id: 'reference-payment-settings' },
     builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
 
+  <% if f.object.errors.present? %>
+    <div class="govuk-error-summary" data-module="govuk-error-summary">
+      <div role="alert">
+      <h2 class="govuk-error-summary__title">
+        <%= t('activemodel.errors.summary_title') %>
+      </h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list govuk-error-message" id="reference_payment_settings-field-error" >
+          <% f.object.errors.full_messages.each_with_index do |error_message, index| %>
+          <li>
+            <a href="#reference_payment_settings-field-error_<%= index%>"  >
+              <%= error_message %>
+            </a>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</div>
+<% end %>
+
   <%= render MojForms::SettingsScreenComponent.new(
     heading:t('settings.reference_number.heading'),
     description: t('settings.reference_number.description',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -577,6 +577,11 @@ en:
           scan_error:  There was a problem with the file upload - try again later
           empty_value_cell: "The selected file cannot contain blank fields"
           invalid_headings: "The selected file's header fields must be labelled correctly"
+        reference_payment_settings:
+          reference_number_disabled: 'You must enable reference numbers before you can add reference numbers to a payment link'
+          missing_payment_link: 'Enter your GOV.UK Pay Payment link URL (You get this from your GOV.UK Pay account)'
+          invalid_payment_url: "Enter a valid GOV.UK payment link URL starting with %{link_start_with}"
+          link_start_with: 'https://www.gov.uk/payments/'
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."
         too_short: "Your answer for ‘%{attribute}’ is too short (%{count} characters at least)"

--- a/spec/models/reference_payment_settings_spec.rb
+++ b/spec/models/reference_payment_settings_spec.rb
@@ -25,8 +25,55 @@ RSpec.describe ReferencePaymentSettings do
   end
 
   describe '#payment_link_checked?' do
-    it 'returns false' do
-      expect(reference_payment_settings.payment_link_checked?).to be_falsey
+    context 'when payment link url is present' do
+      let(:params) { { payment_link_url: 'www.payment_link.gov' } }
+
+      it 'returns true' do
+        expect(reference_payment_settings.payment_link_checked?).to be_truthy
+      end
+    end
+
+    context 'when payment link url is not present' do
+      let(:params) { { payment_link_url: '' } }
+
+      it 'returns false' do
+        expect(reference_payment_settings.payment_link_checked?).to be_falsey
+      end
+    end
+  end
+
+  describe '#valid?' do
+    context 'payment_link_url' do
+      context 'payment_link is enabled' do
+        let(:params) { { payment_link: '1' } }
+
+        it 'does not allow blank' do
+          should_not allow_values('').for(:payment_link_url)
+        end
+      end
+
+      context 'payment_link is disabled' do
+        let(:params) { { payment_link: '0' } }
+
+        it 'does allow blank' do
+          should allow_values('').for(:payment_link_url)
+        end
+      end
+    end
+
+    context 'payment_link' do
+      context 'when reference number is disabled' do
+        let(:params) do
+          {
+            reference_number: '0',
+            payment_link: '1'
+          }
+        end
+
+        it 'returns invalid' do
+          expect(subject).to_not be_valid
+        end
+      end
     end
   end
 end

--- a/spec/models/reference_payment_settings_spec.rb
+++ b/spec/models/reference_payment_settings_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe ReferencePaymentSettings do
     end
   end
 
-  describe '#payment_link_checked?' do
+  describe '#payment_link_url_enabled?' do
     context 'when payment link url is present' do
       let(:params) { { payment_link_url: 'www.payment_link.gov' } }
 
       it 'returns true' do
-        expect(reference_payment_settings.payment_link_checked?).to be_truthy
+        expect(reference_payment_settings.payment_link_url_enabled?).to be_truthy
       end
     end
 
@@ -37,42 +37,7 @@ RSpec.describe ReferencePaymentSettings do
       let(:params) { { payment_link_url: '' } }
 
       it 'returns false' do
-        expect(reference_payment_settings.payment_link_checked?).to be_falsey
-      end
-    end
-  end
-
-  describe '#valid?' do
-    context 'payment_link_url' do
-      context 'payment_link is enabled' do
-        let(:params) { { payment_link: '1' } }
-
-        it 'does not allow blank' do
-          should_not allow_values('').for(:payment_link_url)
-        end
-      end
-
-      context 'payment_link is disabled' do
-        let(:params) { { payment_link: '0' } }
-
-        it 'does allow blank' do
-          should allow_values('').for(:payment_link_url)
-        end
-      end
-    end
-
-    context 'payment_link' do
-      context 'when reference number is disabled' do
-        let(:params) do
-          {
-            reference_number: '0',
-            payment_link: '1'
-          }
-        end
-
-        it 'returns invalid' do
-          expect(subject).to_not be_valid
-        end
+        expect(reference_payment_settings.payment_link_url_enabled?).to be_falsey
       end
     end
   end

--- a/spec/validators/reference_payment_validator_spec.rb
+++ b/spec/validators/reference_payment_validator_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe  ReferencePaymentValidator do
+  let(:subject) { ReferencePaymentSettings.new(params) }
+  let(:service_id) { SecureRandom.uuid }
+  let(:correct_url) { I18n.t('activemodel.errors.models.reference_payment_settings.link_start_with') }
+
+  describe '#validate' do
+    before do
+      subject.validate
+    end
+    context 'when payment link is enabled' do
+      context 'when reference number is disabled' do
+        let(:params) do
+          {
+            reference_number: '0',
+            payment_link: '1',
+            payment_link_url: 'gov.uk'
+          }
+        end
+
+        it 'returns invalid' do
+          expect(subject).to_not be_valid
+        end
+
+        it 'returns an error message' do
+          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.reference_payment_settings.reference_number_disabled'))
+        end
+      end
+
+      context 'when reference number is enabled' do
+        let(:params) do
+          {
+            service_id: service_id,
+            reference_number: '1',
+            payment_link: '1',
+            payment_link_url: correct_url
+          }
+        end
+
+        it 'returns valid' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context 'when payment link is missing' do
+        let(:params) do
+          {
+            reference_number: '1',
+            payment_link: '1',
+            payment_link_url: ''
+          }
+        end
+
+        it 'returns invalid' do
+          expect(subject).to_not be_valid
+        end
+
+        it 'returns an error message' do
+          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.reference_payment_settings.missing_payment_link'))
+        end
+      end
+
+      context 'when payment link url is invalid' do
+        let(:params) do
+          {
+            reference_number: '1',
+            payment_link: '1',
+            payment_link_url: 'dummy.link'
+          }
+        end
+
+        it 'returns invalid' do
+          expect(subject).to_not be_valid
+        end
+
+        it 'returns an error message' do
+          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.reference_payment_settings.invalid_payment_url'))
+        end
+      end
+
+      context 'when reference number is disabled and payment link is missing' do
+        let(:params) do
+          {
+            service_id: service_id,
+            reference_number: '0',
+            payment_link: '1',
+            payment_link_url: ''
+          }
+        end
+
+        it 'should display two error messages' do
+          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.reference_payment_settings.reference_number_disabled'))
+          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.reference_payment_settings.missing_payment_link'))
+        end
+      end
+    end
+  end
+end

--- a/spec/validators/reference_payment_validator_spec.rb
+++ b/spec/validators/reference_payment_validator_spec.rb
@@ -73,7 +73,12 @@ RSpec.describe  ReferencePaymentValidator do
         end
 
         it 'returns an error message' do
-          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.reference_payment_settings.invalid_payment_url'))
+          expect(subject.errors.full_messages).to include(
+            I18n.t(
+              'activemodel.errors.models.reference_payment_settings.invalid_payment_url',
+              link_start_with: I18n.t('activemodel.errors.models.reference_payment_settings.link_start_with')
+            )
+          )
         end
       end
 


### PR DESCRIPTION
Implemented payment link settings validator and the warnings displayed on the template. 
There are 3 warnings:
- If the payment link is ticked reference number has to be ticked as well.
- If the payment link is ticked the url should not be empty
- If the payment link is ticked, the url should be conform and start with 'https://www.gov.uk/payments/'

In addition, we don't cater for the case when the payment link is not ticked but the url is present and valid, this because the payment url field only appears if the payment link is ticked. Adding javascript to make the field appear and disappear  still needs to be done.

A summary of warning is displayed at the top see screenshot:

<img width="1006" alt="Screenshot 2022-12-06 at 15 44 50" src="https://user-images.githubusercontent.com/26165112/205957750-62712e79-f194-4f86-8b88-49b6a987d7c4.png">

Warnings related to reference number are displayed above the reference number checkbox, while the payment link related warnings are located below the corresponding checkbox:
<img width="775" alt="Screenshot 2022-12-06 at 15 44 40" src="https://user-images.githubusercontent.com/26165112/205957787-0ede79d0-11d8-4148-bd39-25469c10739c.png">
