### PR TITLE
Add in arrow if branch destination is down and not in the next column

### DIFF
--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -731,14 +731,26 @@ function applyBranchFlowConnectorPaths(view, $overview) {
             }
             else {
               // DOWN
-              new ConnectorPath.DownForwardDownForwardPath({
-                from_x: branchX - (branchWidth / 2),
-                from_y: branchY,
-                to_x: destinationX,
-                to_y: destinationY,
-                via_x: conditionX + halfBranchNodeWidth,
-                via_y: conditionY
-              }, config);
+              if(nextColumn) {
+                new ConnectorPath.DownForwardDownForwardPath({
+                  from_x: branchX - (branchWidth / 2),
+                  from_y: branchY,
+                  to_x: destinationX,
+                  to_y: destinationY,
+                  via_x: conditionX + halfBranchNodeWidth,
+                  via_y: conditionY
+                }, config);
+              }
+              else {
+                new ConnectorPath.DownForwardUpForwardDownPath({
+                  from_x: branchX - (branchWidth / 2),
+                  from_y: branchY,
+                  to_x: destinationX,
+                  to_y: destinationY,
+                  via_x: conditionX + halfBranchNodeWidth,
+                  via_y: conditionY
+                }, config);
+              }
             }
           }
         }


### PR DESCRIPTION
Another fix for an issue on the COP Form.

When the destination page of a branch was in a lower row (down) and not in the next column, the result was an arrow drawn through a page.

**Issue:**
![image](https://user-images.githubusercontent.com/595564/207904357-dabbe82f-082f-4738-8331-5fe4540a284f.png)

Add in the missing case within the `applyBranchFlowConnectorPaths()` method.

**Result:**
![image](https://user-images.githubusercontent.com/595564/207904689-d9e9b300-41a6-4967-a720-e1a37252dee5.png)

In the specific case shown above, it results in a slightly ridiculous arrow, but this is because the arrows don't know what they have to go around/avoid so branching conditions always go up the the top and back down when skipping columns.

