### PR TITLE
Use SubmissionSetting record to determine whether payment link is enabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,7 +92,10 @@ class ApplicationController < ActionController::Base
   end
 
   def payment_link_enabled?
-    payment_link_config.present?
+    SubmissionSetting.find_by(
+      service_id: service.service_id,
+      deployment_environment: 'dev'
+    ).try(:payment_link?)
   end
   helper_method :payment_link_enabled?
 

--- a/app/helpers/content_substitutor_helper.rb
+++ b/app/helpers/content_substitutor_helper.rb
@@ -15,9 +15,9 @@ module ContentSubstitutorHelper
   end
 
   def payment_link_enabled?
-    ServiceConfiguration.where(
+    SubmissionSetting.find_by(
       service_id: service.service_id,
-      name: 'PAYMENT_LINK'
-    ).present?
+      deployment_environment: 'dev'
+    ).try(:payment_link?)
   end
 end

--- a/app/models/reference_payment_settings.rb
+++ b/app/models/reference_payment_settings.rb
@@ -41,13 +41,10 @@ class ReferencePaymentSettings
   end
 
   def payment_link_has_been_checked?
-    if payment_link.nil?
-      return SubmissionSetting.find_by(
-        service_id: service_id
-      ).try(:payment_link?)
-    end
-
-    payment_link_checked?
+    payment_link_checked? || SubmissionSetting.find_by(
+      service_id: service_id,
+      deployment_environment: 'dev'
+    ).try(:payment_link?)
   end
 
   def valid_payment_link_url

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -191,4 +191,42 @@ RSpec.describe ApplicationController do
       end
     end
   end
+
+  describe '#payment_link_enabled?' do
+    before do
+      allow(controller).to receive(:service).and_return(service)
+      allow(SubmissionSetting).to receive(:find_by).and_return(submission_setting)
+    end
+
+    context 'when payment link is enabled' do
+      let!(:submission_setting) do
+        create(
+          :submission_setting,
+          :dev,
+          :payment_link,
+          service_id: service.service_id
+        )
+      end
+
+      it 'returns true' do
+        expect(controller.payment_link_enabled?).to be_truthy
+      end
+    end
+
+    context 'when payment link is disabled and payment_link_url is present' do
+      let!(:submission_setting) { nil }
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :dev,
+          :payment_link_url,
+          service_id: service.service_id
+        )
+      end
+
+      it 'returns false' do
+        expect(controller.reference_number_enabled?).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/models/reference_payment_settings_spec.rb
+++ b/spec/models/reference_payment_settings_spec.rb
@@ -139,19 +139,11 @@ RSpec.describe ReferencePaymentSettings do
         it 'returns true' do
           expect(reference_payment_settings.payment_link_has_been_checked?).to be_truthy
         end
-
-        it 'does retrieve the record from the database' do
-          expect(subject).to_not receive(:payment_link_checked?)
-        end
       end
 
       context 'when there is no DB record' do
         it 'returns false' do
           expect(reference_payment_settings.payment_link_has_been_checked?).to be_falsey
-        end
-
-        it 'does retrieve the record from the database' do
-          expect(subject).to_not receive(:payment_link_checked?)
         end
       end
     end
@@ -162,14 +154,14 @@ RSpec.describe ReferencePaymentSettings do
       context 'when there is a record in DB' do
         before do
           create(
-            :service_configuration,
-            :payment_link_url,
+            :submission_setting,
+            :payment_link,
             service_id: service.service_id,
             deployment_environment: 'dev'
           )
           create(
-            :service_configuration,
-            :payment_link_url,
+            :submission_setting,
+            :payment_link,
             service_id: service.service_id,
             deployment_environment: 'production'
           )
@@ -178,19 +170,11 @@ RSpec.describe ReferencePaymentSettings do
         it 'returns true' do
           expect(reference_payment_settings.payment_link_has_been_checked?).to be_truthy
         end
-
-        it 'does not retrieve the record from the database' do
-          expect(ServiceConfiguration).to_not receive(:exists?)
-        end
       end
 
       context 'when there is no DB record' do
-        it 'returns false' do
+        it 'returns true' do
           expect(reference_payment_settings.payment_link_has_been_checked?).to be_truthy
-        end
-
-        it 'does not retrieve the record from the database' do
-          expect(ServiceConfiguration).to_not receive(:exists?)
         end
       end
     end


### PR DESCRIPTION
### Use payment_link `SubmissionSetting` in `ContentSubstitutor` class
Now that we will always have a 'PAYMENT_LINK' ServiceConfiguration we will need to use the SubmissionSetting record in the ContentSubstitutor helper to check whether `payment_link` is actually enabled. This will determine whether or not we should show the `{{payment_link}}` placeholder in the confirmation email body.

### Update Application Controller `payment_link_enabled?` method
Now that we use the SubmissionSetting to understand whether payment link is enabled, we need to reflect this in the Application Controller method.
This method indicates whether we should show the payment link styling on the Confirmation Page.

### SubmissionSetting requires a deployment_environment
This fixes a small bug whereby the `payment_link_has_been_checked?` method returned false consistently. This is because the SubmissionSetting class requires a deployment_environment.
We only check one environment (`deployment_environment: 'dev'`) as both environments (dev and production) will have records created and removed at the same time.
Also fix up some tests that were using the ServiceConfiguration rather than the SubmissionSetting record in determining whether `payment_link` was enabled.