### PR TITLE
Update brakeman ignore

### DIFF
--- a/brakeman.ignore
+++ b/brakeman.ignore
@@ -30,7 +30,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/settings/from_address/index.html.erb",
-      "line": 12,
+      "line": 20,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "FromAddressPresenter.new(:from_address => FromAddress.find_or_initialize_by(:service_id => service.service_id), :messages => I18n.t(\"warnings.from_address.settings\"), :service_id => service.service_id).message",
       "render_path": [
@@ -56,6 +56,25 @@
         79
       ],
       "note": "False positive for XSS. No way param input can get to template output."
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 123,
+      "fingerprint": "425dcb3af9624f11f12d777d6f9fe05995719975a155c30012baa6b9dc3487df",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 2.7.7 ends on 2023-03-31",
+      "file": "Gemfile.lock",
+      "line": 280,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": "We have prioritised upgrading to Ruby 3. In the meantime, ignore so we unblock the pipeline."
     },
     {
       "warning_type": "Mass Assignment",
@@ -138,6 +157,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-09-30 13:58:23 +0100",
-  "brakeman_version": "5.3.1"
+  "updated": "2023-01-30 09:38:22 +0000",
+  "brakeman_version": "5.4.0"
 }


### PR DESCRIPTION
We have a EOLRuby warning that is preventing us from deploying the app to production.
This warning tells us to upgrade the app to Ruby 3. We have now prioritised this work, so for the time being ignore this warning.
Ignoring this warning will allow us to continue deploying the app to production.