### PR TITLE
Improve branch edit page performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,15 @@ Install gems:
 Create and migrate the test database:
 `bundle exec rails db:create db:migrate`
 
+You might need to install postgres 
+`brew install postgres`
+and start the database daemon
+`brew services start postgres`
+
 Copy the environment variables into your own .env file:
 `cp .env.development .env`
 
-Compile the necessary assets and run webpack:
+Compile the necessary assets and run webpack (requires yarn):
 `make assets`
 
 Start the Rails server:

--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -59,6 +59,17 @@ class BranchesController < FormController
     redirect_to edit_service_path(service.service_id)
   end
 
+  def branch_destinations
+    @branch_destinations ||= @branch.main_destinations
+  end
+
+  def branch_detached_destinations
+    @branch_detached_destinations ||= @branch.detached_destinations
+  end
+
+  helper_method :branch_destinations
+  helper_method :branch_detached_destinations
+
   private
 
   def branch_metadata

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -23,15 +23,15 @@
       <select class="govuk-select" name="branch[default_next]" id="branch_default_next">
         <%= render partial: "destinations_list",
                   locals: {
-                    destinations: @branch.main_destinations,
+                    destinations: branch_destinations,
                     selected: @branch.previous_flow_default_next
                   }
         %>
-        <% if @branch.detached_destinations.present? %>
+        <% if branch_detached_destinations.present? %>
           <optgroup class="branch-optgroup" label="<%= t('branches.detached_list') %>">
             <%= render partial: "destinations_list",
                       locals: {
-                        destinations: @branch.detached_destinations,
+                        destinations: branch_detached_destinations,
                         selected: @branch.previous_flow_default_next
                       }
             %>

--- a/app/views/branches/_form_conditionals.html.erb
+++ b/app/views/branches/_form_conditionals.html.erb
@@ -25,15 +25,15 @@
           <option value=""><%= t('branches.select_destination') %></option>
           <%= render partial: "destinations_list",
           locals: {
-            destinations: @branch.main_destinations,
+            destinations: branch_destinations,
             selected: conditional.object.next
           }
           %>
-          <% if @branch.detached_destinations.present? %>
+          <% if branch_detached_destinations.present? %>
             <optgroup class="branch-optgroup" label="<%= t('branches.detached_list') %>">
               <%= render partial: "destinations_list",
               locals: {
-                destinations: @branch.detached_destinations,
+                destinations: branch_detached_destinations,
                 selected: conditional.object.next
               }
               %>

--- a/brakeman.ignore
+++ b/brakeman.ignore
@@ -30,7 +30,7 @@
       "check_name": "CrossSiteScripting",
       "message": "Unescaped model attribute",
       "file": "app/views/settings/from_address/index.html.erb",
-      "line": 12,
+      "line": 20,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
       "code": "FromAddressPresenter.new(:from_address => FromAddress.find_or_initialize_by(:service_id => service.service_id), :messages => I18n.t(\"warnings.from_address.settings\"), :service_id => service.service_id).message",
       "render_path": [
@@ -56,6 +56,25 @@
         79
       ],
       "note": "False positive for XSS. No way param input can get to template output."
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 123,
+      "fingerprint": "425dcb3af9624f11f12d777d6f9fe05995719975a155c30012baa6b9dc3487df",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 2.7.7 ends on 2023-03-31",
+      "file": "Gemfile.lock",
+      "line": 286,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
     },
     {
       "warning_type": "Mass Assignment",
@@ -87,7 +106,7 @@
       "check_name": "MassAssignment",
       "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
       "file": "app/controllers/branches_controller.rb",
-      "line": 83,
+      "line": 94,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.require(:branch).permit!",
       "render_path": null,
@@ -138,6 +157,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-09-30 13:58:23 +0100",
-  "brakeman_version": "5.3.1"
+  "updated": "2023-01-31 09:23:12 +0000",
+  "brakeman_version": "5.4.0"
 }


### PR DESCRIPTION
The edit branch page was having performance issues when loading very large forms, this change should drastically reduce the number of objects allocated when rendering the partials for the edit page.

Previously, the conditionals partial would traverse all possible flows _for each_ conditional, to generate a new list of destinations and detached destinations, for each branch, plus the 'otherwise' dropdown.

This results in ~18 million object allocations to render the edit form over about 15 seconds
<img width="1709" alt="image" src="https://user-images.githubusercontent.com/7647632/215547107-159ea884-aff7-4ef8-8bd0-fe2e37a581f8.png">

The change moves the `@branch.destinations` and `@branch.detached_destinations` into a helper method on the controller (so all the partials such as when adding a new conditional) can access a cached-in-memory list of destinations.

This cuts us down to around 3.5 million allocations (in the very large test form) over about 4 seconds
<img width="1707" alt="image" src="https://user-images.githubusercontent.com/7647632/215547511-81ca6ac4-b9b7-4d27-a99f-87030a11a72a.png">

There's still a noticeable jump in allocations when detached pages with branches are present (3 million of the 3.5) but that is an investigation for another PR!