### PR TITLE
Put back the curly quotes into email bodies

### DIFF
--- a/acceptance/features/confirmation_email_spec.rb
+++ b/acceptance/features/confirmation_email_spec.rb
@@ -9,7 +9,7 @@ feature 'Confirmation email' do
   let(:message_body) {
     "Thank you for your submission to ‘#{service_name}’. \n\nA copy of the information you provided is attached to this email."
   }
-  let(:message_subject) { "Your submission to ‘#{service_name}’ " }
+  let(:message_subject) { "Your submission to ‘#{service_name}’" }
   let(:multiple_question_page) { 'Title' }
   let(:email_question) { 'Email address question' }
   let(:text_component_question) { 'Question' }

--- a/acceptance/features/confirmation_email_spec.rb
+++ b/acceptance/features/confirmation_email_spec.rb
@@ -7,9 +7,9 @@ feature 'Confirmation email' do
   let(:question) { 'New Email Component' }
   # Capybara strips out the carriage return `\r`
   let(:message_body) {
-    "Thank you for your submission to '#{service_name}'. \n\nA copy of the information you provided is attached to this email."
+    "Thank you for your submission to ‘#{service_name}’. \n\nA copy of the information you provided is attached to this email."
   }
-  let(:message_subject) { "Your submission to '#{service_name}' " }
+  let(:message_subject) { "Your submission to ‘#{service_name}’ " }
   let(:multiple_question_page) { 'Title' }
   let(:email_question) { 'Email address question' }
   let(:text_component_question) { 'Question' }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,8 +32,8 @@ en:
     service_email_pdf_heading: 'Submission for %{service_name} {{reference_number_placeholder}}'
     service_email_pdf_subheading: ''
     branching_title: 'Branching point %{branching_number}'
-    confirmation_email_subject: "Your submission to '%{service_name}' {{reference_number_placeholder}}"
-    confirmation_email_body: "Thank you for your submission to '%{service_name}'. {{reference_payment_placeholder}}\n\r\nA copy of the information you provided is attached to this email."
+    confirmation_email_subject: "Your submission to ‘%{service_name}’ {{reference_number_placeholder}}"
+    confirmation_email_body: "Thank you for your submission to ‘%{service_name}’. {{reference_payment_placeholder}}\n\r\nA copy of the information you provided is attached to this email."
     reference_number_sentence: "Your reference number is: {{reference_number}}."
     reference_number_subject: ", reference number: {{reference_number}}"
     reference_number: '123-ABCD-456'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,12 +27,12 @@ en:
   default_values:
     service_email_output: ''
     service_email_from: 'no-reply-moj-forms@digital.justice.gov.uk'
-    service_email_subject: 'Submission from %{service_name} {{reference_number_placeholder}}'
+    service_email_subject: 'Submission from %{service_name}{{reference_number_placeholder}}'
     service_email_body: 'Please find attached a submission sent from %{service_name}. {{reference_number_placeholder}}'
     service_email_pdf_heading: 'Submission for %{service_name} {{reference_number_placeholder}}'
     service_email_pdf_subheading: ''
     branching_title: 'Branching point %{branching_number}'
-    confirmation_email_subject: "Your submission to ‘%{service_name}’ {{reference_number_placeholder}}"
+    confirmation_email_subject: "Your submission to ‘%{service_name}’{{reference_number_placeholder}}"
     confirmation_email_body: "Thank you for your submission to ‘%{service_name}’. {{reference_payment_placeholder}}\n\r\nA copy of the information you provided is attached to this email."
     reference_number_sentence: "Your reference number is: {{reference_number}}."
     reference_number_subject: ", reference number: {{reference_number}}"


### PR DESCRIPTION
The curly quotes are necessary because if there is an apostrophe in the
form name it will confuse the kubernetes cli while it is creating the
config map.

Remove space in email subject as there was one space too many in the email subject lines in the locale
file.

Co-authored-by: Chris Pymm <chris.pymm@digital.justice.gov.uk>