### PR TITLE
Skip acceptance test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,12 +384,12 @@ workflows:
           requires:
             - build_web_image
             - build_workers_image
-      - acceptance_tests_eks:
-          requires:
-            - deploy_to_test_eks
+      # - acceptance_tests_eks:
+      #     requires:
+      #       - deploy_to_test_eks
       - deploy_to_live_eks:
-          requires:
-            - acceptance_tests_eks
+          # requires:
+          #   - acceptance_tests_eks
   deploy_testable_branch:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,8 +388,8 @@ workflows:
       #     requires:
       #       - deploy_to_test_eks
       - deploy_to_live_eks:
-          # requires:
-          #   - acceptance_tests_eks
+          requires:
+            - deploy_to_test_eks
   deploy_testable_branch:
     jobs:
       - build:


### PR DESCRIPTION
Skip acceptance test job as we need to deploy to disable publishing but need to rotate keys on the acceptance tests in order for them to pass