### PR TITLE
Fix acceptance tests

### DIFF
--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -19,6 +19,7 @@ feature 'Publishing' do
       I18n.t('activemodel.errors.models.publish_service_creation.password_too_short'),
     ]
   end
+  let(:valid_email) { 'station-master-tama@justice.gov.uk' }
 
   shared_examples 'a publishing page environment' do
     let(:exit_url) { 'exit' }
@@ -220,6 +221,8 @@ feature 'Publishing' do
 
     and_I_set_confirmation_email(true)
     within("form#confirmation-email-submission-#{environment}") do
+      editor.find(:css, "input#confirmation-email-settings-confirmation-email-reply-to-#{environment}-field").set(valid_email)
+
       find('button[type="submit"]').click
     end
   end
@@ -261,7 +264,7 @@ feature 'Publishing' do
     and_I_save_my_email_settings
   end
 
-  def and_I_set_the_email_field(value = 'paul@justice.gov.uk')
+  def and_I_set_the_email_field(value = valid_email)
     editor.find(:css, "#email-settings-service-email-output-#{environment}-field").set(value)
   end
 

--- a/acceptance/features/reference_payment_spec.rb
+++ b/acceptance/features/reference_payment_spec.rb
@@ -29,8 +29,10 @@ feature 'Reference Payment Page' do
     then_I_add_a_page_with_email_component
     when_I_visit_the_confirmation_email_settings_page
     when_I_enable_confirmation_email('dev')
+    then_I_add_a_reply_to_email('iorek.byrnison@digital.justice.gov.uk', 'dev')
     click_button(I18n.t('settings.submission.dev.save_button'))
     when_I_enable_confirmation_email('production')
+    then_I_add_a_reply_to_email('iorek.byrnison@digital.justice.gov.uk', 'production')
     click_button(I18n.t('settings.submission.production.save_button'))
     when_I_visit_the_reference_payment_page
     expect(page).to_not have_css('.govuk-notification-banner__content', text: confirmation_warning_title)
@@ -170,5 +172,10 @@ feature 'Reference Payment Page' do
   def when_I_update_the_question_name
     and_I_edit_the_question
     when_I_save_my_changes
+  end
+
+  ## Confirmation Email Settings Page
+  def then_I_add_a_reply_to_email(email, environment)
+    editor.find(:css, "input#confirmation-email-settings-confirmation-email-reply-to-#{environment}-field").set(email)
   end
 end


### PR DESCRIPTION
The confirmation email settings now requires the user to add an email address.

Previously, the acceptance tests assumed clicking save would mean confirmation emails had been configured. But in these acceptance tests it just triggers a validation error and hence the messaging on the publishing page and reference payment setting pages were not as expected. Updated the acceptance tests so we are now submitting an email for the confirmation email settings page.