### PR TITLE
Testable new soft linebreaks fix

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,7 +7,6 @@
 // Scripts called by javascript_pack_tag
 require("jquery")
 require("jquery-ui")
-require("showdown")
 require("../src/index")
 
 // Entry point for fb-editor stylesheets

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -225,6 +225,7 @@ class EditableContent extends EditableElement {
     this._lineHeight = lineHeight;
     this.$input = $input;
     this.$output = $output;
+    console.log(html);
     this.content = this.#convertToMarkdown(html);
 
     if(config.text.default_content) {
@@ -310,6 +311,13 @@ class EditableContent extends EditableElement {
    **/
   #convertToMarkdown(html) {
     var markdown = this.#converter.makeMarkdown(html);
+    // For some reason <br> tags are not being converted correctly into 2 psaces
+    // and a newline.  This fixes that problem, nut it feels like a bad fix, and
+    // like we shouldn't have to do this!
+    console.log(markdown);
+    markdown = markdown.replace(/<br>\n\n/mig, "  \n");
+    console.log(markdown)
+    return markdown;
     return this.#cleanInput(markdown);
   }
 

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -311,14 +311,17 @@ class EditableContent extends EditableElement {
    **/
   #convertToMarkdown(html) {
     var markdown = this.#converter.makeMarkdown(html);
-    // For some reason <br> tags are not being converted correctly into 2 psaces
-    // and a newline.  This fixes that problem, nut it feels like a bad fix, and
-    // like we shouldn't have to do this!
-    console.log(markdown);
-    markdown = markdown.replace(/<br>\n\n/mig, "  \n");
-    console.log(markdown)
+
+    // As of 30-03-23 the currently published version of showdown does not parse <br> tags
+    // into 2 spaces and a newline. See this issue: https://github.com/showdownjs/showdown/issues/974
+    // A partial fix exists in develop and master branch of the project.
+    // Use a simple regex to fix the problem. N.B. Trailing space is included in
+    // regex because showdown inserts a space between each node before conversion,
+    // meaning the text nodes after a <br> have a leading space
+    markdown = markdown.replace(/<br\s?\/?>\n\n /mig, "  \n");
+
+    markdown = this.#cleanInput(markdown);
     return markdown;
-    return this.#cleanInput(markdown);
   }
 
 

--- a/test/editable_components/editable_content/content_test.js
+++ b/test/editable_components/editable_content/content_test.js
@@ -125,7 +125,6 @@ And one final paragraph.`
 
     });
 
-
     it('should output correct markdown', function() {
       created.instance.$input.val(DIRTY_MARKDOWN);
       created.instance.update();
@@ -138,6 +137,32 @@ And one final paragraph.`
       let html = $(document).find('.EditableContent .output').html();
       expect(html).to.equal(CLEAN_HTML);
     });
+
+  });
+
+  describe('Special Cases', function() {
+    var created;
+
+    beforeEach(function() {
+    });
+
+    afterEach(function() {
+      helpers.teardownView(COMPONENT_ID);
+      created = undefined;
+    });
+
+    it('should handle soft linebreaks', function() {
+      var html = `<p>This is a paragraph</p>
+      <p>Address line 1<br>
+      Address line 2<br>
+      Town<br>
+      Postcode</p>
+      `;
+      created = helpers.createEditableContent(COMPONENT_ID,{}, html );
+
+      expect(created.instance.markdown).to.eql('This is a paragraph\n\nAddress line 1  \nAddress line 2  \nTown  \nPostcode\n\n');
+    });
+  
 
   });
 });

--- a/test/editable_components/editable_content/helpers.js
+++ b/test/editable_components/editable_content/helpers.js
@@ -8,10 +8,10 @@ const constants = {
   EDIT_CLASSNAME: 'active',
 }
 
-function createEditableContent(id, config) {
+function createEditableContent(id, config, htmlContent=null) {
     var html = `<form id="${id}-form">
       </form>
-      <div id="${id}">${constants.HTML_CONTENT}</div>`;
+      <div id="${id}">${htmlContent ?? constants.HTML_CONTENT}</div>`;
 
   $(document.body).append(html);
 


### PR DESCRIPTION
Adds in a regex to cover the fact that showdown doesn't handle `<br>` tags 🤦‍♂️

Replaces `<br>` tag with coortect double-space and newline for markdown.