### PR TITLE
Add tests for EditableCollectionFieldComponent properties

### DIFF
--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -55,6 +55,10 @@ class EditableBase {
     });
   }
 
+  get config() {
+    return this._config;
+  }
+
   get content() {
     return this.$node.text();
   }
@@ -556,6 +560,8 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
     }, config));
 
     this.items = [];
+    // TODO: this should be refactored - preservedItemCount should just be a
+    // config key not dependent on type
     this._preservedItemCount = (this.type == "radios" ? 2 : 1); // Either minimum 2 radios or 1 checkbox.
 
     this.#createCollectionItemTemplate(config);
@@ -966,5 +972,6 @@ module.exports =  {
   EditableTextFieldComponent: EditableTextFieldComponent,
   EditableTextareaFieldComponent: EditableTextareaFieldComponent,
   EditableGroupFieldComponent: EditableGroupFieldComponent,
-  EditableCollectionFieldComponent: EditableCollectionFieldComponent
+  EditableCollectionFieldComponent: EditableCollectionFieldComponent,
+  EditableComponentCollectionItem: EditableComponentCollectionItem,
 }

--- a/test/editable_components/editable_base_test.js
+++ b/test/editable_components/editable_base_test.js
@@ -53,6 +53,19 @@ describe("EditableBase", function() {
       expect(component.$node.length).to.equal(1);
       expect(component.$node.get(0)).to.equal(component.$node.get(0));
     });
