### PR TITLE
Use intersection checking to limit the amount of adjustment calls

### DIFF
--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -91,6 +91,20 @@ class FlowConnectorPath {
     return this.#points;
   }
 
+  // Gets the bounding box of the path
+  // This is used to check path intersections for the adjustment/nudging routine
+  // Theoretically this should include the via points, but including them
+  // results in massively more intersections, and thus a much longer processing
+  // time. But doesn't actually change the end result. So we leave them out.
+  get bounds() {
+    return {
+      x1: Math.min(this.points.from_x, this.points.to_x),
+      y1: Math.min(this.points.from_y, this.points.to_y),
+      x2: Math.max(this.points.from_x, this.points.to_x),
+      y2: Math.max(this.points.from_y, this.points.to_y)
+    };
+  }
+
   // Makeing these readonly access properties because they shouldn't be changed.
   prop(name) {
     var p = this.#prop;

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -835,13 +835,9 @@ function adjustOverlappingFlowConnectorPaths($overview) {
           // If the paths intersect / overlap
           // Call the overlap avoidance functionality and register
           // if anything was moved (reported by its return value).
-          if(utilities.intersects(path.bounds,current.bounds)){
-            // avoidOverlap is super expensive and if anything moves we start
-            // again so we only call it if the paths bounding boxes actually intersect.
-            if(path.avoidOverlap(current)) {
-              somethingMoved = true;
-              return false;
-            }
+          if(path.avoidOverlap(current)) {
+            somethingMoved = true;
+            return false;
           }
         }
       });

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -364,6 +364,19 @@ function intersects(a, b) {
 	return true;
 }
 
+function overlaps(a, b, minimumOverlap) {
+  if( a.end - b.start >= 0 && b.end - a.start >=0 ) {
+    const range = overlapRange(a,b);
+    return (range.end - range.start) >= minimumOverlap;
+  }
+}
+
+function overlapRange(a,b) {
+  return {
+    start: Math.max(a.start, b.start),
+    end: Math.min(a.end, b.end)
+  }
+}
 
 
 
@@ -391,5 +404,6 @@ module.exports  = {
   highestNumber: highestNumber,
   filterObject: filterObject,
   snakeToPascalCase: snakeToPascalCase,
-  intersects: intersects
+  intersects: intersects,
+  overlaps: overlaps
 }

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -357,21 +357,33 @@ function snakeToPascalCase( str ){
     return str.join('');
 }
 
+// Determines if two rectangles have an intersection area
+// a and b are objects with top,left, bottom, right coordinates
+// @param {{x1: number y1: number, x2: number, y2: number}} a
+// @param  {{x1: number y1: number, x2: number, y2: number}} b
+// @return boolean
 function intersects(a, b) {
-	if (a.x1 >= b.x2 || b.x1 >= a.x2) return false; // no horizontal overlap
-	if (a.y1 >= b.y2 || b.y1 >= a.y2) return false; // no vertical overlap
+	if (a.x1 > b.x2 || b.x1 > a.x2) return false; // no horizontal overlap
+	if (a.y1 > b.y2 || b.y1 > a.y2) return false; // no vertical overlap
 
 	return true;
 }
 
