### PR TITLE
Add tests for new dimensions property to all connector_path classes

### DIFF
--- a/test/flow_connector_path/down_forward_down_forward_path/properties_test.js
+++ b/test/flow_connector_path/down_forward_down_forward_path/properties_test.js
@@ -39,6 +39,14 @@ describe("DownForwardDownForwardPath", function() {
       expect(created.connector.path).to.equal("M 701,125 v178 a10,10 0 0 0 10,10 h505 a10,10 0 0 1 10,10 v331 a10,10 0 0 0 10,10 h304");
     });
 
+    it('should calculate the correct dimensions', function() {
+        var dimensions = created.connector.dimensions.current;
+        expect(dimensions.down1).to.equal(178);
+        expect(dimensions.forward1).to.equal(505);
+        expect(dimensions.down2).to.equal(331);
+        expect(dimensions.forward2).to.equal(304);
+    });
+
     it("should return points set in constructor", function() {
       expect(created.connector.points).to.exist;
       expect(created.connector.points.from_x).to.equal(POINTS.from_x);

--- a/test/flow_connector_path/down_forward_path/properties_test.js
+++ b/test/flow_connector_path/down_forward_path/properties_test.js
@@ -40,6 +40,12 @@ describe("DownForwardPath", function() {
       expect(created.connector.path).to.equal("M 701,125 v178 a10,10 0 0 0 10,10 h539");
     });
 
+    it('should calculate the correct dimensions', function() {
+        var dimensions = created.connector.dimensions.current;
+        expect(dimensions.down).to.equal(178);
+        expect(dimensions.forward).to.equal(539);
+    });
+
     it("should return points set in constructor", function() {
       expect(created.connector.points).to.exist;
       expect(created.connector.points.from_x).to.equal(POINTS.from_x);

--- a/test/flow_connector_path/down_forward_up_forward_down_path/properties_test.js
+++ b/test/flow_connector_path/down_forward_up_forward_down_path/properties_test.js
@@ -38,6 +38,15 @@ describe("DownForwardUpForwardDownPath", function() {
       expect(created.connector.path).to.equal("M 701,125 v178 a10,10 0 0 0 10,10 h505 a10,10 0 0 0 10,-10 v-308 a10,10 0 0 1 10,-10 h284 a10,10 0 0 1 10,10 v63 a10,10 0 0 0 10,10 h0");
     });
 
+    it('should calculate the correct dimensions', function() {
+        var dimensions = created.connector.dimensions.current;
+        expect(dimensions.down1).to.equal(178);
+        expect(dimensions.forward1).to.equal(505);
+        expect(dimensions.up).to.equal(308);
+        expect(dimensions.forward2).to.equal(284);
+        expect(dimensions.down2).to.equal(63);
+    });
+
     it("should return points set in constructor", function() {
       expect(created.connector.points).to.exist;
       expect(created.connector.points.from_x).to.equal(POINTS.from_x);

--- a/test/flow_connector_path/down_forward_up_path/properties_test.js
+++ b/test/flow_connector_path/down_forward_up_path/properties_test.js
@@ -39,6 +39,14 @@ describe("DownForwardUpPath", function() {
       expect(created.connector.path).to.equal("M 701,125 v428 a10,10 0 0 0 10,10 h505 a10,10 0 0 0 10,-10 v-480 a10,10 0 0 1 10,-10 h14");
     });
 
+    it('should calculate the correct dimensions', function() {
+        var dimensions = created.connector.dimensions.current;
+        expect(dimensions.down).to.equal(428);
+        expect(dimensions.forward1).to.equal(505);
+        expect(dimensions.up).to.equal(480);
+    });
+
+
     it("should return points set in constructor", function() {
       expect(created.connector.points).to.exist;
       expect(created.connector.points.from_x).to.equal(POINTS.from_x);

--- a/test/flow_connector_path/forward_down_backward_up_path/properties_test.js
+++ b/test/flow_connector_path/forward_down_backward_up_path/properties_test.js
@@ -40,6 +40,13 @@ describe("ForwardDownBackwardUpPath", function() {
       expect(created.connector.path).to.equal("M 1451,313 h70 a10,10 0 0 1 10,10 v283 a10,10 0 0 1 -10,10 h-1232 a10,10 0 0 1 -10,-10 v-533 a10,10 0 0 1 10,-10 h0");
     });
 
+    it('should calculate the correct dimensions', function() {
+        var dimensions = created.connector.dimensions.current;
+        expect(dimensions.forward1).to.equal(70);
+        expect(dimensions.down).to.equal(283);
+        expect(dimensions.backward).to.equal(1232);
+    });
+
     it("should return points set in constructor", function() {
       expect(created.connector.points).to.exist;
       expect(created.connector.points.from_x).to.equal(POINTS.from_x);

--- a/test/flow_connector_path/forward_down_forward_path/properties_test.js
+++ b/test/flow_connector_path/forward_down_forward_path/properties_test.js
@@ -40,6 +40,13 @@ describe("ForwardDownForwardPath", function() {
       expect(created.connector.path).to.equal("M 2701,63 h70 a10,10 0 0 1 10,10 v-20 a10,10 0 0 0 10,10 h2462");
     });
 
+    it('should calculate the correct dimensions', function() {
+        var dimensions = created.connector.dimensions.current;
+        expect(dimensions.forward1).to.equal(70);
+        expect(dimensions.down).to.equal(-20);
+        expect(dimensions.forward2).to.equal(2462);
+    });
+
     it("should return points set in constructor", function() {
       expect(created.connector.points).to.exist;
       expect(created.connector.points.from_x).to.equal(POINTS.from_x);

--- a/test/flow_connector_path/forward_path/properties_test.js
+++ b/test/flow_connector_path/forward_path/properties_test.js
@@ -38,6 +38,11 @@ describe("ForwardPath", function() {
       expect(created.connector.path).to.equal("M 10,12 h15");
     });
 
+    it('should calculate the correct dimensions', function() {
+        var dimensions = created.connector.dimensions.current;
+        expect(dimensions.forward).to.equal(15);
+    });
+
     it("should return points set in constructor", function() {
       expect(created.connector.points).to.exist;
       expect(created.connector.points.from_x).to.equal(POINTS.from_x);

--- a/test/flow_connector_path/forward_up_forward_down_path/properties_test.js
+++ b/test/flow_connector_path/forward_up_forward_down_path/properties_test.js
@@ -37,6 +37,14 @@ describe("ForwardUpForwardDownPath", function() {
       expect(created.connector.path).to.equal("M 10,12 h10 a10,10 0 0 0 10,-10 v-7 a10,10 0 0 1 10,-10 h-45 a10,10 0 0 1 10,10 v22 a10,10 0 0 0 10,10 h0");
     });
 
+    it('should calculate the correct dimensions', function() {
+        var dimensions = created.connector.dimensions.current;
+        expect(dimensions.forward1).to.equal(10);
+        expect(dimensions.up).to.equal(7);
+        expect(dimensions.forward2).to.equal(-45);
+        expect(dimensions.down).to.equal(22);
+    });
+
     it("should return points set in constructor", function() {
       expect(created.connector.points).to.exist;
       expect(created.connector.points.from_x).to.equal(POINTS.from_x);

--- a/test/flow_connector_path/forward_up_forward_path/properties_test.js
+++ b/test/flow_connector_path/forward_up_forward_path/properties_test.js
@@ -37,6 +37,13 @@ describe("ForwardUpForwardPath", function() {
       expect(created.connector.path).to.equal("M 10,12 h10 a10,10 0 0 0 10,-10 v--5 a10,10 0 0 1 10,-10 h-15");
     });
 
+    it('should calculate the correct dimensions', function() {
+        var dimensions = created.connector.dimensions.current;
+        expect(dimensions.forward1).to.equal(10);
+        expect(dimensions.up).to.equal(-5);
+        expect(dimensions.forward2).to.equal(-15);
+    });
+
     it("should return points set in constructor", function() {
       expect(created.connector.points).to.exist;
       expect(created.connector.points.from_x).to.equal(POINTS.from_x);


### PR DESCRIPTION
When updating the flow view recently a `dimensions` propoerty was added in order to facilitate easier testing of arrows.  

This allows for testing the actual calculated dimensions of eeach arrow rather than testing the resulting SVG path, which is very hard to read/understand.

This should make it easier if we ever need to adjust arrows in the future.