### PR TITLE
Show autocomplete warning for pages in main flow only

### DIFF
--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -4,8 +4,9 @@ require_relative '../spec_helper'
 feature 'Publishing' do
   background do
     given_I_am_logged_in
-    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
+    given_I_have_a_service_fixture(fixture: fixture_name)
   end
+  let(:fixture_name) { 'default_new_service_fixture' }
   let(:editor) { EditorApp.new }
   let(:service_name) { generate_service_name }
   let(:page_url) { 'palpatine' }
@@ -174,6 +175,29 @@ feature 'Publishing' do
     then_I_should_see_an_error_message('dev', 'Test')
 
     and_I_cancel
+  end
+
+  context 'autocomplete warning in Live' do
+    let(:fixture_name) { 'autocomplete_page_fixture' }
+    let(:environment) { 'production' }
+    let(:button_disabled) { 'true' }
+    let(:autocomplete_warning_message) do
+      I18n.t("publish.autocomplete_items.#{environment}.message", title: 'Countries Question' )
+    end
+
+    scenario 'unconnected autocomplete page does not block Live publishing' do
+      when_I_visit_the_publishing_page
+      then_I_should_see_autocomplete_warnings
+      then_I_should_see_the_publish_button
+
+      and_I_return_to_flow_page
+      given_I_want_to_change_destination_of_a_page('Service name goes here')
+      when_I_change_destination_to_page('Check your answers')
+
+      when_I_visit_the_publishing_page
+      then_I_should_not_see_autocomplete_warnings
+      then_the_publish_button_should_be_enabled
+    end
   end
 
   def then_I_should_see_the_default_no_service_output_warning_message

--- a/app/presenters/autocomplete_items_presenter.rb
+++ b/app/presenters/autocomplete_items_presenter.rb
@@ -1,10 +1,10 @@
 class AutocompleteItemsPresenter
   include ActionView::Helpers
   include GovukLinkHelper
-  attr_reader :autocomplete_items, :service, :deployment_environment
+  attr_reader :autocomplete_items, :grid, :deployment_environment
 
-  def initialize(service, autocomplete_items, deployment_environment)
-    @service = service
+  def initialize(grid, autocomplete_items, deployment_environment)
+    @grid = grid
     @autocomplete_items = autocomplete_items
     @deployment_environment = deployment_environment
   end
@@ -20,9 +20,8 @@ class AutocompleteItemsPresenter
   end
 
   def pages_with_autocomplete_component
-    service.pages.select do |page|
-      page.components.any?(&:autocomplete?)
-    end
+    @pages_with_autocomplete_component ||=
+      pages_in_main_flow.select { |page| page.components.any?(&:autocomplete?) }
   end
 
   def messages
@@ -42,6 +41,17 @@ class AutocompleteItemsPresenter
   private
 
   def link(component, page)
-    govuk_link_to(component.humanised_title, Rails.application.routes.url_helpers.edit_page_path(service.service_id, page.uuid))
+    govuk_link_to(
+      component.humanised_title,
+      Rails.application.routes.url_helpers.edit_page_path(
+        grid.service.service_id,
+        page.uuid
+      )
+    )
+  end
+
+  def pages_in_main_flow
+    main_flow_uuids = grid.page_uuids
+    grid.service.pages.select { |page| page.uuid.in?(main_flow_uuids) }
   end
 end

--- a/app/presenters/publishing_page_presenter.rb
+++ b/app/presenters/publishing_page_presenter.rb
@@ -27,7 +27,11 @@ class PublishingPagePresenter
   end
 
   def autocomplete_warning
-    @autocomplete_warning ||= AutocompleteItemsPresenter.new(service, service_autocomplete_items, deployment_environment)
+    @autocomplete_warning ||= AutocompleteItemsPresenter.new(
+      MetadataPresenter::Grid.new(service),
+      service_autocomplete_items,
+      deployment_environment
+    )
   end
 
   def service_output_warning

--- a/spec/presenters/autocomplete_items_presenter_spec.rb
+++ b/spec/presenters/autocomplete_items_presenter_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe AutocompleteItemsPresenter do
-  subject(:autocomplete_items_presenter) { described_class.new(service, autocomplete_items, environment) }
+  subject(:autocomplete_items_presenter) { described_class.new(grid, autocomplete_items, environment) }
+  let(:grid) { MetadataPresenter::Grid.new(service) }
   let(:page) { service.find_page_by_url('countries') }
   let(:component_uuid) { page.components.first.uuid }
   let(:component_title) { page.components.first.humanised_title }


### PR DESCRIPTION
For any pages that have an autocomplete page we show a warning on the Publishing page if the user has not uploaded an autocomplete items for any of the autocomplete components in their form.

The Editor also allows pages to become unconnected (detached) should the user decide to do so. The only pages that are followed by the published form are those that are in the main flow therefore there should be no way for a public citizen to reach the unconnected page, unless they magically know its' URL.

Therefore there is no need to show a publishing warning for any autocomplete pages without autocomplete items that do NOT exist in the main flow.

To achieve this, pass the MetadataPresenter::Grid object into the AutocompleteItemsPresenter as the Grid object knows which pages are in the main flow.

Example below:

<img width="1010" alt="Screenshot 2022-12-08 at 16 48 07" src="https://user-images.githubusercontent.com/3466862/206513120-7bbe6f7d-904a-48c6-b37c-1fb844cfe1c2.png">

`Autocomplete Question` page is unconnected, therefore should not block publishing