### PR TITLE
Reduce resize timeout value

### DIFF
--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -493,7 +493,7 @@ function addServicesContentScrollContainer(view) {
 
       // Finished so reveal updated content
       $main.addClass(view.constants.JS_ENHANCEMENT_DONE);
-    }, 750);
+    }, 100);
   });
 }
 


### PR DESCRIPTION
Now that the flow view is 🏎super-fast we don't need the super long timeout on resizing the screen.  Reduced it down to 100ms, which is pretty much instantaneous from a user perspective. 