-function overlaps(a, b, minimumOverlap) {
+// Determines if two ranges have an overlapping section
+// ranges provided must be supplied ordered such that start < end
+// @param {{start: number, end: number}} a
+// @param {{start: number, end: number}} b
+// @param {number} minimumOverlap
+// @return boolean
+function overlaps(a, b, minimumOverlap=0) {
   if( a.end - b.start >= 0 && b.end - a.start >=0 ) {
-    const range = overlapRange(a,b);
-    return (range.end - range.start) >= minimumOverlap;
+    const intersection = rangeIntersection(a,b);
+    return (intersection.end - intersection.start) >= minimumOverlap;
   }
+  return false;
 }
 
-function overlapRange(a,b) {
+function rangeIntersection(a,b) {
   return {
     start: Math.max(a.start, b.start),
     end: Math.min(a.end, b.end)
@@ -405,5 +417,5 @@ module.exports  = {
   filterObject: filterObject,
   snakeToPascalCase: snakeToPascalCase,
   intersects: intersects,
-  overlaps: overlaps
+  overlaps: overlaps,
 }

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -357,6 +357,13 @@ function snakeToPascalCase( str ){
     return str.join('');
 }
 
+function intersects(a, b) {
+	if (a.x1 >= b.x2 || b.x1 >= a.x2) return false; // no horizontal overlap
+	if (a.y1 >= b.y2 || b.y1 >= a.y2) return false; // no vertical overlap
+
+	return true;
+}
+
 
 
 
@@ -384,4 +391,5 @@ module.exports  = {
   highestNumber: highestNumber,
   filterObject: filterObject,
   snakeToPascalCase: snakeToPascalCase,
+  intersects: intersects
 }

--- a/test/flow_connector_line/methods_test.js
+++ b/test/flow_connector_line/methods_test.js
@@ -18,55 +18,52 @@ describe("FlowConnectorLine", function() {
       created = {};
     });
 
-    /* TEST METHOD:  prop()
-     **/
 
-    it("should return overlapAllowed value", function() {
-      expect(created.lines[0].prop("overlapAllowed")).to.be.true;
-      expect(created.lines[1].prop("overlapAllowed")).to.be.false;
-      expect(created.lines[2].prop("overlapAllowed")).to.be.true;
+    describe('prop', function() {
+      it("should return overlapAllowed value", function() {
+        expect(created.lines[0].prop("overlapAllowed")).to.be.true;
+        expect(created.lines[1].prop("overlapAllowed")).to.be.false;
+        expect(created.lines[2].prop("overlapAllowed")).to.be.true;
+      });
+
+      it("should return x value", function() {
+        expect(created.lines[0].prop("x")).to.equal(1451);
+        expect(created.lines[1].prop("x")).to.equal(1531);
+        expect(created.lines[2].prop("x")).to.equal(1541);
+      });
+
+      it("should return y value", function() {
+        expect(created.lines[0].prop("y")).to.equal(313);
+        expect(created.lines[1].prop("y")).to.equal(303);
+        expect(created.lines[2].prop("y")).to.equal(63);
+      });
+
+      it("should return length value", function() {
+        expect(created.lines[0].prop("length")).to.equal(70);
+        expect(created.lines[1].prop("length")).to.equal(230);
+        expect(created.lines[2].prop("length")).to.equal(-2);
+      });
     });
 
-    it("should return x value", function() {
-      expect(created.lines[0].prop("x")).to.equal(1451);
-      expect(created.lines[1].prop("x")).to.equal(1531);
-      expect(created.lines[2].prop("x")).to.equal(1541);
+    describe('testOnlySvg', function() {
+      it("should return svg element", function() {
+        expect(created.lines[0].testOnlySvg().get(0).tagName).to.equal("svg");
+        expect(created.lines[1].testOnlySvg().get(0).tagName).to.equal("svg");
+        expect(created.lines[2].testOnlySvg().get(0).tagName).to.equal("svg");
+      });
+
+      it("should have component class on element", function() {
+        expect(created.lines[0].testOnlySvg().hasClass("FlowConnectorLine")).to.be.true;
+        expect(created.lines[1].testOnlySvg().hasClass("FlowConnectorLine")).to.be.true;
+        expect(created.lines[2].testOnlySvg().hasClass("FlowConnectorLine")).to.be.true;
+      });
+
+      it("should have red stroke for testing path", function() {
+        expect(created.lines[0].testOnlySvg().children("path").eq(0).get(0).style.stroke).to.equal("red");
+        expect(created.lines[1].testOnlySvg().children("path").eq(0).get(0).style.stroke).to.equal("red");
+        expect(created.lines[2].testOnlySvg().children("path").eq(0).get(0).style.stroke).to.equal("red");
+      });
     });
-
-    it("should return y value", function() {
-      expect(created.lines[0].prop("y")).to.equal(313);
-      expect(created.lines[1].prop("y")).to.equal(303);
-      expect(created.lines[2].prop("y")).to.equal(63);
-    });
-
-    it("should return length value", function() {
-      expect(created.lines[0].prop("length")).to.equal(70);
-      expect(created.lines[1].prop("length")).to.equal(230);
-      expect(created.lines[2].prop("length")).to.equal(-2);
-    });
-
-
-    /* TEST METHOD:  testOnlySvg()
-     **/
-
-    it("should return svg element", function() {
-      expect(created.lines[0].testOnlySvg().get(0).tagName).to.equal("svg");
-      expect(created.lines[1].testOnlySvg().get(0).tagName).to.equal("svg");
-      expect(created.lines[2].testOnlySvg().get(0).tagName).to.equal("svg");
-    });
-
-    it("should have component class on element", function() {
-      expect(created.lines[0].testOnlySvg().hasClass("FlowConnectorLine")).to.be.true;
-      expect(created.lines[1].testOnlySvg().hasClass("FlowConnectorLine")).to.be.true;
-      expect(created.lines[2].testOnlySvg().hasClass("FlowConnectorLine")).to.be.true;
-    });
-
-    it("should have red stroke for testing path", function() {
-      expect(created.lines[0].testOnlySvg().children("path").eq(0).get(0).style.stroke).to.equal("red");
-      expect(created.lines[1].testOnlySvg().children("path").eq(0).get(0).style.stroke).to.equal("red");
-      expect(created.lines[2].testOnlySvg().children("path").eq(0).get(0).style.stroke).to.equal("red");
-    });
-
 
   });
 

--- a/test/flow_connector_line/properties_test.js
+++ b/test/flow_connector_line/properties_test.js
@@ -40,9 +40,10 @@ describe("FlowConnectorLine", function() {
     });
 
     it("should return the range", function() {
-      expect(created.lines[0].range.length).to.equal(70);
-      expect(created.lines[0].range[0]).to.equal(1451);
-      expect(created.lines[1].range[0]).to.equal(303);
+      expect(created.lines[0].range.start).to.equal(1451);
+      expect(created.lines[0].range.end).to.equal(1521);
+      expect(created.lines[1].range.start).to.equal(73);
+      expect(created.lines[1].range.end).to.equal(303);
     });
 
   });

--- a/test/utilities/intersects_test.js
+++ b/test/utilities/intersects_test.js
@@ -1,0 +1,43 @@
+require("../setup");
+const utilities = require('../../app/javascript/src/utilities');
+
+describe('utilities.intersects', function() {
+
+  it('should return true if bounds intersect', function() {
+    let a = { x1: 100, y1: 100, x2: 600, y2: 200 };
+    let b = { x1: 200, y1: 150, x2: 600, y2: 200 };
+
+    expect(utilities.intersects(a,b)).to.be.true;
+  })
+
+  it('should return false if vertical bounds do not intersect', function() {
+    let a = { x1: 100, y1: 100, x2: 600, y2: 200 };
+    let b = { x1: 300, y1: 300, x2: 600, y2: 200 };
+
+    expect(utilities.intersects(a,b)).to.be.false;
+  });
+
+  it('should return false if horizontal bounds do not intersect', function() {
+    let a = { x1: 100, y1: 100, x2: 600, y2: 200 };
+    let b = { x1: 100, y1: 800, x2: 1000, y2: 200 };
+
+    expect(utilities.intersects(a,b)).to.be.false;
+  });
+
+  it('should return true if b inside a', function() {
+    let a = { x1: 100, y1: 100, x2: 600, y2: 200 };
+    let b = { x1: 150, y1: 110, x2: 500, y2:180  };
+
+    expect(utilities.intersects(a,b)).to.be.true;
+  });
+
+  it('should return true if bounds are equal', function() {
+    let a = { x1: 100, y1: 100, x2: 600, y2: 200 };
+    let b = { x1: 100, y1: 100, x2: 600, y2: 200 };
+
+    expect(utilities.intersects(a,b)).to.be.true;
+  });
+
+
+});
+

--- a/test/utilities/overlaps_test.js
+++ b/test/utilities/overlaps_test.js
@@ -1,0 +1,34 @@
+require('../setup');
+
+const utilities = require('../../app/javascript/src/utilities');
+
+describe('utilties.overlaps', function() {
+
+  it('should return true if ranges overlap', function() {
+    let a = { start: 10, end: 100 };
+    let b = { start: 50, end: 150};
+
+    expect(utilities.overlaps(a,b)).to.be.true;
+  });
+
+  it('should return true if ranges overlap more than minimum', function() {
+    let a = { start: 10, end: 100};
+    let b = { start: 50, end: 150};
+
+    expect(utilities.overlaps(a,b, 10)).to.be.true;
+  });
+
+  it('should return false if ranges overlap but less than minimum', function() {
+    let a = { start: 10, end: 100};
+    let b = { start: 50, end: 150};
+
+    expect(utilities.overlaps(a,b, 100)).to.be.false;
+  });
+
+  it('should return false if there is no overlap', function() {
+    let a = { start: 10, end: 100};
+    let b = { start: 120, end: 200};
+
+    expect(utilities.overlaps(a,b, 100)).to.be.false;
+  })
+});


### PR DESCRIPTION
The arrow overlap adjustment routine was pretty inefficient, and on large forms such as the COP form was causing the flow view to take over 20 seconds to render to screen.

Previously the adjustment routine looped through every path in the form, and then looped through every path in the form, (On<sup>2</sup>) but if a path was nudged, we start looping over again, in case we've created another collision!  

Most paths in a form are not going to overlap, so schecking every path against every other path is overkill.  Before we do any adjusting, we check to see if the two paths bounding boxes intersect/overlap at all.  If they do, we check to see if any lines overlap and need nudging, but if not, we do nothing.

This results in a far faster routine, as the bounding box math is fast, and prevents many unnecessary loops happeining.

See performance results below:

**Before:**
![image](https://user-images.githubusercontent.com/595564/208147913-d19112c4-0769-48cf-8529-b75ed12414f8.png)


**After:**
![image](https://user-images.githubusercontent.com/595564/208148320-bbdb08f6-4c2d-4c26-9dab-de6b5b2d2e99.png)

Reduced render time by 20s! 🎉 
