### PR TITLE
Improve flow view render performance 🏎

### DIFF
--- a/app/javascript/src/component_flow_condition_item.js
+++ b/app/javascript/src/component_flow_condition_item.js
@@ -28,9 +28,6 @@
  **/
 class FlowConditionItem {
   constructor($node, config) {
-    $node.data("instance", this);
-    $node.addClass("FlowConditionItem");
-
     this.$node = $node;
     this.$from = config.$from;
     this.$next = config.$next;
@@ -42,6 +39,10 @@ class FlowConditionItem {
       x2: config.x_out,
       y2: config.y_out
     };
+
+    $node.data("instance", this);
+    $node.addClass("FlowConditionItem");
+    $node.attr('data-row', this.row);
   }
 }
 

--- a/app/javascript/src/component_flow_condition_item.js
+++ b/app/javascript/src/component_flow_condition_item.js
@@ -40,6 +40,11 @@ class FlowConditionItem {
       y2: config.y_out
     };
 
+    this.position = {
+      left: this.bounds.x1,
+      top: this.bounds.y1,
+    }
+
     $node.data("instance", this);
     $node.addClass("FlowConditionItem");
     $node.attr('data-row', this.row);

--- a/app/javascript/src/component_flow_condition_item.js
+++ b/app/javascript/src/component_flow_condition_item.js
@@ -36,6 +36,12 @@ class FlowConditionItem {
     this.$next = config.$next;
     this.row = config.row;
     this.column = config.column;
+    this.bounds = {
+      x1: config.x_in,
+      y1: config.y_in,
+      x2: config.x_out,
+      y2: config.y_out
+    };
   }
 }
 

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -314,7 +314,7 @@ class ForwardPath extends FlowConnectorPath {
     this.#calculatePath(dimensions);
 
     this.type = "ForwardPath";
-    this.build();
+    // this.build();
   }
 
   get path() {
@@ -368,7 +368,7 @@ class ForwardUpForwardPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions }; // dimensions.current will be added in set #calculatePath()
     this.type = "ForwardUpForwardPath";
     this.#calculatePath(dimensions);
-    this.build();
+    // this.build();
   }
 
   get path() {
@@ -391,7 +391,6 @@ class ForwardUpForwardPath extends FlowConnectorPath {
     }
 
     this.#calculatePath(d);
-    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 
@@ -466,7 +465,7 @@ class ForwardUpForwardDownPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "ForwardUpForwardDownPath";
     this.#calculatePath(dimensions);
-    this.build();
+    // this.build();
   }
 
   get path() {
@@ -501,7 +500,6 @@ class ForwardUpForwardDownPath extends FlowConnectorPath {
     }
 
     this.#calculatePath(d);
-    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 
@@ -597,7 +595,7 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "ForwardDownBackwardUpPath";
     this.#calculatePath(dimensions);
-    this.build();
+    // this.build();
   }
 
   get path() {
@@ -630,7 +628,6 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
     }
 
     this.#calculatePath(d);
-    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 
@@ -722,7 +719,7 @@ class ForwardDownForwardPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "ForwardDownForwardPath";
     this.#calculatePath(dimensions);
-    this.build();
+    // this.build();
   }
 
   get path() {
@@ -745,7 +742,6 @@ class ForwardDownForwardPath extends FlowConnectorPath {
     }
 
     this.#calculatePath(d);
-    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 
@@ -818,7 +814,7 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardDownBackwardUpPath";
     this.#calculatePath(dimensions);
-    this.build();
+    // this.build();
   }
 
   get path() {
@@ -852,7 +848,6 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
            // These lines can be ignored because overlaps are tolerated or not relevant.
     }
     this.#calculatePath(d);
-    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 
@@ -959,7 +954,7 @@ class DownForwardUpPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardUpPath";
     this.#calculatePath(dimensions);
-    this.build();
+    // this.build();
   }
 
   get path() {
@@ -983,7 +978,6 @@ class DownForwardUpPath extends FlowConnectorPath {
     }
 
     this.#calculatePath(d);
-    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 
@@ -1070,7 +1064,7 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardUpForwardDownPath";
     this.#calculatePath(dimensions);
-    this.build();
+    // this.build();
   }
 
   get path() {
@@ -1105,7 +1099,6 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
     }
 
     this.#calculatePath(d);
-    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 
@@ -1213,7 +1206,7 @@ class DownForwardDownForwardPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardDownForwardPath";
     this.#calculatePath(dimensions);
