### PR TITLE
Add tests that prove markdown/html conversion should preserve nested lists

### DIFF
--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -281,7 +281,7 @@ class EditableContent extends EditableElement {
 
   update() {
     // Figure out what content to show in output area.
-    const currentInput = this.$input.val().trim();
+    const currentInput = this.$input.val();
     const defaultContent = this._defaultContent || this._originalContent;
     const markdown = (currentInput == "" ? defaultContent : currentInput);
     const html = this.#convertToHtml(markdown);

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -176,7 +176,7 @@ class EditableContent extends EditableElement {
     var $input = $("<textarea class=\"input\"></textarea>");
     var $output = $("<div class=\"output\"></div>");
     var $span = $("<span>measure</span>");
-    var html = $node.html(); // Stored Markdown is originally converted at template level
+    var html = $node.html().trim(); // Stored Markdown is originally converted at template level
     var lineHeight;
 
     // Use temporary hidden <span> for obtaining lineHeight measurement
@@ -281,7 +281,7 @@ class EditableContent extends EditableElement {
 
   update() {
     // Figure out what content to show in output area.
-    const currentInput = this.$input.val();
+    const currentInput = this.$input.val().trim();
     const defaultContent = this._defaultContent || this._originalContent;
     const markdown = (currentInput == "" ? defaultContent : currentInput);
     const html = this.#convertToHtml(markdown);

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -176,7 +176,7 @@ class EditableContent extends EditableElement {
     var $input = $("<textarea class=\"input\"></textarea>");
     var $output = $("<div class=\"output\"></div>");
     var $span = $("<span>measure</span>");
-    var html = $node.html().trim(); // Stored Markdown is originally converted at template level
+    var html = $node.html(); // Stored Markdown is originally converted at template level
     var lineHeight;
 
     // Use temporary hidden <span> for obtaining lineHeight measurement

--- a/test/editable_components/editable_content/content_test.js
+++ b/test/editable_components/editable_content/content_test.js
@@ -20,10 +20,12 @@ Followed by another paragraph
 ## What about a list or two?
 
 - Item 1
+  - Item 1.1
 - Item 2
 - Item 3
 
 1. First
+  1.1 One point oneth
 2. Second
 3. Third
 
@@ -46,10 +48,12 @@ Followed by another paragraph
 ## What about a list or two?
 
 - Item 1
+  - Item 1.1
 - Item 2
 - Item 3
 
 1. First
+  1.1 One point oneth
 2. Second
 3. Third
 
@@ -65,12 +69,14 @@ And one final paragraph.`
 <p>Followed by another paragraph</p>
 <h2>What about a list or two?</h2>
 <ul>
-<li>Item 1</li>
+<li>Item 1<ul>
+<li>Item 1.1</li></ul></li>
 <li>Item 2</li>
 <li>Item 3</li>
 </ul>
 <ol>
-<li>First</li>
+<li>First<br>
+1.1 One point oneth</li>
 <li>Second</li>
 <li>Third</li>
 </ol>

--- a/test/editable_components/editable_content/content_test.js
+++ b/test/editable_components/editable_content/content_test.js
@@ -25,7 +25,8 @@ Followed by another paragraph
 - Item 3
 
 1. First
-  1.1 One point oneth
+  1. One point oneth
+  2. One point twoeth
 2. Second
 3. Third
 
@@ -53,7 +54,8 @@ Followed by another paragraph
 - Item 3
 
 1. First
-  1.1 One point oneth
+  1. One point oneth
+  2. One point twoeth
 2. Second
 3. Third
 
@@ -75,8 +77,9 @@ And one final paragraph.`
 <li>Item 3</li>
 </ul>
 <ol>
-<li>First<br>
-1.1 One point oneth</li>
+<li>First<ol>
+<li>One point oneth</li>
+<li>One point twoeth</li></ol></li>
 <li>Second</li>
 <li>Third</li>
 </ol>


### PR DESCRIPTION
The whitespace in the markdown is structural and used to denote nested list items.

There's a bug where going in and out of edit mode is mangling whitespace and carriage returns, which is paused for now but these tests I wrote during the process seemed valuable enough to keep (they're really just testing showdown but they'll be handy for preventing regressions when this bug is further investigated)