### PR TITLE
Reference number and payment link acceptance tests

### DIFF
--- a/acceptance/features/confirmation_email_spec.rb
+++ b/acceptance/features/confirmation_email_spec.rb
@@ -116,10 +116,6 @@ feature 'Confirmation email' do
     expect(page).to have_button(I18n.t("settings.submission.#{environment}.save_button"))
   end
 
-  def when_I_enable_confirmation_email(environment)
-    page.find(:css, "input#confirmation-email-settings-send-by-confirmation-email-#{environment}-1-field", visible: false).set(true)
-  end
-
   def when_I_disable_confirmation_email(environment)
     page.find(:css, "input#confirmation-email-settings-send-by-confirmation-email-#{environment}-1-field", visible: false).set(false)
   end
@@ -167,14 +163,6 @@ feature 'Confirmation email' do
     editor.connection_menu(start_page).click
     editor.add_multiple_question.click
     and_I_add_a_page_url(question)
-    when_I_add_the_page
-  end
-
-  def when_I_add_a_single_question_page_with_email_after_start(url:)
-    editor.connection_menu(start_page).click
-    editor.add_single_question.hover
-    editor.add_component(I18n.t('components.list.email')).click
-    editor.page_url_field.set(url)
     when_I_add_the_page
   end
 

--- a/acceptance/features/reference_payment_spec.rb
+++ b/acceptance/features/reference_payment_spec.rb
@@ -1,0 +1,166 @@
+require_relative '../spec_helper'
+
+feature 'Reference Payment Page' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+  let(:start_page) { 'Service name goes here' }
+  let(:payment_link_checkbox) { 'input#reference-payment-settings-payment-link-1-field' }
+  let(:payment_link_field) { 'input#reference-payment-settings-payment-link-url-field' }
+  let(:reference_number_checkbox) { 'input#reference-payment-settings-reference-number-1-field' }
+  let(:payment_link_label) { I18n.t('settings.payment_link.label') }
+  let(:valid_url) { I18n.t('activemodel.errors.models.reference_payment_settings.link_start_with') }
+  let(:confirmation_page_payment_text) { "You still need to pay\nYour reference number is:" }
+  let(:confirmation_warning_title) { I18n.t('settings.reference_number.confirmation_email_warning.title') }
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service_fixture(name: service_name)
+    when_I_visit_the_reference_payment_page
+    then_I_should_see_the_payment_link_settings_configuration
+  end
+
+  scenario 'enable reference number only' do
+    with_setting(reference_number_checkbox, true)
+    click_button(I18n.t('actions.save'))
+    then_I_should_not_see_my_content(I18n.t('activemodel.errors.summary_title'))
+    expect(page).to have_css('.govuk-notification-banner__content', text: confirmation_warning_title)
+    then_checkbox_should_remain_checked(reference_number_checkbox)
+
+    then_I_add_a_page_with_email_component
+    when_I_visit_the_confirmation_email_settings_page
+    when_I_enable_confirmation_email('dev')
+    click_button(I18n.t('settings.submission.dev.save_button'))
+    when_I_enable_confirmation_email('production')
+    click_button(I18n.t('settings.submission.production.save_button'))
+    when_I_visit_the_reference_payment_page
+    expect(page).to_not have_css('.govuk-notification-banner__content', text: confirmation_warning_title)
+  end
+
+  scenario 'configure payment link settings without reference number' do
+    with_setting(payment_link_checkbox, true)
+    then_I_should_see_text(payment_link_label)
+    with_setting(payment_link_field, valid_url)
+    click_button(I18n.t('actions.save'))
+    then_I_should_see_text(I18n.t('activemodel.errors.models.reference_payment_settings.reference_number_disabled'))
+    then_checkbox_should_remain_checked(payment_link_checkbox)
+  end
+
+  scenario 'configure payment link settings without url' do
+    with_setting(reference_number_checkbox, true)
+    with_setting(payment_link_checkbox, true)
+    then_I_should_see_text(payment_link_label)
+    click_button(I18n.t('actions.save'))
+    then_I_should_see_text(I18n.t('activemodel.errors.models.reference_payment_settings.missing_payment_link'))
+    then_checkbox_should_remain_checked(reference_number_checkbox)
+    then_checkbox_should_remain_checked(payment_link_checkbox)
+  end
+
+  scenario 'payment links with invalid url' do
+    with_setting(reference_number_checkbox, true)
+    with_setting(payment_link_checkbox, true)
+    then_I_should_see_text(payment_link_label)
+    with_setting(payment_link_field, 'dummy-url.com')
+    click_button(I18n.t('actions.save'))
+    then_I_should_see_text(
+      I18n.t(
+        'activemodel.errors.models.reference_payment_settings.invalid_payment_url',link_start_with: valid_url
+      )
+    )
+    then_checkbox_should_remain_checked(reference_number_checkbox)
+    then_checkbox_should_remain_checked(payment_link_checkbox)
+  end
+
+  scenario 'email body in confirmation email settings page updates correctly' do
+    with_setting(reference_number_checkbox, true)
+    with_setting(payment_link_checkbox, true)
+    then_I_should_see_text(payment_link_label)
+    with_setting(payment_link_field, valid_url)
+    click_button(I18n.t('actions.save'))
+    then_I_add_a_page_with_email_component
+    when_I_visit_the_confirmation_email_settings_page
+    when_I_enable_confirmation_email('dev')
+    expect(page).to have_content('{{reference_number}}')
+    expect(page).to have_content('{{payment_link}}')
+
+    when_I_visit_the_reference_payment_page
+    with_setting(payment_link_checkbox, false)
+    click_button(I18n.t('actions.save'))
+    when_I_visit_the_confirmation_email_settings_page
+    when_I_enable_confirmation_email('dev')
+    expect(page).to_not have_content('{{payment_link}}')
+    expect(page).to have_content('{{reference_number}}')
+
+    when_I_visit_the_reference_payment_page
+    with_setting(reference_number_checkbox, false)
+    with_setting(payment_link_checkbox, false)
+    click_button(I18n.t('actions.save'))
+    when_I_visit_the_confirmation_email_settings_page
+    when_I_enable_confirmation_email('dev')
+    expect(page).to_not have_content('{{reference_number}}')
+    expect(page).to_not have_content('{{payment_link}}')
+  end
+
+  scenario 'confirmation page styling updates correctly' do
+    with_setting(reference_number_checkbox, true)
+    with_setting(payment_link_checkbox, true)
+    then_I_should_see_text(payment_link_label)
+    with_setting(payment_link_field, valid_url)
+    click_button(I18n.t('actions.save'))
+
+    and_I_return_to_flow_page
+    given_I_edit_a_confirmation_page
+    expect(page).to have_css('div.govuk-panel--confirmation-payment', text: confirmation_page_payment_text)
+
+    when_I_visit_the_reference_payment_page
+    with_setting(payment_link_checkbox, false)
+    click_button(I18n.t('actions.save'))
+    and_I_return_to_flow_page
+    given_I_edit_a_confirmation_page
+    expect(page).to have_css('div.govuk-panel--confirmation', text: "Application complete\nYour reference number is:")
+    then_I_should_not_see_text('You still need to pay')
+
+    when_I_visit_the_reference_payment_page
+    with_setting(payment_link_checkbox, false)
+    with_setting(reference_number_checkbox, false)
+    click_button(I18n.t('actions.save'))
+    and_I_return_to_flow_page
+    given_I_edit_a_confirmation_page
+    expect(page).to have_css('div.govuk-panel--confirmation', text: "Application complete")
+    then_I_should_not_see_text(confirmation_page_payment_text)
+  end
+
+  ## Reference Payment Settings Page
+  def when_I_visit_the_reference_payment_page
+    page.find(:css, '#main-content', visible: true)
+    editor.click_link(I18n.t('settings.name'))
+    expect(page).to have_content(I18n.t('settings.reference_number.lede'))
+    editor.click_link(I18n.t('settings.reference_number.heading'))
+  end
+
+  def then_I_should_see_the_payment_link_settings_configuration
+    expect(page).to have_content(I18n.t('settings.reference_number.heading'))
+    expect(page).to have_content(I18n.t('settings.reference_number.description', href:'user guide' ))
+    expect(page).to have_content(I18n.t('settings.reference_number.hint'))
+    expect(page).to have_content(I18n.t('settings.payment_link.legend'))
+    expect(page).to have_content(I18n.t('settings.payment_link.hint', href:'GOV.UK Pay account'))
+  end
+
+  def with_setting(setting, value)
+    page.find(:css, setting, visible: false).set(value)
+  end
+
+  def then_checkbox_should_remain_checked(attribute)
+    element = find(attribute, visible: false)
+    expect(element.checked?).to eq(true)
+  end
+
+  ## Pages Flow
+  def and_I_edit_the_question
+    editor.question_heading.first.set('New Email Component')
+  end
+
+  def when_I_update_the_question_name
+    and_I_edit_the_question
+    when_I_save_my_changes
+  end
+end

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -548,4 +548,24 @@ module CommonSteps
     expect(page).to have_content(I18n.t('settings.confirmation_email.heading'))
     editor.click_link(I18n.t('settings.confirmation_email.heading'))
   end
+
+  def when_I_enable_confirmation_email(environment)
+    page.find(:css, "input#confirmation-email-settings-send-by-confirmation-email-#{environment}-1-field", visible: false).set(true)
+  end
+
+  def then_I_add_a_page_with_email_component
+    and_I_return_to_flow_page
+    when_I_add_a_single_question_page_with_email_after_start(url: 'new-email')
+    when_I_update_the_question_name
+    and_I_return_to_flow_page
+  end
+
+  def when_I_add_a_single_question_page_with_email_after_start(url:)
+    editor.connection_menu(start_page).click
+    editor.add_single_question.hover
+    editor.add_component(I18n.t('components.list.email')).click
+    editor.page_url_field.set(url)
+    when_I_add_the_page
+  end
+
 end


### PR DESCRIPTION
This PR has tests for:
- Happy path for reference number
- Confirmation email notification when confirmation emails are enabled in one or both environments
- Happy payment link path (payment and reference checked and url valid)
- Payment link validations (invalid url, blank url, reference number not checked)
- Confirmation email body content is correct depending on whether reference number or payment link is enabled
- Ensure check boxes for both reference number and payment link persist when user saves the page
- Confirmation page styling and content changes (payment link enabled vs only reference number enabled)