### PR TITLE
Reply-To: Template changes to Collect Information by Email settings page

### DIFF
--- a/acceptance/features/from_address_spec.rb
+++ b/acceptance/features/from_address_spec.rb
@@ -39,36 +39,6 @@ feature 'From address' do
     then_I_click_the_contact_us_link
   end
 
-  shared_examples 'send data by email page' do
-    scenario 'from address warning messages' do
-      and_I_visit_the_submission_settings_page
-      then_I_should_see_the_send_data_by_email_page
-
-      and_I_set_send_by_email(true)
-      then_I_should_see_the_send_data_by_email_from_address_warnings('default'.to_sym)
-
-      when_I_visit_the_from_address_settings_page
-      when_I_change_my_from_address(configs[:pending][:email])
-      then_I_should_see_the_contact_us_message
-
-      and_I_visit_the_submission_settings_page
-      and_I_set_send_by_email(true)
-      then_I_should_see_the_send_data_by_email_from_address_warnings('pending'.to_sym)
-    end
-  end
-
-  context 'when dev environment' do
-    let(:environment) { 'dev' }
-
-    it_behaves_like 'send data by email page'
-  end
-
-  context 'when production environment' do
-    let(:environment) { 'production' }
-
-    it_behaves_like 'send data by email page'
-  end
-
   ## From Address Settings page
   def then_I_should_see_the_from_address_settings_page
     expect(page).to have_content(I18n.t('settings.from_address.heading'))

--- a/app/views/settings/email/_email_fieldset.html.erb
+++ b/app/views/settings/email/_email_fieldset.html.erb
@@ -1,4 +1,11 @@
 <%= f.govuk_fieldset(legend: { text: f.object.class.human_attribute_name(:email_fieldset) }) do %>
+
+  <% if ENV['REPLY_TO'] == 'enabled' %>
+    <div class="govuk-form-group">
+      <%= f.object.class.human_attribute_name :service_email_from %>
+      <%=f.object.service.service_name %>
+    </div>
+  <% else %>
     <div class="govuk-form-group">
       <%= f.object.class.human_attribute_name :service_email_from %>
       <strong> "<%=f.object.service.service_name %>" </strong>
@@ -18,6 +25,7 @@
         </p>
       <% end %>
     </div>
+  <% end %>
 
     <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.present? ? 'govuk-form-group--error' : '' %>">
       <% if f.object.errors.present? %>


### PR DESCRIPTION
### Update 'collect information by email' settings page
As part of reply-to, we will now use the default no-reply-moj-forms email address as the 'From address'.
So we no longer want users to access the 'From Address' page via the 'Change from address' link, we also do not want to show any warnings related to from address.
This commit removes access to the link and the warnings associated to the from address verification. We now just present the Form name, not the email address.

### Remove failing acceptance tests
Now that we can no longer show any from address warnings on the 'Collect information by email' page, these tests will fail.

#### Before
![Screenshot 2023-02-23 at 11 44 31](https://user-images.githubusercontent.com/29227502/220897589-f24da035-31d0-43e1-ac00-621190b69e08.png)

#### After
![Screenshot 2023-02-23 at 11 44 00](https://user-images.githubusercontent.com/29227502/220897637-cf84602d-950d-4f06-b548-7e775d887e90.png)