### PR TITLE
Add rake task that removes services in the 'dev' deployment env

### DIFF
--- a/app/services/unpublish_dev_services.rb
+++ b/app/services/unpublish_dev_services.rb
@@ -1,0 +1,33 @@
+class UnpublishDevServices
+  include MetadataVersionHelper
+
+  AUTOMATED_TEST_SERVICES = [
+    'cd75ad76-1d4b-4ce5-8a9e-035262cd2683', # New Runner Service
+    'e68dca75-20b8-468e-9436-e97791a914c5', # Branching Fixture 10 Service
+    '57497ef9-61cb-4579-ab93-f686e09d6936'  # Smoke Tests V2
+  ].freeze
+  SELECT_LATEST_PUBLISH_SERVICE_RECORD = 'SELECT DISTINCT ON (service_id) * FROM publish_services ORDER BY service_id, created_at DESC'.freeze
+
+  def call
+    published_dev_services.each do |publish_service|
+      version_metadata = get_version_metadata(publish_service)
+      UnpublishServiceJob.perform_later(
+        publish_service_id: publish_service.id,
+        service_slug: service_slug(version_metadata)
+      )
+    end
+  end
+
+  private
+
+  def published_services
+    @published_services ||=
+      PublishService.find_by_sql(SELECT_LATEST_PUBLISH_SERVICE_RECORD)
+                    .reject { |ps| ps.service_id.in?(AUTOMATED_TEST_SERVICES) }
+                    .select(&:completed?)
+  end
+
+  def published_dev_services
+    published_services.select { |ps| ps.deployment_environment == 'dev' }
+  end
+end

--- a/lib/tasks/unpublish_dev_services.rake
+++ b/lib/tasks/unpublish_dev_services.rake
@@ -1,0 +1,8 @@
+namespace 'unpublish' do
+  desc 'Unpublishes dev services from Test and Live environments.'
+  task dev_services: [:environment, 'db:load_config'] do
+    UnpublishDevServices.new.call
+  rescue StandardError => e
+    Sentry.capture_exception(e)
+  end
+end

--- a/spec/services/unpublish_dev_services_spec.rb
+++ b/spec/services/unpublish_dev_services_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe UnpublishDevServices do
+  subject(:unpublish_dev_services) { described_class.new }
+
+  describe '#call' do
+    let(:version_metadata) { metadata_fixture(:version) }
+    let(:params) do
+      {
+        publish_service_id: published_services.id,
+        service_slug: 'version-fixture'
+      }
+    end
+
+    before do
+      allow(unpublish_dev_services).to receive(:get_version_metadata).and_return(version_metadata)
+      allow(UnpublishServiceJob).to receive(:perform_later).and_call_original
+      allow(UnpublishServiceJob).to receive(:perform_later).with(params)
+
+      unpublish_dev_services.call
+    end
+
+    context 'when service is in dev' do
+      let(:published_services) do
+        create(
+          :publish_service,
+          :dev,
+          service_id: SecureRandom.uuid,
+          status: 'completed'
+        )
+      end
+
+      it 'should unpublish the service' do
+        expect(UnpublishServiceJob).to have_received(:perform_later).with(params)
+      end
+    end
+
+    context 'when service is in production' do
+      let(:published_services) do
+        create(
+          :publish_service,
+          :production,
+          service_id: SecureRandom.uuid,
+          status: 'completed'
+        )
+      end
+
+      it 'should not unpublish the service' do
+        expect(UnpublishServiceJob).to_not have_received(:perform_later).with(params)
+      end
+    end
+
+    context 'when service is in an automated test service' do
+      UnpublishDevServices::AUTOMATED_TEST_SERVICES.each do |service_id|
+        let(:published_services) do
+          create(
+            :publish_service,
+            :dev,
+            service_id: service_id,
+            status: 'completed'
+          )
+        end
+
+        it 'should not unpublish the automated test service' do
+          expect(UnpublishServiceJob).to_not have_received(:perform_later).with(params)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This rake task will remove all services in the 'test-dev' and 'live-dev' namespaces, except any automated test services (acceptance and smoke tests).

It is to be run manually, via the command line, this is because we will (hopefully) only need to run this very rarely.
This rake task has been created as we need to remove published services in 'live-dev' and 'test-dev' due to the need to re-publish all forms as a result of the CircleCi key rotation.

To run: `bundle exec rake unpublish:dev_services`