### PR TITLE
Remove whitespace from payment link url

### DIFF
--- a/app/models/reference_payment_settings.rb
+++ b/app/models/reference_payment_settings.rb
@@ -37,12 +37,16 @@ class ReferencePaymentSettings
   def saved_payment_link_url
     return ServiceConfiguration.find_by(service_id: service_id, name: 'PAYMENT_LINK')&.decrypt_value if payment_link_url.nil?
 
-    payment_link_url
+    valid_payment_link_url
   end
 
   def payment_link_has_been_checked
     return ServiceConfiguration.exists?(service_id: service_id, name: 'PAYMENT_LINK') if payment_link.blank?
 
     payment_link_checked?
+  end
+
+  def valid_payment_link_url
+    payment_link_url.strip
   end
 end

--- a/spec/models/reference_payment_settings_spec.rb
+++ b/spec/models/reference_payment_settings_spec.rb
@@ -225,6 +225,24 @@ RSpec.describe ReferencePaymentSettings do
           expect(ServiceConfiguration).to_not receive(:exists?)
         end
       end
+
+      context 'when payment link url has whitespace' do
+        let(:params) do
+          {
+            payment_link: '1',
+            payment_link_url: 'https://www.gov.uk/payments/123   '
+          }
+        end
+
+        it 'will remove the white space and save to the DB' do
+          expect(
+            ServiceConfiguration.find_by(
+              service_id: service.service_id,
+              name: 'PAYMENT_LINK'
+            ).decrypt_value
+          ).to eq('https://www.gov.uk/payments/123')
+        end
+      end
     end
   end
 end

--- a/spec/models/reference_payment_updater_spec.rb
+++ b/spec/models/reference_payment_updater_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe ReferencePaymentUpdater do
           context 'when the url is present' do
             let(:params) { { payment_link: '1', payment_link_url: url } }
 
-            it 'creates the submission settings' do
+            it 'creates the service configuration' do
               reference_payment_updater.create_or_update!
 
               expect(
@@ -317,7 +317,7 @@ RSpec.describe ReferencePaymentUpdater do
           context 'when the url is missing' do
             let(:params) { { payment_link: '1', payment_link_url: '' } }
 
-            it 'doesn\'t create the submission setting' do
+            it 'doesn\'t create the service configuration' do
               reference_payment_updater.create_or_update!
 
               expect(


### PR DESCRIPTION
When a user inputs a payment link URL with white space, we remove the whites pace before saving it into the database.

Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>