### PR TITLE
Move allowed domains into a custom config

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -8,7 +8,7 @@ class UserSessionsController < ApplicationController
   end
 
   def signup_not_allowed
-    @valid_emails = Auth0UserSession::VALID_EMAIL_DOMAINS
+    @valid_emails = Rails.application.config.allowed_domains
   end
 
   def signup_error

--- a/app/models/from_address.rb
+++ b/app/models/from_address.rb
@@ -1,11 +1,4 @@
 class FromAddress < ApplicationRecord
-  ALLOWED_DOMAINS = [
-    'justice.gov.uk',
-    'digital.justice.gov.uk',
-    'cica.gov.uk',
-    'judicialappointments.gov.uk'
-  ].freeze
-
   before_save :encrypt_email
 
   validates :email, format: {
@@ -40,7 +33,7 @@ class FromAddress < ApplicationRecord
 
   def allowed_domain?
     domain = email_address.split('@').last
-    domain.in?(ALLOWED_DOMAINS)
+    domain.in?(Rails.application.config.allowed_domains)
   end
 
   # If the email is already encrypted then it won't be a

--- a/app/services/auth0_user_session.rb
+++ b/app/services/auth0_user_session.rb
@@ -3,13 +3,6 @@ class Auth0UserSession
   include ActiveModel
   include ActiveModel::Validations
 
-  VALID_EMAIL_DOMAINS = [
-    'justice.gov.uk',
-    'cps.gov.uk',
-    'cica.gov.uk',
-    'judicialappointments.gov.uk'
-  ].freeze
-
   attr_accessor :user_info, :user_id, :created_at, :new_user
 
   validate :email_domain_is_valid
@@ -52,8 +45,8 @@ class Auth0UserSession
 
   def email_domain_is_valid
     user_email = email.to_s.downcase
-    errors.add(:user_info, "email must end with one of #{VALID_EMAIL_DOMAINS}") \
-      unless VALID_EMAIL_DOMAINS.any? do |domain|
+    errors.add(:user_info, "email must end with one of #{Rails.application.config.allowed_domains}") \
+      unless Rails.application.config.allowed_domains.any? do |domain|
         URI::MailTo::EMAIL_REGEXP.match(user_email) &&
           user_email.ends_with?(domain)
       end

--- a/config/initializers/allowed_domains.rb
+++ b/config/initializers/allowed_domains.rb
@@ -1,0 +1,8 @@
+ALLOWED_DOMAINS = [
+  'justice.gov.uk',
+  'digital.justice.gov.uk',
+  'cica.gov.uk',
+  'judicialappointments.gov.uk'
+].freeze
+
+Rails.application.config.allowed_domains = ALLOWED_DOMAINS


### PR DESCRIPTION
We have two domain allow lists that hold the same email domains. Since we are about to add a third domain level allow list for the send to feature, that will also hold the same domains, we should move the list into a custom config. This means we will have a single domain allow list and reduce code repetition.

This commit moves the domains to a custom config and changes the Auth0 and FromAddress classes to reference the new custom config.

Note: the 'cps.gov.uk' domain has been removed as this was used for testing and is no longer required on the allow list.