### PR TITLE
Correctly inject S3 credentials into the Editor deployment

### DIFF
--- a/app/services/publisher/adapters/aws_s3_client.rb
+++ b/app/services/publisher/adapters/aws_s3_client.rb
@@ -3,8 +3,10 @@ require 'aws-sdk-s3'
 class Publisher
   module Adapters
     class AwsS3Client
-      def initialize(platform_deployment)
-        @platform_deployment = platform_deployment
+      def initialize(bucket:, access_key_id:, secret_access_key:)
+        @bucket = bucket
+        @access_key_id = access_key_id
+        @secret_access_key = secret_access_key
       end
 
       REGION = 'eu-west-2'.freeze
@@ -13,24 +15,21 @@ class Publisher
         Rails.logger.info("Uploading #{object_key} to S3")
         s3.put_object(
           body: body,
-          bucket: ENV["AWS_S3_BUCKET_#{platform_deployment}"],
+          bucket: bucket,
           key: object_key
         )
       end
 
       private
 
-      attr_reader :platform_deployment
+      attr_reader :bucket, :access_key_id, :secret_access_key
 
       def s3
         @s3 ||= Aws::S3::Client.new(region: REGION, credentials: credentials)
       end
 
       def credentials
-        Aws::Credentials.new(
-          ENV["AWS_S3_ACCESS_KEY_ID_#{platform_deployment}"],
-          ENV["AWS_S3_SECRET_ACCESS_KEY_#{platform_deployment}"]
-        )
+        Aws::Credentials.new(access_key_id, secret_access_key)
       end
     end
   end

