### PR TITLE
Apply GOVUK link style to links in editable content areas

### DIFF
--- a/app/javascript/styles/shared/_content.scss
+++ b/app/javascript/styles/shared/_content.scss
@@ -10,3 +10,8 @@
 .call-to-action > p {
   margin: 0;
 }
+
+// Apply GOVUk link styles to all links in editable content areas
+.fb-editable[data-fb-content-type="content"] a {
+  @extend %govuk-link;
+}


### PR DESCRIPTION
This adds the standard GOVUK link styles to links within editable content areas.

This is in the `shared/_content.scss` file as it applies both within the editor and in the preview (matching PR in the runner: https://github.com/ministryofjustice/fb-runner/compare/main...GOVUK-link-style-for-editable-content)

### Why is it done this way?
When adding table formatting and call-to-action formatting into editable content areas we use JS in `shared/content.js` My first attempts at doing this used that method - as it feels more 'correct' to actually add the `.govuk-link` class to the elements.

However, this could have worked in the runner (and I did get it working) but there is no real way to apply it in the editor as we convert md -> html -> md and markdown has no way of storing a class on a link.  Also it would have required regexing to find and modify all `a` tags which woudl just end in 😢 
