### PR TITLE
Fix $cta tag rendering in editable content areas

### DIFF
--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -225,7 +225,6 @@ class EditableContent extends EditableElement {
     this._lineHeight = lineHeight;
     this.$input = $input;
     this.$output = $output;
-    console.log(html);
     this.content = this.#convertToMarkdown(html);
 
     if(config.text.default_content) {
@@ -257,11 +256,9 @@ class EditableContent extends EditableElement {
 
   set content(markdown) {
     // Check if configuration requires external adjustment to markdown
-    console.log(markdown)
     if(this._config.markdownAdjustment) {
       markdown = safelyActivateFunction(this._config.markdownAdjustment, markdown);
     }
-    console.log(markdown)
     this.#markdown = markdown;
     this.emitSaveRequired();
   }
@@ -301,7 +298,6 @@ class EditableContent extends EditableElement {
   #output(content) {
     // Check if configuration requires external adjustment to html
     if(this._config.htmlAdjustment) {
-      console.log('adjusting html')
       content = safelyActivateFunction(this._config.htmlAdjustment, content);
     }
 

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -257,10 +257,11 @@ class EditableContent extends EditableElement {
 
   set content(markdown) {
     // Check if configuration requires external adjustment to markdown
+    console.log(markdown)
     if(this._config.markdownAdjustment) {
       markdown = safelyActivateFunction(this._config.markdownAdjustment, markdown);
     }
-
+    console.log(markdown)
     this.#markdown = markdown;
     this.emitSaveRequired();
   }
@@ -291,7 +292,7 @@ class EditableContent extends EditableElement {
     this.content = this.#cleanInput(markdown);
 
     // Add latest content to output area
-    this.$output.html(html);
+    this.#output(html);
 
     this.$node.removeClass(this._config.editClassname);
   }
@@ -300,6 +301,7 @@ class EditableContent extends EditableElement {
   #output(content) {
     // Check if configuration requires external adjustment to html
     if(this._config.htmlAdjustment) {
+      console.log('adjusting html')
       content = safelyActivateFunction(this._config.htmlAdjustment, content);
     }
 

--- a/app/javascript/src/shared/content.js
+++ b/app/javascript/src/shared/content.js
@@ -48,7 +48,9 @@ function supportGovUKTableCSS(html) {
  * ---------------------------------------------------------------------------
  *
  * 1. If we're passing HTML then we expect
- *       <p>$cta something like this $cta </p>
+ *       <p>$cta something like this $cta </p> or
+ *       <p><br>$cta something like this $cta <br></p> or
+ *
  *
  *    and want to turn it into
  *       <div class=\"call-to-action\"><p>something like this</p></div>
@@ -75,7 +77,12 @@ function supportGovUKTableCSS(html) {
  **/
 function supportGovSpeakCtaMarkup(content) {
   console.log(content)
-  // 1.
+  // 1.  \$cta            - match fixed string $cta
+  //      (?:<br\s?\/>)?  - optionally match <br> | <br/> | <br /> without capturing group
+  //      \n?             - optional newline
+  //      (.*)?           - optional capture all characters
+  //      \n?             - optional newline
+  //      \$cta           - match fixed $cta string
   content = content.replace(/<p>\$cta(?:<br\s?\/?>)?\n?(.*)?\n?\$cta<\/p>/migs, "<div class=\"call-to-action\"><p>$1</p></div>");
   // 2.
   content = content.replace(/\$cta (.*)\$cta/migs, "$cta\n$1\n$cta");

--- a/app/javascript/src/shared/content.js
+++ b/app/javascript/src/shared/content.js
@@ -74,10 +74,13 @@ function supportGovUKTableCSS(html) {
  *
  **/
 function supportGovSpeakCtaMarkup(content) {
+  console.log(content)
   // 1.
-  content = content.replace(/<p>\$cta\n?(.*)?\n?\$cta<\/p>/mig, "<div class=\"call-to-action\"><p>$1</p></div>");
+  content = content.replace(/<p>\$cta(?:<br\s?\/?>)?\n?([^<]*)(?:<br\s?\/?>)?\n?\$cta<\/p>/mig, "<div class=\"call-to-action\"><p>$1</p></div>");
   // 2.
-  content = content.replace(/\$cta It looks like this. \$cta/, "$cta\nIt looks like this.\n$cta");
+  content = content.replace(/\$cta (.*)\$cta/migs, "$cta\n$1\n$cta");
+
+  console.log(content)
   return content;
 }
 

--- a/app/javascript/src/shared/content.js
+++ b/app/javascript/src/shared/content.js
@@ -76,7 +76,7 @@ function supportGovUKTableCSS(html) {
 function supportGovSpeakCtaMarkup(content) {
   console.log(content)
   // 1.
-  content = content.replace(/<p>\$cta(?:<br\s?\/?>)?\n?([^<]*)(?:<br\s?\/?>)?\n?\$cta<\/p>/mig, "<div class=\"call-to-action\"><p>$1</p></div>");
+  content = content.replace(/<p>\$cta(?:<br\s?\/?>)?\n?(.*)?\n?\$cta<\/p>/migs, "<div class=\"call-to-action\"><p>$1</p></div>");
   // 2.
   content = content.replace(/\$cta (.*)\$cta/migs, "$cta\n$1\n$cta");
 

--- a/app/javascript/src/shared/content.js
+++ b/app/javascript/src/shared/content.js
@@ -76,18 +76,25 @@ function supportGovUKTableCSS(html) {
  *
  **/
 function supportGovSpeakCtaMarkup(content) {
-  console.log(content)
-  // 1.  \$cta            - match fixed string $cta
-  //      (?:<br\s?\/>)?  - optionally match <br> | <br/> | <br /> without capturing group
-  //      \n?             - optional newline
-  //      (.*)?           - optional capture all characters
-  //      \n?             - optional newline
-  //      \$cta           - match fixed $cta string
-  content = content.replace(/<p>\$cta(?:<br\s?\/?>)?\n?(.*)?\n?\$cta<\/p>/migs, "<div class=\"call-to-action\"><p>$1</p></div>");
-  // 2.
-  content = content.replace(/\$cta (.*)\$cta/migs, "$cta\n$1\n$cta");
+  // 1.   \$cta             - match fixed string $cta
+  //      (?:<br\s?\/>)?    - optionally match <br> | <br/> | <br /> without capturing group
+  //      \n?               - optional newline
+  //      (.+?(?=\$cta))?   - optional capture all characters until the next fixed $cta string (this allows us to match multiple $cta blocks)
+  //      \n?               - optional newline
+  //      \$cta             - match fixed $cta string
+  //      flags 
+  //      (i) case-insensitive, 
+  //      (g) global - allows multiple matches, 
+  //      (s) single line - allows . to include newline characters.
+  content = content.replace(/<p>\$cta(?:<br\s?\/?>)?\n?(.+?(?=\$cta))?\n?\$cta<\/p>/igs, "<div class=\"call-to-action\"><p>$1</p></div>");
+  
+  // 2.   \$cta                    - match fixed string $cta
+  //      (?:\s)?                  - optional space (non-capturing)
+  //      (.+?(?=[\n\r]?\$cta))    - capture everything upto the next fixed $cta string  [\n\r]? allows the $cta to optionally be on a newline, without capturing the newline)
+  //      (?:\s)?                  - optional space (non-capturing)
+  //      \$cta                    - match fixed string $cta
+  content = content.replace(/\$cta(?:\s)?(.+?(?=[\n\r]?\$cta))(?:\s)?\$cta/migs, "\$cta\n$1\n\$cta");
 
-  console.log(content)
   return content;
 }
 

--- a/app/javascript/styles/shared/_content.scss
+++ b/app/javascript/styles/shared/_content.scss
@@ -7,8 +7,12 @@
   padding: 2em
 }
 
-.call-to-action > p {
-  margin: 0;
+.call-to-action > p:first-child {
+  margin-top: 0;
+}
+
+.call-to-action > p:last-child {
+  margin-bottom: 0;
 }
 
 // Apply GOVUk link styles to all links in editable content areas

--- a/test/editable_components/editable_content/adjustments_test.js
+++ b/test/editable_components/editable_content/adjustments_test.js
@@ -16,40 +16,157 @@ describe('EditableContent', function() {
       markdownAdjustment: markdownAdjustment
     }
 
-    beforeEach(function() {
-      // created = helpers.createEditableContent(COMPONENT_ID);
-    });
-
     afterEach(function() {
       helpers.teardownView(COMPONENT_ID);
       created = undefined;
     });
 
     describe('GovSpeak CTA Markup support', function() {
-      it('works without <br> tags', function(){      
-        const html = `<p>This is a paragraph</p>
+      describe('HTML to markdown', function() {
+
+        it('allows single line $cta block', function(){      
+          const html = `<p>This is a paragraph</p>
           <p>$cta This is a call to action $cta</p>`;
 
-        created = helpers.createEditableContent(COMPONENT_ID, config, html );
+          const markdown = 'This is a paragraph\n\n$cta\nThis is a call to action \n$cta\n\n';
 
-        expect(created.instance.markdown).to.eql('This is a paragraph\n\n$cta\nThis is a call to action \n$cta\n\n');
+          created = helpers.createEditableContent(COMPONENT_ID, config, html );
+
+          expect(created.instance.markdown).to.eql(markdown);
+        });
+
+        it('allows linebreaks around before/after $cta tags', function(){      
+          const html = `<p>This is a paragraph</p>
+          <p>$cta
+          This is a call to action
+          $cta</p>`;
+
+          const markdown = 'This is a paragraph\n\n$cta\nThis is a call to action \n$cta\n\n';
+
+          created = helpers.createEditableContent(COMPONENT_ID, config, html );
+
+          expect(created.instance.markdown).to.eql(markdown);
+        });
+
+        it('allows soft linebreaks within $cta contents', function(){      
+          const html = `<p>This is a paragraph</p>
+          <p>$cta
+            This is my call to action<br>
+            with a new line
+            $cta</p>`;
+
+          const markdown = 'This is a paragraph\n\n$cta\nThis is my call to action  \nwith a new line \n$cta\n\n';
+
+          created = helpers.createEditableContent(COMPONENT_ID, config, html );
+
+          expect(created.instance.markdown).to.eql(markdown);
+        });
+
+        it('allows multiple paragraphs within $cta block', function() {
+          const html = `<p>This is a paragraph</p>
+          <p>$cta
+          This is my call to action.</p>
+
+          <p>It contains two paragraphs.
+          $cta</p>`;
+
+          const markdown = 'This is a paragraph\n\n$cta\nThis is my call to action.\n\nIt contains two paragraphs. \n$cta\n\n';
+
+          created = helpers.createEditableContent(COMPONENT_ID, config, html );
+
+          expect(created.instance.markdown).to.eql(markdown);
+        });
+
+        it('allows multiple $cta blocks within a content area', function(){
+          const html = `<p>This is a paragraph</p>
+          <p>$cta
+          This is my first call to action.</p>
+
+          <p>It contains two paragraphs.
+          $cta</p>
+
+          <p>$cta
+          This is the second call to action.
+          $cta</p>`;
+
+          const markdown = 'This is a paragraph\n\n$cta\nThis is my first call to action.\n\nIt contains two paragraphs. \n$cta\n\n$cta\nThis is the second call to action. \n$cta\n\n';
+
+          created = helpers.createEditableContent(COMPONENT_ID, config, html );
+
+          expect(created.instance.markdown).to.eql(markdown);
+        });
       });
+      
+      describe('Markdown to HTML', function() {
+        beforeEach(function() {
+          created = helpers.createEditableContent(COMPONENT_ID, config, '' );
+        })
 
-      it('works with soft linebreaks', function(){      
-        const html = `<p>This is a paragraph</p>
-          <p>$cta 
-          This is a call to action  <br> with a soft linebreak 
-        $cta</p>`;
+        it('allows single line $cta block', function(){      
+          const markdown = 'This is a paragraph\n\n$cta\nThis is a call to action \n$cta\n\n';
+          const html = `<p>This is a paragraph</p>
+<div class="call-to-action"><p>This is a call to action <br>
+</p></div>`;
 
-        created = helpers.createEditableContent(COMPONENT_ID, config, html );
+          created.instance.$input.val(markdown);
+          created.instance.update()
 
-        expect(created.instance.markdown).to.eql('This is a paragraph\n\n$cta\nThis is a call to action  \nwith a soft linebreak $cta\n\n');
+          expect(created.instance.$output.html()).to.eql(html);
+        });
+
+        it('allows linebreaks around before/after $cta tags', function(){      
+          const markdown = 'This is a paragraph\n\n$cta\nThis is a call to action \n$cta\n\n';
+          const html = `<p>This is a paragraph</p>
+<div class="call-to-action"><p>This is a call to action <br>
+</p></div>`;
+
+          created.instance.$input.val(markdown);
+          created.instance.update()
+
+          expect(created.instance.$output.html()).to.eql(html);
+        });
+
+        it('allows soft linebreaks within $cta contents', function(){      
+          const markdown = 'This is a paragraph\n\n$cta\nThis is my call to action  \nwith a new line \n$cta\n\n';
+          const html = `<p>This is a paragraph</p>
+<div class="call-to-action"><p>This is my call to action  <br>
+with a new line <br>
+</p></div>`;
+
+          created.instance.$input.val(markdown);
+          created.instance.update()
+
+          expect(created.instance.$output.html()).to.eql(html);
+        });
+
+        it('allows multiple paragraphs within $cta block', function() {
+          const markdown = 'This is a paragraph\n\n$cta\nThis is my call to action.\n\nIt contains two paragraphs. \n$cta\n\n';
+          const html = `<p>This is a paragraph</p>
+<div class="call-to-action"><p>This is my call to action.</p>
+<p>It contains two paragraphs. <br>
+</p></div>`;
+
+          created.instance.$input.val(markdown);
+          created.instance.update()
+
+          expect(created.instance.$output.html()).to.eql(html);
+        });
+
+        it('allows multiple $cta blocks within a content area', function(){
+          const markdown = 'This is a paragraph\n\n$cta\nThis is my first call to action.\n\nIt contains two paragraphs. $cta\n\n$cta This is the second call to action. \n$cta\n\n';
+          const html = `<p>This is a paragraph</p>
+<div class="call-to-action"><p>This is my first call to action.</p>
+<p>It contains two paragraphs. </p></div>
+<div class="call-to-action"><p> This is the second call to action. <br>
+</p></div>`;
+
+          created.instance.$input.val(markdown);
+          created.instance.update()
+
+          expect(created.instance.$output.html()).to.eql(html);
+        });
       });
     });
-
   });
-
-  
-
 });
 

--- a/test/editable_components/editable_content/adjustments_test.js
+++ b/test/editable_components/editable_content/adjustments_test.js
@@ -1,0 +1,55 @@
+
+require('../../setup');
+const {
+  htmlAdjustment,
+  markdownAdjustment
+} = require('../../../app/javascript/src/shared/content');
+
+describe('EditableContent', function() {
+  const helpers = require('./helpers');
+  const COMPONENT_ID = 'editable-content-adjustments-test';
+
+  describe('Adjustments', function() {
+    var created;
+    var config = {
+      htmlAdjustment: htmlAdjustment,
+      markdownAdjustment: markdownAdjustment
+    }
+
+    beforeEach(function() {
+      // created = helpers.createEditableContent(COMPONENT_ID);
+    });
+
+    afterEach(function() {
+      helpers.teardownView(COMPONENT_ID);
+      created = undefined;
+    });
+
+    describe('GovSpeak CTA Markup support', function() {
+      it('works without <br> tags', function(){      
+        const html = `<p>This is a paragraph</p>
+          <p>$cta This is a call to action $cta</p>`;
+
+        created = helpers.createEditableContent(COMPONENT_ID, config, html );
+
+        expect(created.instance.markdown).to.eql('This is a paragraph\n\n$cta\nThis is a call to action \n$cta\n\n');
+      });
+
+      it('works with soft linebreaks', function(){      
+        const html = `<p>This is a paragraph</p>
+          <p>$cta 
+          This is a call to action  <br> with a soft linebreak 
+        $cta</p>`;
+
+        created = helpers.createEditableContent(COMPONENT_ID, config, html );
+
+        expect(created.instance.markdown).to.eql('This is a paragraph\n\n$cta\nThis is a call to action  \nwith a soft linebreak $cta\n\n');
+      });
+    });
+
+  });
+
+  
+
+});
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -3420,6 +3420,7 @@ jquery-ui@^1.13.2:
 "jquery@>=1.8.0 <4.0.0", jquery@^3.6.4:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.4.tgz#ba065c188142100be4833699852bf7c24dc0252f"
+  integrity sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Content within $cta 'tags' in editable content areas was not being rendered to HTML correctly when leaving the editable area.

The previous regex wasn't matching correctly.  This PR updates and improves the regex to match correctly (and match more / be more forgiving)

Now all of the following syntax will work:

```
$cta all in one line call to action $cta
```

```
$cta
call to action content
$cta
```

```
$cta
call to action content  
with a linebreak
$cta
```

```
$cta
call to action content

with another paragraph
$cta
```

```
$cta
call to action content
$cta

$cta
and a second cta in the same content block 
(I know this would be **strongly** not recommended, but I figured while I was doing things with regexes I should probably just make it work anyway)
$cta
```