### PR TITLE
Update to node 16.20.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ jobs:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-            nvm install v16.19.1
-            nvm alias default 16.19.1
+            nvm install v16.20.0
+            nvm alias default 16.20.0
 
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ New editor from the MoJ online.
 
 ## Prerequisites
 * Docker
-* Node (version 16.19.1 LTS)
+* Node (version 16.20.0 LTS)
 * Ruby v2.7.7
 * Postgresql
 * Yarn
 
 ## Setup
-Ensure you are running Node version 16.19.1 LTS. Easiest is to install [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) and then:
-`nvm install 16.19.1`
-`nvm use 16.19.1`
+Ensure you are running Node version 16.20.0 LTS. Easiest is to install [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) and then:
+`nvm install 16.20.0`
+`nvm use 16.20.0`
 
 Install gems:
 `bundle`

--- a/acceptance/Dockerfile
+++ b/acceptance/Dockerfile
@@ -5,7 +5,7 @@ ARG UID=1001
 RUN apk add git yarn build-base postgresql-contrib postgresql-dev bash libcurl
 RUN apk add build-base bash tzdata chromium-chromedriver chromium zlib-dev xorg-server
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs npm
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=16.20.0-r0 npm
 
 WORKDIR /usr/src/app
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update
 RUN apk add git yarn build-base postgresql-contrib postgresql-dev \
       bash libcurl curl
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs npm
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=16.20.0-r0 npm
 RUN apk add clamav-daemon
 RUN apk add --no-cache gcompat
 

--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -4,7 +4,7 @@ ARG UID=1001
 
 RUN apk add git yarn build-base postgresql-contrib postgresql-dev bash libcurl curl
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs npm
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=16.20.0-r0 npm
 
 ARG KUBE_VERSION="1.21.0"
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fb_editor",
   "private": true,
   "engines": {
-    "node": "16.19.1"
+    "node": "16.20.0"
   },
   "scripts": {
     "jstest": "mocha --recursive"


### PR DESCRIPTION
APK have pulled the previous version of node.
This commit bumps to node version 16.20.0

Circle run: 
https://app.circleci.com/pipelines/github/ministryofjustice/fb-editor/7945/workflows/ac176318-e265-4635-924e-e912d24966d7