-    this.build();
+    // this.build();
   }
 
   get path() {
@@ -1237,7 +1230,6 @@ class DownForwardDownForwardPath extends FlowConnectorPath {
     }
 
     this.#calculatePath(d);
-    this.$node.find("path:first").attr("d", this.#path);
     return nudged;
   }
 
@@ -1321,7 +1313,7 @@ class DownForwardPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardPath";
     this.#calculatePath(dimensions);
-    this.build();
+    // this.build();
   }
 
   get path() {

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -92,6 +92,10 @@ class FlowConnectorPath {
     return this.#points;
   }
 
+  get dimensions() {
+    return this.config.dimensions;
+  }
+
   // Gets the bounding box of the path
   // This is used to check path intersections for the adjustment/nudging routine
   get bounds() {
@@ -796,9 +800,9 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
   constructor(points, config) {
     super(points, config);
 
-    var down1 = Math.round(utilities.difference(points.from_y, this.points.via_y));
-    var down2 = Math.round(utilities.difference(config.bottom, this.points.via_y));
-    var up = Math.round(this.points.from_y - this.points.to_y) + down1 + down2;
+    var down1 = Math.round(utilities.difference(points.from_y, this.points.via_y)); // from start to condition y
+    var down2 = Math.round(utilities.difference(config.bottom, this.points.via_y)); // from condition y to bottom
+    var up = Math.round(this.points.from_y - this.points.to_y) + down1 + down2; // down1 + down2 + difference between from_y and to_y (could be negative)
 
     var dimensions = {
       down1: down1 - CURVE_SPACING,

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -130,7 +130,7 @@ class FlowConnectorPath {
 
   // Main function to created the connector view and add functionality.
   // Includes commented out, dev only function useful in development.
-  build() {
+  render() {
     var flowConnectorPath = this;
 
     this.$node = createSvg(createPath(this.path) + createArrowPath(this.points));
@@ -314,7 +314,6 @@ class ForwardPath extends FlowConnectorPath {
     this.#calculatePath(dimensions);
 
     this.type = "ForwardPath";
-    // this.build();
   }
 
   get path() {
@@ -368,7 +367,6 @@ class ForwardUpForwardPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions }; // dimensions.current will be added in set #calculatePath()
     this.type = "ForwardUpForwardPath";
     this.#calculatePath(dimensions);
-    // this.build();
   }
 
   get path() {
@@ -465,7 +463,6 @@ class ForwardUpForwardDownPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "ForwardUpForwardDownPath";
     this.#calculatePath(dimensions);
-    // this.build();
   }
 
   get path() {
@@ -595,7 +592,6 @@ class ForwardDownBackwardUpPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "ForwardDownBackwardUpPath";
     this.#calculatePath(dimensions);
-    // this.build();
   }
 
   get path() {
@@ -719,7 +715,6 @@ class ForwardDownForwardPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "ForwardDownForwardPath";
     this.#calculatePath(dimensions);
-    // this.build();
   }
 
   get path() {
@@ -814,7 +809,6 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardDownBackwardUpPath";
     this.#calculatePath(dimensions);
-    // this.build();
   }
 
   get path() {
@@ -954,7 +948,6 @@ class DownForwardUpPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardUpPath";
     this.#calculatePath(dimensions);
-    // this.build();
   }
 
   get path() {
@@ -1064,7 +1057,6 @@ class DownForwardUpForwardDownPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardUpForwardDownPath";
     this.#calculatePath(dimensions);
-    // this.build();
   }
 
   get path() {
@@ -1206,7 +1198,6 @@ class DownForwardDownForwardPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardDownForwardPath";
     this.#calculatePath(dimensions);
-    // this.build();
   }
 
   get path() {
@@ -1313,7 +1304,6 @@ class DownForwardPath extends FlowConnectorPath {
     this.#config.dimensions = { original: dimensions };
     this.type = "DownForwardPath";
     this.#calculatePath(dimensions);
-    // this.build();
   }
 
   get path() {

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -91,6 +91,20 @@ class FlowConnectorPath {
     return this.#points;
   }
 
+  // Gets the bounding box of the path
+  // This is used to check path intersections for the adjustment/nudging routine
+  // Theoretically this should include the via points, but including them
+  // results in massively more intersections, and thus a much longer processing
+  // time. But doesn't actually change the end result. So we leave them out.
+  get bounds() {
+    return {
+      x1: Math.min(this.points.from_x, this.points.to_x),
+      y1: Math.min(this.points.from_y, this.points.to_y),
+      x2: Math.max(this.points.from_x, this.points.to_x),
+      y2: Math.max(this.points.from_y, this.points.to_y)
+    };
+  }
+
   // Makeing these readonly access properties because they shouldn't be changed.
   prop(name) {
     var p = this.#prop;

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -795,12 +795,17 @@ class DownForwardDownBackwardUpPath extends FlowConnectorPath {
 
   constructor(points, config) {
     super(points, config);
+
+    var down1 = Math.round(utilities.difference(points.from_y, this.points.via_y));
+    var down2 = Math.round(utilities.difference(config.bottom, this.points.via_y));
+    var up = Math.round(this.points.from_y - this.points.to_y) + down1 + down2;
+
     var dimensions = {
-      down1: Math.round(utilities.difference(points.from_y, this.points.via_y) - CURVE_SPACING),
+      down1: down1 - CURVE_SPACING,
       forward1: Math.round(this.points.via_x - (CURVE_SPACING * 2)),
-      down2: Math.round(utilities.difference(config.bottom, this.points.via_y) - CURVE_SPACING * 2),
+      down2: down2 - CURVE_SPACING*2,
       backward: Math.round(this.points.via_x + utilities.difference(this.points.from_x, this.points.to_x)),
-      up: Math.round((utilities.difference(config.bottom, config.top) - this.points.to_y) - CURVE_SPACING * 2),
+      up: up - CURVE_SPACING * 2,
       forward2: 0
     }
 

--- a/app/javascript/src/component_flow_item.js
+++ b/app/javascript/src/component_flow_item.js
@@ -24,9 +24,6 @@
  **/
 class FlowItem {
   constructor($node, config) {
-    $node.data("instance", this);
-    $node.addClass("FlowItem");
-
     this.$node = $node;
     this.id = config.id;
     this.next = config.next;
@@ -39,6 +36,9 @@ class FlowItem {
       y2: config.y_out
     };
 
+    $node.data("instance", this);
+    $node.addClass("FlowItem");
+    $node.attr('data-row', this.row);
   }
 }
 

--- a/app/javascript/src/component_flow_item.js
+++ b/app/javascript/src/component_flow_item.js
@@ -15,7 +15,6 @@
 
 
 
-
 /* FlowItem component
  * ------------------------
  * Positionable item expected within a Flow Layout.
@@ -33,10 +32,11 @@ class FlowItem {
     this.next = config.next;
     this.row = config.row;
     this.column = config.column;
-    this.coords = {
-      x_in: config.x_in,
-      x_out: config.x_out,
-      y: config.y,
+    this.bounds = {
+      x1: config.x_in,
+      y1: config.y_in,
+      x2: config.x_out,
+      y2: config.y_out
     };
 
   }

--- a/app/javascript/src/component_flow_item.js
+++ b/app/javascript/src/component_flow_item.js
@@ -36,6 +36,11 @@ class FlowItem {
       y2: config.y_out
     };
 
+    this.position = {
+      left: this.bounds.x1,
+      top: this.bounds.y1,
+    }
+
     $node.data("instance", this);
     $node.addClass("FlowItem");
     $node.attr('data-row', this.row);

--- a/app/javascript/src/components/menus/activated_menu.js
+++ b/app/javascript/src/components/menus/activated_menu.js
@@ -68,11 +68,17 @@ class ActivatedMenu {
   #currentFocusIndex
 
   constructor($menu, config) {
-    if(!config.container_id) {
-      config.container_id = uniqueString("menu");
+    let defaults = {
+      container_id: uniqueString("menu"),
+      render: true,
     }
 
+    config = mergeObjects(defaults, config);
+
     this.$node = $menu;
+    this.$parent = $menu.parent();
+    this.$node.detach();
+
     this.#config = config;
     this.#className = "ActivatedMenu";
 
@@ -106,7 +112,11 @@ class ActivatedMenu {
     this.$node.data("instance", this); // Add reference for instance from original node.
     this.$items = this.$node.find(ITEMS_SELECTOR);
     this.#currentFocusIndex = 0;
-    this.close();
+
+    if(config.render) {
+      this.close();
+      this.render();
+    }
   }
 
   get config() {
@@ -127,6 +137,11 @@ class ActivatedMenu {
 
   set currentActivator(element) {
     this.#state.activator = element;
+  }
+
+  render() {
+    this.activator.render();
+    this.container.render();
   }
 
   isOpen() {
@@ -213,7 +228,7 @@ class ActivatedMenu {
 
   #initializeMenuItems() {
     const menu = this;
-    this.$node.find('li').each( function() {
+    menu.$node.find('li').each( function() {
       new ActivatedMenuItem($(this), menu);
     });
   }

--- a/app/javascript/src/components/menus/activated_menu.js
+++ b/app/javascript/src/components/menus/activated_menu.js
@@ -85,6 +85,7 @@ class ActivatedMenu {
     this.#addAttributes();
     this.activator = new ActivatedMenuActivator(this, config);
     this.container = new ActivatedMenuContainer(this, config);
+    this.container.$node.hide();
 
     // Default position settings (can be set on instantiation or overide
     // on-the-fly by passing to component.open() function. Passing in a
@@ -140,8 +141,8 @@ class ActivatedMenu {
   }
 
   render() {
-    this.activator.render();
     this.container.render();
+    this.activator.render();
   }
 
   isOpen() {

--- a/app/javascript/src/components/menus/activated_menu_activator.js
+++ b/app/javascript/src/components/menus/activated_menu_activator.js
@@ -45,21 +45,11 @@ class ActivatedMenuActivator {
 
     this.#addAttributes();
     this.#bindEventHandlers();
+
   }
 
   render() {
     this.menu.$parent.append(this.$node);
-  }
-
-   /**
-    * Inserts the activator button into the DOM before the menu
-    * if $node is not provided it will be created
-    * @param {jQuery|undefined} $node jquery node for the button
-    * @return {jQuery} button node
-    */
-  #insertNode($node) {
-
-    return $node;
   }
 
    /**

--- a/app/javascript/src/components/menus/activated_menu_activator.js
+++ b/app/javascript/src/components/menus/activated_menu_activator.js
@@ -28,43 +28,48 @@ class ActivatedMenuActivator {
 
   /**
    * @param {ActivatedMenu} the menu instance to be activated
-   * @param {object} ActivatedMenu configuration object 
+   * @param {object} ActivatedMenu configuration object
    */
   constructor(menu, config) {
     let $node = config.activator;
     this.#config = config;
     this.#className = "ActivatedMenuActivator";
     this.menu = menu;
-    this.$node = this.#insertNode($node);
+
+    if(!$node || $node.length < 1) {
+      this.$node = this.#createNode();
+    } else {
+      this.$node = $node;
+    }
     this.$node.data("instance", this);
-    
+
     this.#addAttributes();
     this.#bindEventHandlers();
+  }
+
+  render() {
+    this.menu.$parent.append(this.$node);
   }
 
    /**
     * Inserts the activator button into the DOM before the menu
     * if $node is not provided it will be created
     * @param {jQuery|undefined} $node jquery node for the button
-    * @return {jQuery} button node 
+    * @return {jQuery} button node
     */
   #insertNode($node) {
-    if(!$node || $node.length < 1) {
-      $node = this.#createNode();
-    }
-    this.menu.$node.before($node);
 
     return $node;
   }
 
    /**
     * Creates a button element using config
-    * @return {jQuery} 
+    * @return {jQuery}
     */
   #createNode() {
       const $node = $(
-        createElement("button", 
-                      this.#config.activator_text, 
+        createElement("button",
+                      this.#config.activator_text,
                       this.#config.activator_classname
         )
       );
@@ -98,7 +103,7 @@ class ActivatedMenuActivator {
 
     this.$node.on("keydown", (event) => {
       let key = event.originalEvent.code;
-      
+
       switch(key) {
         case 'Enter':
         case 'Space':
@@ -113,7 +118,7 @@ class ActivatedMenuActivator {
           event.preventDefault();
 
           this.menu.currentActivator = event.currentTarget;
-          this.menu.open(); 
+          this.menu.open();
           this.menu.focusLast();
           break;
       }

--- a/app/javascript/src/components/menus/activated_menu_container.js
+++ b/app/javascript/src/components/menus/activated_menu_container.js
@@ -33,12 +33,7 @@ class ActivatedMenuContainer {
     this.$node.data("instance", this);
 
     this.#addAttributes();
-    // this.#insertNode();
     this.#bindEventHandlers();
-
-    if(config.render) {
-      this.render();
-    }
   }
 
   #addAttributes() {

--- a/app/javascript/src/components/menus/activated_menu_container.js
+++ b/app/javascript/src/components/menus/activated_menu_container.js
@@ -8,11 +8,11 @@
  * The constructor object accept the same configuration object as an Activated
  * Menu.  The relevant keys are:
  *  - container_id (string) an HTML id attribute to be applied to the generated
- *                          ActivatedMenuContainer element.  If none is provided 
+ *                          ActivatedMenuContainer element.  If none is provided
  *                          a unique id will be generated.
  *  - container_classname (string) class(es) to be applied to the generated menu
  *                                 container element
- * 
+ *
  **/
 
 const { createElement } = require('../../utilities');
@@ -23,7 +23,7 @@ class ActivatedMenuContainer {
 
   /**
    * @param {ActivatedMenu} the menu instance to be activated
-   * @param {object} ActivatedMenu configuration object 
+   * @param {object} ActivatedMenu configuration object
    */
   constructor(menu, config) {
     this.#config = config;
@@ -31,26 +31,29 @@ class ActivatedMenuContainer {
     this.menu = menu;
     this.$node = $(createElement("div"));
     this.$node.data("instance", this);
-    
+
     this.#addAttributes();
-    this.#insertNode(); 
+    // this.#insertNode();
     this.#bindEventHandlers();
-    
+
+    if(config.render) {
+      this.render();
+    }
   }
 
   #addAttributes() {
     this.$node.attr("id", this.#config.container_id);
-    this.$node.addClass(this.#className); 
+    this.$node.addClass(this.#className);
     if(this.#config.container_classname) {
       this.$node.addClass(this.#config.container_classname);
     }
-    this.$node.css("width", this.menu.$node.width() + "px"); // Required for alternative positioning.
+    //this.$node.css("width", this.menu.$node.width() + "px"); // Required for alternative positioning.
   }
 
   // Add Container to DOM then put the menu inside it.
   // Lastly, move to just inside body for z-index reasons.
-  #insertNode() {
-    this.menu.$node.before(this.$node);
+  render() {
+    this.menu.$parent.append(this.$node);
     this.$node.append(this.menu.$node);
     $(document.body).append(this.$node);
   }

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -642,24 +642,30 @@ function applyBranchFlowConnectorPaths(view, $overview) {
     $conditions.each(function(index) {
       var $condition = $(this);
       var condition = $condition.data("instance"); // FlowConditionItem
-      var $destination = $("[data-fb-id=" + $condition.data("next") + "]", $overview);
+      var $destination = $('[data-fb-id="'+ $condition.data("next")+'"]', $overview);
       var destination = $destination.data("instance"); // FlowItem
 
       // --------------------------------------------------------------------------------------------
-      // TODO: Temporary hack to prevent missing destination item bug  breaking the layout
-      // https://trello.com/c/iCDLMDgo/1836-bug-branchcondition-destination-page-is-in-detached-items
-      if($destination.length < 1) return true;
+      // Ensure we have a destination
+      // Prevent missing destination item bug breaking the layout - this
+      // shouldn't happen, so we need to fix it!
+      // TODO: https://trello.com/c/iCDLMDgo/1836-bug-branchcondition-destination-page-is-in-detached-items
       // --------------------------------------------------------------------------------------------
+      try {
+        var destinationX = destination.position.left;
+        var destinationY = destination.row * rowHeight + (rowHeight / 4);
+        var destinationColumn = destination.column;
+        var destinationRow = destination.row;
+      } catch(err) {
+        view.sentry.send(err);
+      }
+      if(destinationX == undefined || destinationY == undefined) return true;
 
-      var destinationX = destination.position.left;
-      var destinationY = destination.row * rowHeight + (rowHeight / 4);
       var conditionX = $condition.outerWidth(true) - 25; // 25 because we don't want lines to start at edge of column space
       var conditionY = $condition.data('row') * FLOW_GRID_ROW_HEIGHT + (FLOW_GRID_ROW_HEIGHT / 4);
       var halfBranchNodeWidth = (branchWidth / 2);
       var conditionColumn = condition.column;
       var conditionRow = condition.row;
-      var destinationColumn = destination.column;
-      var destinationRow = destination.row;
       var backward = conditionColumn > destinationColumn;
       var sameColumn = (conditionColumn == destinationColumn);
       var sameRow = (conditionRow == destinationRow);

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -239,24 +239,21 @@ function layoutDetachedItemsOverview(view) {
 **/
 function createAndPositionFlowItems(view, $overview) {
   var $columns = $(".column", $overview);
-  var rowHeight = FLOW_GRID_ROW_HEIGHT;
   var left = 0;
 
-  var $allItems = $();
+  var allItems = [];
 
   // Loop over found columns created from the flow
   $columns.each(function(column) {
-    var $column = $(this);
     var $items = $(SELECTOR_FLOW_ITEM, this);
     var conditionsLeft = 0;
     var top = 0; // TODO: Where should this come from? (see also COLUMN_SPACING)
 
-    $allItems = $allItems.add($items);
+    allItems.push( ...$items.get() );
     $items.detach();
 
     $items.each(function(row) {
       var $item = $(this);
-      var itemWidth = FLOW_ITEM_WIDTH;
       var conditionTop = (FLOW_GRID_ROW_HEIGHT / 4);
       var $conditions = $(SELECTOR_FLOW_CONDITION, this);
 
@@ -324,7 +321,8 @@ function createAndPositionFlowItems(view, $overview) {
 
   // Ditch the columns.
   $columns.remove();
-  $overview.append($allItems);
+  // reinsert all the items
+  $overview.append(allItems);
 }
 
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -835,13 +835,9 @@ function adjustOverlappingFlowConnectorPaths($overview) {
           // If the paths intersect / overlap
           // Call the overlap avoidance functionality and register
           // if anything was moved (reported by its return value).
-          if(utilities.intersects(path.bounds,current.bounds)){
-            // avoidOverlap is super expensive and if anything moves we start
-            // again so we only call it if the paths bounding boxes actually intersect.
-            if(path.avoidOverlap(current)) {
-              somethingMoved = true;
-              return false;
-            }
+          if(path.avoidOverlap(current)) {
+            somethingMoved = true;
+            return false;
           }
         }
       });

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -59,7 +59,7 @@ ServicesController.edit = function() {
   view.$flowOverview = $("#flow-overview");
   view.$flowDetached = $("#flow-detached");
   view.$flowStandalone = $("#flow-standalone-pages");
-  view.page.flowItemsRowHeight = utilities.maxHeight($(SELECTOR_FLOW_ITEM).eq(0)); // There is always a Start page.
+  view.page.flowItemsRowHeight = FLOW_GRID_ROW_HEIGHT;
   view.menus = [];
 
   createPageAdditionDialog(view);
@@ -75,7 +75,7 @@ ServicesController.edit = function() {
     layoutDetachedItemsOverview(view);
   }
 
-  view.menus.forEach( (menu) => menu.render() );
+  renderActivatedMenus(view);
 
   addServicesContentScrollContainer(view);
   view.ready();
@@ -432,7 +432,7 @@ function adjustOverviewWidth($overview) {
 
 /* VIEW HELPER FUNCTION:
  * ---------------------
- * To try and fix scrolling issues for the ServicresEdit page
+ * To try and fix scrolling issues for the ServicesEdit page
  * when flow overview areas extend beyond the restricted width
  * of the main content area.
  * @view (Object) Reference to the overall view instance of Services#edit action.
@@ -583,19 +583,18 @@ function adjustScrollDimensionsAndPositions($body, $container, $main, $header, $
  **/
 function applyPageFlowConnectorPaths(view, $overview) {
   var $items = $overview.find('.flow-page[data-next]:not([data-next="trailing-route"])');
-  var rowHeight = view.page.flowItemsRowHeight;
 
   $items.each(function() {
     var $item = $(this);
     var next = $item.data("next");
-    var fromX = $item.position().left + $item.outerWidth() + 1; // + 1 for design spacing
-    var fromY = $item.position().top + (rowHeight / 4);
+    var fromX = $item.data('instance').position.left + FLOW_ITEM_WIDTH + 1; // + 1 for design spacing
+    var fromY = $item.data('instance').position.top + (FLOW_GRID_ROW_HEIGHT / 4);
     var $next = $("[data-fb-id=" + next + "]", $overview);
 
 
     try {
-      var toX = $next.position().left - 1; // - 1 for design spacing
-      var toY = $next.position().top + (rowHeight / 4);
+      var toX = $next.data('instance').position.left - 1; // - 1 for design spacing
+      var toY = $next.data('instance').position.top + (FLOW_GRID_ROW_HEIGHT / 4);
     } catch(err) {
       view.sentry.send(err);
     }
@@ -630,14 +629,14 @@ function applyPageFlowConnectorPaths(view, $overview) {
  * dealing with them separately from other page arrows.
  **/
 function applyBranchFlowConnectorPaths(view, $overview) {
-  var rowHeight = view.page.flowItemsRowHeight;
+  var rowHeight = FLOW_GRID_ROW_HEIGHT;
   var $flowItemElements = $overview.find(SELECTOR_FLOW_ITEM);
 
   $flowItemElements.filter(SELECTOR_FLOW_BRANCH).each(function() {
     var $branch = $(this);
-    var branchX = $branch.position().left + $branch.outerWidth() + 1; // + 1 for design gap
-    var branchY = $branch.position().top + (rowHeight / 2);
-    var branchWidth = $branch.outerWidth();
+    var branchX = $branch.data('instance').position.left + FLOW_ITEM_WIDTH + 1; // + 1 for design gap
+    var branchY = $branch.data('instance').position.top + (FLOW_GRID_ROW_HEIGHT / 2);
+    var branchWidth = FLOW_ITEM_WIDTH;
     var $conditions = $branch.find(SELECTOR_FLOW_CONDITION);
 
     $conditions.each(function(index) {
@@ -652,11 +651,10 @@ function applyBranchFlowConnectorPaths(view, $overview) {
       if($destination.length < 1) return true;
       // --------------------------------------------------------------------------------------------
 
-      var destinationX = $destination.position().left;
-      // var destinationY = $destination.position().top + (rowHeight / 4);
+      var destinationX = destination.position.left;
       var destinationY = destination.row * rowHeight + (rowHeight / 4);
       var conditionX = $condition.outerWidth(true) - 25; // 25 because we don't want lines to start at edge of column space
-      var conditionY = $branch.position().top + $condition.position().top;
+      var conditionY = $condition.data('row') * FLOW_GRID_ROW_HEIGHT + (FLOW_GRID_ROW_HEIGHT / 4);
       var halfBranchNodeWidth = (branchWidth / 2);
       var conditionColumn = condition.column;
       var conditionRow = condition.row;
@@ -858,6 +856,10 @@ function applyRouteEndFlowConnectorPaths(view, $overview) {
 
 function renderFlowConnectorPaths($container) {
   $container.data('paths').forEach( (path) => { path.render() });
+}
+
+function renderActivatedMenus(view) {
+  view.menus.forEach( (menu) => menu.render() );
 }
 
 /* VIEW HELPER FUNCTION:

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -365,10 +365,9 @@ function adjustOverviewHeight($overview) {
   var top, bottom, height;
 
   $items.each(function() {
-    var $item = $(this);
-    var top = $item.data('instance').bounds.y1;
-    bottomNumbers.push(top + FLOW_GRID_ROW_HEIGHT);
+    var top = $(this).data('instance').bounds.y1;
     topNumbers.push(top);
+    bottomNumbers.push(top + FLOW_GRID_ROW_HEIGHT);
   });
 
   $paths.each(function() {
@@ -636,7 +635,8 @@ function applyBranchFlowConnectorPaths(view, $overview) {
       // --------------------------------------------------------------------------------------------
 
       var destinationX = $destination.position().left;
-      var destinationY = $destination.position().top + (rowHeight / 4);
+      // var destinationY = $destination.position().top + (rowHeight / 4);
+      var destinationY = destination.row * rowHeight + (rowHeight / 4);
       var conditionX = $condition.outerWidth(true) - 25; // 25 because we don't want lines to start at edge of column space
       var conditionY = $branch.position().top + $condition.position().top;
       var halfBranchNodeWidth = (branchWidth / 2);

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -225,7 +225,6 @@ function layoutDetachedItemsOverview(view) {
     adjustOverviewHeight($group);
     applyPageFlowConnectorPaths(view, $group);
     applyBranchFlowConnectorPaths(view, $group);
-    // adjustOverlappingFlowConnectorPaths($group);
     adjustBranchConditionPositions($group);
     adjustOverviewHeight($group);
     adjustOverviewWidth($group);
@@ -267,7 +266,8 @@ function createAndPositionFlowItems(view, $overview) {
         next: $item.attr("data-next"),
         x_in: left,
         x_out: left + FLOW_ITEM_WIDTH,
-        y: top + (FLOW_GRID_ROW_HEIGHT / 4),
+        y_in: top,
+        y_out: top + FLOW_GRID_ROW_HEIGHT,
         column: column,
         row: row
       });
@@ -297,7 +297,11 @@ function createAndPositionFlowItems(view, $overview) {
           $from: $condition.attr("data-from"),
           $next: $condition.attr("data-next"),
           column: column,
-          row: row + index
+          row: row + index,
+          x_in: FLOW_ITEM_WIDTH,
+          x_out: FLOW_ITEM_WIDTH + FLOW_CONDITION_WIDTH,
+          y_in: conditionTop,
+          y_out: conditionTop + FLOW_GRID_ROW_HEIGHT,
         });
 
         conditionTop += FLOW_GRID_ROW_HEIGHT;
@@ -333,7 +337,8 @@ function createAndPositionFlowItems(view, $overview) {
 function adjustBranchConditionPositions($overview) {
   var strokeWidth = $(".FlowConnectorPath path").eq(0).css("stroke-width") || "";
   var lineHeight = Number(strokeWidth.replace("px", "")) || 0;
-  $overview.find(".flow-expressions").each(function() {
+  var $expressions = $overview.find('.flow-expressions');
+  $expressions.each(function() {
     var $this = $(this);
     var expressionHeight = Number($this.height()) || 0;
     $this.css({
@@ -396,19 +401,10 @@ function adjustOverviewHeight($overview) {
  **/
 function adjustOverviewWidth($overview) {
   var $items = $([SELECTOR_FLOW_ITEM, SELECTOR_FLOW_CONDITION, SELECTOR_FLOW_LINE_PATH].join(", "), $overview);
-  var leftNumbers = [];
-  var rightNumbers = [];
   var left, right;
 
-  $items.each(function() {
-    var $item = $(this);
-    var offsetLeft = Math.ceil($item.offset().left);
-    leftNumbers.push(offsetLeft);
-    rightNumbers.push(offsetLeft + $item.width());
-  });
-
-  left = utilities.lowestNumber(leftNumbers);
-  right = utilities.highestNumber(rightNumbers);
+  left = $items.last().offset().left;
+  right = $items.first().offset().left + FLOW_ITEM_WIDTH + COLUMN_SPACING;
   $overview.width((right - left) + "px");
 }
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -60,6 +60,7 @@ ServicesController.edit = function() {
   view.$flowDetached = $("#flow-detached");
   view.$flowStandalone = $("#flow-standalone-pages");
   view.page.flowItemsRowHeight = utilities.maxHeight($(SELECTOR_FLOW_ITEM).eq(0)); // There is always a Start page.
+  view.menus = [];
 
   createPageAdditionDialog(view);
   createPageMenus(view);
@@ -73,6 +74,8 @@ ServicesController.edit = function() {
   if(view.$flowDetached.length) {
     layoutDetachedItemsOverview(view);
   }
+
+  view.menus.forEach( (menu) => menu.render() );
 
   addServicesContentScrollContainer(view);
   view.ready();
@@ -114,16 +117,19 @@ function createPageAdditionDialog(view) {
  **/
 function createPageMenus(view) {
   $("[data-component='ItemActionMenu']").each((_, el) => {
-    new PageMenu($(el), {
-      view: view,
-      preventDefault: true, // Stops the default action of triggering element.
-      menu: {
-        position: {
-          my: "left top",
-          at: "left top",
-        }
-      }
-    });
+    view.menus.push(
+      new PageMenu($(el), {
+        view: view,
+        preventDefault: true, // Stops the default action of triggering element.
+        menu: {
+          position: {
+            my: "left top",
+            at: "left top",
+          }
+        },
+        render: false,
+      })
+    );
   });
 }
 /* VIEW SETUP FUNCTION:
@@ -132,16 +138,19 @@ function createPageMenus(view) {
  **/
 function createConnectionMenus(view) {
   $("[data-component='ConnectionMenu']").each((_, el) => {
-    new ConnectionMenu($(el), {
-      view: view,
-      preventDefault: true, // Stops the default action of triggering element.
-      menu: {
-        position: {
-          my: "left top",
-          at: "left top",
-        }
-      }
-    });
+    view.menus.push(
+      new ConnectionMenu($(el), {
+        view: view,
+        preventDefault: true, // Stops the default action of triggering element.
+        menu: {
+          position: {
+            my: "left top",
+            at: "left top",
+          }
+        },
+        render: false,
+      })
+    );
   });
 }
 

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -364,6 +364,19 @@ function intersects(a, b) {
 	return true;
 }
 
+function overlaps(a, b, minimumOverlap) {
+  if( a.end - b.start >= 0 && b.end - a.start >=0 ) {
+    const range = overlapRange(a,b);
+    return (range.end - range.start) >= minimumOverlap;
+  }
+}
+
+function overlapRange(a,b) {
+  return {
+    start: Math.max(a.start, b.start),
+    end: Math.min(a.end, b.end)
+  }
+}
 
 
 
@@ -391,5 +404,6 @@ module.exports  = {
   highestNumber: highestNumber,
   filterObject: filterObject,
   snakeToPascalCase: snakeToPascalCase,
-  intersects: intersects
+  intersects: intersects,
+  overlaps: overlaps
 }

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -357,21 +357,33 @@ function snakeToPascalCase( str ){
     return str.join('');
 }
 
+// Determines if two rectangles have an intersection area
+// a and b are objects with top,left, bottom, right coordinates
+// @param {{x1: number y1: number, x2: number, y2: number}} a
+// @param  {{x1: number y1: number, x2: number, y2: number}} b
+// @return boolean
 function intersects(a, b) {
-	if (a.x1 >= b.x2 || b.x1 >= a.x2) return false; // no horizontal overlap
-	if (a.y1 >= b.y2 || b.y1 >= a.y2) return false; // no vertical overlap
+	if (a.x1 > b.x2 || b.x1 > a.x2) return false; // no horizontal overlap
+	if (a.y1 > b.y2 || b.y1 > a.y2) return false; // no vertical overlap
 
 	return true;
 }
 
-function overlaps(a, b, minimumOverlap) {
+// Determines if two ranges have an overlapping section
+// ranges provided must be supplied ordered such that start < end
+// @param {{start: number, end: number}} a
+// @param {{start: number, end: number}} b
+// @param {number} minimumOverlap
+// @return boolean
+function overlaps(a, b, minimumOverlap=0) {
   if( a.end - b.start >= 0 && b.end - a.start >=0 ) {
-    const range = overlapRange(a,b);
-    return (range.end - range.start) >= minimumOverlap;
+    const intersection = rangeIntersection(a,b);
+    return (intersection.end - intersection.start) >= minimumOverlap;
   }
+  return false;
 }
 
-function overlapRange(a,b) {
+function rangeIntersection(a,b) {
   return {
     start: Math.max(a.start, b.start),
     end: Math.min(a.end, b.end)
@@ -405,5 +417,5 @@ module.exports  = {
   filterObject: filterObject,
   snakeToPascalCase: snakeToPascalCase,
   intersects: intersects,
-  overlaps: overlaps
+  overlaps: overlaps,
 }

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -357,6 +357,13 @@ function snakeToPascalCase( str ){
     return str.join('');
 }
 
+function intersects(a, b) {
+	if (a.x1 >= b.x2 || b.x1 >= a.x2) return false; // no horizontal overlap
+	if (a.y1 >= b.y2 || b.y1 >= a.y2) return false; // no vertical overlap
+
+	return true;
+}
+
 
 
 
@@ -384,4 +391,5 @@ module.exports  = {
   highestNumber: highestNumber,
   filterObject: filterObject,
   snakeToPascalCase: snakeToPascalCase,
+  intersects: intersects
 }

--- a/test/flow_connector_line/methods_test.js
+++ b/test/flow_connector_line/methods_test.js
@@ -18,55 +18,52 @@ describe("FlowConnectorLine", function() {
       created = {};
     });
 
-    /* TEST METHOD:  prop()
-     **/
 
-    it("should return overlapAllowed value", function() {
-      expect(created.lines[0].prop("overlapAllowed")).to.be.true;
-      expect(created.lines[1].prop("overlapAllowed")).to.be.false;
-      expect(created.lines[2].prop("overlapAllowed")).to.be.true;
+    describe('prop', function() {
+      it("should return overlapAllowed value", function() {
+        expect(created.lines[0].prop("overlapAllowed")).to.be.true;
+        expect(created.lines[1].prop("overlapAllowed")).to.be.false;
+        expect(created.lines[2].prop("overlapAllowed")).to.be.true;
+      });
+
+      it("should return x value", function() {
+        expect(created.lines[0].prop("x")).to.equal(1451);
+        expect(created.lines[1].prop("x")).to.equal(1531);
+        expect(created.lines[2].prop("x")).to.equal(1541);
+      });
+
+      it("should return y value", function() {
+        expect(created.lines[0].prop("y")).to.equal(313);
+        expect(created.lines[1].prop("y")).to.equal(303);
+        expect(created.lines[2].prop("y")).to.equal(63);
+      });
+
+      it("should return length value", function() {
+        expect(created.lines[0].prop("length")).to.equal(70);
+        expect(created.lines[1].prop("length")).to.equal(230);
+        expect(created.lines[2].prop("length")).to.equal(-2);
+      });
     });
 
-    it("should return x value", function() {
-      expect(created.lines[0].prop("x")).to.equal(1451);
-      expect(created.lines[1].prop("x")).to.equal(1531);
-      expect(created.lines[2].prop("x")).to.equal(1541);
+    describe('testOnlySvg', function() {
+      it("should return svg element", function() {
+        expect(created.lines[0].testOnlySvg().get(0).tagName).to.equal("svg");
+        expect(created.lines[1].testOnlySvg().get(0).tagName).to.equal("svg");
+        expect(created.lines[2].testOnlySvg().get(0).tagName).to.equal("svg");
+      });
+
+      it("should have component class on element", function() {
+        expect(created.lines[0].testOnlySvg().hasClass("FlowConnectorLine")).to.be.true;
+        expect(created.lines[1].testOnlySvg().hasClass("FlowConnectorLine")).to.be.true;
+        expect(created.lines[2].testOnlySvg().hasClass("FlowConnectorLine")).to.be.true;
+      });
+
+      it("should have red stroke for testing path", function() {
+        expect(created.lines[0].testOnlySvg().children("path").eq(0).get(0).style.stroke).to.equal("red");
+        expect(created.lines[1].testOnlySvg().children("path").eq(0).get(0).style.stroke).to.equal("red");
+        expect(created.lines[2].testOnlySvg().children("path").eq(0).get(0).style.stroke).to.equal("red");
+      });
     });
-
-    it("should return y value", function() {
-      expect(created.lines[0].prop("y")).to.equal(313);
-      expect(created.lines[1].prop("y")).to.equal(303);
-      expect(created.lines[2].prop("y")).to.equal(63);
-    });
-
-    it("should return length value", function() {
-      expect(created.lines[0].prop("length")).to.equal(70);
-      expect(created.lines[1].prop("length")).to.equal(230);
-      expect(created.lines[2].prop("length")).to.equal(-2);
-    });
-
-
-    /* TEST METHOD:  testOnlySvg()
-     **/
-
-    it("should return svg element", function() {
-      expect(created.lines[0].testOnlySvg().get(0).tagName).to.equal("svg");
-      expect(created.lines[1].testOnlySvg().get(0).tagName).to.equal("svg");
-      expect(created.lines[2].testOnlySvg().get(0).tagName).to.equal("svg");
-    });
-
-    it("should have component class on element", function() {
-      expect(created.lines[0].testOnlySvg().hasClass("FlowConnectorLine")).to.be.true;
-      expect(created.lines[1].testOnlySvg().hasClass("FlowConnectorLine")).to.be.true;
-      expect(created.lines[2].testOnlySvg().hasClass("FlowConnectorLine")).to.be.true;
-    });
-
-    it("should have red stroke for testing path", function() {
-      expect(created.lines[0].testOnlySvg().children("path").eq(0).get(0).style.stroke).to.equal("red");
-      expect(created.lines[1].testOnlySvg().children("path").eq(0).get(0).style.stroke).to.equal("red");
-      expect(created.lines[2].testOnlySvg().children("path").eq(0).get(0).style.stroke).to.equal("red");
-    });
-
 
   });
 

--- a/test/flow_connector_line/properties_test.js
+++ b/test/flow_connector_line/properties_test.js
@@ -40,9 +40,10 @@ describe("FlowConnectorLine", function() {
     });
 
     it("should return the range", function() {
-      expect(created.lines[0].range.length).to.equal(70);
-      expect(created.lines[0].range[0]).to.equal(1451);
-      expect(created.lines[1].range[0]).to.equal(303);
+      expect(created.lines[0].range.start).to.equal(1451);
+      expect(created.lines[0].range.end).to.equal(1521);
+      expect(created.lines[1].range.start).to.equal(73);
+      expect(created.lines[1].range.end).to.equal(303);
     });
 
   });

--- a/test/flow_connector_path/component_test.js
+++ b/test/flow_connector_path/component_test.js
@@ -26,7 +26,7 @@ describe("FlowConnectorPath", function() {
       });
 
       // Base class FlowConnectorPath does not call build() function from constructor.
-      created.connector.build();
+      created.connector.render();
     });
 
     after(function() {

--- a/test/flow_connector_path/down_forward_down_backward_up_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_down_backward_up_path/methods_test.js
@@ -57,13 +57,7 @@ describe("DownForwardDownBackwardUpPath", function() {
      *
      * Same method as FlowConnectorPath but with sub-class specific differences.
      **/
-    it("should build the $node", function() {
-      expect(created.connector.build).to.exist;
-      expect(created.connector.$node).to.exist;
-
-      // Now call the build() function and see what happens.
-      created.connector.build();
-
+    it("should render the $node", function() {
       expect(created.connector.$node).to.exist;
       expect(created.connector.$node.length).to.equal(1);
 
@@ -180,6 +174,7 @@ describe("DownForwardDownBackwardUpPath", function() {
         top: 5,
         bottom: 10
       });
+      clashingPath.connector.render();
 
       var originalPath = clashingPath.connector.path;
       expect(clashingPath.connector.config.dimensions).to.eql(created.connector.config.dimensions);
@@ -207,6 +202,7 @@ describe("DownForwardDownBackwardUpPath", function() {
         top: 5,
         bottom: 10
       });
+      nonClashingPath.connector.render();
 
       var originalPath = nonClashingPath.connector.path;
       expect(created.connector.avoidOverlap(nonClashingPath.connector)).to.be.false;

--- a/test/flow_connector_path/down_forward_down_backward_up_path/properties_test.js
+++ b/test/flow_connector_path/down_forward_down_backward_up_path/properties_test.js
@@ -35,7 +35,16 @@ describe("DownForwardDownBackwardUpPath", function() {
 
     it("should return path set in constructor", function() {
       expect(created.connector.path).to.exist;
-      expect(created.connector.path).to.equal("M 1951,125 v178 a10,10 0 0 0 10,10 h505 a10,10 0 0 1 10,10 v283 a10,10 0 0 1 -10,10 h-626 a10,10 0 0 1 -10,-10 v--578 a10,10 0 0 1 10,-10 h0");
+      expect(created.connector.path).to.equal("M 1951,125 v178 a10,10 0 0 0 10,10 h505 a10,10 0 0 1 10,10 v283 a10,10 0 0 1 -10,10 h-626 a10,10 0 0 1 -10,-10 v-33 a10,10 0 0 1 10,-10 h0");
+    });
+
+    it('should calculate the correct dimensions', function() {
+        var dimensions = created.connector.dimensions.current;
+        expect(dimensions.down1).to.equal(178);
+        expect(dimensions.forward1).to.equal(505);
+        expect(dimensions.down2).to.equal(283);
+        expect(dimensions.backward).to.equal(626);
+        expect(dimensions.up).to.equal(33);
     });
 
     it("should return points set in constructor", function() {

--- a/test/flow_connector_path/down_forward_down_forward_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_down_forward_path/methods_test.js
@@ -58,13 +58,7 @@ describe("DownForwardDownForwardPath", function() {
      *
      * Same method as FlowConnectorPath but with sub-class specific differences.
      **/
-    it("should build the $node", function() {
-      expect(created.connector.build).to.exist;
-      expect(created.connector.$node).to.exist;
-
-      // Now call the build() function and see what happens.
-      created.connector.build();
-
+    it("should render the $node", function() {
       expect(created.connector.$node).to.exist;
       expect(created.connector.$node.length).to.equal(1);
 

--- a/test/flow_connector_path/down_forward_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_path/methods_test.js
@@ -59,13 +59,7 @@ describe("DownForwardPath", function() {
      *
      * Same method as FlowConnectorPath but with sub-class specific differences.
      **/
-    it("should build the $node", function() {
-      expect(created.connector.build).to.exist;
-      expect(created.connector.$node).to.exist;
-
-      // Now call the build() function and see what happens.
-      created.connector.build();
-
+    it("should render the $node", function() {
       expect(created.connector.$node).to.exist;
       expect(created.connector.$node.length).to.equal(1);
 

--- a/test/flow_connector_path/down_forward_up_forward_down_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_up_forward_down_path/methods_test.js
@@ -53,17 +53,11 @@ describe("DownForwardUpForwardDownPath", function() {
       expect(created.connector.prop("to").id).to.equal(c.FAKE_FLOW_ITEM_2.id);
     });
 
-    /* TEST METHOD: build()
+    /* TEST METHOD: render()
      *
      * Same method as FlowConnectorPath but with sub-class specific differences.
      **/
-    it("should build the $node", function() {
-      expect(created.connector.build).to.exist;
-      expect(created.connector.$node).to.exist;
-
-      // Now call the build() function and see what happens.
-      created.connector.build();
-
+    it("should render the $node", function() {
       expect(created.connector.$node).to.exist;
       expect(created.connector.$node.length).to.equal(1);
 

--- a/test/flow_connector_path/down_forward_up_path/methods_test.js
+++ b/test/flow_connector_path/down_forward_up_path/methods_test.js
@@ -53,17 +53,11 @@ describe("DownForwardUpPath", function() {
       expect(created.connector.prop("to").id).to.equal(c.FAKE_FLOW_ITEM_2.id);
     });
 
-    /* TEST METHOD: build()
+    /* TEST METHOD: render()
      *
      * Same method as FlowConnectorPath but with sub-class specific differences.
      **/
-    it("should build the $node", function() {
-      expect(created.connector.build).to.exist;
-      expect(created.connector.$node).to.exist;
-
-      // Now call the build() function and see what happens.
-      created.connector.build();
-
+    it("should render the $node", function() {
       expect(created.connector.$node).to.exist;
       expect(created.connector.$node.length).to.equal(1);
 

--- a/test/flow_connector_path/forward_down_backward_up_path/methods_test.js
+++ b/test/flow_connector_path/forward_down_backward_up_path/methods_test.js
@@ -55,17 +55,11 @@ describe("ForwardDownBackwardUpPath", function() {
       expect(created.connector.prop("to").id).to.equal(c.FAKE_FLOW_ITEM_2.id);
     });
 
-    /* TEST METHOD: build()
+    /* TEST METHOD: render()
      *
      * Same method as FlowConnectorPath but with sub-class specific differences.
      **/
-    it("should build the $node", function() {
-      expect(created.connector.build).to.exist;
-      expect(created.connector.$node).to.exist;
-
-      // Now call the build() function and see what happens.
-      created.connector.build();
-
+    it("should render the $node", function() {
       expect(created.connector.$node).to.exist;
       expect(created.connector.$node.length).to.equal(1);
 

--- a/test/flow_connector_path/forward_down_forward_path/methods_test.js
+++ b/test/flow_connector_path/forward_down_forward_path/methods_test.js
@@ -52,17 +52,11 @@ describe("ForwardDownForwardPath", function() {
       expect(created.connector.prop("to").id).to.equal(c.FAKE_FLOW_ITEM_2.id);
     });
 
-    /* TEST METHOD: build()
+    /* TEST METHOD: render()
      *
      * Same method as FlowConnectorPath but with sub-class specific differences.
      **/
-    it("should build the $node", function() {
-      expect(created.connector.build).to.exist;
-      expect(created.connector.$node).to.exist;
-
-      // Now call the build() function and see what happens.
-      created.connector.build();
-
+    it("should render the $node", function() {
       expect(created.connector.$node).to.exist;
       expect(created.connector.$node.length).to.equal(1);
 

--- a/test/flow_connector_path/forward_path/methods_test.js
+++ b/test/flow_connector_path/forward_path/methods_test.js
@@ -52,17 +52,11 @@ describe("ForwardPath", function() {
       expect(created.connector.prop("to").id).to.equal(c.FAKE_FLOW_ITEM_2.id);
     });
 
-    /* TEST METHOD: build()
+    /* TEST METHOD: render()
      *
      * Same method as FlowConnectorPath but with sub-class specific differences.
      **/
-    it("should build the $node", function() {
-      expect(created.connector.build).to.exist;
-      expect(created.connector.$node).to.exist;
-
-      // Now call the build() function and see what happens.
-      created.connector.build();
-
+    it("should render the $node", function() {
       expect(created.connector.$node).to.exist;
       expect(created.connector.$node.length).to.equal(1);
 

--- a/test/flow_connector_path/forward_up_forward_down_path/methods_test.js
+++ b/test/flow_connector_path/forward_up_forward_down_path/methods_test.js
@@ -55,17 +55,11 @@ describe("ForwardUpForwardDownPath", function() {
       expect(created.connector.prop("to").id).to.equal(c.FAKE_FLOW_ITEM_2.id);
     });
 
-    /* TEST METHOD: build()
+    /* TEST METHOD: render()
      *
      * Same method as FlowConnectorPath but with sub-class specific differences.
      **/
-    it("should build the $node", function() {
-      expect(created.connector.build).to.exist;
-      expect(created.connector.$node).to.exist;
-
-      // Now call the build() function and see what happens.
-      created.connector.build();
-
+    it("should render the $node", function() {
       expect(created.connector.$node).to.exist;
       expect(created.connector.$node.length).to.equal(1);
 

--- a/test/flow_connector_path/forward_up_forward_path/methods_test.js
+++ b/test/flow_connector_path/forward_up_forward_path/methods_test.js
@@ -55,17 +55,11 @@ describe("ForwardUpForwardPath", function() {
       expect(created.connector.prop("to").id).to.equal(c.FAKE_FLOW_ITEM_2.id);
     });
 
-    /* TEST METHOD: build()
+    /* TEST METHOD: render()
      *
      * Same method as FlowConnectorPath but with sub-class specific differences.
      **/
-    it("should build the $node", function() {
-      expect(created.connector.build).to.exist;
-      expect(created.connector.$node).to.exist;
-
-      // Now call the build() function and see what happens.
-      created.connector.build();
-
+    it("should render the $node", function() {
       expect(created.connector.$node).to.exist;
       expect(created.connector.$node.length).to.equal(1);
 

--- a/test/flow_connector_path/helpers.js
+++ b/test/flow_connector_path/helpers.js
@@ -58,10 +58,13 @@ function createFlowConnectorPath(type, id, points, config) {
     }
   }
 
+  var path = new ConnectorPaths[type](points, conf);
+  path.render();
+
   return {
     points: points,
     config: conf,
-    connector: new ConnectorPaths[type](points, conf)
+    connector: path
   }
 }
 

--- a/test/flow_connector_path/methods_test.js
+++ b/test/flow_connector_path/methods_test.js
@@ -59,15 +59,9 @@ describe("FlowConnectorPath", function() {
     });
 
 
-    /* TEST METHOD: build()
+    /* TEST METHOD: render()
      **/
-    it("should build the $node", function() {
-      expect(created.connector.build).to.exist;
-      expect(created.connector.$node).to.not.exist;
-
-      // Now call the build() function and see what happens.
-      created.connector.build();
-
+    it("should render the $node", function() {
       expect(created.connector.$node).to.exist;
       expect(created.connector.$node.length).to.equal(1);
     });

--- a/test/flow_connector_path/properties_test.js
+++ b/test/flow_connector_path/properties_test.js
@@ -27,7 +27,7 @@ describe("FlowConnectorPath", function() {
       });
 
       // Base class FlowConnectorPath does not call build() function from constructor.
-      created.connector.build();
+      created.connector.render();
     });
 
     after(function() {

--- a/test/flow_item/helpers.js
+++ b/test/flow_item/helpers.js
@@ -11,7 +11,8 @@ const constants = {
     column: 3,
     x_in: 100,
     x_out: 150,
-    y: 20
+    y_in: 20,
+    y_out: 500
   },
 
   TEXT_HEADING: "This is a heading",

--- a/test/flow_item/properties_test.js
+++ b/test/flow_item/properties_test.js
@@ -40,14 +40,16 @@ describe("FlowItem", function() {
       expect(created.item.column).to.equal(c.FAKE_FLOW_ITEM_CONFIG.column);
     });
 
-    it("should return the coords", function() {
-      expect(created.item.coords.x_in).to.equal(c.FAKE_FLOW_ITEM_CONFIG.x_in);
-      expect(created.item.coords.x_out).to.equal(c.FAKE_FLOW_ITEM_CONFIG.x_out);
-      expect(created.item.coords.x_y).to.equal(c.FAKE_FLOW_ITEM_CONFIG.x_y);
-      expect(created.item.coords).to.eql({
-                                           x_in: c.FAKE_FLOW_ITEM_CONFIG.x_in,
-                                           x_out: c.FAKE_FLOW_ITEM_CONFIG.x_out,
-                                           y: c.FAKE_FLOW_ITEM_CONFIG.y
+    it("should return the bounds", function() {
+      expect(created.item.bounds.x1).to.equal(c.FAKE_FLOW_ITEM_CONFIG.x_in);
+      expect(created.item.bounds.x2).to.equal(c.FAKE_FLOW_ITEM_CONFIG.x_out);
+      expect(created.item.bounds.y1).to.equal(c.FAKE_FLOW_ITEM_CONFIG.y_in);
+      expect(created.item.bounds.y2).to.equal(c.FAKE_FLOW_ITEM_CONFIG.y_out);
+      expect(created.item.bounds).to.eql({
+                                           x1: c.FAKE_FLOW_ITEM_CONFIG.x_in,
+                                           x2: c.FAKE_FLOW_ITEM_CONFIG.x_out,
+                                           y1: c.FAKE_FLOW_ITEM_CONFIG.y_in,
+                                           y2: c.FAKE_FLOW_ITEM_CONFIG.y_out
                                          });
     });
 

--- a/test/menus/activated_menu/helpers.js
+++ b/test/menus/activated_menu/helpers.js
@@ -33,7 +33,8 @@ function createActivatedMenu(id, config) {
     activator_text: constants.TEXT_ACTIVATOR,
     id: id,
     preventDefault: true,
-    selection_event: constants.EVENT_SELECTION_NAME
+    selection_event: constants.EVENT_SELECTION_NAME,
+    render: true,
   }, config);
 
   return {

--- a/test/menus/activated_menu_activator/helpers.js
+++ b/test/menus/activated_menu_activator/helpers.js
@@ -29,6 +29,7 @@ function createActivatedMenuActivator(id, config) {
   var $container = $("#" + id + constants.ID_CONTAINER_SUFFIX);
   var fakeMenu = {
     $node: $("#" + id + constants.ID_MENU_SUFFIX),
+    $parent: $container,
     state: {
       open: false,
       focus: false,
@@ -47,13 +48,14 @@ function createActivatedMenuActivator(id, config) {
 
   // Construct basic config that could be passed to ActivatedMenuActivator creation.
   var conf = GlobalHelpers.mergeConfig({
-    id: id
+    id: id,
   }, config);
 
   var activeMenuActivator = new ActivatedMenuActivator(fakeMenu, conf);
+  activeMenuActivator.render();
 
   // ActivatedMenuActivator $node gets placed to just before the menu $node.
-  var $component = fakeMenu.$node.prev();
+  var $component = $("#" + id + constants.ID_CONTAINER_SUFFIX).children().last();
   $component.attr("id", id + constants.ID_COMPONENT_SUFFIX);
 
   return {

--- a/test/utilities/intersects_test.js
+++ b/test/utilities/intersects_test.js
@@ -1,0 +1,43 @@
+require("../setup");
+const utilities = require('../../app/javascript/src/utilities');
+
+describe('utilities.intersects', function() {
+
+  it('should return true if bounds intersect', function() {
+    let a = { x1: 100, y1: 100, x2: 600, y2: 200 };
+    let b = { x1: 200, y1: 150, x2: 600, y2: 200 };
+
+    expect(utilities.intersects(a,b)).to.be.true;
+  })
+
+  it('should return false if vertical bounds do not intersect', function() {
+    let a = { x1: 100, y1: 100, x2: 600, y2: 200 };
+    let b = { x1: 300, y1: 300, x2: 600, y2: 200 };
+
+    expect(utilities.intersects(a,b)).to.be.false;
+  });
+
+  it('should return false if horizontal bounds do not intersect', function() {
+    let a = { x1: 100, y1: 100, x2: 600, y2: 200 };
+    let b = { x1: 100, y1: 800, x2: 1000, y2: 200 };
+
+    expect(utilities.intersects(a,b)).to.be.false;
+  });
+
+  it('should return true if b inside a', function() {
+    let a = { x1: 100, y1: 100, x2: 600, y2: 200 };
+    let b = { x1: 150, y1: 110, x2: 500, y2:180  };
+
+    expect(utilities.intersects(a,b)).to.be.true;
+  });
+
+  it('should return true if bounds are equal', function() {
+    let a = { x1: 100, y1: 100, x2: 600, y2: 200 };
+    let b = { x1: 100, y1: 100, x2: 600, y2: 200 };
+
+    expect(utilities.intersects(a,b)).to.be.true;
+  });
+
+
+});
+

--- a/test/utilities/overlaps_test.js
+++ b/test/utilities/overlaps_test.js
@@ -1,0 +1,34 @@
+require('../setup');
+
+const utilities = require('../../app/javascript/src/utilities');
+
+describe('utilties.overlaps', function() {
+
+  it('should return true if ranges overlap', function() {
+    let a = { start: 10, end: 100 };
+    let b = { start: 50, end: 150};
+
+    expect(utilities.overlaps(a,b)).to.be.true;
+  });
+
+  it('should return true if ranges overlap more than minimum', function() {
+    let a = { start: 10, end: 100};
+    let b = { start: 50, end: 150};
+
+    expect(utilities.overlaps(a,b, 10)).to.be.true;
+  });
+
+  it('should return false if ranges overlap but less than minimum', function() {
+    let a = { start: 10, end: 100};
+    let b = { start: 50, end: 150};
+
+    expect(utilities.overlaps(a,b, 100)).to.be.false;
+  });
+
+  it('should return false if there is no overlap', function() {
+    let a = { start: 10, end: 100};
+    let b = { start: 120, end: 200};
+
+    expect(utilities.overlaps(a,b, 100)).to.be.false;
+  })
+});


### PR DESCRIPTION
This turned into a bit of a beast of a PR (sorry). Hopefully each commit within should be fairly understandable.

These changes make several improvements to how the flow view is rendered in order to improve the time it takes to display the flow.  Large forms, such as the COP form could take up to 15 seconds (after the DOM has loaded) to process and render the flow view to screen.

## Use intersection checking on the lines before we do overlap comparison
Previously every single line was checked against every single other line in the form to see if there were overlaps and things needed to be nudged.  As soon as a line is nudged, we need to start the process over again.  On large forms many lines may have bounds that do not intersect, so there is no way their lines can overlap.  By checking for bounds intersection first, we can prevent a bunch of unnecessary line comparison.

## Reducing re-layout in the browser
Accessing CSS properties from JS forces the browser to re-layout (it needs to re-calculate the position of everything on the screen in order to know the information you want) this is expensive and slow, doing a lot of re-layout is called "layout thrashing" and it is bad.

![image](https://user-images.githubusercontent.com/595564/214518521-3109f94c-a1eb-41dc-b209-c638d4a8ade7.png)
![image](https://user-images.githubusercontent.com/595564/214539984-1844130c-89d3-4c46-b2f9-29f5ee489bf6.png)
Every bit of red in the screenshot above is the browser recalculating layout 🙁

One of the biggest issues was that we were causing re-layout when looping over the arrows, and the flow items.

### Batch rendering arrows
Instead of inserting the arrows into the DOM within a loop, and then later doing all the adjustments. We create them without attaching them into the DOM, store them in arrays, and do all of our adjustments on them, and insert them into the DOM in one operation at the end.

### Batch rendering of flow items.
These items start in the DOM, so we detach them from the DOM before we do our positioning of them, and then re-insert them at the end when we're done.

### Batch render Page Menus and Connection Menus
Similar approach here - separate the creation and rendering step. However as these menus are sued elsewhere, where we are less concerned about performance and can render them immediately, we add a default config option for `render` which defaults to `true`.

### Reduce reading values that cause re-layout 
Anywhere the JS calls `.position()`, `.offset()`, `.css`, `.width()` or '.height()` will cause re-layout.  
* In many places these calls could be refactored out.  In some places we were querying for the width or height of a flow item - these are fixed numbers now, so we can replace them with constants. 
* In others, we were wanting the offset position of the flow item - which had already been calculated earlier in the process. So we now store the calculated position on the object itself and query from there when we need it, not from the DOM.

## Other small tweaks / fixes made along the way

### Fixing the DownForwardDownBackwardUp arrow
This arrow seemd to cause some issues and wasn't being positioned correctly (the final up line wasn't going to the correct place).  Adjusted the calculation of the line to use the already calculated down lengths.  In order to test this, a `dimensions` property getter was added to the class so that we could test the individual dimensions, rather than testing the obscure output of the SVG path.<sup>*</sup>

### Fix the top offset to include the position of long branch expressions.
If a condition expression is super long, and on the first row of the form, it could overflow the top of the form view.  The code was supposed to do this already, however the way the expressions were positioned had changed so it no longer worked correctly.  Fixed this, and improved the code to only look at expressions on the first row of the form. 

## Final result
![image](https://user-images.githubusercontent.com/595564/214536841-0ed4d09b-861d-40ed-9a20-8aba76b266ed.png)
![image](https://user-images.githubusercontent.com/595564/214540466-ff405a86-b5f9-431a-98f6-52b511bd4979.png)
Much less red 🙂

### Before:
**DOMContentLoaded:** 3588ms
**OnLoad:** 9737ms
**Δ DCL-OL:** 6209ms
**Total Blocking Time:** 7276ms

### After:
**DOMContentLoaded:** 3317ms
**OnLoad:** 4429ms
**Δ DCL-OL:** 1112ms
**Total Blocking Time:** 1767ms

All measurements an average of 4 page loads.

**DOMContentLoaded:** When the DOM has been loaded, parsed and is ready.
**OnLoad:** When all loading and scripting is complete.
**Total Blocking Time:** Amount of time the JS is blocking the main thread (meaning the page is not fully interactive)

These aren't the best metrics, but the old version of the page wasn;t loading well enough for devtools to report First Contentful Paint / Largest Contentful Paint metrics.

**We've shortened the OnLoad event firing by 5 seconds!** 

Worth noting that `onLoad` is a late metric - the page will have rendered and been interactive before this.  However in the old version of the form `onLoad` was roughtly equivalent to the flow view rendering, whereas in the new version the flow view is rendered ~0.5 seconds prior to `onLoad`.

<sup>*</sup> A further PR will be needed to add dimensions tests to the other line test files.





