### PR TITLE
Add character count to new form name dialog input

### DIFF
--- a/app/javascript/src/page_form_list.js
+++ b/app/javascript/src/page_form_list.js
@@ -15,7 +15,7 @@
 
 const DialogForm = require('./component_dialog_form');
 const DefaultController = require('./controller_default');
-
+const { CharacterCount } = require('govuk-frontend');
 
 class FormListPage extends DefaultController {
   constructor(app) {
@@ -23,6 +23,10 @@ class FormListPage extends DefaultController {
 
     // Create dialog for handling new form input and error reporting.
     new CreateFormDialog($("[data-component='FormCreateDialog']"));
+    var $characterCount = document.querySelector('[data-module="govuk-character-count"]')
+    if ($characterCount) {
+      new CharacterCount($characterCount).init()
+    }
   }
 }
 

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -27,12 +27,18 @@
            data-component="FormCreateDialog">
         <%= form_for(@service_creation, url: services_path) do |f| %>
           <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
-            <%= f.label :service_name, class: "govuk-label govuk-label--m" %>
-            <% f.object.errors.each do |error|  %>
-              <p class="govuk-error-message"><%= error.message %></p>
-            <% end %>
-            <div class="govuk-hint" id="service-name-hint"> <%= t('services.form_name_hint', max_length: Editor::Service::MAXIMUM)%></div>
-            <%= f.text_field :service_name, class: "govuk-input", 'aria-describedby': 'service-name-hint'%>
+            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="57">
+              <%= f.label :service_name, class: "govuk-label govuk-label--m" %>
+              <% f.object.errors.each do |error|  %>
+                <p class="govuk-error-message"><%= error.message %></p>
+              <% end %>
+              <div class="govuk-hint" id="service-name-hint"> <%= t('services.form_name_hint', max_length: Editor::Service::MAXIMUM)%></div>
+              <%= f.text_field :service_name, class: "govuk-input govuk-js-character-count", 'aria-describedby': 'service-name-hint service_creation_service_name-info'%>
+              <div id="service_creation_service_name-info" class="govuk-hint govuk-character-count__message">
+                You can enter up to 57 characters
+              </div>
+            </div>
+
           </div>
           <%= f.button t('services.create'), class: "govuk-button fb-govuk-button", type: 'submit' %>
         <% end %>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -27,7 +27,7 @@
            data-component="FormCreateDialog">
         <%= form_for(@service_creation, url: services_path) do |f| %>
           <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
-            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="57">
+            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="<%= Editor::Service::MAXIMUM %>">
               <%= f.label :service_name, class: "govuk-label govuk-label--m" %>
               <% f.object.errors.each do |error|  %>
                 <p class="govuk-error-message"><%= error.message %></p>
@@ -35,7 +35,7 @@
               <div class="govuk-hint" id="service-name-hint"> <%= t('services.form_name_hint', max_length: Editor::Service::MAXIMUM)%></div>
               <%= f.text_field :service_name, class: "govuk-input govuk-js-character-count", 'aria-describedby': 'service-name-hint service_creation_service_name-info'%>
               <div id="service_creation_service_name-info" class="govuk-hint govuk-character-count__message">
-                You can enter up to 57 characters
+                You can enter up to <%= Editor::Service::MAXIMUM %> characters
               </div>
             </div>
 


### PR DESCRIPTION
Adds the GOVUK live character count module to the new from name input.

<img width="866" alt="image" src="https://user-images.githubusercontent.com/595564/208862318-9d642ed4-6af6-4ea2-999f-be75eebf5537.png">

<img width="868" alt="image" src="https://user-images.githubusercontent.com/595564/208862475-53549b80-a9df-4b9d-8433-998a40f3826e.png">
