### PR TITLE
Limit service name to 57 characters in length

### DIFF
--- a/acceptance/features/create_service_spec.rb
+++ b/acceptance/features/create_service_spec.rb
@@ -99,13 +99,13 @@ feature 'Create a service' do
 
   def then_I_should_see_a_validation_message_for_min_length
     expect(editor).to have_content(
-      I18n.t('activemodel.errors.messages.too_short', attribute: 'Give your form a name', count: '3')
+      I18n.t('activemodel.errors.messages.too_short', count: '3')
     )
   end
 
   def then_I_should_see_a_validation_message_for_max_length
     expect(editor).to have_content(
-      I18n.t('activemodel.errors.messages.too_long', attribute: 'Give your form a name', count: '128')
+      I18n.t('activemodel.errors.messages.too_long', count: '57')
     )
   end
 

--- a/acceptance/features/create_service_spec.rb
+++ b/acceptance/features/create_service_spec.rb
@@ -99,13 +99,13 @@ feature 'Create a service' do
 
   def then_I_should_see_a_validation_message_for_min_length
     expect(editor).to have_content(
-      I18n.t('activemodel.errors.messages.too_short', count: '3')
+      I18n.t('activemodel.errors.messages.too_short', count: Editor::Service::MINIMUM)
     )
   end
 
   def then_I_should_see_a_validation_message_for_max_length
     expect(editor).to have_content(
-      I18n.t('activemodel.errors.messages.too_long', count: '57')
+      I18n.t('activemodel.errors.messages.too_long', count: Editor::Service::MAXIMUM)
     )
   end
 

--- a/acceptance/features/update_settings_form_information_spec.rb
+++ b/acceptance/features/update_settings_form_information_spec.rb
@@ -13,39 +13,46 @@ feature 'Update settings form information' do
     and_I_go_to_update_the_form_details_in_settings
   end
 
-#  scenario 'current service name as input value' do
-#    then_I_should_see_the_current_service_name_in_the_input
-#  end
+  #########################################################
+  #########################################################
+  # These are commented out currently as we do not allow uses to change the
+  # form name. At some point we will add back in that feature and we can then
+  # uncomment these tests
+  # scenario 'current service name as input value' do
+  #   then_I_should_see_the_current_service_name_in_the_input
+  # end
 
-#  scenario 'validates the service name' do
-#    given_I_update_a_service_with_empty_name
-#    when_I_update_the_service
-#    then_I_should_see_a_validation_message_for_required
-#  end
+  # scenario 'validates the service name' do
+  #   given_I_update_a_service_with_empty_name
+  #   when_I_update_the_service
+  #   then_I_should_see_a_validation_message_for_required
+  # end
 
-#  scenario 'validates the service name min length' do
-#    given_I_update_a_service_with_one_character
-#    when_I_update_the_service
-#    then_I_should_see_a_validation_message_for_min_length
-#  end
+  # scenario 'validates the service name min length' do
+  #   given_I_update_a_service_with_one_character
+  #   when_I_update_the_service
+  #   then_I_should_see_a_validation_message_for_min_length
+  # end
 
-#  scenario 'validates the service name max length' do
-#    given_I_update_a_service_with_many_characters
-#    when_I_update_the_service
-#    then_I_should_see_a_validation_message_for_max_length
-#  end
+  # scenario 'validates the service name max length' do
+  #   given_I_update_a_service_with_many_characters
+  #   when_I_update_the_service
+  #   then_I_should_see_a_validation_message_for_max_length
+  # end
 
-#  scenario 'updates the service in settings' do
-#    given_I_update_the_service_name
-#    then_I_should_see_the_new_service_name
-#  end
+  # scenario 'updates the service in settings' do
+  #   given_I_update_the_service_name
+  #   then_I_should_see_the_new_service_name
+  # end
 
-#  scenario 'validates uniqueness of the service name' do
-#    given_I_have_another_service
-#    and_I_go_to_update_the_form_details_in_settings
-#    when_I_try_to_change_service_name_adding_an_existing_service_name
-#    then_I_should_see_the_unique_validation_message
-#  end
+  # scenario 'validates uniqueness of the service name' do
+  #   given_I_have_another_service
+  #   and_I_go_to_update_the_form_details_in_settings
+  #   when_I_try_to_change_service_name_adding_an_existing_service_name
+  #   then_I_should_see_the_unique_validation_message
+  # end
+  #########################################################
+  #########################################################
 
   def and_I_go_to_update_the_form_details_in_settings
     editor.load

