### PR TITLE
Confirmation email answers update

### DIFF
--- a/acceptance/features/confirmation_email_spec.rb
+++ b/acceptance/features/confirmation_email_spec.rb
@@ -8,6 +8,7 @@ feature 'Confirmation email' do
   # Capybara strips out the carriage return `\r`
   let(:message_body) {
     "Thank you for your submission to ‘#{service_name}’. \n\nA copy of the information you provided is attached to this email."
+    I18n.t('default_values.confiramtion_email_body', service_name: service_name).gsub!('{{refernce_number_placeholder}}','')
   }
   let(:message_subject) { "Your submission to ‘#{service_name}’" }
   let(:multiple_question_page) { 'Title' }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
     branching_title: 'Branching point %{branching_number}'
     confirmation_email_reply_to: ''
     confirmation_email_subject: "Your submission to ‘%{service_name}’{{reference_number_placeholder}}"
-    confirmation_email_body: "Thank you for your submission to ‘%{service_name}’. {{reference_payment_placeholder}}\n\r\nA copy of the information you provided is attached to this email and included below."
+    confirmation_email_body: "Thank you for your submission to ‘%{service_name}’. {{reference_payment_placeholder}}\n\r\nYour answers are shown below and attached to this email."
     reference_number_sentence: "Your reference number is: {{reference_number}}."
     reference_number_subject: ", reference number: {{reference_number}}"
     reference_number: '123-ABCD-456'
@@ -493,7 +493,7 @@ en:
         email_fieldset: Email
         pdf_fieldset: PDF attachment
         pdf_sample: See sample PDF
-        pdf_hint: All answers will be written in a pdf attached to the email
+        pdf_hint: Answers will be inserted below the message and attached separately in a PDF.
         csv_attachment: CSV attachment
         csv_hint: A comma-separated values (CSV) lists all the answers in plain text, separated by commas. It can be imported into spreadsheets and other applications.
         csv_sample: See sample CSV

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
     branching_title: 'Branching point %{branching_number}'
     confirmation_email_reply_to: ''
     confirmation_email_subject: "Your submission to ‘%{service_name}’{{reference_number_placeholder}}"
-    confirmation_email_body: "Thank you for your submission to ‘%{service_name}’. {{reference_payment_placeholder}}\n\r\nA copy of the information you provided is attached to this email."
+    confirmation_email_body: "Thank you for your submission to ‘%{service_name}’. {{reference_payment_placeholder}}\n\r\nA copy of the information you provided is attached to this email and included below."
     reference_number_sentence: "Your reference number is: {{reference_number}}."
     reference_number_subject: ", reference number: {{reference_number}}"
     reference_number: '123-ABCD-456'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -374,7 +374,7 @@ en:
     confirmation_email:
       heading: 'Send a confirmation email'
       lede: Send the people who complete your form a copy of their data.
-      description: Send the people completing your form a confirmation email with their information attached in a PDF.
+      description: Send the people completing your form a confirmation email with a copy of their answers.
   warnings:
     confirmation_email:
       message: 'Your form must include an email question to enable a %{href}.'


### PR DESCRIPTION
Updates to the default text on the confirmation email settings page for including user answers in the confirmation email.