### PR TITLE
Make user search work in the admin dashboard

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -18,6 +18,33 @@ module Admin
     # Overwrite any of the RESTful controller actions to implement custom behavior
     # For example, you may want to send an email after a foo is updated.
     #
+    def index
+      authorize_resource(resource_class)
+      search_term = params[:search].to_s.strip
+      # Because our data is encryopted in the db we can't search using where
+      # LIKE - so we have to force Administrate to not search.
+      resources = filter_resources(scoped_resource, search_term: '')
+      resources = apply_collection_includes(resources)
+      resources = order.apply(resources)
+
+      # If there's a search term we need to filter the returned data using
+      # select. Otherwise we apply DB pagination
+      resources = if search_term.present?
+                    resources.select { |resource| resource.name.downcase.include?(search_term) || resource.email.downcase.include?(search_term) }
+                  else
+                    paginate_resources(resources)
+                  end
+
+      page = Administrate::Page::Collection.new(dashboard, order: order)
+
+      render locals: {
+        resources: resources,
+        search_term: search_term,
+        page: page,
+        show_search_bar: show_search_bar?
+      }
+    end
+    #
     # def update
     #   super
     #   send_foo_updated_email(requested_resource)

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -8,10 +8,10 @@ class UserDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    id: Field::String,
+    id: Field::String.with_options(searchable: false),
     email: Field::String,
     name: Field::String,
-    timezone: Field::String,
+    timezone: Field::String.with_options(searchable: false),
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,46 @@
+<%#
+# Index
+
+This view is the template for the index page.
+It is responsible for rendering the search bar, header and pagination.
+It renders the `_table` partial to display details about the resources.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Collection][1].
+  Contains helper methods to help display a table,
+  and knows which attributes should be displayed in the resource's table.
+- `resources`:
+  An instance of `ActiveRecord::Relation` containing the resources
+  that match the user's search criteria.
+  By default, these resources are passed to the table partial to be displayed.
+- `search_term`:
+  A string containing the term the user has searched for, if any.
+- `show_search_bar`:
+  A boolean that determines if the search bar should be shown.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<%=
+  render("index_header",
+    resources: resources,
+    search_term: search_term,
+    page: page,
+    show_search_bar: show_search_bar,
+  )
+%>
+
+<section class="main-content__body main-content__body--flush">
+  <%= render(
+    "collection",
+    collection_presenter: page,
+    collection_field_name: resource_name,
+    page: page,
+    resources: resources,
+    table_title: "page-title"
+  ) %>
+
+  <%= render("pagination", resources: resources) unless resources.is_a? Array %>
+</section>


### PR DESCRIPTION
Makes the search work for users in the admin area.

This should just work out-of-the-box with Administrate (the admin gem we use).  A bit of digging uncovered the reason why it doesn't work - the values in our database are encrypted!
This means it's not possible to do an `ILIKE` search of the column values.

Our data is encrypted by rails before insertion and decrypted on attribute access in rails.  this means Postgres has no knowledge of the data and no possible way to search the data before return from the database.

This PR is a solution to the problem that works, it's definitely no elegant, and would have issues with large datasets, but it works for our purposes.

We override the Administrate index method and 

* Force administrate not to search
* If a search term is present, search the returned data using ruby `select`
* Otherwise, paginate

We then have to override the `users#index` view as the local `resources` variable can now be an `Array` after searching, and calling `paginate` on an array throws an error.


