### PR TITLE
Do not clear the payment link url field when a user unchecks the payment link checkbox

### DIFF
--- a/app/models/reference_payment_settings.rb
+++ b/app/models/reference_payment_settings.rb
@@ -40,8 +40,10 @@ class ReferencePaymentSettings
     valid_payment_link_url
   end
 
-  def payment_link_has_been_checked
-    return ServiceConfiguration.exists?(service_id: service_id, name: 'PAYMENT_LINK') if payment_link.blank?
+  def payment_link_has_been_checked?
+    return SubmissionSetting.find_by(
+      service_id: service_id
+    ).try(:payment_link?) if payment_link.nil?
 
     payment_link_checked?
   end

--- a/app/models/reference_payment_settings.rb
+++ b/app/models/reference_payment_settings.rb
@@ -41,9 +41,11 @@ class ReferencePaymentSettings
   end
 
   def payment_link_has_been_checked?
-    return SubmissionSetting.find_by(
-      service_id: service_id
-    ).try(:payment_link?) if payment_link.nil?
+    if payment_link.nil?
+      return SubmissionSetting.find_by(
+        service_id: service_id
+      ).try(:payment_link?)
+    end
 
     payment_link_checked?
   end

--- a/app/models/reference_payment_updater.rb
+++ b/app/models/reference_payment_updater.rb
@@ -60,12 +60,6 @@ class ReferencePaymentUpdater
       create_or_update_service_configuration(config: 'PAYMENT_LINK', deployment_environment: 'dev', value: payment_link_url)
       create_or_update_service_configuration(config: 'PAYMENT_LINK', deployment_environment: 'production', value: payment_link_url)
     end
-
-    unless reference_payment_settings.payment_link_url_present? ||
-        reference_payment_settings.payment_link_checked?
-      remove_service_configuration('PAYMENT_LINK', 'dev')
-      remove_service_configuration('PAYMENT_LINK', 'production')
-    end
   end
 
   def create_or_update_service_configuration(config:, deployment_environment:, value: reference_number)

--- a/app/models/reference_payment_updater.rb
+++ b/app/models/reference_payment_updater.rb
@@ -18,6 +18,7 @@ class ReferencePaymentUpdater
 
   def create_or_update!
     ActiveRecord::Base.transaction do
+      save_submission_settings
       save_config_reference_number
       save_config_payment_link
       save_config_with_defaults
@@ -25,6 +26,21 @@ class ReferencePaymentUpdater
   end
 
   private
+
+  def save_submission_settings
+    create_or_update_submission_setting('dev')
+    create_or_update_submission_setting('production')
+  end
+
+  def create_or_update_submission_setting(deployment_environment)
+    submission_setting = SubmissionSetting.find_or_initialize_by(
+      service_id: service.service_id,
+      deployment_environment: deployment_environment
+    )
+
+    submission_setting.payment_link = reference_payment_settings.payment_link_checked?
+    submission_setting.save!
+  end
 
   def save_config_reference_number
     if reference_payment_settings.reference_number_enabled?

--- a/app/models/service_configuration.rb
+++ b/app/models/service_configuration.rb
@@ -44,6 +44,14 @@ class ServiceConfiguration < ApplicationRecord
     name.in?(SECRETS)
   end
 
