### PR TITLE
Api submission

### DIFF
--- a/app/models/admin/api_submission_settings.rb
+++ b/app/models/admin/api_submission_settings.rb
@@ -9,7 +9,7 @@ module Admin
     validates :deployment_environment, inclusion: {
       in: Rails.application.config.deployment_environments
     }
-    validates :service, presence: true
+    validates :service, :service_output_json_key, presence: true
     validate :is_url_valid
 
     URL_ERROR = 'Endpoint field should be a valid URL. '.freeze

--- a/app/models/admin/api_submission_settings.rb
+++ b/app/models/admin/api_submission_settings.rb
@@ -30,7 +30,7 @@ module Admin
     def is_key_valid_length
       return if @service_output_json_key == ''
 
-      if @service_output_json_key.nil? || @service_output_json_key.length != 16
+      if @service_output_json_key.nil? || @service_output_json_key.length != 17
         errors.add(:base, KEY_LENGTH_ERROR)
       end
     end

--- a/app/models/admin/api_submission_settings.rb
+++ b/app/models/admin/api_submission_settings.rb
@@ -10,9 +10,8 @@ module Admin
       in: Rails.application.config.deployment_environments
     }
     validates :service, presence: true
-    validate :is_key_valid_length, :is_url_valid
+    validate :is_url_valid
 
-    KEY_LENGTH_ERROR = 'Key length must be 16. '.freeze
     URL_ERROR = 'Endpoint field should be a valid URL. '.freeze
 
     # rubocop:disable Lint/DuplicateMethods. This is required to display in view
@@ -26,14 +25,6 @@ module Admin
     # rubocop:enable Lint/DuplicateMethods
 
     private
-
-    def is_key_valid_length
-      return if @service_output_json_key == ''
-
-      if @service_output_json_key.nil? || @service_output_json_key.length != 17
-        errors.add(:base, KEY_LENGTH_ERROR)
-      end
-    end
 
     def is_url_valid
       return if @service_output_json_endpoint == ''

--- a/app/views/admin/api_submission/_form.html.erb
+++ b/app/views/admin/api_submission/_form.html.erb
@@ -36,7 +36,7 @@
     width: 'two-thirds',
     id: settings_field_id(f, :service_output_json_key, deployment_environment),
     hint: {
-      text: 'This is the 16 characters key'
+      text: 'This is the 17 characters key'
       } %>
   </div>
 

--- a/app/views/admin/api_submission/_form.html.erb
+++ b/app/views/admin/api_submission/_form.html.erb
@@ -23,7 +23,7 @@
     width: 'two-thirds',
     id: settings_field_id(f, :service_output_json_endpoint, deployment_environment),
     hint: {
-      text: 'This is the json output endpoint URL'
+      text: 'This is the JSON output endpoint URL'
       } %>
   </div>
 
@@ -36,7 +36,7 @@
     width: 'two-thirds',
     id: settings_field_id(f, :service_output_json_key, deployment_environment),
     hint: {
-      text: 'This is the 17 characters key'
+      text: 'This is the JSON output endpoint key'
       } %>
   </div>
 

--- a/spec/models/admin/api_submission_settings_spec.rb
+++ b/spec/models/admin/api_submission_settings_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Admin::ApiSubmissionSettings, type: :model do
       described_class.new(params.merge(service:))
     end
     let(:params) { {} }
+    let(:service_output_json_key) { 'f89ea3f29cbdece2x' }
 
     context 'deployment environment' do
-      let(:service_output_json_key) { 'f89ea3f29cbdece2x' }
       let(:service_output_json_endpoint) { 'valid.gov.uk' }
       let(:params) { { service_output_json_key:, service_output_json_endpoint: } }
 
@@ -19,58 +19,8 @@ RSpec.describe Admin::ApiSubmissionSettings, type: :model do
       end
     end
 
