### PR TITLE
Api::BranchesController should return 401 if there is no session

### DIFF
--- a/app/controllers/api/branches_controller.rb
+++ b/app/controllers/api/branches_controller.rb
@@ -14,4 +14,10 @@ class Api::BranchesController < BranchesController
 
     render layout: false
   end
+
+  def require_user!
+    unless user_signed_in?
+      render json: { message: 'Unauthorised' }, status: :unauthorized
+    end
+  end
 end

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -237,6 +237,12 @@ function updateDomByApiRequest(url, placement) {
     }
 
     safelyActivateFunction(placement.done, $node);
+  })
+  .fail(function(xhr) {
+    // If session has expired, redirect to login
+    if(xhr.status === 401) {
+      window.location.href='/';
+    }
   });
 }
 

--- a/test/branches/branch_answer_test.js
+++ b/test/branches/branch_answer_test.js
@@ -1,6 +1,5 @@
 require("../setup");
 
-
 describe("BranchAnswer", function() {
 
   const helpers = require("./branch_helpers.js");
@@ -17,11 +16,17 @@ describe("BranchAnswer", function() {
     // Hijack $.get to fake a response
     get = $.get;
     $.get = function(urlNotNeeded, response) {
-      response(`<div class="answer">
+        response(`<div class="answer">
                   <select><option>is</option></select>
                   <select><option>This answer value</option></select>
                 </div>`);
-    }
+
+        return({
+          fail: function(callback) {
+            callback({ status: 401 });
+          }
+        });
+      }
 
     // Remove any Answer that is hardcoded.
     $answer = $(c.SELECTOR_PRE_BRANCH_ANSWER, created.$node).remove();

--- a/test/branches/branch_condition_test.js
+++ b/test/branches/branch_condition_test.js
@@ -80,6 +80,12 @@ describe("BranchCondition", function() {
           <select><option>is</option></select>
           <select><option>This answer value</option></select>
         </div>`);
+
+        return({
+          fail: function(callback) {
+            callback({ status: 'error' });
+          }
+        });
       }
     });
 

--- a/test/utilities/update_dom_by_api_request_test.js
+++ b/test/utilities/update_dom_by_api_request_test.js
@@ -12,6 +12,12 @@ describe('utilities.updateDomByApiRequest', function() {
     $(document.body).append("<p id=\"" + TARGET_ID + "\"></p>");
     $.get = function(urlNotNeeded, response) {
       response("<span id=\"" + INSERT_ID + "\">Luke</span>");
+
+      return({
+          fail: function(callback) {
+            callback({ status: 'error' });
+          }
+        });
     }
   });
 


### PR DESCRIPTION
## Issue
If a users session timed out while on the branching screen, and they then performed an interaction that triggered an api request.  That request was returning the login screen html, which was then being inserted into the page - causing it to look very strange.

## Cause
The `Api::BranchesController` - unlike the other controllers within the `Api` namespace - inherits from the main `BranchesController`.  This mean it was calling the main namespace `require_user!` method, which performs a redirect if the user session is no longer active.

## Solution
Add `require_user!` method into the `Api::BranchesController` which returns a JSON response with an unauthorized status. This is duplicated from the main `ApiController`, not overly DRY, but didn't seem worth another mixin/helper.  It seems unlikely that any other api controllers will need to inherit from a class other than the ApiController.

The `updateDOMByApiRequest` utility method was updated to handle reciving a failure response, and then issue a redirect to the login screen.

Som adjustments to tests were required as they were mocking `$.get` so these mocks needed changing to be able to respond to `.fail`



