### PR TITLE
Testable undo redo error modal

### DIFF
--- a/acceptance/features/undo_redo_spec.rb
+++ b/acceptance/features/undo_redo_spec.rb
@@ -50,8 +50,10 @@ feature 'Undo redo page' do
     and_I_click_the_move_button
     then_page_1_should_be_after_page_2
     and_I_click_button('undo_move')
+    sleep(2)
     then_page_2_should_be_after_page_1
     and_I_click_button('redo_move')
+    sleep(2)
     then_page_1_should_be_after_page_2
   end
 
@@ -60,8 +62,10 @@ feature 'Undo redo page' do
     when_I_change_destination_to_page('page 1')
     then_next_to_page_2_is_page_1
     and_I_click_button('undo_change_next_page')
+    sleep(2)
     then_page_2_should_be_after_page_1
     and_I_click_button('redo_change_next_page')
+    sleep(2)
     then_next_to_page_2_is_page_1
   end
 
@@ -79,7 +83,7 @@ feature 'Undo redo page' do
 
   def and_I_click_button(name)
     page.find(:css, '#main-content', visible: true)
-    find('.fb-govuk-button', text: I18n.t("actions.undo_redo.#{name}")).click
+    page.find('.fb-govuk-button', text: I18n.t("actions.undo_redo.#{name}")).click
   end
 
 end

--- a/app/controllers/api/undo_controller.rb
+++ b/app/controllers/api/undo_controller.rb
@@ -15,11 +15,6 @@ module Api
     end
 
     def call_previous_version
-      ## FOR TESTING ONLY - DO NOT DEPLOY
-      if params[:action] == 'redo'
-        render json: { action: params[:action] }, status: :bad_request and return
-      end
-
       response = MetadataApiClient::Version.previous(service.service_id)
       if response.errors?
         render json: { action: params[:action] }, status: :bad_request and return

--- a/app/controllers/api/undo_controller.rb
+++ b/app/controllers/api/undo_controller.rb
@@ -15,15 +15,27 @@ module Api
     end
 
     def call_previous_version
+      ## FOR TESTING ONLY - DO NOT DEPLOY
+      if params[:action] == 'redo'
+        render json: { action: params[:action] }, status: :bad_request and return
+      end
+
       response = MetadataApiClient::Version.previous(service.service_id)
-      return head :bad_request if response.errors?
+      if response.errors?
+        render json: { action: params[:action] }, status: :bad_request and return
+      end
 
       new_version = MetadataApiClient::Version.create(service_id: service.service_id, payload: response.metadata)
-      return head :bad_request if new_version.errors?
+      if new_version.errors?
+        render json: { action: params[:action] }, status: :bad_request and return
+      end
 
       session[:undo] = UndoPresenter.toggle(session[:undo][:action], session[:undo][:undoable_action]) if session[:undo]
-
-      redirect_to edit_service_path(service.service_id)
+      if request.xhr?
+        render json: { redirect: edit_service_path(service.service_id).to_s }
+      else
+        redirect_to edit_service_path(service.service_id)
+      end
     end
   end
 end

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -66,6 +66,7 @@ ServicesController.edit = function() {
   createPageMenus(view);
   createConnectionMenus(view);
   createExpanderComponents();
+  setupUndoRedoButton(view);
 
   if(view.$flowOverview.length) {
     layoutFormFlowOverview(view);
@@ -151,6 +152,32 @@ function createConnectionMenus(view) {
         render: false,
       })
     );
