### PR TITLE
Payment link url validation

### DIFF
--- a/app/models/reference_payment_updater.rb
+++ b/app/models/reference_payment_updater.rb
@@ -45,8 +45,7 @@ class ReferencePaymentUpdater
       create_or_update_service_configuration(config: 'PAYMENT_LINK', deployment_environment: 'production', value: payment_link_url)
     end
 
-    unless reference_payment_settings.payment_link_url_present? ||
-        reference_payment_settings.payment_link_checked?
+    unless reference_payment_settings.payment_link_checked?
       remove_service_configuration('PAYMENT_LINK', 'dev')
       remove_service_configuration('PAYMENT_LINK', 'production')
     end

--- a/app/validators/reference_payment_validator.rb
+++ b/app/validators/reference_payment_validator.rb
@@ -1,19 +1,17 @@
 class ReferencePaymentValidator < ActiveModel::Validator
   def validate(record)
-    if !record.reference_number_enabled? && record.payment_link_checked?
+    return unless record.payment_link_checked?
+
+    unless record.reference_number_enabled?
       record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.reference_number_disabled'))
     end
 
-    if reference_and_payment_checked_with_url_missing(record) || payment_link_checked_with_url_missing(record)
+    if record.payment_link_url.blank?
       record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.missing_payment_link'))
     end
 
-    if record.payment_link_checked? && !record.payment_link_url.start_with?(gov_uk_link)
+    if !record.payment_link_url.start_with?(gov_uk_link) && record.payment_link_url.present?
       record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.invalid_payment_url', link_start_with: gov_uk_link))
-    end
-
-    if payment_link_not_checked_with_url_present(record)
-      record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.payment_link_disabled'))
     end
   end
 
@@ -21,17 +19,5 @@ class ReferencePaymentValidator < ActiveModel::Validator
 
   def gov_uk_link
     I18n.t('activemodel.errors.models.reference_payment_settings.link_start_with')
-  end
-
-  def payment_link_checked_with_url_missing(record)
-    record.payment_link_checked? && record.payment_link_url.blank?
-  end
-
-  def reference_and_payment_checked_with_url_missing(record)
-    record.reference_number_enabled? && record.payment_link_checked? && !record.payment_link_url_enabled?
-  end
-
-  def payment_link_not_checked_with_url_present(record)
-    !record.payment_link_checked? && record.payment_link_url_present?
   end
 end

--- a/spec/models/reference_payment_updater_spec.rb
+++ b/spec/models/reference_payment_updater_spec.rb
@@ -286,6 +286,19 @@ RSpec.describe ReferencePaymentUpdater do
             ).to be_empty
           end
         end
+
+        context 'when a user unticked the box and payment url is present' do
+          let(:params) { { payment_link_url: 'payment-link.com', payment_link: '0' } }
+
+          it 'removes the records from the database' do
+            expect(
+              ServiceConfiguration.where(
+                service_id: service.service_id,
+                name: 'PAYMENT_LINK'
+              )
+            ).to be_empty
+          end
+        end
       end
 
       context 'when payment link doesn\'t exist in the db' do

--- a/spec/validators/reference_payment_validator_spec.rb
+++ b/spec/validators/reference_payment_validator_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe  ReferencePaymentValidator do
       context 'when reference number is disabled' do
         let(:params) do
           {
+            service_id: service_id,
             reference_number: '0',
             payment_link: '1',
             payment_link_url: 'gov.uk'
@@ -44,6 +45,7 @@ RSpec.describe  ReferencePaymentValidator do
       context 'when payment link is missing' do
         let(:params) do
           {
+            service_id: service_id,
             reference_number: '1',
             payment_link: '1',
             payment_link_url: ''
@@ -54,14 +56,16 @@ RSpec.describe  ReferencePaymentValidator do
           expect(subject).to_not be_valid
         end
 
-        it 'returns an error message' do
+        it 'returns one error message' do
           expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.reference_payment_settings.missing_payment_link'))
+          expect(subject.errors.count).to eq(1)
         end
       end
 
       context 'when payment link url is invalid' do
         let(:params) do
           {
+            service_id: service_id,
             reference_number: '1',
             payment_link: '1',
             payment_link_url: 'dummy.link'
@@ -103,36 +107,30 @@ RSpec.describe  ReferencePaymentValidator do
       context 'when payment url is present' do
         let(:params) do
           {
+            service_id: service_id,
             reference_number: '1',
             payment_link: '0',
             payment_link_url: correct_url
           }
         end
 
-        it 'returns invalid' do
-          expect(subject).to_not be_valid
-        end
-
-        it 'returns an error message' do
-          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.reference_payment_settings.payment_link_disabled'))
+        it 'returns valid' do
+          expect(subject).to be_valid
         end
       end
 
       context 'when payment url is invalid' do
         let(:params) do
           {
+            service_id: service_id,
             reference_number: '1',
             payment_link: '0',
             payment_link_url: 'url'
           }
         end
 
-        it 'returns invalid' do
-          expect(subject).to_not be_valid
-        end
-
-        it 'include some error messages' do
-          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.reference_payment_settings.payment_link_disabled'))
+        it 'returns valid' do
+          expect(subject).to be_valid
         end
       end
     end


### PR DESCRIPTION
### Do not save `payment_link_url` to the DB if payment_link is disabled
When payment_link is not checked we need to remove the record from the` ServiceConfiguration` table to ensure this is not injected during the publishing mechanism.

### Only validate when payment link is enabled
We only want to validate the record if payment link is enabled, this is so validation errors do not trigger if there is a pre-existing `payment_link_url` in the input filed but the user then unchecks the payment link box.

At the moment, when a user enables payment link but leaves the url input field blank, two validations trigger. One for a blank input field and another for the incorrect url format. We only want to have the error for blank input trigger in this instance.

![Screenshot 2022-12-16 at 11 58 58](https://user-images.githubusercontent.com/29227502/208094008-0fdb0cff-14d4-4df5-aab7-145e74f41e76.png)