--- a/acceptance/features/update_settings_form_information_spec.rb
+++ b/acceptance/features/update_settings_form_information_spec.rb
@@ -96,13 +96,13 @@ feature 'Update settings form information' do
 
   def then_I_should_see_a_validation_message_for_min_length
     expect(editor).to have_content(
-      I18n.t('activemodel.errors.messages.too_short', attribute: 'Form name', count: '3')
+      I18n.t('activemodel.errors.messages.too_short', count: '3')
     )
   end
 
   def then_I_should_see_a_validation_message_for_max_length
     expect(editor).to have_content(
-      I18n.t('activemodel.errors.messages.too_long', attribute: 'Form name', count: '128')
+      I18n.t('activemodel.errors.messages.too_long', count: '57')
     )
   end
 

--- a/acceptance/features/update_settings_form_information_spec.rb
+++ b/acceptance/features/update_settings_form_information_spec.rb
@@ -103,13 +103,13 @@ feature 'Update settings form information' do
 
   def then_I_should_see_a_validation_message_for_min_length
     expect(editor).to have_content(
-      I18n.t('activemodel.errors.messages.too_short', count: '3')
+      I18n.t('activemodel.errors.messages.too_short', count: Editor::Service::MINIMUM)
     )
   end
 
   def then_I_should_see_a_validation_message_for_max_length
     expect(editor).to have_content(
-      I18n.t('activemodel.errors.messages.too_long', count: '57')
+      I18n.t('activemodel.errors.messages.too_long', count: Editor::Service::MAXIMUM)
     )
   end
 

--- a/acceptance/fixtures/autocomplete_page_fixture.json
+++ b/acceptance/fixtures/autocomplete_page_fixture.json
@@ -96,7 +96,7 @@
   "created_by": "c2df7129-db18-4df6-9fad-0a1f6e0cafd9",
   "service_id": "c4805211-2ba3-4ace-ba22-bc4faa999a61",
   "version_id": "b7669cc1-ab0e-4020-b129-9c63faef80c2",
