### PR TITLE
Update link to reflect correct url

### DIFF
--- a/app/views/settings/reference_payment/index.html.erb
+++ b/app/views/settings/reference_payment/index.html.erb
@@ -27,7 +27,7 @@
     heading:t('settings.reference_number.heading'),
     description: t('settings.reference_number.description',
                     href: t('settings.reference_number.href',
-                      url: t('partials.header.user_guide_url')+'settings/#references'
+                      url: t('partials.header.home_url')+'settings/#references'
                     )
                   ).html_safe
     ) do |c| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,7 @@ en:
       forms: Your forms
       sign_out: Sign out %{user_name}
       user_guide: "User guide"
+      home_url: "https://moj-forms.service.justice.gov.uk/"
       user_guide_url: "https://moj-forms.service.justice.gov.uk/user-guide/"
       user_guide_check_confirm_url: 'https://moj-forms.service.justice.gov.uk/building-and-editing/#check-confirm'
   home:


### PR DESCRIPTION
This link is currently broken as it was pointing to the user guide section, when we need to point to the settings section. Update the link so it points to the reference number section.