+  def do_not_inject_payment_link?
+    name == 'PAYMENT_LINK' &&
+      SubmissionSetting.find_by(
+        service_id: service_id,
+        deployment_environment: deployment_environment
+      ).try(:payment_link?).blank?
+  end
+
   def do_not_send_submission?
     name.in?(SUBMISSION) &&
       SubmissionSetting.find_by(

--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -130,7 +130,12 @@ class Publisher
     end
 
     def config_map
-      service_configuration.reject(&:secrets?).reject(&:do_not_send_submission?).reject(&:do_not_send_confirmation_email?).reject(&:not_in_maintenance_mode?)
+      service_configuration
+        .reject(&:secrets?)
+        .reject(&:do_not_send_submission?)
+        .reject(&:do_not_send_confirmation_email?)
+        .reject(&:not_in_maintenance_mode?)
+        .reject(&:do_not_inject_payment_link?)
     end
 
     def secrets

--- a/app/validators/reference_payment_validator.rb
+++ b/app/validators/reference_payment_validator.rb
@@ -10,12 +10,8 @@ class ReferencePaymentValidator < ActiveModel::Validator
       record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.missing_payment_link'))
     end
 
-    unless record.payment_link_url.start_with?(gov_uk_link)
+    if record.payment_link_url.present? && !record.payment_link_url.start_with?(gov_uk_link)
       record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.invalid_payment_url', link_start_with: gov_uk_link))
-    end
-
-    if payment_link_not_checked_with_url_present(record)
-      record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.payment_link_disabled'))
     end
   end
 
@@ -31,9 +27,5 @@ class ReferencePaymentValidator < ActiveModel::Validator
 
   def reference_and_payment_checked_with_url_missing(record)
     record.reference_number_enabled? && !record.payment_link_url_enabled?
-  end
-
-  def payment_link_not_checked_with_url_present(record)
-    !record.payment_link_checked? && record.payment_link_url_present?
   end
 end

--- a/app/validators/reference_payment_validator.rb
+++ b/app/validators/reference_payment_validator.rb
@@ -2,7 +2,7 @@ class ReferencePaymentValidator < ActiveModel::Validator
   def validate(record)
     return unless record.payment_link_checked?
 
-    if !record.reference_number_enabled?
+    unless record.reference_number_enabled?
       record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.reference_number_disabled'))
     end
 

--- a/app/validators/reference_payment_validator.rb
+++ b/app/validators/reference_payment_validator.rb
@@ -1,6 +1,8 @@
 class ReferencePaymentValidator < ActiveModel::Validator
   def validate(record)
-    if !record.reference_number_enabled? && record.payment_link_checked?
+    return unless record.payment_link_checked?
+
+    if !record.reference_number_enabled?
       record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.reference_number_disabled'))
     end
 
@@ -8,7 +10,7 @@ class ReferencePaymentValidator < ActiveModel::Validator
       record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.missing_payment_link'))
     end
 
-    if record.payment_link_checked? && !record.payment_link_url.start_with?(gov_uk_link)
+    unless record.payment_link_url.start_with?(gov_uk_link)
       record.errors.add(:base, I18n.t('activemodel.errors.models.reference_payment_settings.invalid_payment_url', link_start_with: gov_uk_link))
     end
 
@@ -28,7 +30,7 @@ class ReferencePaymentValidator < ActiveModel::Validator
   end
 
   def reference_and_payment_checked_with_url_missing(record)
-    record.reference_number_enabled? && record.payment_link_checked? && !record.payment_link_url_enabled?
+    record.reference_number_enabled? && !record.payment_link_url_enabled?
   end
 
   def payment_link_not_checked_with_url_present(record)

--- a/app/views/settings/reference_payment/_form.html.erb
+++ b/app/views/settings/reference_payment/_form.html.erb
@@ -33,7 +33,7 @@
           multiple: false,
           link_errors: true,
           label: { text: t('settings.payment_link.label') },
-          checked: f.object.payment_link_has_been_checked,
+          checked: f.object.payment_link_has_been_checked?,
           aria: {
               describedby: 'payment_link_hint payment_link_warning'
             }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -584,7 +584,6 @@ en:
           missing_payment_link: 'Enter your GOV.UK Pay Payment link URL (You get this from your GOV.UK Pay account)'
           invalid_payment_url: "Enter a valid GOV.UK payment link URL starting with %{link_start_with}"
           link_start_with: 'https://www.gov.uk/payments/'
-          payment_link_disabled: 'You must enable payment link before you can add a payment link url'
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."
         too_short: "Your answer for ‘%{attribute}’ is too short (%{count} characters at least)"

--- a/db/migrate/20221216160440_add_payment_link_submission_setting.rb
+++ b/db/migrate/20221216160440_add_payment_link_submission_setting.rb
@@ -1,0 +1,5 @@
+class AddPaymentLinkSubmissionSetting < ActiveRecord::Migration[6.1]
+  def change
+    add_column :submission_settings, :payment_link, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_19_162209) do
+ActiveRecord::Schema.define(version: 2022_12_16_160440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(version: 2022_10_19_162209) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "service_csv_output", default: false
     t.boolean "send_confirmation_email", default: false
+    t.boolean "payment_link", default: false
     t.index ["service_id", "deployment_environment"], name: "submission_settings_id_and_environment"
     t.index ["service_id"], name: "index_submission_settings_on_service_id"
   end

--- a/spec/factories/submission_settings.rb
+++ b/spec/factories/submission_settings.rb
@@ -25,5 +25,9 @@ FactoryBot.define do
     trait :send_confirmation_email do
       send_confirmation_email { true }
     end
+
+    trait :payment_link do
+      payment_link { true }
+    end
   end
 end

--- a/spec/models/reference_payment_settings_spec.rb
+++ b/spec/models/reference_payment_settings_spec.rb
@@ -118,26 +118,26 @@ RSpec.describe ReferencePaymentSettings do
     end
   end
 
-  describe '#payment_link_has_been_checked' do
+  describe '#payment_link_has_been_checked?' do
     context 'payment_link is blank' do
       context 'when there is a DB record' do
         before do
           create(
-            :service_configuration,
-            :payment_link_url,
+            :submission_setting,
+            :payment_link,
             service_id: service.service_id,
             deployment_environment: 'dev'
           )
           create(
-            :service_configuration,
-            :payment_link_url,
+            :submission_setting,
+            :payment_link,
             service_id: service.service_id,
             deployment_environment: 'production'
           )
         end
 
         it 'returns true' do
-          expect(reference_payment_settings.payment_link_has_been_checked).to be_truthy
+          expect(reference_payment_settings.payment_link_has_been_checked?).to be_truthy
         end
 
         it 'does retrieve the record from the database' do
@@ -147,7 +147,7 @@ RSpec.describe ReferencePaymentSettings do
 
       context 'when there is no DB record' do
         it 'returns false' do
-          expect(reference_payment_settings.payment_link_has_been_checked).to be_falsey
+          expect(reference_payment_settings.payment_link_has_been_checked?).to be_falsey
         end
 
         it 'does retrieve the record from the database' do
@@ -176,7 +176,7 @@ RSpec.describe ReferencePaymentSettings do
         end
 
         it 'returns true' do
-          expect(reference_payment_settings.payment_link_has_been_checked).to be_truthy
+          expect(reference_payment_settings.payment_link_has_been_checked?).to be_truthy
         end
 
         it 'does not retrieve the record from the database' do
@@ -186,7 +186,7 @@ RSpec.describe ReferencePaymentSettings do
 
       context 'when there is no DB record' do
         it 'returns false' do
-          expect(reference_payment_settings.payment_link_has_been_checked).to be_truthy
+          expect(reference_payment_settings.payment_link_has_been_checked?).to be_truthy
         end
 
         it 'does not retrieve the record from the database' do

--- a/spec/models/reference_payment_updater_spec.rb
+++ b/spec/models/reference_payment_updater_spec.rb
@@ -251,6 +251,38 @@ RSpec.describe ReferencePaymentUpdater do
             expect(setting).to be_truthy
           end
         end
+
+        context 'payment link' do
+          before do
+            reference_payment_updater.create_or_update!
+          end
+
+          context 'when payment link is enabled' do
+            let(:params) { { payment_link: '1' } }
+
+            it 'updates the payment link' do
+              setting = SubmissionSetting.find_by(
+                service_id: service.service_id,
+                deployment_environment: environment
+              ).try(:payment_link?)
+
+              expect(setting).to be_truthy
+            end
+          end
+
+          context 'when payment link is disabled' do
+            let(:params) { { payment_link: '0' } }
+
+            it 'updates the payment link' do
+              setting = SubmissionSetting.find_by(
+                service_id: service.service_id,
+                deployment_environment: environment
+              ).try(:payment_link?)
+
+              expect(setting).to be_falsey
+            end
+          end
+        end
       end
     end
 

--- a/spec/models/reference_payment_updater_spec.rb
+++ b/spec/models/reference_payment_updater_spec.rb
@@ -273,6 +273,12 @@ RSpec.describe ReferencePaymentUpdater do
           context 'when payment link is disabled' do
             let(:params) { { payment_link: '0' } }
 
+            before do
+              create(:service_configuration, :payment_link_url, service_id: service.service_id, deployment_environment: environment)
+
+              reference_payment_updater.create_or_update!
+            end
+
             it 'updates the payment link' do
               setting = SubmissionSetting.find_by(
                 service_id: service.service_id,
@@ -306,17 +312,6 @@ RSpec.describe ReferencePaymentUpdater do
           )
 
           reference_payment_updater.create_or_update!
-        end
-
-        context 'when a user unticked the box and payment url is empty' do
-          it 'removes the records from the database' do
-            expect(
-              ServiceConfiguration.where(
-                service_id: service.service_id,
-                name: 'PAYMENT_LINK'
-              )
-            ).to be_empty
-          end
         end
       end
 

--- a/spec/services/publisher/service_provisioner_spec.rb
+++ b/spec/services/publisher/service_provisioner_spec.rb
@@ -227,7 +227,8 @@ RSpec.describe Publisher::ServiceProvisioner do
           build(:service_configuration, :encoded_public_key, deployment_environment: 'dev', service_id: service_id),
           build(:service_configuration, :username, deployment_environment: 'dev', service_id: service_id),
           build(:service_configuration, :service_email_from, deployment_environment: 'dev', service_id: service_id),
-          build(:service_configuration, :maintenance_page_heading, deployment_environment: 'dev', service_id: service_id)
+          build(:service_configuration, :maintenance_page_heading, deployment_environment: 'dev', service_id: service_id),
+          build(:service_configuration, :payment_link_url, deployment_environment: 'dev', service_id: service_id)
         ]
       }
     end
