### PR TITLE
Add re-publish functionality to admin dashboard

### DIFF
--- a/app/views/admin/services/show.html.erb
+++ b/app/views/admin/services/show.html.erb
@@ -76,6 +76,12 @@
         class: "govuk-button fb-govuk-button",
         disable_with: 'Unpublishing. . .'
     %>
+    <%= link_to 'Re-publish Live', admin_service_republish_path(
+      @service.service_id, @published_to_live[:id], 'production'),
+      method: :post,
+      class: "govuk-button fb-govuk-button",
+      disable_with: 'Re-publishing. . .'
+    %>
     <% end %>
 
     <h2 class="govuk-heading-m govuk-!-margin-top-5">
@@ -119,6 +125,12 @@
         method: :post,
         class: "govuk-button fb-govuk-button",
         disable_with: 'Unpublishing. . .'
+    %>
+    <%= link_to 'Re-publish Test', admin_service_republish_path(
+      @service.service_id, @published_to_test[:id], 'dev'),
+      method: :post,
+      class: "govuk-button fb-govuk-button",
+      disable_with: 'Re-publishing. . .'
     %>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     resources :services, only: [:index, :show, :edit, :update, :create] do
       post '/unpublish/:publish_service_id/:deployment_environment',
         to: 'services#unpublish', as: :unpublish
+      post '/republish/:publish_service_id/:deployment_environment',
+        to: 'services#republish', as: :republish
 
       resources :versions, only: [:update, :edit, :show]
     end


### PR DESCRIPTION
This functionality will re-publish the most recently published version of a service.

This does this by creating a new `PublishServiceCreation` object, which takes in the `ServiceConfiguration` for 'BASIC_AUTH_USER' and 'BASIC_AUTH_PASS' of the service_id, if these exists (ie: if the existing services requires a username/password to access it).

We need to create a new `PublishServiceCreation` as this object understands whether a particular service requires authentication, and it can retrieve the a username/password from the `ServiceConfiguration` table, but it does not hold onto this information after a form is published so we cannot just re-use the last `PublishServiceCreation` object.

Similar to the Unpublish button, the re-publish button will only appear if there is a service that has been published:

![Screenshot 2023-02-02 at 09 04 40](https://user-images.githubusercontent.com/29227502/216280919-ee1be272-e04b-4c58-ba1a-a8cb2ee972ca.png)