+  });
+}
+
+function setupUndoRedoButton(view) {
+  const button = document.querySelector('[data-element="undo-redo-button"]');
+  if(!button) return;
+  const form = button.closest('form');
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const url = form.getAttribute('action');
+
+    button.setAttribute('disabled', '');
+    $.get(url)
+      .done( (response) => {
+        if(response.redirect) {
+          window.location = response.redirect;
+        }
+      })
+      .fail((response) => {
+        button.removeAttribute('disabled');
+        const action = response.responseJSON?.action;
+        view.dialog.open({
+          heading: view.text.dialogs.undo_redo_error.heading,
+          content: action ? view.text.dialogs.undo_redo_error[action]?.content : view.text.dialogs.undo_redo_error.content,
+        }); 
+      });
   });
 }
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -171,8 +171,8 @@ function setupUndoRedoButton(view) {
         }
       })
       .fail((response) => {
-        button.removeAttribute('disabled');
         const action = response.responseJSON?.action;
+        button.parentNode.removeChild(button);
         view.dialog.open({
           heading: view.text.dialogs.undo_redo_error.heading,
           content: action ? view.text.dialogs.undo_redo_error[action]?.content : view.text.dialogs.undo_redo_error.content,

--- a/app/javascript/styles/_mixins.scss
+++ b/app/javascript/styles/_mixins.scss
@@ -46,6 +46,13 @@
     background-color: govuk-colour("blue");
     color: govuk-colour("white");
   }
+
+  &[disabled] {
+    background-color: govuk-colour("white");
+    border: govuk-colour("blue") solid 2px;
+    color: govuk-colour("blue");
+    opacity: 0.5;
+  }
 }
 
 @mixin focus {

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -56,6 +56,17 @@
           button_disabled: "<%= t('dialogs.autocomplete.button_disabled') %>",
           success: "<%= t('dialogs.autocomplete.success') %>"
         },
+        undo_redo_error: {
+          heading: "<%= t('dialogs.undo_redo_error.heading') %>",
+          content: "<%= t('dialogs.undo_redo_error.content') %>",
+          undo: {
+            content: "<%= t('dialogs.undo_redo_error.undo.content') %>"
+          },
+          redo: {
+            content: "<%= t('dialogs.undo_redo_error.redo.content') %>"
+          }
+
+        },
         button_change_destination: "<%= t('dialogs.destination.button_change') %>",
         button_move: "<%= t('dialogs.move.button') %>",
         button_cancel: "<%= t('dialogs.button_cancel') %>",

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -2,9 +2,11 @@
   <h1 class="govuk-heading-xl"><%= t('pages.flow.heading') %></h1>
 
   <% if @undo_redo_button.present?%>
-    <%= link_to @undo_redo_button[:text],
+    <%= button_to @undo_redo_button[:text],
       api_service_previous_version_path(service.service_id, action: @undo_redo_button[:action],undoable_action: @undo_redo_button[:undoable_action]),
-      class: 'fb-govuk-button fb-govuk-button-inverted fb-govuk-button--inline' %>
+      method: :get,
+      class: 'fb-govuk-button fb-govuk-button-inverted fb-govuk-button--inline',
+      data: { element: 'undo-redo-button' } %>
   <% end %>
 
   <%= link_to t('actions.preview_form'),

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -2,11 +2,13 @@
   <h1 class="govuk-heading-xl"><%= t('pages.flow.heading') %></h1>
 
   <% if @undo_redo_button.present?%>
-    <%= button_to @undo_redo_button[:text],
-      api_service_previous_version_path(service.service_id, action: @undo_redo_button[:action],undoable_action: @undo_redo_button[:undoable_action]),
+    <%= button_to api_service_previous_version_path(service.service_id, action: @undo_redo_button[:action],undoable_action: @undo_redo_button[:undoable_action]),
       method: :get,
       class: 'fb-govuk-button fb-govuk-button-inverted fb-govuk-button--inline',
-      data: { element: 'undo-redo-button' } %>
+      data: { element: 'undo-redo-button' } do
+        @undo_redo_button[:text]
+      end
+      %>
   <% end %>
 
   <%= link_to t('actions.preview_form'),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,13 @@ en:
       you_cannot_move_this_page: 'You cannot move this page yet'
       stacked_branches_not_supported_message: 'Moving this page would result in 2 branching points in a row, which is not currently possible. Try combining your branching rules into 1 branching point.'
       branch_destination_no_default_next_message: 'You cannot leave a branch without any pages. Either edit the branching point or add another page to the branch first.'
+    undo_redo_error:
+      heading: There was a problem
+      content: We were unable to complete your last action. Please try again. 
+      undo:
+        content: We were unable to undo your last action. Please try again. 
+      redo:
+        content: We were unable to redo your last action. Please try again. 
     component_validations:
       date:
         day: Day

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,7 +50,7 @@ en:
     button_delete_option: 'Delete option'
     button_delete_component: 'Delete component'
     button_delete_page: 'Delete page'
-    button_ok: 'Ok'
+    button_ok: 'OK'
     button_understood: 'Understood'
     button_update: 'Update'
     heading: General heading here
@@ -78,11 +78,11 @@ en:
       branch_destination_no_default_next_message: 'You cannot leave a branch without any pages. Either edit the branching point or add another page to the branch first.'
     undo_redo_error:
       heading: There was a problem
-      content: We were unable to complete your last action. Please try again. 
+      content: We were unable to complete your last action.
       undo:
-        content: We were unable to undo your last action. Please try again. 
+        content: We were unable to undo your last action.
       redo:
-        content: We were unable to redo your last action. Please try again. 
+        content: We were unable to redo your last action.
     component_validations:
       date:
         day: Day
@@ -190,7 +190,7 @@ en:
     add_check_answers: 'Add check answers page'
     add_confirmation: 'Add confirmation page'
     reconnect_confirmation: 'Reconnect confirmation page'
-    ok: 'Ok'
+    ok: 'OK'
     submit: 'Submit'
     upload_options: Upload options
     open_in_new_window: '(opens in a new window)'


### PR DESCRIPTION
Adds a pretty generic error message in a modal that is displayed if an undo or a redo action fails to complete.

If the action fails, its likely due to an issue with the metadata, and retrying the action is unlikely to succeed so we remove the button on failure.