### PR TITLE
bump metadata presenter to 2.17.37

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,9 @@ gem 'delayed_job_active_record'
 # one of these lines:
 # gem 'metadata_presenter',
 #     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'payment-link-heading-exit-page'
+# branch: 'payment-link-heading-exit-page'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.17.36'
+gem 'metadata_presenter', '2.17.37'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.36)
+    metadata_presenter (2.17.37)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -473,7 +473,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 2.17.36)
+  metadata_presenter (= 2.17.37)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
Bumps metadata presenter gem to 2.17.37 to fix issues with the send body content editable field on the check answers page.