### PR TITLE
Add URL validation on form creation

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -10,6 +10,14 @@ class ServicesController < PermissionsController
     @service_creation = ServiceCreation.new(service_creation_params)
 
     if @service_creation.create
+
+      if ENV['NAME_SLUG'] == 'enabled'
+        FormNameUpdater.new(
+          service_id: @service_creation.service_id,
+          service_name: @service_creation.service_name
+        ).create_or_update!
+      end
+
       redirect_to edit_service_path(@service_creation.service_id)
     else
       render :index

--- a/app/models/form_name_updater.rb
+++ b/app/models/form_name_updater.rb
@@ -1,0 +1,65 @@
+class FormNameUpdater
+  attr_reader :service_id, :service_name
+
+  def initialize(service_id:, service_name:)
+    @service_id = service_id
+    @service_name = service_name
+  end
+
+  def create_or_update!
+    ActiveRecord::Base.transaction do
+      save_config_service_slug
+    end
+  end
+
+  private
+
+  def save_config_service_slug
+    create_or_update_service_configuration(config: 'SERVICE_SLUG', deployment_environment: 'dev')
+    create_or_update_service_configuration(config: 'SERVICE_SLUG', deployment_environment: 'production')
+  end
+
+  def create_or_update_service_configuration(config:, deployment_environment:, value: service_slug)
+    setting = find_or_initialize_setting(config, deployment_environment)
+    setting.value = value
+    setting.save!
+  end
+
+  def find_or_initialize_setting(config, deployment_environment)
+    ServiceConfiguration.find_or_initialize_by(
+      service_id:,
+      deployment_environment:,
+      name: config
+    )
+  end
+
+  def service_slug
+    @service_slug ||= begin
+      return parameterized_service_slug if unique_service_slug?
+
+      # Replace the last 3 chars with random 3 alpha-numric chars
+      parameterized_service_slug.gsub(/.{3}$/, SecureRandom.alphanumeric(3)).downcase
+    end
+  end
+
+  def parameterized_service_slug
+    # parameterize, use first non-numeric char and limit to 57 chars
+    @parameterized_service_slug ||= service_name.parameterize.slice(service_name.index(/\D/), 57)
+  end
+
+  def unique_service_slug?
+    all_service_slugs.exclude?(parameterized_service_slug)
+  end
+
+  def all_service_slugs
+    @all_service_slugs ||= existing_service_slugs.concat(previous_service_slugs)
+  end
+
+  def existing_service_slugs
+    @existing_service_slugs ||= ServiceConfiguration.where(name: 'SERVICE_SLUG').map(&:decrypt_value)
+  end
+
+  def previous_service_slugs
+    @previous_service_slugs ||= ServiceConfiguration.where(name: 'PREVIOUS_SERVICE_SLUG').map(&:decrypt_value)
+  end
+end

--- a/spec/factories/service_configurations.rb
+++ b/spec/factories/service_configurations.rb
@@ -129,5 +129,10 @@ FactoryBot.define do
       name { 'SERVICE_SLUG' }
       value { 'eat-slugs-malfoy' }
     end
+
+    trait :previous_service_slug do
+      name { 'PREVIOUS_SERVICE_SLUG' }
+      value { 'slug-life' }
+    end
   end
 end

