### PR TITLE
Update confirmation page thumbnail background color when payment link…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
   def flow_thumbnail_link(args)
     link_to edit_page_path(
       service.service_id, args[:uuid]
-    ), class: "flow-thumbnail #{args[:thumbnail]}", 'aria-hidden': true, tabindex: -1 do
+    ), class: "flow-thumbnail #{args[:thumbnail]} #{payment_link_enabled? ? 'payment-enabled' : ''}", 'aria-hidden': true, tabindex: -1 do
       concat image_pack_tag('thumbnails/thumbs_header.png', class: 'header', alt: '')
       concat tag.span("#{t('actions.edit')}: ", class: 'govuk-visually-hidden')
       concat tag.span(args[:title], class: 'text')

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -925,6 +925,12 @@ a[disabled] {
     }
   }
 
+  &.confirmation.payment-enabled {
+    span {
+      background-color: $govuk-link-colour;
+    }
+  }
+
   &.standalone {
     border:  $govuk-link-colour solid 2px;
     box-sizing: border-box;


### PR DESCRIPTION
When payment links are enabled the application confirmation page has a blue header instead of green.

This PR updates the flow view thumbnail to reflect this and show a blue background to match.

![image](https://user-images.githubusercontent.com/595564/214618600-951fd239-58a0-4997-940a-a3cb2c662994.png)
Without payment links enabled


![image](https://user-images.githubusercontent.com/595564/214618429-0b71daad-1771-474b-b504-e1ec27e36b50.png)
With payment links enabled