### PR TITLE
Increase the read timeout but keep the open timeout as is

### DIFF
--- a/app/services/metadata_api_client/connection.rb
+++ b/app/services/metadata_api_client/connection.rb
@@ -1,7 +1,8 @@
 module MetadataApiClient
   class Connection
     SUBSCRIPTION = 'metadata_api.client'
-    TIMEOUT = 10
+    OPEN_TIMEOUT = 10
+    TIMEOUT = 15
 
     attr_reader :connection
 
@@ -13,7 +14,7 @@ module MetadataApiClient
         conn.response :json
         conn.response :raise_error
         conn.use :instrumentation, name: SUBSCRIPTION
-        conn.options[:open_timeout] = TIMEOUT
+        conn.options[:open_timeout] = OPEN_TIMEOUT
         conn.options[:timeout] = TIMEOUT
 
         conn.request :authorization, 'Bearer', service_access_token


### PR DESCRIPTION
We have an error which only affects the read timeout. This has occurred when a user has tried to publish a form unsuccessfully.

We think because the form being published is large, it is taking too long to read the metadata from the metadata api and is then timing out.

This PR will only change the read timeout as the open timeout is not the issue.

Faraday's `open_timeout` is equivalent to Net::HTTP's `open_timeout`.
Faraday's `timeout` is equivalent to Net::HTTP's `read_timeout`.

Open timeout: Number of seconds to wait for the connection to open.
Read timeout: Number of seconds to wait for one block to be read.