### PR TITLE
Inject a tag into confirmation email body

### DIFF
--- a/app/models/service_configuration.rb
+++ b/app/models/service_configuration.rb
@@ -26,6 +26,7 @@ class ServiceConfiguration < ApplicationRecord
   BASIC_AUTH_USER = 'BASIC_AUTH_USER'.freeze
   BASIC_AUTH_PASS = 'BASIC_AUTH_PASS'.freeze
   REFERENCE_PARAM = '?reference='.freeze
+  A_TAG = '<a href="{{payment_link}}">{{payment_link}}</a>'.freeze
 
   before_save :encrypt_value
 
@@ -80,13 +81,19 @@ class ServiceConfiguration < ApplicationRecord
   end
 
   def config_map_value
-    name == 'PAYMENT_LINK' ? payment_reference : decrypt_value
+    send(name.downcase)
+  rescue NoMethodError
+    decrypt_value
   end
 
   private
 
-  def payment_reference
+  def payment_link
     decrypt_value + REFERENCE_PARAM
+  end
+
+  def confirmation_email_body
+    decrypt_value.gsub('{{payment_link}}', A_TAG)
   end
 
   def encrypt_value

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,8 +32,8 @@ en:
     service_email_pdf_heading: 'Submission for %{service_name} {{reference_number_placeholder}}'
     service_email_pdf_subheading: ''
     branching_title: 'Branching point %{branching_number}'
-    confirmation_email_subject: "Your submission to ‘%{service_name}’ {{reference_number_placeholder}}"
-    confirmation_email_body: "Thank you for your submission to ‘%{service_name}’. {{reference_payment_placeholder}}\n\r\nA copy of the information you provided is attached to this email."
+    confirmation_email_subject: "Your submission to '%{service_name}' {{reference_number_placeholder}}"
+    confirmation_email_body: "Thank you for your submission to '%{service_name}'. {{reference_payment_placeholder}}\n\r\nA copy of the information you provided is attached to this email."
     reference_number_sentence: "Your reference number is: {{reference_number}}."
     reference_number_subject: ", reference number: {{reference_number}}"
     reference_number: '123-ABCD-456'

--- a/spec/models/service_configuration_spec.rb
+++ b/spec/models/service_configuration_spec.rb
@@ -261,12 +261,11 @@ RSpec.describe ServiceConfiguration, type: :model do
     end
 
     describe '#config_map_value' do
-      let(:payment_link) { 'some-payment-link' }
-      let(:service_configuration) do
-        create(:service_configuration, :dev, :payment_link_url, value: payment_link)
-      end
-
       context 'when name is PAYMENT_LINK' do
+        let(:payment_link) { 'some-payment-link' }
+        let(:service_configuration) do
+          create(:service_configuration, :dev, :payment_link_url, value: payment_link)
+        end
         let(:expected_payment_link) do
           "#{payment_link}#{ServiceConfiguration::REFERENCE_PARAM}"
         end
@@ -276,7 +275,20 @@ RSpec.describe ServiceConfiguration, type: :model do
         end
       end
 
-      context 'when name is not PAYMENT_LINK' do
+      context 'when CONFIRMATION_EMAIL_BODY' do
+        let(:service_configuration) do
+          create(:service_configuration, :dev, :confirmation_email_body, value: 'Pay at {{payment_link}}. At some point')
+        end
+        let(:expected_confirmation_email_body) do
+          'Pay at <a href="{{payment_link}}">{{payment_link}}</a>. At some point'
+        end
+
+        it 'should insert the a tag with the payment link placeholder' do
+          expect(service_configuration.config_map_value).to eq(expected_confirmation_email_body)
+        end
+      end
+
+      context 'when name is not PAYMENT_LINK or CONFIRMATION_EMAIL_BODY' do
         let(:service_configuration) do
           create(:service_configuration, :dev, :confirmation_email_subject, value: 'subject')
         end


### PR DESCRIPTION
When a user has enabled the confirmation email with payment link then we need to inject an a tag into the body so that it is clickable once it has been processed by the submitter.

The runner will gsub both the {{payment_link}} placeholders before submitting the payload.