-    context 'service_output_json_key' do
-      let(:deployment_environment) { 'dev' }
-      let(:service_output_json_endpoint) { 'http://this-valid-url.com' }
-      let(:params) { { deployment_environment:, service_output_json_endpoint:, service_output_json_key: } }
-      let(:expected_error) { described_class::KEY_LENGTH_ERROR }
-
-      context 'has to be 17 characters long' do
-        let(:service_output_json_key) { '98957af1a0424376z' }
-
-        it 'is valid' do
-          expect(subject).to be_valid
-        end
-      end
-
-      context 'is empty to reset configuration' do
-        let(:service_output_json_key) { '' }
-
-        it 'is valid' do
-          expect(subject).to be_valid
-        end
-      end
-
-      context 'key length is too short' do
-        let(:service_output_json_key) { 'abc' }
-
-        it 'setting should be invalid' do
-          expect(subject).to_not be_valid
-        end
-
-        it 'should have errors' do
-          subject.valid?
-          expect(subject.errors.first.type).to eq(expected_error)
-        end
-      end
-
-      context 'key length is too long' do
-        let(:service_output_json_key) { 'c8c6f4710e6ebf28f89ea3f29cbdece2' }
-
-        it 'setting should be invalid' do
-          expect(subject).to_not be_valid
-        end
-
-        it 'should have errors' do
-          subject.valid?
-          expect(subject.errors.first.type).to eq(expected_error)
-        end
-      end
-    end
-
     context 'service_output_json_endpoint' do
       let(:deployment_environment) { 'production' }
-      let(:service_output_json_key) { 'f89ea3f29cbdece2x' }
       let(:params) { { deployment_environment:, service_output_json_endpoint:, service_output_json_key: } }
       let(:expected_error) { described_class::URL_ERROR }
 

--- a/spec/models/admin/api_submission_settings_spec.rb
+++ b/spec/models/admin/api_submission_settings_spec.rb
@@ -53,5 +53,17 @@ RSpec.describe Admin::ApiSubmissionSettings, type: :model do
         end
       end
     end
+
+    context 'service_output_json_key' do
+      let(:service_output_json_key) { nil }
+
+      it 'do not allow nil' do
+        expect(subject).to_not be_valid
+      end
+
+      it 'allow blank' do
+        should allow_values('').for(:service_output_json_key)
+      end
+    end
   end
 end

--- a/spec/models/admin/api_submission_settings_spec.rb
+++ b/spec/models/admin/api_submission_settings_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::ApiSubmissionSettings, type: :model do
     let(:params) { {} }
 
     context 'deployment environment' do
-      let(:service_output_json_key) { 'f89ea3f29cbdece2' }
+      let(:service_output_json_key) { 'f89ea3f29cbdece2x' }
       let(:service_output_json_endpoint) { 'valid.gov.uk' }
       let(:params) { { service_output_json_key:, service_output_json_endpoint: } }
 
@@ -25,8 +25,8 @@ RSpec.describe Admin::ApiSubmissionSettings, type: :model do
       let(:params) { { deployment_environment:, service_output_json_endpoint:, service_output_json_key: } }
       let(:expected_error) { described_class::KEY_LENGTH_ERROR }
 
-      context 'has to be 16 characters long' do
-        let(:service_output_json_key) { '98957af1a0424376' }
+      context 'has to be 17 characters long' do
+        let(:service_output_json_key) { '98957af1a0424376z' }
 
         it 'is valid' do
           expect(subject).to be_valid
@@ -70,7 +70,7 @@ RSpec.describe Admin::ApiSubmissionSettings, type: :model do
 
     context 'service_output_json_endpoint' do
       let(:deployment_environment) { 'production' }
-      let(:service_output_json_key) { 'f89ea3f29cbdece2' }
+      let(:service_output_json_key) { 'f89ea3f29cbdece2x' }
       let(:params) { { deployment_environment:, service_output_json_endpoint:, service_output_json_key: } }
       let(:expected_error) { described_class::URL_ERROR }
 


### PR DESCRIPTION
## Change
Endpoint key is actually 17 characters long instead of 16 so instead of updating the adapters key, along with the submitter, the tech docs and other places where it is mentioned or used we remove the length restriction for more flexibility.

## Testing
We were able to receive a submission on the base adapter url: 
https://formbuilder-base-adapter-test.apps.live.cloud-platform.service.justice.gov.uk/submission
