### PR TITLE
Remove from address publish warnings for Test and Live environments

### DIFF
--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -123,21 +123,8 @@ feature 'Publishing' do
 
       when_I_visit_the_publishing_page
       then_I_should_not_see_autocomplete_warnings
-      then_I_should_see_the_publish_button
+      then_the_publish_button_should_be_enabled
     end
-
-    scenario 'when from address is not validated' do
-      when_I_enable_the_submission_settings
-      when_I_visit_the_publishing_page
-      then_I_should_see_from_address_warning('default')
-
-      when_I_visit_the_from_address_settings_page
-      when_I_change_my_from_address('miriel@numenor.me')
-
-      when_I_visit_the_publishing_page
-      then_I_should_see_from_address_warning('pending')
-    end
-
   end
 
   context 'when dev environment' do
@@ -343,15 +330,6 @@ feature 'Publishing' do
 
   def then_I_should_see_the_submission_warning_message
     expect(editor.text).to include(I18n.t("warnings.publish.#{environment}.heading"))
-  end
-
-
-  def then_I_should_see_the_submission_confiramtion_email_warning_message
-    expect(editor.text).to include(I18n.t("warnings.publish.#{environment}.heading"))
-  end
-
-  def then_I_should_see_from_address_warning(status)
-    expect(editor.text).to include(I18n.t("warnings.from_address.publishing.#{environment}.#{status}", link: I18n.t("warnings.from_address.link_text")))
   end
 
   def then_I_should_see_autocomplete_warnings

--- a/app/presenters/publishing_page_presenter.rb
+++ b/app/presenters/publishing_page_presenter.rb
@@ -73,7 +73,7 @@ class PublishingPagePresenter
 
     return presenters if deployment_environment == 'dev'
 
-    presenters.push(from_address_warning) if service_output_warning.blank?
+    presenters.push(from_address_warning) if service_output_warning.blank? && !ENV['REPLY_TO'] == 'enabled'
     presenters.push(autocomplete_warning)
   end
 end

--- a/app/views/publish/_publish_environment.html.erb
+++ b/app/views/publish/_publish_environment.html.erb
@@ -15,7 +15,9 @@
   <% if environment == 'dev' %>
     <% if presenter.service_output_warning.blank? %>
       <%= render 'publish/warnings/submission', warning: presenter.submission_warnings, environment: environment %>
-      <%= render 'publish/warnings/from_address', warning: presenter.from_address_warning, environment: environment %>
+      <% if ENV['REPLY_TO'] == 'disabled' %>
+        <%= render 'publish/warnings/from_address', warning: presenter.from_address_warning, environment: environment %>
+      <% end %>
     <% end %>
     <%= render 'publish/warnings/autocomplete', warning: presenter.autocomplete_warning, environment: environment %>
   <% end %>

--- a/spec/presenters/publishing_page_presenter_spec.rb
+++ b/spec/presenters/publishing_page_presenter_spec.rb
@@ -70,8 +70,7 @@ RSpec.describe PublishingPagePresenter do
         let(:presenters) do
           [
             submission_pages_presenter,
-            autocomplete_warning,
-            from_address_warning
+            autocomplete_warning
           ]
         end
 


### PR DESCRIPTION
Now that email addresses for reply-to will be validated on save, we no longer require this warning.

Hide warnings in the template and only add the from_address warnings if the environment variable is disabled.

#### Before
![Screenshot 2023-02-23 at 15 59 54](https://user-images.githubusercontent.com/29227502/220961842-e3fb7371-5a9a-422b-86ff-d63fef3f42b1.png)

#### After
![Screenshot 2023-02-23 at 15 59 19](https://user-images.githubusercontent.com/29227502/220961877-58e4bc0c-47af-45b4-a463-3efe9e4cf6ab.png)