@@ -275,6 +276,24 @@ RSpec.describe Publisher::ServiceProvisioner do
       context 'when not in maintenance mode' do
         it 'should not include the maintenance config' do
           expect(service_provisioner.config_map.map(&:name)).to_not include('MAINTENANCE_PAGE_HEADING')
+        end
+      end
+    end
+
+    context 'do_not_inject_payment_link' do
+      context 'when payment_link is present' do
+        before do
+          create(:submission_setting, :payment_link, service_id: service_id, deployment_environment: 'dev')
+        end
+
+        it 'should include submission configuration' do
+          expect(service_provisioner.config_map.map(&:name)).to include('PAYMENT_LINK')
+        end
+      end
+
+      context 'when payment link is not present' do
+        it 'should include submission configuration' do
+          expect(service_provisioner.config_map.map(&:name)).to_not include('PAYMENT_LINK')
         end
       end
     end

--- a/spec/validators/reference_payment_validator_spec.rb
+++ b/spec/validators/reference_payment_validator_spec.rb
@@ -103,36 +103,15 @@ RSpec.describe  ReferencePaymentValidator do
       context 'when payment url is present' do
         let(:params) do
           {
+            service_id: service_id,
             reference_number: '1',
             payment_link: '0',
             payment_link_url: correct_url
           }
         end
 
