### PR TITLE
EditableContent component tests

### DIFF
--- a/app/javascript/src/utilities_content.js
+++ b/app/javascript/src/utilities_content.js
@@ -1,0 +1,89 @@
+const showdown  = require('showdown');
+const converter = new showdown.Converter({
+                    noHeaderId: true,
+                    strikethrough: true,
+                    omitExtraWLInCodeBlocks: true,
+                    simplifiedAutoLink: false,
+                    tables: true,
+                    disableForced4SpacesIndentedSublists: true
+                  });
+const sanitizeHtml = require('sanitize-html');
+
+showdown.setFlavor('github');
+
+/* Convert HTML to Markdown by tapping into third-party code.
+ * Includes clean up of HTML by stripping attributes and unwanted trailing spaces.
+ **/
+function convertToMarkdown(html) {
+  var markdown = converter.makeMarkdown(html);
+  return cleanInput(markdown);
+}
+
+
+/* Convert Markdown to HTML by tapping into third-party code.
+ * Includes clean up of both Markdown and resulting HTML to fix noticed issues.
+ **/
+function convertToHtml(markdown) {
+  var html = converter.makeHtml(markdown);
+  return cleanInput(html);
+}
+
+
+/* Opportunity safely strip out anything that we don't want here.
+ *
+ * 1. Something in makeMarkdown is adding <!-- --> markup to the result
+ *    so we're trying to get rid of it.
+ *
+ * 2. sanitize-html is altering automatic link syntax by removing
+ *    everything in (including) angle brackets added by showdown.
+ *
+ *    e.g. [link text](<http://some.url/here>)
+ *
+ *         results in this incorrect markdown (and output):
+ *         [link text]()
+ *
+ *         so we're stripping out the angle brackets to leave this:
+ *         [link text](http://some.url/here)
+ *
+ *         which give us the correct link element (url+text).
+ *
+ * 3. sanitize-html is removing <some@email.com> formatted markup that
+ *    is the recommended syntax in some documentation. This bit will
+ *    filter for that syntax and convert to $mailtosome@email.com$mailto
+ *    which will help to bypass sanitize-html (see step 5).
+ *
+ * 4. Converts unwanted HTML from input (when passed HTML or Markdown).
+ *    Note: Because we're converting from Markup, we need to be careful
+ *          about what is converted into entity or escaped form for
+ *          that reason, we are trying to be minimalistic in approach.
+ *
+ * 5. To follow step 3 (and this must happen after step 4), we now filter
+ *    for $mailtosome@email.com$mailto and replace with the original
+ *    angle brackets to reset to <some@email.com> markdown. It's worth
+ *    noting that, after saving, the markdown of <some@email.com> gets
+ *    converted to [some@email.com](mailto:some@email.com) anyway.
+ *
+ * 6. Fix markdown to blockquote element conversion (broken by the
+ *    sanitize-html) script converting bracket > into &gt; entity.
+ **/
+function cleanInput(input) {
+  // 1.
+  input = input.replace(/\n<!--.*?-->/mig, "");
+  // 2.
+  input = input.replace(/\]\(\<(.*?)\>\)/mig, "]($1)");
+  // 3.
+  input = input.replace(/\<([\w\-\.]+@{1}[\w\-\.]+)>/mig, "$mailto$1$mailto");
+  // 4.
+  input = sanitizeHtml(input);
+  // 5.
+  input = input.replace(/\$mailto([\w\-\.]+@{1}[\w\-\.]+)\$mailto/mig, "<$1>");
+  // 6.
+  input = input.replace(/\n&gt;(\s{1}.*?\n)/mig, "\n>$1");
+  return input;
+}
+
+module.exports  = {
+  convertToMarkdown: convertToMarkdown,
+  convertToHtml: convertToHtml,
+  cleanInput: cleanInput,
+}