--- a/app/services/publisher/adapters/cloud_platform.rb
+++ b/app/services/publisher/adapters/cloud_platform.rb
@@ -21,7 +21,7 @@ class Publisher
       def pre_publishing
         ::Publisher::Utils::ServiceMetadataFiles.new(
           service_provisioner,
-          Publisher::Adapters::AwsS3Client.new(service_provisioner.platform_deployment_underscore)
+          aws_s3_adapter
         ).upload
 
         ::Publisher::Utils::KubernetesConfiguration.new(
@@ -87,6 +87,14 @@ class Publisher
 
       def config_files?
         Dir["#{config_dir}/*"].any?
+      end
+
+      def aws_s3_adapter
+        Publisher::Adapters::AwsS3Client.new(
+          bucket: service_provisioner.aws_s3_bucket_name,
+          access_key_id: service_provisioner.aws_s3_access_key_id,
+          secret_access_key: service_provisioner.aws_s3_secret_access_key
+        )
       end
     end
   end

--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -143,19 +143,15 @@ class Publisher
     end
 
     def aws_s3_access_key_id
-      ENV["AWS_S3_ACCESS_KEY_ID_#{platform_deployment_underscore}"]
+      ENV["AWS_S3_ACCESS_KEY_ID_#{deployment_environment_upcase}"]
     end
 
     def aws_s3_secret_access_key
-      ENV["AWS_S3_SECRET_ACCESS_KEY_#{platform_deployment_underscore}"]
+      ENV["AWS_S3_SECRET_ACCESS_KEY_#{deployment_environment_upcase}"]
     end
 
     def aws_s3_bucket_name
-      ENV["AWS_S3_BUCKET_#{platform_deployment_underscore}"]
-    end
-
-    def platform_deployment_underscore
-      @platform_deployment_underscore ||= platform_deployment.underscore.upcase
+      ENV["AWS_S3_BUCKET_#{deployment_environment_upcase}"]
     end
 
     private
@@ -193,6 +189,10 @@ class Publisher
 
         response.respond_to?(:metadata) ? response.metadata : {}
       end
+    end
+
+    def deployment_environment_upcase
+      @deployment_environment_upcase ||= deployment_environment.upcase
     end
   end
 end

--- a/deploy-eks/fb-editor-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-editor-chart/templates/deployment.yaml
@@ -143,7 +143,6 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: aws_ses_access_key_id
-
       volumes:
         - name: tmp-files
           emptyDir: {}
@@ -256,36 +255,36 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: slack_publish_webhook
-          - name: AWS_S3_ACCESS_KEY_ID_{{ .Values.environmentName | upper }}_DEV
+          - name: AWS_S3_ACCESS_KEY_ID_DEV
             valueFrom:
               secretKeyRef:
-                name: s3-service-metadata-{{ .Values.environmentName }}
-                key: aws_s3_access_key_id_{{ .Values.environmentName }}_dev
-          - name: AWS_S3_SECRET_ACCESS_KEY_{{ .Values.environmentName | upper }}_DEV
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: aws_s3_access_key_id_dev
+          - name: AWS_S3_SECRET_ACCESS_KEY_DEV
             valueFrom:
               secretKeyRef:
-                name: s3-service-metadata-{{ .Values.environmentName }}
-                key: aws_s3_secret_access_key_{{ .Values.environmentName }}_dev
-          - name: AWS_S3_BUCKET_{{ .Values.environmentName | upper }}_DEV
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: aws_s3_secret_access_key_dev
+          - name: AWS_S3_BUCKET_DEV
             valueFrom:
               secretKeyRef:
-                name: s3-service-metadata-{{ .Values.environmentName }}
-                key: aws_s3_bucket_{{ .Values.environmentName }}_dev
-          - name: AWS_S3_ACCESS_KEY_ID_{{ .Values.environmentName | upper }}_PRODUCTION
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: aws_s3_bucket_dev
+          - name: AWS_S3_ACCESS_KEY_ID_PRODUCTION
             valueFrom:
               secretKeyRef:
-                name: s3-service-metadata-{{ .Values.environmentName }}
-                key: aws_s3_access_key_id_{{ .Values.environmentName }}_production
-          - name: AWS_S3_SECRET_ACCESS_KEY_{{ .Values.environmentName | upper }}_PRODUCTION
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: aws_s3_access_key_id_production
+          - name: AWS_S3_SECRET_ACCESS_KEY_PRODUCTION
             valueFrom:
               secretKeyRef:
-                name: s3-service-metadata-{{ .Values.environmentName }}
-                key: aws_s3_secret_access_key_{{ .Values.environmentName }}_production
-          - name: AWS_S3_BUCKET_{{ .Values.environmentName | upper }}_PRODUCTION
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: aws_s3_secret_access_key_production
+          - name: AWS_S3_BUCKET_PRODUCTION
             valueFrom:
               secretKeyRef:
-                name: s3-service-metadata-{{ .Values.environmentName }}
-                key: aws_s3_bucket_{{ .Values.environmentName }}_production
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: aws_s3_bucket_production
       volumes:
         - name: tmp-files
           emptyDir: {}

--- a/deploy-eks/fb-editor-chart/templates/secrets.yaml
+++ b/deploy-eks/fb-editor-chart/templates/secrets.yaml
@@ -20,3 +20,9 @@ data:
   pingdom_alert_integration_id: {{ .Values.pingdom_alert_integration_id }}
   aws_ses_access_key_id: {{ .Values.aws_ses_access_key_id }}
   aws_ses_secret_access_key: {{ .Values.aws_ses_secret_access_key }}
+  aws_s3_bucket_dev: {{ .Values.aws_s3_bucket_dev }}
+  aws_s3_access_key_id_dev: {{ .Values.aws_s3_access_key_id_dev }}
+  aws_s3_secret_access_key_dev: {{ .Values.aws_s3_secret_access_key_dev }}
+  aws_s3_bucket_production: {{ .Values.aws_s3_bucket_production }}
+  aws_s3_access_key_id_production: {{ .Values.aws_s3_access_key_id_production }}
+  aws_s3_secret_access_key_production: {{ .Values.aws_s3_secret_access_key_production }}

--- a/spec/services/publisher/adapters/aws_s3_client_spec.rb
+++ b/spec/services/publisher/adapters/aws_s3_client_spec.rb
@@ -1,18 +1,16 @@
 RSpec.describe Publisher::Adapters::AwsS3Client do
   subject(:aws_s3_client) do
-    described_class.new(platform_deployment)
+    described_class.new(
+      bucket: bucket,
+      access_key_id: 'some-access-key_id',
+      secret_access_key: 'some-secret-access-key'
+    )
   end
-  let(:platform_deployment) { 'TEST_DEV' }
 
   describe '#upload' do
     let(:body) { { foo: 'bar' } }
     let(:bucket) { 'some-bucket' }
     let(:object_key) { 'some-object-key' }
-
-    before do
-      allow(ENV).to receive(:[])
-      allow(ENV).to receive(:[]).with("AWS_S3_BUCKET_#{platform_deployment}").and_return(bucket)
-    end
 
     it 'should upload an object to s3' do
       expect_any_instance_of(Aws::S3::Client).to receive(:put_object).with(

--- a/spec/services/publisher/utils/kubernetes_configuration_spec.rb
+++ b/spec/services/publisher/utils/kubernetes_configuration_spec.rb
@@ -66,13 +66,13 @@ RSpec.describe Publisher::Utils::KubernetesConfiguration do
       .with(service_id: '0da69306-cafd-4d32-bbee-fff98cac74ce')
       .and_return(MetadataApiClient::Items.new(autocomplete_items))
     allow(ENV).to receive(:[])
-      .with('AWS_S3_ACCESS_KEY_ID_TEST_DEV')
+      .with('AWS_S3_ACCESS_KEY_ID_DEV')
       .and_return('access-key-id')
     allow(ENV).to receive(:[])
-      .with('AWS_S3_SECRET_ACCESS_KEY_TEST_DEV')
+      .with('AWS_S3_SECRET_ACCESS_KEY_DEV')
       .and_return('secret-access-key')
     allow(ENV).to receive(:[])
-      .with('AWS_S3_BUCKET_TEST_DEV')
+      .with('AWS_S3_BUCKET_DEV')
       .and_return('bucket-name')
   end
 


### PR DESCRIPTION
We now inject the AWS S3 credentials and bucket names for all the environments using the secrets configuration.

We can remove the need for the 'TEST' and 'LIVE' from the injected environment variable names. We only need 'DEV' and 'PRODUCTION' in order to distinguish between the different bucket and which credentials to use during publishing.