### PR TITLE
Styling on confirmation page when payment link is enabled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'maintenance-page'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.17.27'
+gem 'metadata_presenter', '2.17.28'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.27)
+    metadata_presenter (2.17.28)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -459,7 +459,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.17.27)
+  metadata_presenter (= 2.17.28)
   omniauth-auth0 (~> 3.0.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,4 +85,13 @@ class ApplicationController < ActionController::Base
   def reference_number_config
     @reference_number_config ||= ServiceConfiguration.find_by(service_id: service.service_id, name: 'REFERENCE_NUMBER')
   end
+
+  def payment_link_enabled?
+    payment_link_config.present?
+  end
+  helper_method :payment_link_enabled?
+
+  def payment_link_config
+    @payment_link_config ||= ServiceConfiguration.find_by(service_id: service.service_id, name: 'PAYMENT_LINK')
+  end
 end

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -1174,6 +1174,11 @@ html {
   }
 }
 
+.govuk-panel--confirmation-payment {
+  @extend .govuk-panel--confirmation;
+  background-color: $govuk-brand-colour;
+}
+
 .govuk-radios__input:disabled + .govuk-radios__label,
 .govuk-checkboxes__input:disabled + .govuk-checkboxes__label {
 	opacity: 1;


### PR DESCRIPTION
When payment link is enabled, we want the confirmation page to look different as it will signify the user still needs to action the actual payment.

Bump to presenter v2.17.28

### Screenshot
![Screenshot 2022-12-14 at 12 20 32](https://user-images.githubusercontent.com/29227502/207594291-dbbb5fe4-fe15-4071-997b-9f4fda8196ae.png)