### PR TITLE
Add reference param onto payment link when publishing

### DIFF
--- a/app/models/service_configuration.rb
+++ b/app/models/service_configuration.rb
@@ -25,6 +25,7 @@ class ServiceConfiguration < ApplicationRecord
   ]
   BASIC_AUTH_USER = 'BASIC_AUTH_USER'.freeze
   BASIC_AUTH_PASS = 'BASIC_AUTH_PASS'.freeze
+  REFERENCE_PARAM = '?reference='.freeze
 
   before_save :encrypt_value
 
@@ -78,7 +79,15 @@ class ServiceConfiguration < ApplicationRecord
     Base64.strict_encode64(decrypt_value) if decrypt_value.present?
   end
 
+  def config_map_value
+    name == 'PAYMENT_LINK' ? payment_reference : decrypt_value
+  end
+
   private
+
+  def payment_reference
+    decrypt_value + REFERENCE_PARAM
+  end
 
   def encrypt_value
     self.value = EncryptionService.new.encrypt(value)

--- a/config/publisher/cloud_platform/config_map.yaml.erb
+++ b/config/publisher/cloud_platform/config_map.yaml.erb
@@ -7,6 +7,6 @@ data: <% config_map.each do |configuration|  %>
   <% if configuration.name == 'ENCODED_PUBLIC_KEY' %>
     <%= configuration.name %>: "<%= configuration.encode64 %>"
   <% else %>
-    <%= configuration.name %>: "<%= configuration.decrypt_value %>"
+    <%= configuration.name %>: "<%= configuration.config_map_value %>"
   <% end %>
 <% end %>

--- a/spec/models/service_configuration_spec.rb
+++ b/spec/models/service_configuration_spec.rb
@@ -259,5 +259,32 @@ RSpec.describe ServiceConfiguration, type: :model do
         end
       end
     end
+
+    describe '#config_map_value' do
+      let(:payment_link) { 'some-payment-link' }
+      let(:service_configuration) do
+        create(:service_configuration, :dev, :payment_link_url, value: payment_link)
+      end
+
+      context 'when name is PAYMENT_LINK' do
+        let(:expected_payment_link) do
+          "#{payment_link}#{ServiceConfiguration::REFERENCE_PARAM}"
+        end
+
+        it 'should return the decrypted value with the reference param' do
+          expect(service_configuration.config_map_value).to eq(expected_payment_link)
+        end
+      end
+
+      context 'when name is not PAYMENT_LINK' do
+        let(:service_configuration) do
+          create(:service_configuration, :dev, :confirmation_email_subject, value: 'subject')
+        end
+
+        it 'should return just the decrypted value' do
+          expect(service_configuration.config_map_value).to eq('subject')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
We do not want to show the user the '?reference=' request parameter in the field on the settings page. So we leave it as the value that the user initially entered and then only add the request parameter when we publish the form.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>