--- a/spec/models/form_name_updater_spec.rb
+++ b/spec/models/form_name_updater_spec.rb
@@ -1,0 +1,134 @@
+RSpec.describe FormNameUpdater do
+  subject(:form_name_updater) do
+    described_class.new(
+      service_id: service.service_id,
+      service_name: ServiceCreation.new(attributes).service_name
+    )
+  end
+  let(:current_user) { double(id: '1') }
+  let(:service_configuration) do
+    ServiceConfiguration.find_by(
+      service_id: service.service_id,
+      name: 'SERVICE_SLUG'
+    )
+  end
+
+  describe '#create_or_update' do
+    context 'on form creation' do
+      context 'when service slug is unique' do
+        let(:attributes) { { service_name: 'I am a unique service' } }
+        let(:expected_service_slug) { 'i-am-a-unique-service' }
+
+        it 'updates the service configuration subject' do
+          form_name_updater.create_or_update!
+          service_configuration.reload
+          expect(
+            service_configuration.decrypt_value
+          ).to eq(expected_service_slug)
+        end
+      end
+
+      context 'when there is a duplicate service slug' do
+        let!(:existing_service_configuration) do
+          create(
+            :service_configuration,
+            :dev,
+            :service_slug,
+            service_id: SecureRandom.uuid
+          )
+        end
+        let(:attributes) { { service_name: 'Eat slugs malfoy' } }
+        let(:expected_service_slug) { 'eat-slugs-malfoy' }
+
+        it 'changes the last three characters for uniqueness' do
+          form_name_updater.create_or_update!
+          service_configuration.reload
+          expect(
+            service_configuration.decrypt_value.last(3)
+          ).to_not eq(expected_service_slug.last(3))
+          expect(
+            service_configuration.decrypt_value.first(12)
+          ).to eq(expected_service_slug.first(12))
+        end
+
+        context 'when there is a duplicate previous service slug config' do
+          let!(:existing_service_configuration) do
+            create(
+              :service_configuration,
+              :dev,
+              :previous_service_slug,
+              service_id: SecureRandom.uuid
+            )
+          end
+          let(:attributes) { { service_name: 'Slug Life' } }
+          let(:expected_service_slug) { 'slug-life' }
+
+          it 'changes the last three characters for uniqueness' do
+            form_name_updater.create_or_update!
+            service_configuration.reload
+            expect(
+              service_configuration.decrypt_value.last(3)
+            ).to_not eq(expected_service_slug.last(3))
+            expect(
+              service_configuration.decrypt_value.first(6)
+            ).to eq(expected_service_slug.first(6))
+          end
+        end
+      end
+
+      context 'when service name is longer than 57 chars' do
+        let(:attributes) do
+          {
+            service_name: 'This is a very very very very long service name cut me off now'
+          }
+        end
+        let(:expected_service_slug) { 'this-is-a-very-very-very-very-long-service-name-cut-me-of' }
+
+        it 'creates a service configuration object with 57 characters' do
+          form_name_updater.create_or_update!
+          service_configuration.reload
+          expect(
+            service_configuration.decrypt_value.length
+          ).to eq(57)
+          expect(
+            service_configuration.decrypt_value
+          ).to eq(expected_service_slug)
+        end
+      end
+
+      context 'when service name contains special characters' do
+        let(:attributes) do
+          {
+            service_name: 'All 0f the ("special") characters?!'
+          }
+        end
+        let(:expected_service_slug) { 'all-0f-the-special-characters' }
+
+        it 'creates a unique service configuration object removing non-alphanumeric characters' do
+          form_name_updater.create_or_update!
+          service_configuration.reload
+          expect(
+            service_configuration.decrypt_value
+          ).to eq(expected_service_slug)
+        end
+      end
+
+      context 'when the form name begins with a number' do
+        let(:attributes) do
+          {
+            service_name: '123remove the prefix 123'
+          }
+        end
+        let(:expected_service_slug) { 'remove-the-prefix-123' }
+
+        it 'removes the leading numbers' do
+          form_name_updater.create_or_update!
+          service_configuration.reload
+          expect(
+            service_configuration.decrypt_value
+          ).to eq(expected_service_slug)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are separating the form name and the URL. Since the URL will no longer be derived from the form name, we need to create the URL at the point of form creation to present back to the user on the Form Name settings page.

On form creation, we will use the given form name to create a 'SERVICE_SLUG' service configuration. We will be removing most of the validations on the form name, so we will now need to validate the generated SERVICE_SLUG. 

We ensure the SERVICE_SLUG is:
- 57 chars in length
- Stripped of special characters and parameterised
- Checked against existing SERVICE_SLUG and PREVIOUS_SERVICE_SLUG service configs for uniqueness
- Does not begin with a number

If the SERVICE_SLUG is not unique, we replace the last 3 chars with randomised alphanumeric chars.
There is no check against legacy form URLs as we will keep this validation on form creation anyway.

Note: We have the `SERVICE_SLUG` service config  creation feature flagged so it will only be created for new services in the Test Editor
