### PR TITLE
Save payment link service configuration to the database

### DIFF
--- a/app/javascript/src/controller_reference_payment.js
+++ b/app/javascript/src/controller_reference_payment.js
@@ -1,0 +1,32 @@
+const DefaultController = require('./controller_default');
+const Expander = require('./component_expander');
+
+class ReferencePaymentController extends DefaultController {
+  constructor(app) {
+    super(app);
+
+    switch(app.page.action) {
+      case 'create':
+      case 'index':
+        this.#index();
+      break;
+    }
+  }
+
+  #index() {
+    this.#addExpanderEnhancement();
+  }
+
+  #addExpanderEnhancement() {
+    var $paymentField = $(".fb-payment-field");
+    var $revealedInput = $paymentField.find('[data-component="Expander"]');
+    var $checkbox = $("input[type=checkbox]", $paymentField);
+    new Expander($revealedInput, {
+      activator_source: $checkbox,
+      auto_open: $checkbox.attr('checked')||$(".govuk-form-group--error", $paymentField).length,
+      wrap_content: false,
+    });
+  }
+}
+
+module.exports = ReferencePaymentController;

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -8,6 +8,7 @@ const FormAnalyticsController = require('./controller_form_analytics');
 const FromAddressController = require('./controller_from_address');
 const CollectionEmailController = require('./controller_collection_email');
 const ConfirmationEmailController = require('./controller_confirmation_email');