+
+    it('should have a config getter', function() {
+      expect(component.config).to.exist;
+      expect(component.config).to.eql({
+        editClassname: EDITABLE_CLASSNAME,
+        form: $form,
+        id: EDITABLE_INPUT_ID,
+        type: 'editable-type',
+        data: {
+          _uuid: EDITABLE_UUID
+        }
+      })
+    })
   })
 
   describe('Methods', function(){

--- a/test/editable_components/editable_collection_field_component/helpers.js
+++ b/test/editable_components/editable_collection_field_component/helpers.js
@@ -1,0 +1,125 @@
+const { EditableCollectionFieldComponent } = require('../../../app/javascript/src/editable_components');
+const GlobalHelpers = require('../../helpers');
+
+const constants = {
+  EDIT_CLASSNAME: 'editable-editing',
+  SELECTOR_LABEL: '.editable-label',
+  SELECTOR_HINT: '.editable-hint',
+  SELECTOR_ITEM: '.editable-collection-item',
+  SELECTOR_ITEM_LABEL: '.editable-collection-item-label',
+  SELECTOR_ITEM_HINT: '.editable-collection-item-hint',
+  COMPONENT_UUID: '5653-2378-7382-2376'
+}
+
+function createEditableCollectionFieldComponent(id, config, itemCount=3, type="checkbox") {
+  var html = `
+      <form id="${id}-form">
+      </form>
+
+    <div id="${id}">
+      <fieldset>
+        <legend class="editable-label">Legend</legend>
+        <div class="editable-hint">Hint</div>
+        <div class="editable-collection-items">
+
+        </div>
+      </fieldset>
+    </div>
+  `;
+
+  $(document.body).append(html);
+
+  let itemHtml = ``;
+  let itemData = [];
+
+  for(i=0; i < itemCount; i++ ) {
+    itemHtml += `
+      <div class="editable-collection-item">
+        <input class="" id="item_${i}" name="item_${i} type="${type}" value="value_${i}">
+        <label class="editable-collection-item-label" for="item_${i}">
+          Label for Item ${i}
+        </label>
+        <div id="item_${i}_hint" class="editable-collection-item-hint">
+          Hint for Item ${i}
+        </div>
+      </div>
+    `;
+    itemData.push({
+      _uuid: '1234567890-'+i,
+      _id: 'item_'+i,
+      value: 'value_'+i,
+    })
+  }
+
+
+  $('.editable-collection-items').append(itemHtml);
+
+  $node = $(document).find('#'+id);
+  $form = $(document).find('#'+id+'-form');
+
+  var conf = {
+    editClassname: constants.EDIT_CLASSNAME,
+    form: $form,
+    id: id,
+    type: 'editable-type',
+    data: {
+      _uuid: constants.COMPONENT_UUID,
+      items: itemData,
+    },
+    text: {
+      edit: 'Edit',
+    },
+    selectorElementLabel: constants.SELECTOR_LABEL,
+    selectorElementHint: constants.SELECTOR_HINT,
+    selectorCollectionItem: constants.SELECTOR_ITEM,
+    selectorCollectionItemLabel: constants.SELECTOR_ITEM_LABEL,
+    selectorCollectionItemHint: constants.SELECTOR_ITEM_HINT,
+  }
+  // include any passed config items.
+  if(config) {
+    for(var prop in config) {
+      if(config.hasOwnProperty(prop)) {
+        conf[prop] = config[prop];
+      }
+    }
+  }
+
+
+  var created = new EditableCollectionFieldComponent($node, conf);
+
+  return {
+    instance: created,
+    $node: $node,
+  }
+}
+
+function createEditableRadiosComponent(id, config) {
+  var conf = {
+    type: 'radios'
+  }
+
+  if(config) {
+    for(var prop in config) {
+      if(config.hasOwnProperty(prop)) {
+        conf[prop] = config[prop];
+      }
+    }
+  }
+
+  return createEditableCollectionFieldComponent(id, conf, 3, "radio");
+}
+
+function teardownView(id) {
+    $("#" + id).remove();
+}
+
+module.exports = {
+  constants: constants,
+  createEditableCollectionFieldComponent: createEditableCollectionFieldComponent,
+  createEditableRadiosComponent: createEditableRadiosComponent,
+  teardownView: teardownView,
+}
+
+
+
+

--- a/test/editable_components/editable_collection_field_component/properties_test.js
+++ b/test/editable_components/editable_collection_field_component/properties_test.js
@@ -1,0 +1,93 @@
+const { createEditableCollectionFieldComponent } = require('./helpers');
+const { EditableComponentCollectionItem } = require('../../../app/javascript/src/editable_components');
+
+require('../../setup');
+
+describe('EditableCollectionFieldComponent', function() {
+  const helpers = require('./helpers');
+  const c = helpers.constants;
+  const COMPONENT_ID = 'editable-collection-field-component-properties-test';
+
+  describe('Properties', function() {
+
+    afterEach(function() {
+      helpers.teardownView(COMPONENT_ID);
+    });
+
+    describe('items', function() {
+      var created;
+
+      beforeEach(function() {
+        created = helpers.createEditableCollectionFieldComponent(COMPONENT_ID);
+      });
+
+      it('should have a public items property', function() {
+        expect(created.instance.items).to.exist;
+        expect(created.instance.items).to.be.an('array');
+        expect(created.instance.items.length).to.equal(3);
+      });
+
+      it('should contain the correct number of items', function() {
+        helpers.teardownView(COMPONENT_ID);
+        created = createEditableCollectionFieldComponent(COMPONENT_ID, {}, 2);
+
+        expect(created.instance.items.length).to.equal(2);
+      });
+
+      it('should contain EditableCollectionItem instances', function() {
+        created.instance.items.forEach((item) => {
+          expect(item).to.be.an.instanceof(EditableComponentCollectionItem);
+        })
+      });
+
+      it('should initialise EditableCollectionItems with config', function() {
+        created.instance.items.forEach((item) => {
+          expect(item.config).to.exist
+          expect(item.config).to.not.have.any.keys([ 'items' ]);
+          expect(item.config).to.include.keys([ 'preserveItem' ]);
+          expect(item.config.data).to.include.all.keys([ '_uuid', '_id', 'value' ]);
+          expect(item.config.data._uuid).to.not.equal(c.COMPONENT_UUID);
+        });
+      });
+
+      it('should set config.preserveItem correctly for checkboxes', function() {
+        expect(created.instance.items[0].config.preserveItem).to.be.true;
+        expect(created.instance.items[1].config.preserveItem).to.be.false;
+      });
+
+      it('should set config.preserveItem key correctly for radios', function() {
+        helpers.teardownView(COMPONENT_ID)
+        created = helpers.createEditableRadiosComponent(COMPONENT_ID);
+
+        expect(created.instance.items[0].config.preserveItem).to.be.true;
+        expect(created.instance.items[1].config.preserveItem).to.be.true;
+        expect(created.instance.items[2].config.preserveItem).to.be.false;
+      });
+    });
+
+    describe('$itemTemplate', function() {
+      var created;
+
+      beforeEach(function() {
+        created = helpers.createEditableCollectionFieldComponent(COMPONENT_ID);
+      });
+
+      it('should have an $itemTemplate property', function() {
+        expect(created.instance.$itemTemplate).to.exist;
+      });
+
+      it('should be different to the first item', function() {
+        var $firstItem = created.instance.$node.find(c.SELECTOR_ITEM).first();
+
+        expect(created.instance.$itemTemplate).to.not.equal($firstItem);
+      });
+
+      it('should have config data', function() {
+          expect(created.instance.$itemTemplate.data('config')).to.exist;
+        var templateConfig = created.instance.$itemTemplate.data('config');
+          expect(templateConfig).to.not.have.any.keys([ 'items' ]);
+          expect(templateConfig.data).to.not.have.any.keys([ '_uuid' ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Due to complexity, breaking the testing for EditableCollectionField into separate PRs for easier review.

This adds tests for the public properties of `EditableCollectionFieldComponent`.

Also added a config getter (and matching test) onto the base `EditableComponent` class in order to facilitate easier testing;  `config` is a private property in the class, exposing a getter means we can read out and iterrogate values in tests.