### PR TITLE
Fix return value of in_progress? method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -104,7 +104,7 @@ class ApplicationController < ActionController::Base
   end
 
   def in_progress?
-    false
+    true
   end
   helper_method :in_progress?
 


### PR DESCRIPTION
This method appears to be badly named (I think I must have adjusted the boolean return value at somepoint in development in the runner and then not fully reverted that line of exporation!)  🤦‍♂️ sorry

It actually needs to return true here to prevent the session timeout partials being added into the view in preview.

The proper fix probably requires the method being fixed in the runner to return the alternate value and then the condition switched in the presenter. This quickly resolves the editor preview issue though