### PR TITLE
Escape double inverted commas in confirmation email a tag

### DIFF
--- a/app/models/service_configuration.rb
+++ b/app/models/service_configuration.rb
@@ -26,7 +26,7 @@ class ServiceConfiguration < ApplicationRecord
   BASIC_AUTH_USER = 'BASIC_AUTH_USER'.freeze
   BASIC_AUTH_PASS = 'BASIC_AUTH_PASS'.freeze
   REFERENCE_PARAM = '?reference='.freeze
-  A_TAG = '<a href="{{payment_link}}">{{payment_link}}</a>'.freeze
+  A_TAG = '<a href=\"{{payment_link}}\">{{payment_link}}</a>'.freeze
 
   before_save :encrypt_value
 

--- a/spec/models/service_configuration_spec.rb
+++ b/spec/models/service_configuration_spec.rb
@@ -285,7 +285,7 @@ RSpec.describe ServiceConfiguration, type: :model do
           )
         end
         let(:expected_confirmation_email_body) do
-          'You need to pay<br /><br /><br />Pay at <a href="{{payment_link}}">{{payment_link}}</a>.<br />At some point'
+          'You need to pay<br /><br /><br />Pay at <a href=\"{{payment_link}}\">{{payment_link}}</a>.<br />At some point'
         end
 
         it 'should insert the a tag with the payment link placeholder' do


### PR DESCRIPTION
This is required to keep valid yaml syntax especially for when a form name has a single inverted comma in it. e.g 'a123's form'