### PR TITLE
Change editor session to last during working hours

### DIFF
--- a/deploy-eks/fb-editor-chart/templates/sessions_trim.yaml
+++ b/deploy-eks/fb-editor-chart/templates/sessions_trim.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fb-editor-cron-sessions-trim-{{ .Values.environmentName }}
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 spec:
-  schedule: "*/30 * * * *"
+  schedule: "0 20 * * *"
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3
   jobTemplate:

--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -1,9 +1,7 @@
 namespace 'db:sessions' do
-  desc 'Trim old sessions from the table (> 90 minutes)'
+  desc 'Trim all sessions from the table'
   task trim: [:environment, 'db:load_config'] do
-    cutoff_period = 90.minutes.ago
     ActiveRecord::SessionStore::Session
-    .where('updated_at < ?', cutoff_period)
     .delete_all
   rescue StandardError => e
     Sentry.capture_exception(e)


### PR DESCRIPTION
Update session clear job to delete all sessions, update cron schedule to fire once per day at 20:00

Users will be logged out at 20:00 and will need to log in again when next using the editor, we aim to allow users to log in at the start of the working day then be logged out at 2000 hrs

This lines up with the auth0 session anyway which lasts 10 hours, and alleviates user pain points (not to mention accessibility issues) around being unable to extend your session and being logged out every 90 mins.

We have future work planned soon (this quarter) to introduce RBAC anyway which will invalidate how we currently manage user identity and sessions.

Cron syntax from crontab
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/7647632/226383991-58cfd731-a497-401f-bc8d-37ba79c62f37.png">