--- a/test/editable_components/editable_content/callbacks_test.js
+++ b/test/editable_components/editable_content/callbacks_test.js
@@ -2,9 +2,7 @@ require('../../setup');
 
 describe('EditableContent', function() {
   const helpers = require('./helpers');
-  const c = helpers.constants;
   const COMPONENT_ID = 'editable-content-callbacks-test';
-  const COMPONENT_CLASSNAME = 'EditableContent';
 
   describe('Callbacks', function() {
     var created;

--- a/test/editable_components/editable_content/callbacks_test.js
+++ b/test/editable_components/editable_content/callbacks_test.js
@@ -1,0 +1,41 @@
+require('../../setup');
+
+describe('EditableContent', function() {
+  const helpers = require('./helpers');
+  const c = helpers.constants;
+  const COMPONENT_ID = 'editable-content-callbacks-test';
+  const COMPONENT_CLASSNAME = 'EditableContent';
+
+  describe('Callbacks', function() {
+    var created;
+    var markdownAdjust = sinon.spy();
+
+    beforeEach(function() {
+      created = helpers.createEditableContent(COMPONENT_ID, {
+        markdownAdjustment: markdownAdjust,
+      });
+    });
+
+    afterEach(function() {
+      helpers.teardownView(COMPONENT_ID);
+      created = undefined;
+    });
+
+    describe('set content()', function() {
+      it('should apply markdown adjustments', function() {
+        markdownAdjust.resetHistory()
+        const updated_content =  '## My new markdown\n\nA paragraph';
+        created.instance.content = updated_content;
+        expect(markdownAdjust).to.have.been.calledOnceWith(updated_content);
+      });
+
+      it('should call emitSaveRequired', function() {
+        const spy = sinon.spy(created.instance, "emitSaveRequired");
+        const updated_content =  '## My new markdown\n\nA paragraph';
+        created.instance.content = updated_content;
+        expect(spy).to.have.been.calledOnce;
+      });
+    });
+
+  });
+});

--- a/test/editable_components/editable_content/component_test.js
+++ b/test/editable_components/editable_content/component_test.js
@@ -1,0 +1,58 @@
+require('../../setup');
+
+describe('EditableContent', function() {
+
+  const helpers = require('./helpers');
+  const c = helpers.constants;
+  const COMPONENT_ID = 'editable-content-component-test';
+  const COMPONENT_CLASSNAME = 'EditableContent';
+
+  describe('Component', function() {
+    var created;
+
+    beforeEach(function() {
+      created = helpers.createEditableContent(COMPONENT_ID);
+    });
+
+    afterEach(function() {
+      helpers.teardownView(COMPONENT_ID);
+      created = undefined;
+    });
+
+    it('should remove the contentEditable attribute', function() {
+      var $element = $('#'+COMPONENT_ID);
+      expect($element.attr('contenteditable')).to.equal('false');
+    });
+
+    it('should add the textbox role', function() {
+      var $element = $('#'+COMPONENT_ID);
+      expect($element.attr('role')).to.equal('textbox');
+
+    });
+
+    it('should add the component class name', function() {
+      var $element = $('#'+COMPONENT_ID);
+      expect($element.hasClass(COMPONENT_CLASSNAME)).to.be.true
+    });
+
+    it('should create an input textarea', function() {
+      var $input = $('#'+COMPONENT_ID).find('.input');
+      expect($input).to.exist;
+      expect($input.get(0).nodeName.toLowerCase()).to.equal("textarea");
+      expect($input.length).to.equal(1);
+    });
+
+    it('should create an output container', function() {
+      var $output = $('#'+COMPONENT_ID).find('.output');
+      expect($output).to.exist;
+      expect($output.length).to.equal(1);
+    });
+
+    it('should add the content into the output', function() {
+      var $output = $('#'+COMPONENT_ID).find('.output');
+      expect($output.html()).to.equal(c.HTML_CONTENT)
+    });
+
+
+  });
+});

--- a/test/editable_components/editable_content/component_test.js
+++ b/test/editable_components/editable_content/component_test.js
@@ -8,10 +8,9 @@ describe('EditableContent', function() {
   const COMPONENT_CLASSNAME = 'EditableContent';
 
   describe('Component', function() {
-    var created;
 
     beforeEach(function() {
-      created = helpers.createEditableContent(COMPONENT_ID);
+      helpers.createEditableContent(COMPONENT_ID);
     });
 
     afterEach(function() {

--- a/test/editable_components/editable_content/content_test.js
+++ b/test/editable_components/editable_content/content_test.js
@@ -2,9 +2,7 @@ require('../../setup');
 
 describe('EditableContent', function() {
   const helpers = require('./helpers');
-  const c = helpers.constants;
   const COMPONENT_ID = 'editable-content-content-test';
-  const COMPONENT_CLASSNAME = 'EditableContent';
 
   const DIRTY_MARKDOWN = `
 # My content
@@ -78,10 +76,6 @@ And one final paragraph.`
 </ol>
 <p>And one final paragraph.</p>`
 
-  const getHtml = () => {
-    return $(document).find('.EditableContent .output').html();
-  }
-
   describe('Content', function() {
     var created;
 
@@ -97,7 +91,6 @@ And one final paragraph.`
     it('should remove <!-- --> from content', function() {
       created.instance.$input.val(DIRTY_MARKDOWN);
       created.instance.update();
-      let html = getHtml();
       expect(created.instance.markdown).to.not.include('<!-- -->');
     });
 
@@ -133,7 +126,7 @@ And one final paragraph.`
     it('should output correct html', function() {
       created.instance.$input.val(DIRTY_MARKDOWN);
       created.instance.update();
-      let html = getHtml();
+      let html = $(document).find('.EditableContent .output').html();
       expect(html).to.equal(CLEAN_HTML);
     });
 

--- a/test/editable_components/editable_content/content_test.js
+++ b/test/editable_components/editable_content/content_test.js
@@ -1,0 +1,141 @@
+require('../../setup');
+
+describe('EditableContent', function() {
+  const helpers = require('./helpers');
+  const c = helpers.constants;
+  const COMPONENT_ID = 'editable-content-content-test';
+  const COMPONENT_CLASSNAME = 'EditableContent';
+
+  const DIRTY_MARKDOWN = `
+# My content
+
+This is my lovely content. It has problems.
+
+Here is a link [click me](<https://google.com>).
+
+Here is an email address <email@address.com> it should come out as a link
+
+> This is a blockquote.
+
+Followed by another paragraph
+
+## What about a list or two?
+
+- Item 1
+- Item 2
+- Item 3
+
+1. First
+2. Second
+3. Third
+
+And one final paragraph.
+
+`
+
+  const CLEAN_MARKDOWN = `# My content
+
+This is my lovely content. It has problems.
+
+Here is a link [click me](https://google.com).
+
+Here is an email address <email@address.com> it should come out as a link
+
+> This is a blockquote.
+
+Followed by another paragraph
+
+## What about a list or two?
+
+- Item 1
+- Item 2
+- Item 3
+
+1. First
+2. Second
+3. Third
+
+And one final paragraph.`
+
+  const CLEAN_HTML = `<h1>My content</h1>
+<p>This is my lovely content. It has problems.</p>
+<p>Here is a link <a href="https://google.com">click me</a>.</p>
+<p>Here is an email address <a href="mailto:email@address.com">email@address.com</a> it should come out as a link</p>
+<blockquote>
+  <p>This is a blockquote.</p>
+</blockquote>
+<p>Followed by another paragraph</p>
+<h2>What about a list or two?</h2>
+<ul>
+<li>Item 1</li>
+<li>Item 2</li>
+<li>Item 3</li>
+</ul>
+<ol>
+<li>First</li>
+<li>Second</li>
+<li>Third</li>
+</ol>
+<p>And one final paragraph.</p>`
+
+  const getHtml = () => {
+    return $(document).find('.EditableContent .output').html();
+  }
+
+  describe('Content', function() {
+    var created;
+
+    beforeEach(function() {
+      created = helpers.createEditableContent(COMPONENT_ID);
+    });
+
+    afterEach(function() {
+      helpers.teardownView(COMPONENT_ID);
+      created = undefined;
+    });
+
+    it('should remove <!-- --> from content', function() {
+      created.instance.$input.val(DIRTY_MARKDOWN);
+      created.instance.update();
+      let html = getHtml();
+      expect(created.instance.markdown).to.not.include('<!-- -->');
+    });
+
+    it('should remove angle brackets from links created by showdown', function() {
+      created.instance.$input.val(DIRTY_MARKDOWN);
+      created.instance.update();
+      expect(created.instance.markdown).to.not.include('[click me](<https://google.com>)');
+      expect(created.instance.markdown).to.include('[click me](https://google.com)');
+    });
+
+    it('should contain mailto link <email@address.com>', function() {
+      created.instance.$input.val(DIRTY_MARKDOWN);
+      created.instance.update();
+      expect(created.instance.markdown).to.not.include('$mailtoemail@address.com$mailto');
+      expect(created.instance.markdown).to.include('<email@address.com>');
+    });
+
+    it('should contain correct markdown blockquote syntax', function() {
+      created.instance.$input.val(DIRTY_MARKDOWN);
+      created.instance.update();
+      expect(created.instance.markdown).to.not.include('&gt; This is a blockquote');
+      expect(created.instance.markdown).to.include('> This is a blockquote');
+
+    });
+
+
+    it('should output correct markdown', function() {
+      created.instance.$input.val(DIRTY_MARKDOWN);
+      created.instance.update();
+      expect(created.instance.markdown).to.equal(CLEAN_MARKDOWN);
+    });
+
+    it('should output correct html', function() {
+      created.instance.$input.val(DIRTY_MARKDOWN);
+      created.instance.update();
+      let html = getHtml();
+      expect(html).to.equal(CLEAN_HTML);
+    });
+
+  });
+});

--- a/test/editable_components/editable_content/events_test.js
+++ b/test/editable_components/editable_content/events_test.js
@@ -3,18 +3,15 @@ const { EditableContent } = require('../../../app/javascript/src/editable_compon
 
 describe('EditableContent', function() {
   const helpers = require('./helpers');
-  const c = helpers.constants;
   const COMPONENT_ID = 'editable-content-events-test';
-  const COMPONENT_CLASSNAME = 'EditableContent';
 
   describe('Events', function() {
-    var created;
     var spy;
 
     beforeEach(function() {
       sinon.createSandbox();
       spy = sinon.spy(EditableContent.prototype);
-      created = helpers.createEditableContent(COMPONENT_ID);
+      helpers.createEditableContent(COMPONENT_ID);
     });
 
     afterEach(function() {

--- a/test/editable_components/editable_content/events_test.js
+++ b/test/editable_components/editable_content/events_test.js
@@ -1,0 +1,50 @@
+require('../../setup');
+const { EditableContent } = require('../../../app/javascript/src/editable_components');
+
+describe('EditableContent', function() {
+  const helpers = require('./helpers');
+  const c = helpers.constants;
+  const COMPONENT_ID = 'editable-content-events-test';
+  const COMPONENT_CLASSNAME = 'EditableContent';
+
+  describe('Events', function() {
+    var created;
+    var spy;
+
+    beforeEach(function() {
+      sinon.createSandbox();
+      spy = sinon.spy(EditableContent.prototype);
+      created = helpers.createEditableContent(COMPONENT_ID);
+    });
+
+    afterEach(function() {
+      sinon.restore();
+      helpers.teardownView(COMPONENT_ID);
+      created = undefined;
+    });
+
+    it('should call edit on click $output', function() {
+      const $output = $(document).find('.EditableContent .output')
+      $output.trigger('click');
+
+      expect(spy.edit).to.have.been.calledOnce;
+    })
+
+    it('should call edit on focus $output', function() {
+      const $output = $(document).find('.EditableContent .output')
+      $output.trigger('focus.editablecontent');
+      $output.focus();
+
+      expect(spy.edit).to.have.been.calledOnce;
+    })
+
+    it('should call update on blur $input', function() {
+      const $input = $(document).find('.EditableContent .input')
+      $input.trigger('blur');
+
+      expect(spy.update).to.have.been.calledOnce;
+    })
+
+  });
+
+});

--- a/test/editable_components/editable_content/helpers.js
+++ b/test/editable_components/editable_content/helpers.js
@@ -1,16 +1,17 @@
 const { EditableContent } = require('../../../app/javascript/src/editable_components');
 
 const constants = {
-  EDITABLE_DEFAULT_CONTENT: '[Optional content]',
+  DEFAULT_CONTENT: '[Optional content]',
   HTML_CONTENT: '<h1>Heading</h1><p>This is a paragraph</p><ul><li>Item 1</li><li>Item 2</li></ul>',
-  MARKDOWN_CONTENT: '# Heading\r\n\r\nThis is a paragraph\r\n\r\n* Item 1\r\n* Item 2\r\n',
+  MARKDOWN_CONTENT: '# Heading\n\nThis is a paragraph\n\n- Item 1\n- Item 2\n\n\n',
+  UUID: '1234567890',
+  EDIT_CLASSNAME: 'active',
 }
 
 function createEditableContent(id, config, content) {
-    var text = content ? content : constants.EDITABLE_RAW_CONTENT;
     var html = `<form id="${id}-form">
       </form>
-      <div id="${id}">${HTML_CONTENT}</div>`;
+      <div id="${id}">${constants.HTML_CONTENT}</div>`;
 
   $(document.body).append(html);
 
@@ -23,10 +24,10 @@ function createEditableContent(id, config, content) {
       id: id,
       type: 'content',
       data: {
-        _uuid: '1234567890'
+        _uuid: constants.UUID,
       },
       text: {
-        default_content: ''
+        default_content: constants.DEFAULT_CONTENT
       }
   }
   // include any passed config items.

--- a/test/editable_components/editable_content/helpers.js
+++ b/test/editable_components/editable_content/helpers.js
@@ -1,0 +1,59 @@
+const { EditableContent } = require('../../../app/javascript/src/editable_components');
+
+const constants = {
+  EDITABLE_DEFAULT_CONTENT: '[Optional content]',
+  HTML_CONTENT: '<h1>Heading</h1><p>This is a paragraph</p><ul><li>Item 1</li><li>Item 2</li></ul>',
+  MARKDOWN_CONTENT: '# Heading\r\n\r\nThis is a paragraph\r\n\r\n* Item 1\r\n* Item 2\r\n',
+}
+
+function createEditableContent(id, config, content) {
+    var text = content ? content : constants.EDITABLE_RAW_CONTENT;
+    var html = `<form id="${id}-form">
+      </form>
+      <div id="${id}">${HTML_CONTENT}</div>`;
+
+  $(document.body).append(html);
+
+    $node = $(document).find('#'+id);
+    $form = $(document).find('#'+id+'-form');
+
+  var conf = {
+      editClassname: constants.EDIT_CLASSNAME,
+      form: $form,
+      id: id,
+      type: 'content',
+      data: {
+        _uuid: '1234567890'
+      },
+      text: {
+        default_content: ''
+      }
+  }
+  // include any passed config items.
+  if(config) {
+    for(var prop in config) {
+      if(config.hasOwnProperty(prop)) {
+        conf[prop] = config[prop];
+      }
+    }
+  }
+
+  element = new EditableContent($node, conf);
+
+  return {
+    instance: element,
+    $node: $node,
+    $form: $form,
+  }
+}
+
+function teardownView(id) {
+    $("#" + id).remove();
+    $("#" + id + "-form").remove();
+}
+
+module.exports = {
+  constants: constants,
+  createEditableContent: createEditableContent,
+  teardownView: teardownView
+}

--- a/test/editable_components/editable_content/helpers.js
+++ b/test/editable_components/editable_content/helpers.js
@@ -8,7 +8,7 @@ const constants = {
   EDIT_CLASSNAME: 'active',
 }
 
-function createEditableContent(id, config, content) {
+function createEditableContent(id, config) {
     var html = `<form id="${id}-form">
       </form>
       <div id="${id}">${constants.HTML_CONTENT}</div>`;

--- a/test/editable_components/editable_content/methods_test.js
+++ b/test/editable_components/editable_content/methods_test.js
@@ -3,10 +3,10 @@ require('../../setup');
 describe('EditableContent', function() {
   const helpers = require('./helpers');
   const c = helpers.constants;
-  const COMPONENT_ID = 'editable-content-properties-test';
+  const COMPONENT_ID = 'editable-content-methods-test';
   const COMPONENT_CLASSNAME = 'EditableContent';
 
-  describe('Properties', function() {
+  describe('Methods', function() {
     var created;
 
     beforeEach(function() {

--- a/test/editable_components/editable_content/methods_test.js
+++ b/test/editable_components/editable_content/methods_test.js
@@ -4,7 +4,6 @@ describe('EditableContent', function() {
   const helpers = require('./helpers');
   const c = helpers.constants;
   const COMPONENT_ID = 'editable-content-methods-test';
-  const COMPONENT_CLASSNAME = 'EditableContent';
 
   describe('Methods', function() {
     var created;

--- a/test/editable_components/editable_content/methods_test.js
+++ b/test/editable_components/editable_content/methods_test.js
@@ -1,0 +1,137 @@
+require('../../setup');
+
+describe('EditableContent', function() {
+  const helpers = require('./helpers');
+  const c = helpers.constants;
+  const COMPONENT_ID = 'editable-content-properties-test';
+  const COMPONENT_CLASSNAME = 'EditableContent';
+
+  describe('Properties', function() {
+    var created;
+
+    beforeEach(function() {
+      created = helpers.createEditableContent(COMPONENT_ID);
+    });
+
+    afterEach(function() {
+      helpers.teardownView(COMPONENT_ID);
+      created = undefined;
+    });
+
+    describe('get content()',function() {
+      it('should return markdown if no config data', function() {
+        delete created.instance._config.data;
+
+        expect(created.instance.content).to.equal(c.MARKDOWN_CONTENT);
+      });
+
+      it('should return json if config data is present', function(){
+        const data = {
+          content: c.MARKDOWN_CONTENT,
+          _uuid: c.UUID,
+        }
+        expect(JSON.parse(created.instance.content)).to.have.all.keys(['content', '_uuid'])
+        expect(JSON.parse(created.instance.content)).to.eql(data)
+      });
+
+      it('should return content as an empty string if it matches the default', function(){
+        created.instance.content = c.DEFAULT_CONTENT;
+        const data = {
+          content: '',
+          _uuid: c.UUID,
+        }
+        expect(JSON.parse(created.instance.content)).to.have.all.keys(['content', '_uuid'])
+        expect(JSON.parse(created.instance.content)).to.eql(data)
+      });
+    });
+
+    describe('set content()', function() {
+      it('should store the provided content', function() {
+        const updated_content =  '## My new markdown\n\nA paragraph'
+        created.instance.content = updated_content;
+
+        expect(created.instance.markdown).to.equal(updated_content)
+      });
+    });
+
+    describe('get markdown()', function() {
+      it('should return the markdown', function() {
+        expect(created.instance.markdown).to.equal(c.MARKDOWN_CONTENT)
+      });
+    });
+
+    describe('edit()', function(){
+      it('should apply the editClassname to the $node', function() {
+        expect(created.instance.$node.hasClass(c.EDIT_CLASSNAME)).to.be.false;
+        created.instance.edit();
+        expect(created.instance.$node.hasClass(c.EDIT_CLASSNAME)).to.be.true;
+      });
+
+      it('should add the markdown to the $input', function() {
+        created.instance.$input.val('');
+        created.instance.edit();
+        expect(created.instance.$input.val()).to.equal(c.MARKDOWN_CONTENT);
+      });
+
+      it('should focus the input', function() {
+        const el = created.instance.$input.get(0);
+        created.instance.edit();
+        expect(document.activeElement).to.eql(el);
+      });
+    });
+
+    describe('focus()', function(){
+     it('should apply the editClassname to the $node', function() {
+        expect(created.instance.$node.hasClass(c.EDIT_CLASSNAME)).to.be.false;
+        created.instance.edit();
+        expect(created.instance.$node.hasClass(c.EDIT_CLASSNAME)).to.be.true;
+      });
+
+      it('should add the markdown to the $input', function() {
+        created.instance.$input.val('');
+        created.instance.edit();
+        expect(created.instance.$input.val()).to.equal(c.MARKDOWN_CONTENT);
+      });
+
+      it('should focus the input', function() {
+        const el = created.instance.$input.get(0);
+        created.instance.edit();
+        expect(document.activeElement).to.eql(el);
+      });
+
+    });
+
+    describe('update()', function(){
+      it('should remove the editClassname from the $node', function() {
+        created.instance.edit();
+        expect(created.instance.$node.hasClass(c.EDIT_CLASSNAME)).to.be.true;
+        created.instance.update();
+        expect(created.instance.$node.hasClass(c.EDIT_CLASSNAME)).to.be.false;
+      });
+
+      it('should update the markdown', function() {
+        const updated_content =  '## My new markdown\n\nA paragraph'
+        created.instance.$input.val(updated_content);
+
+        created.instance.update();
+        expect(created.instance.markdown).to.equal(updated_content);
+      });
+
+      it('should output the defaultContent if $input is empty', function(){
+        created.instance.$input.val('');
+        created.instance.update();
+        expect(created.instance.$output.html()).to.equal(`<p>${c.DEFAULT_CONTENT}</p>`)
+      });
+
+      it('should add the html to the $output element', function(){
+        const updated_content =  '## My new markdown\n\nA paragraph'
+        created.instance.$input.val(updated_content);
+
+        created.instance.update();
+
+        expect(created.instance.$output.html()).to.equal(`<h2>My new markdown</h2>\n<p>A paragraph</p>`);
+      });
+    });
+
+  });
+});

--- a/test/editable_components/editable_content/properties_test.js
+++ b/test/editable_components/editable_content/properties_test.js
@@ -2,9 +2,7 @@ require('../../setup');
 
 describe('EditableContent', function() {
   const helpers = require('./helpers');
-  const c = helpers.constants;
   const COMPONENT_ID = 'editable-content-properties-test';
-  const COMPONENT_CLASSNAME = 'EditableContent';
 
   describe('Properties', function() {
     var created;

--- a/test/editable_components/editable_content/properties_test.js
+++ b/test/editable_components/editable_content/properties_test.js
@@ -1,0 +1,41 @@
+require('../../setup');
+
+describe('EditableContent', function() {
+  const helpers = require('./helpers');
+  const c = helpers.constants;
+  const COMPONENT_ID = 'editable-content-properties-test';
+  const COMPONENT_CLASSNAME = 'EditableContent';
+
+  describe('Properties', function() {
+    var created;
+
+    beforeEach(function() {
+      created = helpers.createEditableContent(COMPONENT_ID);
+    });
+
+    afterEach(function() {
+      helpers.teardownView(COMPONENT_ID);
+      created = undefined;
+    });
+
+    it('should have an $input property', function() {
+      var $input = $('#'+COMPONENT_ID).find('.input');
+      expect(created.instance.$input).to.exist;
+      expect(created.instance.$input).to.be.an.instanceof($)
+      expect(created.instance.$input.length).to.equal(1);
+      expect(created.instance.$input).to.eql($input);
+    });
+
+    it('should have an $output property', function() {
+      var $output = $('#'+COMPONENT_ID).find('.output');
+      expect(created.instance.$output).to.exist;
+      expect(created.instance.$output).to.be.an.instanceof($)
+      expect(created.instance.$output.length).to.equal(1);
+      expect(created.instance.$output).to.eql($output);
+    });
+
+    it('should have a markdown property', function() {
+      expect(created.instance.markdown).to.exist;
+    });
+  });
+});


### PR DESCRIPTION
Adds tests for the editable content component.

Includes a couple of small refactors:

* rename the pseud-private `_content` variable to `#markdown` private property.  This makes it actually private, and better communicates *what* is actually stored in it compared to the `content` property.
* Extract `convertToHtml`, `convertToMarkdown` and `cleanInput` functions to a utilities file. 

The intent with these tests is to test the class itself, and not its specific output/conversion - we're not trying to test the showdown markdown converter!

However, the `cleanInput()` method is doing transformations specific to our implementation and quirks of showdown and sanitise-html so I have added in some tests to esure we are testing for those corrections working.


