### PR TITLE
Fix interpolation of hint id attribute

### DIFF
--- a/app/views/settings/confirmation_email/_form.html.erb
+++ b/app/views/settings/confirmation_email/_form.html.erb
@@ -15,7 +15,7 @@
     <%= f.govuk_check_boxes_fieldset :"send_by_confirmation_email_#{deployment_environment}",
       multiple: false,
       legend: { text: t("publish.#{deployment_environment}.heading"), size: 'l'} do %>
-      <div class="govuk-hint" id="send_by_confirmation_email_#{deployment_environment}_hint"><%= t("publish.#{deployment_environment}.description") %></div>
+      <div class="govuk-hint" id=<%= "send_by_confirmation_email_#{deployment_environment}_hint" %>><%= t("publish.#{deployment_environment}.description") %></div>
       <%= f.govuk_check_box :"send_by_confirmation_email_#{deployment_environment}", 1, 0,
         multiple: false,
         link_errors: true,


### PR DESCRIPTION
The deployment environment was not interpolating correctly in the template, causing an accessibility issue as the hint id was not unique. This commit fixes this.


### Before
![Screenshot 2023-03-10 at 10 37 20](https://user-images.githubusercontent.com/29227502/224294878-3072d85f-c8c9-47c6-9d44-64d806380103.png)

### After
![Screenshot 2023-03-10 at 10 36 16](https://user-images.githubusercontent.com/29227502/224294907-6550e15f-98ac-40e2-b2cb-e1d5631365ec.png)
