### PR TITLE
Fix insertion position of add component button

### DIFF
--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -682,8 +682,8 @@ function workaroundForDefaultText(view) {
 
 function editPageContentViewCustomisations() {
   var $button1 = $("[data-component=add-content]");
-  var $target = $("#new_answers :submit");
-  $target.before($button1);
+  var $target = $("#new_answers");
+  $target.append($button1);
 }
 
 
@@ -710,8 +710,8 @@ function editPageConfirmationViewCustomisations() {
 
 function editPageMultipleQuestionsViewCustomisations() {
   var $button1 = $("[data-component=add-component]");
-  var $target = $("#new_answers input:submit");
-  $target.before($button1);
+  var $target = $("#new_answers");
+  $target.append($button1);
   accessibilityQuestionViewEnhancements(this);
 }
 


### PR DESCRIPTION
The save and return feature moves the continue button into a button group with the 'svae for later' button.  This breaks the position of the inserted add-component button in the editor.


This fix changes the insertion point from 'after the submit button in the form' to simply 'before the end of the form' which will work whetehr save and return if flagged on or not.

Without Save and return:
```
<form>
  ....
  <button type="submit">Continue</button>
  <!-- button would be inserted here -->
</form>
```

With save and return:
```
<form>
  ....
  <div class="govuk-button-group">
    <button type="submit">Continue</button>
    <button type="submit">Save for later</button>
  </div>
  <!-- button would be inserted here -->
</form>
```