-        it 'returns invalid' do
-          expect(subject).to_not be_valid
-        end
-
-        it 'returns an error message' do
-          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.reference_payment_settings.payment_link_disabled'))
-        end
-      end
-
-      context 'when payment url is invalid' do
-        let(:params) do
-          {
-            reference_number: '1',
-            payment_link: '0',
-            payment_link_url: 'url'
-          }
-        end
-
-        it 'returns invalid' do
-          expect(subject).to_not be_valid
-        end
-
-        it 'include some error messages' do
-          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.reference_payment_settings.payment_link_disabled'))
+        it 'returns valid' do
+          expect(subject).to be_valid
         end
       end
     end


### PR DESCRIPTION
### Add payment link column to `SubmissionSettings` table
We need to add a `payment_link` submission setting to enable us to keep the payment link url in the database and to keep track of whether the user has enabled or disabled payment links.

### Update record with payment link Submission Setting
We now have a `payment_link` submission setting, this will need to be updated in the database when a user enables/disables payment link checkbox.

### Update the reference payment validator
We now have a guard clause and only need to run the validator if payment link is checked.
We also only want to show one validation error when payment link is enabled but the payment link url field is blank instead of showing two errors.

### Keep `PAYMENT_LINK` service configuration
We do not want to remove the `PAYMENT_LINK` service configuration from the database as we now need to show this value back to user when they uncheck the payment link checkbox.

### Do not inject payment link service config when disabled
Since we no longer delete the 'PAYMENT_LINK' service config we need to ensure we do not inject this config into the Runner on publishing if `payment_link` submission setting is disabled.