### PR TITLE
Disable the publishing buttons for both environments

### DIFF
--- a/app/presenters/publishing_page_presenter.rb
+++ b/app/presenters/publishing_page_presenter.rb
@@ -43,9 +43,11 @@ class PublishingPagePresenter
   end
 
   def publish_button_disabled?
-    return if deployment_environment == 'dev'
+    true
 
-    submission_warnings.messages.any? || autocomplete_warning.messages.any?
+    # return if deployment_environment == 'dev'
+
+    # submission_warnings.messages.any? || autocomplete_warning.messages.any?
   end
 
   private

--- a/spec/presenters/publishing_page_presenter_spec.rb
+++ b/spec/presenters/publishing_page_presenter_spec.rb
@@ -100,7 +100,8 @@ RSpec.describe PublishingPagePresenter do
       before do
         allow_any_instance_of(PublishServiceCreation).to receive(:no_service_output?).and_return(true)
       end
-      it 'returns falsey' do
+
+      xit 'returns falsey' do
         expect(subject.publish_button_disabled?).to be_falsey
       end
     end
@@ -118,7 +119,7 @@ RSpec.describe PublishingPagePresenter do
             allow_any_instance_of(SubmissionWarningsPresenter).to receive(:messages).and_return(['Some messages'])
           end
 
-          it 'returns falsey' do
+          xit 'returns falsey' do
             expect(subject.publish_button_disabled?).to be_falsey
           end
         end
@@ -129,7 +130,7 @@ RSpec.describe PublishingPagePresenter do
             allow_any_instance_of(AutocompleteItemsPresenter).to receive(:component_uuids_without_items).and_return(['Some components uuids'])
           end
 
-          it 'returns falsey' do
+          xit 'returns falsey' do
             expect(subject.publish_button_disabled?).to be_falsey
           end
         end
@@ -140,7 +141,7 @@ RSpec.describe PublishingPagePresenter do
             allow_any_instance_of(AutocompleteItemsPresenter).to receive(:messages).and_return([])
           end
 
-          it 'returns falsey' do
+          xit 'returns falsey' do
             expect(subject.publish_button_disabled?).to be_falsey
           end
         end
@@ -182,7 +183,7 @@ RSpec.describe PublishingPagePresenter do
             allow_any_instance_of(AutocompleteItemsPresenter).to receive(:messages).and_return([])
           end
 
-          it 'returns falsey' do
+          xit 'returns falsey' do
             expect(subject.publish_button_disabled?).to be_falsey
           end
         end


### PR DESCRIPTION
We need to prevent users from publishing for a short period of time while we make some changes.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>
Co-authored-by: Steven Leighton <steven.leighton@digital.justice.gov.uk>