### PR TITLE
Flow view layout fixes

### DIFF
--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -351,6 +351,7 @@ function adjustOverviewHeight($overview) {
   // Move the overview area down to avoid paths overlapping content above.
   if(topOverlap > 0) {
     $overview.css("margin-top", topOverlap + "px");
+    $overview.css("top", topOverlap + "px");
   }
 
   // Adjustment to make the height over overview area contain the height

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -953,9 +953,13 @@ html {
 
 #flow-overview {
   background-color: govuk-colour("white");
-  margin-bottom: 100px;
   min-height: 200px; // Temporary workaround of intermittent height calculation issues
   position: relative;
+}
+
+#flow-overview,
+.flow-detached-group {
+  margin-bottom: 100px;
 }
 
 #flow-standalone-pages {


### PR DESCRIPTION
This PR adds fixes for 2 small things on the flow view.

### Arrows overflowing the top of the view
Arrows were going out of viewport at the top of the flow.
The `adjustOverflowHeight()` function shoudl have been correcting for this, however it was using `margin-top` to adjust the position.  Since that method was implemented, the title section of the page has been adjusted to use `position: fixed` meaning that the `margin-top` was not being 'measured' from the title element anymore.  Adjusting to use `top` offsets it from its container - resulting in the correct offset.`

**Before:**
![image](https://user-images.githubusercontent.com/595564/207855109-a6ae01b3-1685-44ac-a9bf-9b696756094e.png)

**After:**
![image](https://user-images.githubusercontent.com/595564/207855539-9d4ea6a3-cc34-48ac-aa2b-57741c9f6b46.png)


### Add margin between flow-detached-groups
The main flow view has a margin bottom to separate the 'Unconnected section' however each flow group within the unconnected section had no margin/spacing applied and so could overlap.  Adjusted CSS to apply the saem margin to detached flows as to the main flow.

**Before:**
![image](https://user-images.githubusercontent.com/595564/207855612-f3ef6c2b-0183-449d-b655-ed1fa8b37e66.png)

**After:**
![image](https://user-images.githubusercontent.com/595564/207855686-5e0a1c26-bff8-4a98-be4e-e27a8508cb6d.png)