+const ReferencePaymentController = require('./controller_reference_payment');
 
 const {
   snakeToPascalCase,
@@ -85,6 +86,11 @@ switch(controllerAndAction()) {
   case "ConfirmationEmailController#index":
   case "ConfirmationEmailController#create":
     Controller = ConfirmationEmailController;
+    break;
+
+  case "ReferencePaymentController#index":
+  case "ReferencePaymentController#create":
+    Controller = ReferencePaymentController;
     break;
 
   default:

--- a/app/models/reference_payment_settings.rb
+++ b/app/models/reference_payment_settings.rb
@@ -31,4 +31,8 @@ class ReferencePaymentSettings
   def payment_link_checked?
     payment_link == '1'
   end
+
+  def saved_payment_link_url
+    @saved_payment_link_url ||= (ServiceConfiguration.find_by(service_id: service_id, name: 'PAYMENT_LINK').decrypt_value if ServiceConfiguration.exists?(service_id: service_id, name: 'PAYMENT_LINK'))
+  end
 end

--- a/app/models/reference_payment_settings.rb
+++ b/app/models/reference_payment_settings.rb
@@ -11,7 +11,9 @@ class ReferencePaymentSettings
   validates_with ReferencePaymentValidator
 
   def reference_number_checked?
-    reference_number_enabled? || ServiceConfiguration.exists?(service_id: service_id, name: 'REFERENCE_NUMBER')
+    return ServiceConfiguration.exists?(service_id: service_id, name: 'REFERENCE_NUMBER') if reference_number.blank?
+
+    reference_number_enabled?
   end
 
   def reference_number_enabled?
@@ -33,6 +35,14 @@ class ReferencePaymentSettings
   end
 
   def saved_payment_link_url
-    @saved_payment_link_url ||= (ServiceConfiguration.find_by(service_id: service_id, name: 'PAYMENT_LINK').decrypt_value if ServiceConfiguration.exists?(service_id: service_id, name: 'PAYMENT_LINK'))
+    return ServiceConfiguration.find_by(service_id: service_id, name: 'PAYMENT_LINK')&.decrypt_value if payment_link_url.nil?
+
+    payment_link_url
+  end
+
+  def payment_link_has_been_checked
+    return ServiceConfiguration.exists?(service_id: service_id, name: 'PAYMENT_LINK') if payment_link.blank?
+
+    payment_link_checked?
   end
 end

--- a/app/models/reference_payment_updater.rb
+++ b/app/models/reference_payment_updater.rb
@@ -3,7 +3,6 @@ class ReferencePaymentUpdater
 
   attr_reader :service, :reference_payment_settings
 
-  CONFIGS = %w[REFERENCE_NUMBER PAYMENT_LINK].freeze
   CONFIG_WITH_DEFAULTS = %w[
     CONFIRMATION_EMAIL_SUBJECT
     CONFIRMATION_EMAIL_BODY
@@ -19,38 +18,37 @@ class ReferencePaymentUpdater
 
   def create_or_update!
     ActiveRecord::Base.transaction do
-      save_config
+      save_config_reference_number
+      save_config_payment_link
       save_config_with_defaults
     end
   end
 
   private
 
-  def save_config
-    CONFIGS.each do |config|
-      if reference_payment_settings.reference_number_enabled? && config == 'REFERENCE_NUMBER'
-        create_or_update_service_configuration(config: config, deployment_environment: 'dev')
-        create_or_update_service_configuration(config: config, deployment_environment: 'production')
-      end
+  def save_config_reference_number
+    if reference_payment_settings.reference_number_enabled?
+      create_or_update_service_configuration(config: 'REFERENCE_NUMBER', deployment_environment: 'dev')
+      create_or_update_service_configuration(config: 'REFERENCE_NUMBER', deployment_environment: 'production')
+    end
 
-      if !reference_payment_settings.reference_number_enabled? && config == 'REFERENCE_NUMBER'
-        remove_service_configuration(config, 'dev')
-        remove_service_configuration(config, 'production')
-      end
+    unless reference_payment_settings.reference_number_enabled?
+      remove_service_configuration('REFERENCE_NUMBER', 'dev')
+      remove_service_configuration('REFERENCE_NUMBER', 'production')
+    end
+  end
 
-      if reference_payment_settings.payment_link_url_present? &&
-          reference_payment_settings.payment_link_checked? &&
-          config == 'PAYMENT_LINK'
-        create_or_update_service_configuration(config: config, deployment_environment: 'dev', value: payment_link_url)
-        create_or_update_service_configuration(config: config, deployment_environment: 'production', value: payment_link_url)
-      end
+  def save_config_payment_link
+    if reference_payment_settings.payment_link_url_present? &&
+        reference_payment_settings.payment_link_checked?
+      create_or_update_service_configuration(config: 'PAYMENT_LINK', deployment_environment: 'dev', value: payment_link_url)
+      create_or_update_service_configuration(config: 'PAYMENT_LINK', deployment_environment: 'production', value: payment_link_url)
+    end
 
-      next unless (!reference_payment_settings.payment_link_url_present? ||
-          !reference_payment_settings.payment_link_checked?) &&
-        config == 'PAYMENT_LINK'
-
-      remove_service_configuration(config, 'dev')
-      remove_service_configuration(config, 'production')
+    unless reference_payment_settings.payment_link_url_present? ||
+        reference_payment_settings.payment_link_checked?
+      remove_service_configuration('PAYMENT_LINK', 'dev')
+      remove_service_configuration('PAYMENT_LINK', 'production')
     end
   end
 

--- a/app/models/reference_payment_updater.rb
+++ b/app/models/reference_payment_updater.rb
@@ -3,7 +3,7 @@ class ReferencePaymentUpdater
 
   attr_reader :service, :reference_payment_settings
 
-  CONFIGS = %w[REFERENCE_NUMBER].freeze
+  CONFIGS = %w[REFERENCE_NUMBER PAYMENT_LINK].freeze
   CONFIG_WITH_DEFAULTS = %w[
     CONFIRMATION_EMAIL_SUBJECT
     CONFIRMATION_EMAIL_BODY
@@ -28,10 +28,22 @@ class ReferencePaymentUpdater
 
   def save_config
     CONFIGS.each do |config|
-      if reference_payment_settings.reference_number_enabled?
+      if reference_payment_settings.reference_number_enabled? && config == 'REFERENCE_NUMBER'
         create_or_update_service_configuration(config: config, deployment_environment: 'dev')
         create_or_update_service_configuration(config: config, deployment_environment: 'production')
-      else
+      end
+
+      if !reference_payment_settings.reference_number_enabled? && config == 'REFERENCE_NUMBER'
+        remove_service_configuration(config, 'dev')
+        remove_service_configuration(config, 'production')
+      end
+
+      if reference_payment_settings.payment_link_url_present? && config == 'PAYMENT_LINK'
+        create_or_update_service_configuration(config: config, deployment_environment: 'dev', value: reference_payment_settings.payment_link_url)
+        create_or_update_service_configuration(config: config, deployment_environment: 'production', value: reference_payment_settings.payment_link_url)
+      end
+
+      if !reference_payment_settings.payment_link_url_present? && config == 'PAYMENT_LINK'
         remove_service_configuration(config, 'dev')
         remove_service_configuration(config, 'production')
       end

--- a/app/models/reference_payment_updater.rb
+++ b/app/models/reference_payment_updater.rb
@@ -38,15 +38,19 @@ class ReferencePaymentUpdater
         remove_service_configuration(config, 'production')
       end
 
-      if reference_payment_settings.payment_link_url_present? && config == 'PAYMENT_LINK'
-        create_or_update_service_configuration(config: config, deployment_environment: 'dev', value: reference_payment_settings.payment_link_url)
-        create_or_update_service_configuration(config: config, deployment_environment: 'production', value: reference_payment_settings.payment_link_url)
+      if reference_payment_settings.payment_link_url_present? &&
+          reference_payment_settings.payment_link_checked? &&
+          config == 'PAYMENT_LINK'
+        create_or_update_service_configuration(config: config, deployment_environment: 'dev', value: payment_link_url)
+        create_or_update_service_configuration(config: config, deployment_environment: 'production', value: payment_link_url)
       end
 
-      if !reference_payment_settings.payment_link_url_present? && config == 'PAYMENT_LINK'
-        remove_service_configuration(config, 'dev')
-        remove_service_configuration(config, 'production')
-      end
+      next unless (!reference_payment_settings.payment_link_url_present? ||
+          !reference_payment_settings.payment_link_checked?) &&
+        config == 'PAYMENT_LINK'
+
+      remove_service_configuration(config, 'dev')
+      remove_service_configuration(config, 'production')
     end
   end
 
@@ -83,5 +87,9 @@ class ReferencePaymentUpdater
 
   def reference_number
     @reference_number ||= reference_payment_settings.reference_number
+  end
+
+  def payment_link_url
+    @payment_link_url ||= reference_payment_settings.payment_link_url
   end
 end

--- a/app/validators/reference_payment_validator.rb
+++ b/app/validators/reference_payment_validator.rb
@@ -11,6 +11,10 @@ class ReferencePaymentValidator < ActiveModel::Validator
     if record.payment_link_checked? && !record.payment_link_url.start_with?(gov_uk_link)
       record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.invalid_payment_url', link_start_with: gov_uk_link))
     end
+
+    if payment_link_not_checked_with_url_present(record)
+      record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.payment_link_disabled'))
+    end
   end
 
   private
@@ -25,5 +29,9 @@ class ReferencePaymentValidator < ActiveModel::Validator
 
   def reference_and_payment_checked_with_url_missing(record)
     record.reference_number_enabled? && record.payment_link_checked? && !record.payment_link_url_enabled?
+  end
+
+  def payment_link_not_checked_with_url_present(record)
+    !record.payment_link_checked? && record.payment_link_url_present?
   end
 end

--- a/app/views/settings/reference_payment/_form.html.erb
+++ b/app/views/settings/reference_payment/_form.html.erb
@@ -2,8 +2,7 @@
       multiple: false,
       legend: { text: t('settings.reference_number.legend'), size: 'l'} do %>
   <div class="govuk-hint" id="reference_number_hint"><%= t('settings.reference_number.hint') %></div>
-
-    <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.present? ? 'govuk-form-group--error' : 'govuk-details__text' %>">
+    <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.full_messages.any? { |s| s.include?('reference number')} ? 'govuk-form-group--error' :'' %>">
       <% if f.object.errors.present? %>
         <% f.object.errors.full_messages.each_with_index do |error_message, index| %>
           <% if error_message.include?('reference number') %>
@@ -34,7 +33,7 @@
           multiple: false,
           link_errors: true,
           label: { text: t('settings.payment_link.label') },
-          checked: f.object.payment_link_url_enabled?,
+          checked: f.object.payment_link_has_been_checked,
           aria: {
               describedby: 'payment_link_hint payment_link_warning'
             }

--- a/app/views/settings/reference_payment/_form.html.erb
+++ b/app/views/settings/reference_payment/_form.html.erb
@@ -24,37 +24,39 @@
           }
       %>
 <% end %>
-
-<% if ENV['PAYMENT_LINK'] == 'enabled' %>
-  <%= f.govuk_check_boxes_fieldset :"payment_link",
-      multiple: false,
-      legend: { text: t('settings.payment_link.legend'), size: 'l'} do %>
-      <div class="govuk-hint" id="payment_link_hint"><%= t('settings.payment_link.hint', href: t('settings.payment_link.href', url: t('settings.payment_link.url'))).html_safe %></div>
-      <%= f.govuk_check_box :"payment_link", 1, 0,
+<div class='fb-payment-field'>
+  <% if ENV['PAYMENT_LINK'] == 'enabled' %>
+    <%= f.govuk_check_boxes_fieldset :"payment_link",
         multiple: false,
-        link_errors: true,
-        label: { text: t('settings.payment_link.label') },
-        checked: f.object.payment_link_url_enabled?,
-        aria: {
-            describedby: 'payment_link_hint payment_link_warning'
-          }
-      %>
+        legend: { text: t('settings.payment_link.legend'), size: 'l'} do %>
+        <div class="govuk-hint" id="payment_link_hint"><%= t('settings.payment_link.hint', href: t('settings.payment_link.href', url: t('settings.payment_link.url'))).html_safe %></div>
+        <%= f.govuk_check_box :"payment_link", 1, 0,
+          multiple: false,
+          link_errors: true,
+          label: { text: t('settings.payment_link.label') },
+          checked: f.object.payment_link_url_enabled?,
+          aria: {
+              describedby: 'payment_link_hint payment_link_warning'
+            }
+        %>
 
-    <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.present? ? 'govuk-form-group--error' : 'govuk-details__text' %>">
-      <% if f.object.errors.present? %>
-        <% f.object.errors.full_messages.each_with_index do |error_message, index| %>
-          <% if !error_message.include?('reference number') %>
-            <p id="reference_payment_settings-field-error_<%=index %>" class="govuk-error-message">
-              <span class="govuk-visually-hidden">Error:</span> <%= error_message %>
-            </p>
+    <div data-component="Expander">
+      <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.present? ? 'govuk-form-group--error' : 'govuk-details__text' %>">
+        <% if f.object.errors.present? %>
+          <% f.object.errors.full_messages.each_with_index do |error_message, index| %>
+            <% if !error_message.include?('reference number') %>
+              <p id="reference_payment_settings-field-error_<%=index %>" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span> <%= error_message %>
+              </p>
+            <% end %>
           <% end %>
         <% end %>
-      <% end %>
-
-      <%= f.text_field :"payment_link_url",
-        label: 'GovUK Pay',
-        class: "govuk-input width-responsive-two-thirds govuk-input--error",
-        value: f.object.saved_payment_link_url %>
+        <%= f.govuk_text_field :payment_link_url,
+          label: {text: 'Your GOV.UK Pay payment URL'},
+          class: "govuk-input width-responsive-two-thirds",
+          value: f.object.saved_payment_link_url %>
+      </div>
     </div>
+    <% end %>
   <% end %>
-<% end %>
+<div>

--- a/app/views/settings/reference_payment/_form.html.erb
+++ b/app/views/settings/reference_payment/_form.html.erb
@@ -34,7 +34,7 @@
         multiple: false,
         link_errors: true,
         label: { text: t('settings.payment_link.label') },
-        checked: f.object.payment_link_checked?,
+        checked: f.object.payment_link_url_enabled?,
         aria: {
             describedby: 'payment_link_hint payment_link_warning'
           }
@@ -54,7 +54,7 @@
       <%= f.text_field :"payment_link_url",
         label: 'GovUK Pay',
         class: "govuk-input width-responsive-two-thirds govuk-input--error",
-        value: '' %>
+        value: f.object.saved_payment_link_url %>
     </div>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -583,6 +583,7 @@ en:
           missing_payment_link: 'Enter your GOV.UK Pay Payment link URL (You get this from your GOV.UK Pay account)'
           invalid_payment_url: "Enter a valid GOV.UK payment link URL starting with %{link_start_with}"
           link_start_with: 'https://www.gov.uk/payments/'
+          payment_link_disabled: 'You must enable payment link before you can add a payment link url'
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."
         too_short: "Your answer for ‘%{attribute}’ is too short (%{count} characters at least)"

--- a/spec/factories/service_configurations.rb
+++ b/spec/factories/service_configurations.rb
@@ -104,5 +104,10 @@ FactoryBot.define do
       name { 'REFERENCE_NUMBER' }
       value { '1' }
     end
+
+    trait :payment_link_url do
+      name { 'PAYMENT_LINK' }
+      value { 'https://www.gov.uk/payments/123' }
+    end
   end
 end

--- a/spec/models/reference_payment_settings_spec.rb
+++ b/spec/models/reference_payment_settings_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ReferencePaymentSettings do
     )
   end
   let(:params) { {} }
+  let(:valid_url) { "#{I18n.t('activemodel.errors.models.reference_payment_settings.link_start_with')}123" }
 
   describe '#reference_number_checked?' do
     context 'when reference number is ticked' do
@@ -14,9 +15,45 @@ RSpec.describe ReferencePaymentSettings do
         expect(reference_payment_settings.reference_number_checked?).to be_truthy
       end
 
-      context 'when reference number is not ticked' do
-        let(:params) { { reference_number: '0' } }
+      it 'does not retrieve the record in the database' do
+        expect(ServiceConfiguration).to_not receive(:exists?)
+      end
+    end
 
+    context 'when reference number is not ticked' do
+      let(:params) { { reference_number: '0' } }
+
+      it 'returns false' do
+        expect(reference_payment_settings.reference_number_checked?).to be_falsey
+      end
+
+      it 'does not retrieve the record in the database' do
+        expect(ServiceConfiguration).to_not receive(:exists?)
+      end
+    end
+
+    context 'reference number is nil' do
+      context 'when there is a DB record' do
+        before do
+          create(
+            :service_configuration,
+            :reference_number,
+            service_id: service.service_id,
+            deployment_environment: 'dev'
+          )
+          create(
+            :service_configuration,
+            :reference_number,
+            service_id: service.service_id,
+            deployment_environment: 'production'
+          )
+        end
+
+        it 'returns true' do
+          expect(reference_payment_settings.reference_number_checked?).to be_truthy
+        end
+      end
+      context 'when there is no DB record' do
         it 'returns false' do
           expect(reference_payment_settings.reference_number_checked?).to be_falsey
         end
@@ -25,19 +62,168 @@ RSpec.describe ReferencePaymentSettings do
   end
 
   describe '#payment_link_url_enabled?' do
-    context 'when payment link url is present' do
-      let(:params) { { payment_link_url: 'www.payment_link.gov' } }
+    context 'when there is a DB record' do
+      before do
+        create(
+          :service_configuration,
+          :payment_link_url,
+          service_id: service.service_id,
+          deployment_environment: 'dev'
+        )
+        create(
+          :service_configuration,
+          :payment_link_url,
+          service_id: service.service_id,
+          deployment_environment: 'production'
+        )
+      end
 
-      it 'returns true' do
-        expect(reference_payment_settings.payment_link_url_enabled?).to be_truthy
+      context 'when payment link url is present' do
+        context 'and checkbox is ticked' do
+          let(:params) { { payment_link: '1', payment_link_url: 'www.payment_link.gov' } }
+
+          it 'returns true' do
+            expect(reference_payment_settings.payment_link_url_enabled?).to be_truthy
+          end
+        end
+      end
+
+      context 'when payment link url is not present' do
+        it 'returns true' do
+          expect(reference_payment_settings.payment_link_url_enabled?).to be_truthy
+        end
+
+        it 'returns the existing record from DB' do
+          expect(ServiceConfiguration.exists?(service_id: service.service_id, name: 'PAYMENT_LINK')).to be_truthy
+        end
       end
     end
 
-    context 'when payment link url is not present' do
-      let(:params) { { payment_link_url: '' } }
+    context 'when there is not DB record' do
+      context 'when payment link url is present' do
+        let(:params) { { payment_link_url: valid_url } }
 
-      it 'returns false' do
-        expect(reference_payment_settings.payment_link_url_enabled?).to be_falsey
+        it 'returns true' do
+          expect(reference_payment_settings.payment_link_url_enabled?).to be_truthy
+        end
+      end
+
+      context 'when payment link url is not present' do
+        context 'cannot get any record from the DB' do
+          it 'returns false' do
+            expect(reference_payment_settings.payment_link_url_enabled?).to be_falsey
+          end
+        end
+      end
+    end
+  end
+
+  describe '#payment_link_has_been_checked' do
+    context 'payment_link is blank' do
+      context 'when there is a DB record' do
+        before do
+          create(
+            :service_configuration,
+            :payment_link_url,
+            service_id: service.service_id,
+            deployment_environment: 'dev'
+          )
+          create(
+            :service_configuration,
+            :payment_link_url,
+            service_id: service.service_id,
+            deployment_environment: 'production'
+          )
+        end
+
+        it 'returns true' do
+          expect(reference_payment_settings.payment_link_has_been_checked).to be_truthy
+        end
+
+        it 'does retrieve the record from the database' do
+          expect(subject).to_not receive(:payment_link_checked?)
+        end
+      end
+
+      context 'when there is no DB record' do
+        it 'returns false' do
+          expect(reference_payment_settings.payment_link_has_been_checked).to be_falsey
+        end
+
+        it 'does retrieve the record from the database' do
+          expect(subject).to_not receive(:payment_link_checked?)
+        end
+      end
+    end
+
+    context 'payment link is ticked' do
+      let(:params) { { payment_link: '1', payment_link_url: '' } }
+
+      context 'when there is a record in DB' do
+        before do
+          create(
+            :service_configuration,
+            :payment_link_url,
+            service_id: service.service_id,
+            deployment_environment: 'dev'
+          )
+          create(
+            :service_configuration,
+            :payment_link_url,
+            service_id: service.service_id,
+            deployment_environment: 'production'
+          )
+        end
+
+        it 'returns true' do
+          expect(reference_payment_settings.payment_link_has_been_checked).to be_truthy
+        end
+
+        it 'does not retrieve the record from the database' do
+          expect(ServiceConfiguration).to_not receive(:exists?)
+        end
+      end
+
+      context 'when there is no DB record' do
+        it 'returns false' do
+          expect(reference_payment_settings.payment_link_has_been_checked).to be_truthy
+        end
+
+        it 'does not retrieve the record from the database' do
+          expect(ServiceConfiguration).to_not receive(:exists?)
+        end
+      end
+    end
+  end
+
+  describe '#saved_payment_link_url' do
+    context 'there is a service configuration saved in DB' do
+      before do
+        create(
+          :service_configuration,
+          :payment_link_url,
+          service_id: service.service_id,
+          deployment_environment: 'dev'
+        )
+        create(
+          :service_configuration,
+          :payment_link_url,
+          service_id: service.service_id,
+          deployment_environment: 'production'
+        )
+      end
+      context 'payment link url is nil' do
+        it 'will call the DB' do
+          expect(subject).to_not receive(:payment_link_url)
+        end
+      end
+
+      context 'payment link url is filled in' do
+        let(:params) { { payment_link: '1', payment_link_url: valid_url } }
+
+        it 'will not access the DB' do
+          expect(ServiceConfiguration).to_not receive(:exists?)
+        end
       end
     end
   end

--- a/spec/models/reference_payment_updater_spec.rb
+++ b/spec/models/reference_payment_updater_spec.rb
@@ -255,6 +255,7 @@ RSpec.describe ReferencePaymentUpdater do
     end
 
     context 'payment link' do
+      let(:url) { 'https://www.gov.uk/payments/123' }
       context 'when payment link exists in the db' do
         let(:params) { { payment_link_url: '', payment_link: '0' } }
 
@@ -275,7 +276,7 @@ RSpec.describe ReferencePaymentUpdater do
           reference_payment_updater.create_or_update!
         end
 
-        context 'when a user unticked the box' do
+        context 'when a user unticked the box and payment url is empty' do
           it 'removes the records from the database' do
             expect(
               ServiceConfiguration.where(
@@ -290,8 +291,7 @@ RSpec.describe ReferencePaymentUpdater do
       context 'when payment link doesn\'t exist in the db' do
         context 'when a user ticks the box' do
           context 'when the url is present' do
-            let(:url) { 'https://www.gov.uk/payments/123' }
-            let(:params) { { payment_link_url: url } }
+            let(:params) { { payment_link: '1', payment_link_url: url } }
 
             it 'creates the submission settings' do
               reference_payment_updater.create_or_update!
@@ -330,17 +330,34 @@ RSpec.describe ReferencePaymentUpdater do
         end
 
         context 'when a user does not tick the box' do
-          let(:params) { { payment_link: '0', payment_link_url: '' } }
+          context 'the payment link url is empty' do
+            let(:params) { { payment_link: '0', payment_link_url: '' } }
 
-          it 'doesn\'t create the submission settings' do
-            reference_payment_updater.create_or_update!
+            it 'doesn\'t create the submission settings' do
+              reference_payment_updater.create_or_update!
 
-            expect(
-              ServiceConfiguration.where(
-                service_id: service.service_id,
-                name: 'PAYMENT_LINK'
-              )
-            ).to be_empty
+              expect(
+                ServiceConfiguration.where(
+                  service_id: service.service_id,
+                  name: 'PAYMENT_LINK'
+                )
+              ).to be_empty
+            end
+          end
+
+          context 'the payment link url is present' do
+            let(:params) { { payment_link: '0', payment_link_url: url } }
+
+            it 'doesn\'t create the submission settings' do
+              reference_payment_updater.create_or_update!
+
+              expect(
+                ServiceConfiguration.where(
+                  service_id: service.service_id,
+                  name: 'PAYMENT_LINK'
+                )
+              ).to be_empty
+            end
           end
         end
       end

--- a/spec/models/reference_payment_updater_spec.rb
+++ b/spec/models/reference_payment_updater_spec.rb
@@ -253,5 +253,97 @@ RSpec.describe ReferencePaymentUpdater do
         end
       end
     end
+
+    context 'payment link' do
+      context 'when payment link exists in the db' do
+        let(:params) { { payment_link_url: '', payment_link: '0' } }
+
+        before do
+          create(
+            :service_configuration,
+            :payment_link_url,
+            service_id: service.service_id,
+            deployment_environment: 'dev'
+          )
+          create(
+            :service_configuration,
+            :payment_link_url,
+            service_id: service.service_id,
+            deployment_environment: 'production'
+          )
+
+          reference_payment_updater.create_or_update!
+        end
+
+        context 'when a user unticked the box' do
+          it 'removes the records from the database' do
+            expect(
+              ServiceConfiguration.where(
+                service_id: service.service_id,
+                name: 'PAYMENT_LINK'
+              )
+            ).to be_empty
+          end
+        end
+      end
+
+      context 'when payment link doesn\'t exist in the db' do
+        context 'when a user ticks the box' do
+          context 'when the url is present' do
+            let(:url) { 'https://www.gov.uk/payments/123' }
+            let(:params) { { payment_link_url: url } }
+
+            it 'creates the submission settings' do
+              reference_payment_updater.create_or_update!
+
+              expect(
+                ServiceConfiguration.find_by(
+                  service_id: service.service_id,
+                  name: 'PAYMENT_LINK',
+                  deployment_environment: 'dev'
+                ).decrypt_value
+              ).to eq(url)
+
+              expect(
+                ServiceConfiguration.find_by(
+                  service_id: service.service_id,
+                  name: 'PAYMENT_LINK',
+                  deployment_environment: 'production'
+                ).decrypt_value
+              ).to eq(url)
+            end
+          end
+          context 'when the url is missing' do
+            let(:parans) { { payment_link: '1', payment_link_url: '' } }
+
+            it 'doesn\'t create the submission setting' do
+              reference_payment_updater.create_or_update!
+
+              expect(
+                ServiceConfiguration.where(
+                  service_id: service.service_id,
+                  name: 'PAYMENT_LINK'
+                )
+              ).to be_empty
+            end
+          end
+        end
+
+        context 'when a user does not tick the box' do
+          let(:params) { { payment_link: '0', payment_link_url: '' } }
+
+          it 'doesn\'t create the submission settings' do
+            reference_payment_updater.create_or_update!
+
+            expect(
+              ServiceConfiguration.where(
+                service_id: service.service_id,
+                name: 'PAYMENT_LINK'
+              )
+            ).to be_empty
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/reference_payment_updater_spec.rb
+++ b/spec/models/reference_payment_updater_spec.rb
@@ -313,8 +313,9 @@ RSpec.describe ReferencePaymentUpdater do
               ).to eq(url)
             end
           end
+
           context 'when the url is missing' do
-            let(:parans) { { payment_link: '1', payment_link_url: '' } }
+            let(:params) { { payment_link: '1', payment_link_url: '' } }
 
             it 'doesn\'t create the submission setting' do
               reference_payment_updater.create_or_update!

--- a/spec/validators/reference_payment_validator_spec.rb
+++ b/spec/validators/reference_payment_validator_spec.rb
@@ -98,5 +98,43 @@ RSpec.describe  ReferencePaymentValidator do
         end
       end
     end
+
+    context 'when payment link is disabled' do
+      context 'when payment url is present' do
+        let(:params) do
+          {
+            reference_number: '1',
+            payment_link: '0',
+            payment_link_url: correct_url
+          }
+        end
+
+        it 'returns invalid' do
+          expect(subject).to_not be_valid
+        end
+
+        it 'returns an error message' do
+          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.reference_payment_settings.payment_link_disabled'))
+        end
+      end
+
+      context 'when payment url is invalid' do
+        let(:params) do
+          {
+            reference_number: '1',
+            payment_link: '0',
+            payment_link_url: 'url'
+          }
+        end
+
+        it 'returns invalid' do
+          expect(subject).to_not be_valid
+        end
+
+        it 'include some error messages' do
+          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.reference_payment_settings.payment_link_disabled'))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
We implemented the logic to store and retrieve the payment url settings in the ServiceConfiguration table as PAYMENT_LINK, with the value being the payment link url. 
For removing the PAYMENT_LINK configuration we have to either untick the checkbox or to empty the payment link url.
Whereas for adding the PAYMENT_LINK configuration we check that both the checkbox is ticked and the payment url is present.
 
We also added the expander capability to the payment url field in the view template, so when you check the payment link checkbox the url field is revealed. 