### PR TITLE
Fix Editor preview footer link bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ gem 'delayed_job_active_record'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'update-start-page-template'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'fix-preview-footer-links'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.18.4'
+# gem 'metadata_presenter', '2.18.4'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ gem 'delayed_job_active_record'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'fix-preview-footer-links'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'update-start-page-template'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '2.18.4'
+gem 'metadata_presenter', '2.18.6'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 1dd67c9cb98cedce0bd72d2d2dbf4d3a895b1d58
+  branch: fix-preview-footer-links
+  specs:
+    metadata_presenter (2.18.4)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 6.0.3.4, < 6.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -224,11 +235,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.18.4)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 6.0.3.4, < 6.2.0)
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
@@ -476,7 +482,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 2.18.4)
+  metadata_presenter!
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 1dd67c9cb98cedce0bd72d2d2dbf4d3a895b1d58
-  branch: fix-preview-footer-links
-  specs:
-    metadata_presenter (2.18.4)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 6.0.3.4, < 6.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -235,6 +224,11 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    metadata_presenter (2.18.6)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 6.0.3.4, < 6.2.0)
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
@@ -482,7 +476,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter!
+  metadata_presenter (= 2.18.6)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/acceptance/features/preview_form_spec.rb
+++ b/acceptance/features/preview_form_spec.rb
@@ -32,18 +32,22 @@ feature 'Preview form' do
     then_I_can_navigate_until_the_end_of_the_form(preview_form)
   end
 
-  scenario 'preview the standalone pages' do
+  scenario 'preview the standalone page from start page' do
     preview_form = when_I_preview_the_form
     then_I_should_preview_the_cookies_page(preview_form)
-    within_window(preview_form) do
-      then_I_should_not_see_a_back_link
-    end
+  end
+
+  scenario 'preview standalone page after start page' do
+    preview_form = when_I_preview_the_form
+    then_I_navigate_to_the_next_page(preview_form)
+    then_I_should_preview_the_cookies_page(preview_form)
   end
 
   def then_I_should_preview_the_cookies_page(preview_form)
     within_window(preview_form) do
       page.find_link('Cookies').click
       expect(page.find('h1').text).to eq('Cookies')
+      then_I_should_not_see_a_back_link
     end
   end
 
@@ -147,6 +151,14 @@ feature 'Preview form' do
       page.click_button I18n.t('actions.submit')
       then_I_should_not_see_a_back_link
       expect(page).to have_content('Application complete')
+    end
+  end
+
+  def then_I_navigate_to_the_next_page(preview_form)
+    within_window(preview_form) do
+      expect(page).to have_content('Service name goes here')
+      then_I_should_not_see_a_back_link
+      page.click_button 'Start now'
     end
   end
 

--- a/app/validators/metadata_url_validator.rb
+++ b/app/validators/metadata_url_validator.rb
@@ -10,6 +10,7 @@ class MetadataUrlValidator < ActiveModel::EachValidator
     ping
     reserved
     unauthorised
+    preview
   ].freeze
 
   def validate_each(record, attribute, value)


### PR DESCRIPTION
Currently, when we are on a page other than the start page in preview mode and we click on any of the footer links, we receive an error.
This is because the presenter gem would check if the editor url ended in 'preview' to ascertain whether the editor was in preview and then construct the footer links accordingly.

Bug is fixed in this Presenter bump: https://github.com/ministryofjustice/fb-metadata-presenter/pull/311

### Bump to presenter 2.18.6

### Add 'preview' to reserved url list
Since we look for any instance of 'preview' in the url to check if we are using the Editor in preview mode, we should prevent users from naming their pages 'preview'.

![Screenshot 2023-04-27 at 10 51 01](https://user-images.githubusercontent.com/29227502/234827862-a677085f-3408-430c-8f8c-d1bd12ffb406.png)