### PR TITLE
Amend payment link url to return blank anchor link

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -78,7 +78,7 @@ class ApplicationController < ActionController::Base
   helper_method :show_reference_number
 
   def payment_link_url
-    payment_link_config.decrypt_value
+    '#' # We don't have a real reference number so we can't link anywhere.
   end
   helper_method :payment_link_url
 


### PR DESCRIPTION
Updates the payment_link_url method to return a blank anchor link as we don;t have a valid reference number - so there's no point sending them to GOV.UK Pay.