### PR TITLE
Allow time for autocomplete page to load in acceptance test

### DIFF
--- a/acceptance/features/edit_single_question_autocomplete_page_spec.rb
+++ b/acceptance/features/edit_single_question_autocomplete_page_spec.rb
@@ -77,6 +77,7 @@ feature 'Edit single question autocomplete page' do
   def then_I_should_see_my_changes_in_the_form(preview_form, change)
     within_window(preview_form) do
       page.find('.autocomplete__input').click
+      sleep(1) # allow time for page to load
       expect(page).to have_content(change)
     end
   end


### PR DESCRIPTION
This acceptance test is flaky and fails regularly, with an error stating the expected text cannot be found.
This could be because the test is attempting to click on the autocomplete drop down box before the options have completely loaded.
Add a sleep to allow the page to load before running the assertion.