### PR TITLE
Update browser-tools orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   slack: circleci/slack@3.4.2
   ruby: circleci/ruby@1.4.0
   node: circleci/node@5.1.0
-  browser-tools: circleci/browser-tools@1.2.4
+  browser-tools: circleci/browser-tools@1.4.1
   kubernetes: circleci/kubernetes@0.12.0
 
 jobs:


### PR DESCRIPTION
There has been some flakiness with installing Google Chrome on our CircleCI run so updating browser-tools orb to latest version.

#### CircleCI run:
https://app.circleci.com/pipelines/github/ministryofjustice/fb-editor/8158/workflows/1d10fabf-1030-420e-9f7b-f9ef871e5c98