### PR TITLE
Remove and recreate the email identity on AWS when it becomes 'unverfied'

### DIFF
--- a/spec/services/from_address_creation_spec.rb
+++ b/spec/services/from_address_creation_spec.rb
@@ -112,6 +112,25 @@ RSpec.describe FromAddressCreation, type: :model do
       end
     end
 
+    context 'when sending enabled is false in aws' do
+      # this happens when the email verification link expires and the identity status changes to 'unverified' in AWS
+      let(:email_identity) { double(get_email_identity: true, sending_enabled: false) }
+      let(:email) { 'atreyu@justice.gov.uk' }
+
+      before do
+        create(:from_address, :pending, service_id: service_id, email: 'atreyu@justice.gov.uk')
+        allow(from_address_creation).to receive(:email_identity).and_return(email_identity)
+        allow(email_service).to receive(:get_email_identity).and_return(double)
+        expect(email_service).to receive(:delete_email_identity).with(email).and_return(double(successful?: true))
+        expect(email_service).to receive(:create_email_identity).with(email).and_return(double(successful?: true))
+        from_address_creation.save
+      end
+
+      it 'sets the from address status to pending' do
+        expect(from_address.reload.status).to eq('pending')
+      end
+    end
+
     context 'when the email is blank' do
       let(:email) { '' }
       it 'saves the default email address to the DB' do


### PR DESCRIPTION
[Trello](https://trello.com/c/BseYevGm/3164-from-address-not-showing-as-validated)

This is to address a bug whereby a user adds a from address email and the email is not verified within the 24hr time frame. This sets the identity status on AWS dashboard to 'unverified'.
When the user attempts to save the same email address again, it does not fall into any of the conditions in the `verify_email` method. This is because:
- `get_email_identity` will return something, as the email identity has been created before
- `sending_enabled` will be false, as the email was never verified.

Since it does not fall into either condition, the status will become `nil` in our database, which in turn will not trigger the notification banner in the templates. Meaning the user cannot ever have the ability to resend the validation link. To re-trigger a verification email we have to delete the email identity and create a new email identity.

This commit fixes this by adding an extra condition, that checks if the email identity is present and has not yet been verified. In this case we ensure the status is `pending`.