### PR TITLE
Add continue to pay button customisations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'maintenance-page'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.17.28'
+gem 'metadata_presenter', '2.17.29'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.28)
+    metadata_presenter (2.17.29)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -462,7 +462,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.7)
-  metadata_presenter (= 2.17.28)
+  metadata_presenter (= 2.17.29)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -77,6 +77,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :show_reference_number
 
+  def payment_link_url
+    payment_link_config.decrypt_value
+  end
+  helper_method :payment_link_url
+
   def reference_number_enabled?
     reference_number_config.present?
   end

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -109,6 +109,7 @@ PagesController.edit = function() {
 
     case "page.confirmation":
          // No customisations required for this view.
+         editPageConfirmationViewCustomisations(view);
          break;
 
     case "page.checkanswers":
@@ -695,6 +696,16 @@ function editPageCheckAnswersViewCustomisations() {
   $target2.before($button2);
   $button2.attr("data-fb-field-name", "page[add_extra_component]");
 }
+
+function editPageConfirmationViewCustomisations() {
+  var $payButton = $('[data-component="pay-button"]');
+  var $addContentButton = $('[data-component="add-content"]');
+  if($payButton && $addContentButton) {
+    $addContentButton.after($payButton);
+    $payButton.attr('disabled', 'disabled');
+    $payButton.attr('tabindex', '-1');
+  }
+};
 
 
 function editPageMultipleQuestionsViewCustomisations() {

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -40,6 +40,10 @@ html {
   display: none;
 }
 
+a[disabled] {
+  pointer-events: none;
+}
+
 .sr-only {
   height: 1px;
   left: -10000px;


### PR DESCRIPTION
Bumps metadata presenter to 2.17.29 to include continue to pay button (if enabled)

Adds customisations to the confirmation page edit screen:
* Place the 'Continue to pay' button after the 'Add content' button
* Disable the link - for mouse users with `pointer-events: none` for keyboard users with `tabindex="-1"` 

![image](https://user-images.githubusercontent.com/595564/208143865-997dc5fd-e7ff-421b-9d0f-3b6ff2e92213.png)