-  "service_name": "Acceptance-test-Stormtrooper-FN-78a0f4f3-fdd6-4386-88a1-7aa23ebe582c",
+  "service_name": "Acceptance-Test-O8QfGX3WoFRRlmv4",
   "configuration": {
     "meta": {
       "_id": "config.meta",

--- a/acceptance/fixtures/checkboxes_page_fixture.json
+++ b/acceptance/fixtures/checkboxes_page_fixture.json
@@ -111,7 +111,7 @@
   "created_by": "47a4e5d7-92ad-464c-b01a-e3bd0a1ee454",
   "service_id": "ca7b2d85-a2c7-4cec-a528-a51b2531fb14",
   "version_id": "b4089161-9ff8-401f-b8cc-3ba658c19b35",
-  "service_name": "Acceptance-test-Stormtrooper-FN-d9738695-33e1-484c-9af9-5476db0aea73",
+  "service_name": "Acceptance-Test-vINyFGMpJIoknUS9",
   "configuration": {
     "meta": {
       "_id": "config.meta",

--- a/acceptance/fixtures/preview_form_fixture.json
+++ b/acceptance/fixtures/preview_form_fixture.json
@@ -348,7 +348,7 @@
   "created_by": "47a4e5d7-92ad-464c-b01a-e3bd0a1ee454",
   "service_id": "21152909-fbfc-4e1a-96da-ab8f7f2e808a",
   "version_id": "f13687bf-1296-4b99-a34d-b2c375f848fb",
-  "service_name": "Acceptance-test-Stormtrooper-FN-3003aab9-9c86-494d-934a-64226eee2af1",
+  "service_name": "Acceptance-Test-4oy4tBnX7ORORtvK",
   "configuration": {
     "meta": {
       "_id": "config.meta",

--- a/acceptance/fixtures/radios_page_fixture.json
+++ b/acceptance/fixtures/radios_page_fixture.json
@@ -111,7 +111,7 @@
   "created_by": "47a4e5d7-92ad-464c-b01a-e3bd0a1ee454",
   "service_id": "6a61ef72-c86c-4767-8bd9-8bc67a5b251e",
   "version_id": "2cd3a5b1-e595-4057-a8a0-a73e73c579b0",
-  "service_name": "Acceptance-test-Stormtrooper-FN-1b437d11-ddaf-426d-879d-627449b6aa3c",
+  "service_name": "Acceptance-Test-vyLnKlILQpIyDn6D",
   "configuration": {
     "meta": {
       "_id": "config.meta",

--- a/acceptance/support/test_helpers.rb
+++ b/acceptance/support/test_helpers.rb
@@ -1,5 +1,5 @@
 module TestHelpers
   def generate_service_name
-    "Acceptance-test-Stormtrooper-FN-#{SecureRandom.uuid}"
+    "Acceptance-Test-#{SecureRandom.alphanumeric}"
   end
 end

--- a/app/services/editor/service.rb
+++ b/app/services/editor/service.rb
@@ -3,8 +3,11 @@ module Editor
     include ActiveModel::Model
     attr_accessor :service_name, :current_user, :service_id, :latest_metadata
 
+    MINIMUM = 3
+    MAXIMUM = 57
+
     validates :service_name, presence: true
-    validates :service_name, length: { minimum: 3, maximum: 57 }, allow_blank: true
+    validates :service_name, length: { minimum: MINIMUM, maximum: MAXIMUM }, allow_blank: true
     validates :service_name, format: { with: /\A[a-zA-Z][\sa-zA-Z0-9-'’()]*\z/ }, allow_blank: true
     validates :service_name, legacy_service_name: true
 

--- a/app/services/editor/service.rb
+++ b/app/services/editor/service.rb
@@ -4,7 +4,7 @@ module Editor
     attr_accessor :service_name, :current_user, :service_id, :latest_metadata
 
     validates :service_name, presence: true
-    validates :service_name, length: { minimum: 3, maximum: 128 }, allow_blank: true
+    validates :service_name, length: { minimum: 3, maximum: 57 }, allow_blank: true
     validates :service_name, format: { with: /\A[a-zA-Z][\sa-zA-Z0-9-'’()]*\z/ }, allow_blank: true
     validates :service_name, legacy_service_name: true
 

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -31,7 +31,7 @@
             <% f.object.errors.each do |error|  %>
               <p class="govuk-error-message"><%= error.message %></p>
             <% end %>
-            <div class="govuk-hint" id="service-name-hint"> <%= t('services.form_name_hint')%></div>
+            <div class="govuk-hint" id="service-name-hint"> <%= t('services.form_name_hint', max_length: Editor::Service::MAXIMUM)%></div>
             <%= f.text_field :service_name, class: "govuk-input", 'aria-describedby': 'service-name-hint'%>
           </div>
           <%= f.button t('services.create'), class: "govuk-button fb-govuk-button", type: 'submit' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -452,7 +452,7 @@ en:
   services:
     heading: 'Your forms'
     edit: 'Edit'
-    form_name_hint: "It cannot start with a number or include special characters except ' - ( )"
+    form_name_hint: "Maximum 57 characters, including spaces. It cannot start with a number or include special characters except ' - ( )"
     preview: 'Preview'
     create: 'Create a new form'
     cancel: 'Cancel'
@@ -586,8 +586,8 @@ en:
           link_start_with: 'https://www.gov.uk/payments/'
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."
-        too_short: "Your answer for ‘%{attribute}’ is too short (%{count} characters at least)"
-        too_long: "Your answer for ‘%{attribute}’ is too long (%{count} characters at most)"
+        too_short: Form names must be %{count} characters or more
+        too_long: Form names must be %{count} characters or fewer
         invalid: "Your answer for ‘%{attribute}' contains characters that are not allowed."
         taken: "Your answer for ‘%{attribute}' is already used by another form. Please modify it."
         unprocessable: 'There is an error in the metadata. Please try again and if the error persists contact us in the #ask-formbuilder channel'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -452,7 +452,7 @@ en:
   services:
     heading: 'Your forms'
     edit: 'Edit'
-    form_name_hint: "Maximum 57 characters, including spaces. It cannot start with a number or include special characters except ' - ( )"
+    form_name_hint: "Maximum %{max_length} characters, including spaces. It cannot start with a number or include special characters except ' - ( )"
     preview: 'Preview'
     create: 'Create a new form'
     cancel: 'Cancel'


### PR DESCRIPTION
Until such time as we can separate out the URL from the service name we need to limit the service name length to 57 characters.

This is because Kubernetes has a limit of 63 characters for URL chunks as well as certain labels that are used throughout each Form's configuration.

https://kubernetes.io/docs/concepts/overview/working-with-objects/names/

On top of that Cloud Platform sometimes prefix `cname-` before the hostname that is generated by the Editor therefore we can only really allow 57 characters in total.

Once we have a separate service_slug field in the metadata we can up this constraint to something a bit more reasonable.

It is necessary to change the Acceptance Test form names to not use a
uuid as that makes them way too long.

<img width="751" alt="Screenshot 2022-12-19 at 14 35 56" src="https://user-images.githubusercontent.com/3466862/208456321-1e81ad31-5c78-4885-8a64-ce13fa9eda63.png">
<img width="756" alt="Screenshot 2022-12-19 at 14 36 20" src="https://user-images.githubusercontent.com/3466862/208456329-e9650433-26a1-4e3d-8c34-ad64b69c1e34.png">
