### PR TITLE
Inject line break tags into email bodies

### DIFF
--- a/app/models/service_configuration.rb
+++ b/app/models/service_configuration.rb
@@ -93,7 +93,15 @@ class ServiceConfiguration < ApplicationRecord
   end
 
   def confirmation_email_body
-    decrypt_value.gsub('{{payment_link}}', A_TAG)
+    inject_line_breaks(decrypt_value).gsub('{{payment_link}}', A_TAG)
+  end
+
+  def service_email_body
+    inject_line_breaks(decrypt_value)
+  end
+
+  def inject_line_breaks(text)
+    text.gsub(/\n|\r/, '<br />')
   end
 
   def encrypt_value

--- a/spec/models/service_configuration_spec.rb
+++ b/spec/models/service_configuration_spec.rb
@@ -277,14 +277,37 @@ RSpec.describe ServiceConfiguration, type: :model do
 
       context 'when CONFIRMATION_EMAIL_BODY' do
         let(:service_configuration) do
-          create(:service_configuration, :dev, :confirmation_email_body, value: 'Pay at {{payment_link}}. At some point')
+          create(
+            :service_configuration,
+            :dev,
+            :confirmation_email_body,
+            value: "You need to pay\n\r\nPay at {{payment_link}}.\nAt some point"
+          )
         end
         let(:expected_confirmation_email_body) do
-          'Pay at <a href="{{payment_link}}">{{payment_link}}</a>. At some point'
+          'You need to pay<br /><br /><br />Pay at <a href="{{payment_link}}">{{payment_link}}</a>.<br />At some point'
         end
 
         it 'should insert the a tag with the payment link placeholder' do
           expect(service_configuration.config_map_value).to eq(expected_confirmation_email_body)
+        end
+      end
+
+      context 'when SERVICE_EMAIL_BODY' do
+        let(:service_configuration) do
+          create(
+            :service_configuration,
+            :dev,
+            :service_email_body,
+            value: "Some email\n\r\nbody saying some\nthings"
+          )
+        end
+        let(:expected_service_email_body) do
+          'Some email<br /><br /><br />body saying some<br />things'
+        end
+
+        it 'should insert the a tag with the payment link placeholder' do
+          expect(service_configuration.config_map_value).to eq(expected_service_email_body)
         end
       end
 


### PR DESCRIPTION
Both the service email body and the confirmation email body need to have the line breaks and carriage returns replaced by <br /> tags so that the correct formatting is shown when they are sent by AWS SES.