### PR TITLE
Add service_slug_config method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'update-start-page-template'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '2.19.3'
+gem 'metadata_presenter', '2.20.0'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.19.3)
+    metadata_presenter (2.20.0)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -477,7 +477,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 2.19.3)
+  metadata_presenter (= 2.20.0)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -126,4 +126,11 @@ class ApplicationController < ActionController::Base
     request.script_name.include?('preview')
   end
   helper_method :editor_preview?
+
+  def service_slug_config
+    @service_slug_config ||= ServiceConfiguration.find_by(
+      service_id: service.service_id,
+      name: 'SERVICE_SLUG'
+    )&.decrypt_value
+  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -283,4 +283,34 @@ RSpec.describe ApplicationController do
       end
     end
   end
+
+  describe '#service_slug_config' do
+    before do
+      allow(controller).to receive(:service).and_return(service)
+      allow(ServiceConfiguration).to receive(:find_by).and_return(service_configuration)
+    end
+
+    context 'when SERVICE_SLUG exists' do
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :dev,
+          :service_slug,
+          service_id: service.service_id
+        )
+      end
+
+      it 'returns service slug' do
+        expect(controller.service_slug_config).to eq('eat-slugs-malfoy')
+      end
+    end
+
+    context 'when SERVICE_SLUG does not exist' do
+      let!(:service_configuration) { nil }
+
+      it 'returns nil' do
+        expect(controller.service_slug_config).to be_nil
+      end
+    end
+  end
 end

--- a/spec/factories/service_configurations.rb
+++ b/spec/factories/service_configurations.rb
@@ -124,5 +124,10 @@ FactoryBot.define do
       name { 'SAVE_AND_RETURN' }
       value { '1' }
     end
+
+    trait :service_slug do
+      name { 'SERVICE_SLUG' }
+      value { 'eat-slugs-malfoy' }
+    end
   end
 end


### PR DESCRIPTION
This will use the 'SERVICE_SLUG' value in the ServiceConfiguration table. If it does not exist, we parameterize the service_name.

For now, this is to allow for backwards compatibility.