### PR TITLE
Add UI changes for form name and slug settings

### DIFF
--- a/acceptance/features/create_service_spec.rb
+++ b/acceptance/features/create_service_spec.rb
@@ -24,6 +24,8 @@ feature 'Create a service' do
   background do
     given_I_am_logged_in
     given_I_want_to_create_a_service
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[]).with('NAME_SLUG').and_return('enabled')
   end
 
   scenario 'validates the service name' do
@@ -39,6 +41,7 @@ feature 'Create a service' do
   end
 
   scenario 'validates the service name max length' do
+
     given_I_add_a_service_with_many_characters
     when_I_create_the_service
     then_I_should_see_a_validation_message_for_max_length

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -127,6 +127,12 @@ class ApplicationController < ActionController::Base
   end
   helper_method :editor_preview?
 
+  def service_slug
+    return service_slug_config if service_slug_config.present?
+
+    service.service_slug
+  end
+
   def service_slug_config
     @service_slug_config ||= ServiceConfiguration.find_by(
       service_id: service.service_id,

--- a/app/controllers/settings/form_name_url_controller.rb
+++ b/app/controllers/settings/form_name_url_controller.rb
@@ -1,0 +1,38 @@
+class Settings::FormNameUrlController < FormController
+  before_action :assign_form_object, only: :index
+
+  def index; end
+
+  def create
+    @form_name_url_settings = FormNameUrlSettings.new(service_params)
+
+    if @form_name_url_settings.create
+      FormNameUpdater.new(
+        service_id: service.service_id,
+        service_name: params[:service][:service_slug]
+      ).create_or_update!
+
+      redirect_to settings_form_name_url_index_path(service.service_id)
+    else
+      render :index
+    end
+  end
+
+  private
+
+  def service_params
+    params.require(:service).permit(:service_name, :service_slug).merge(
+      service_id: service.service_id,
+      latest_metadata: service.to_h
+    )
+  end
+
+  def assign_form_object
+    @form_name_url_settings = FormNameUrlSettings.new(
+      service_id: service.service_id,
+      latest_metadata: service.to_h,
+      service_name: service.service_name,
+      service_slug:
+    )
+  end
+end

--- a/app/javascript/src/index.js
+++ b/app/javascript/src/index.js
@@ -8,6 +8,7 @@ const FormAnalyticsController = require('./controller_form_analytics');
 const CollectionEmailController = require('./controller_collection_email');
 const ConfirmationEmailController = require('./controller_confirmation_email');
 const ReferencePaymentController = require('./controller_reference_payment');
+const GOVUKFrontend = require('govuk-frontend')
 
 const {
   snakeToPascalCase,
@@ -92,4 +93,7 @@ switch(controllerAndAction()) {
        Controller = DefaultController;
 }
 
-$(document).ready( () =>  new Controller(app) );
+$(document).ready( () =>  {
+  new Controller(app);
+  GOVUKFrontend.initAll();
+});

--- a/app/javascript/src/page_form_list.js
+++ b/app/javascript/src/page_form_list.js
@@ -15,7 +15,6 @@
 
 const DialogForm = require('./component_dialog_form');
 const DefaultController = require('./controller_default');
-const { CharacterCount } = require('govuk-frontend');
 
 class FormListPage extends DefaultController {
   constructor(app) {
@@ -23,10 +22,6 @@ class FormListPage extends DefaultController {
 
     // Create dialog for handling new form input and error reporting.
     new CreateFormDialog($("[data-component='FormCreateDialog']"));
-    var $characterCount = document.querySelector('[data-module="govuk-character-count"]')
-    if ($characterCount) {
-      new CharacterCount($characterCount).init()
-    }
   }
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -1226,3 +1226,31 @@ dl > div:not(:first-of-type){
   margin-top: govuk-spacing(7);
 }
 
+.govuk-character-count .govuk-input {
+  margin-bottom: 5px;
+}
+
+.fb-domain-input {
+  position:relative;
+  
+  .govuk-input {
+    width: 85%;
+  }
+
+  &__suffix {
+    position: absolute;
+    left: calc(85% + 5px);
+    bottom: 36px;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    .govuk-input {
+      width: 100%;
+    }
+
+    .fb-domain-input__suffix {
+      display: none;
+    }
+  }
+}
+

--- a/app/models/form_name_url_settings.rb
+++ b/app/models/form_name_url_settings.rb
@@ -1,0 +1,48 @@
+class FormNameUrlSettings
+  include ActiveModel::Model
+  include MetadataVersion
+  attr_accessor :service_id, :latest_metadata, :service_name, :service_slug
+
+  MINIMUM = 3
+
+  validates :service_name, :service_slug, presence: true
+  validates :service_name, legacy_service_name: true
+  validates :service_name, length: { minimum: MINIMUM, maximum: 150 }, allow_blank: true
+  validates :service_slug, length: { minimum: MINIMUM, maximum: 57 }, allow_blank: true
+  validates :service_slug, format: { with: /\A[a-zA-Z][\sa-z0-9-]*\z/ }, allow_blank: true
+  validates :service_slug, format: { with: /\A\S+\Z/ }, allow_blank: true
+
+  def create
+    return false if invalid?
+
+    version = MetadataApiClient::Version.create(
+      service_id:,
+      payload: metadata
+    )
+
+    if version.errors?
+      errors.add(:base, :invalid, message: version.errors)
+      false
+    else
+      @version = version
+    end
+  end
+
+  def saved_service_name
+    params(:service_name).presence || service_name
+  end
+
+  def saved_service_slug
+    service_slug
+  end
+
+  private
+
+  def params(setting_name)
+    instance_variable_get(:"@#{setting_name}")
+  end
+
+  def metadata
+    latest_metadata.merge(service_name:)
+  end
+end

--- a/app/services/editor/service.rb
+++ b/app/services/editor/service.rb
@@ -4,7 +4,8 @@ module Editor
     attr_accessor :service_name, :current_user, :service_id, :latest_metadata
 
     MINIMUM = 3
-    MAXIMUM = 57
+    MAXIMUM = ENV['NAME_SLUG'] == 'enabled' ? 255 : 57
+    URL_MAXIMUM = 57
 
     validates :service_name, presence: true
     validates :service_name, length: { minimum: MINIMUM, maximum: MAXIMUM }, allow_blank: true

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -27,17 +27,19 @@
            data-component="FormCreateDialog">
         <%= form_for(@service_creation, url: services_path) do |f| %>
           <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
-            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="<%= Editor::Service::MAXIMUM %>">
+            <%= tag.div class: 'govuk-character-count', data: { module: 'govuk-character-count', maxlength: Editor::Service::MAXIMUM, threshold: ENV['NAME_SLUG'] == 'enabled' ? 90 : 0 } do %>
               <%= f.label :service_name, class: "govuk-label govuk-label--m" %>
               <% f.object.errors.each do |error|  %>
                 <p class="govuk-error-message"><%= error.message %></p>
               <% end %>
-              <div class="govuk-hint" id="service-name-hint"> <%= t('services.form_name_hint', max_length: Editor::Service::MAXIMUM)%></div>
+              <div class="govuk-hint" id="service-name-hint"> 
+                <%= ENV['NAME_SLUG'] == 'enabled' ? t('services.form_name_change_hint') : t('services.form_name_hint', max_length: Editor::Service::MAXIMUM)%>
+              </div>
               <%= f.text_field :service_name, class: "govuk-input govuk-js-character-count", 'aria-describedby': 'service-name-hint service_creation_service_name-info'%>
               <div id="service_creation_service_name-info" class="govuk-hint govuk-character-count__message">
                 You can enter up to <%= Editor::Service::MAXIMUM %> characters
               </div>
-            </div>
+            <% end %>
 
           </div>
           <%= f.button t('services.create'), class: "govuk-button fb-govuk-button", type: 'submit' %>

--- a/app/views/settings/form_name_url/index.html.erb
+++ b/app/views/settings/form_name_url/index.html.erb
@@ -10,24 +10,7 @@
     html: { id: 'form-name-url-settings' },
     builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
 
-    <% if f.object.errors.present? %>
-      <div class="govuk-error-summary" data-module="govuk-error-summary">
-        <div role="alert">
-          <h2 class="govuk-error-summary__title"><%= t('activemodel.errors.summary_title') %></h2>
-          <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list govuk-error-message" id="form-name-url-settings-field-error" >
-              <% f.object.errors.full_messages.each_with_index do |error_message, index| %>
-              <li>
-                <a href="#form-name-url-serttings-field-error_<%= index%>"  >
-                  <%= error_message %>
-                </a>
-              </li>
-            <% end %>
-            </ul>
-          </div>
-        </div>
-      </div>
-    <% end %>
+    <%= f.govuk_error_summary %>
 
     <%= f.govuk_fieldset legend: { text:t('settings.form_name.form_name.label'), size: 's', id: 'form-name-legend' }, class:"govuk-!-margin-bottom-6" do %>   
         <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-6"><%= t('settings.form_name.form_name.lede', href:  t('settings.form_name.form_name.href') ).html_safe %></p>

--- a/app/views/settings/form_name_url/index.html.erb
+++ b/app/views/settings/form_name_url/index.html.erb
@@ -1,0 +1,64 @@
+<%= mojf_settings_screen(
+  heading:t('settings.form_name.heading')
+  ) do |c| %>
+
+  <% c .with_back_link(href: settings_path) %>
+
+  <%= form_for @form_name_url_settings,
+    as: :service,
+    url: settings_form_name_url_index_path(service.service_id),
+    html: { id: 'form-name-url-settings' },
+    builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+
+    <% if f.object.errors.present? %>
+      <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div role="alert">
+          <h2 class="govuk-error-summary__title"><%= t('activemodel.errors.summary_title') %></h2>
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list govuk-error-message" id="form-name-url-settings-field-error" >
+              <% f.object.errors.full_messages.each_with_index do |error_message, index| %>
+              <li>
+                <a href="#form-name-url-serttings-field-error_<%= index%>"  >
+                  <%= error_message %>
+                </a>
+              </li>
+            <% end %>
+            </ul>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.present? ? 'govuk-form-group--error' : '' %>">
+      <%= f.govuk_text_field :service_name,
+        label: { text: t('settings.form_name.form_name.label') },
+        hint: {
+          text: t('settings.form_name.form_name.lede',
+          href:  t('settings.form_name.form_name.href')
+          ).html_safe
+          },
+        id: "service-name-field",
+        class: "govuk-input width-responsive-two-thirds",
+        value: f.object.saved_service_name %>
+    </div>
+
+
+    <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.present? ? 'govuk-form-group--error' : '' %>">
+      <%= f.govuk_text_field :service_slug,
+        label: { text: t('settings.form_name.form_slug.label') },
+        hint: {
+          text: t('settings.form_name.form_slug.lede',
+          href:  t('settings.form_name.form_slug.href')
+          ).html_safe
+          },
+        suffix_text: t('settings.form_name.form_slug.domain'),
+        id: "service-name-field",
+        class: "govuk-input width-responsive-two-thirds",
+        value: f.object.saved_service_slug %>
+    </div>
+
+    <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
+      <%= t('actions.save') %>
+    </button>
+  <% end %>
+<% end %>

--- a/app/views/settings/form_name_url/index.html.erb
+++ b/app/views/settings/form_name_url/index.html.erb
@@ -29,33 +29,37 @@
       </div>
     <% end %>
 
-    <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.present? ? 'govuk-form-group--error' : '' %>">
-      <%= f.govuk_text_field :service_name,
-        label: { text: t('settings.form_name.form_name.label') },
-        hint: {
-          text: t('settings.form_name.form_name.lede',
-          href:  t('settings.form_name.form_name.href')
-          ).html_safe
-          },
-        id: "service-name-field",
-        class: "govuk-input width-responsive-two-thirds",
-        value: f.object.saved_service_name %>
-    </div>
+    <%= f.govuk_fieldset legend: { text:t('settings.form_name.form_name.label'), size: 's', id: 'form-name-legend' }, class:"govuk-!-margin-bottom-6" do %>   
+        <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-6"><%= t('settings.form_name.form_name.lede', href:  t('settings.form_name.form_name.href') ).html_safe %></p>
+
+        <%= f.govuk_text_field :service_name,
+          label: ->  {},
+          class: "govuk-input width-responsive-two-thirds",
+          value: f.object.saved_service_name,
+          'aria-labelledby': 'form-name-legend' %>
+    <% end %>
 
 
-    <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.present? ? 'govuk-form-group--error' : '' %>">
-      <%= f.govuk_text_field :service_slug,
-        label: { text: t('settings.form_name.form_slug.label') },
-        hint: {
-          text: t('settings.form_name.form_slug.lede',
-          href:  t('settings.form_name.form_slug.href')
-          ).html_safe
-          },
-        suffix_text: t('settings.form_name.form_slug.domain'),
-        id: "service-name-field",
-        class: "govuk-input width-responsive-two-thirds",
-        value: f.object.saved_service_slug %>
-    </div>
+    <%= f.govuk_fieldset legend: { text: t('settings.form_name.form_slug.label'), size: 's', id: 'form-url-legend' } do %>   
+      <p><%= t('settings.form_name.form_slug.lede', href:  t('settings.form_name.form_slug.href')).html_safe %></p>
+      <div class="fb-domain-input">
+        <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="<%= Editor::Service::URL_MAXIMUM %>">
+          <%= f.govuk_text_field :service_slug,
+            label: -> {},
+            hint: { text: t('settings.form_name.form_slug.hint'), class: 'govuk-!-margin-bottom-4' },
+            class: "govuk-input  govuk-js-character-count",
+            value: f.object.saved_service_slug,
+            'aria-labelledby': 'form-url-legend'
+          %>
+          <div id="service-service-slug-field-info" class="govuk-hint govuk-character-count__message">
+            You can enter up to <%= Editor::Service::URL_MAXIMUM %> characters
+          </div>
+          <div class="fb-domain-input__suffix" aria-hidden="true">
+            <%= t('settings.form_name.form_slug.domain') %>
+          </div>
+        </div>
+      </div>
+    <% end %>
 
     <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
       <%= t('actions.save') %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,10 +1,12 @@
 <%= mojf_settings_screen(heading:t('settings.name')) do |c| %>
   <nav class="govuk-navigation" aria-labelledby="page-heading">
     <dl class="fb-settings-list">
+      <% unless( ENV['NAME_SLUG'].present? && ENV['NAME_SLUG'] == 'enabled' ) %>
       <div>
         <dt><%= link_to t('settings.form_information.heading'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %></dt>
         <dd class="govuk-hint"><%= t('settings.form_information.lede') %></dd>
       </div>
+    <% end %>
       <% if ENV['NAME_SLUG'] == 'enabled' %>
         <div>
           <dt><%= link_to t('settings.form_name.heading'), settings_form_name_url_index_path(service.service_id), class: 'govuk-link' %></dt>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -5,6 +5,12 @@
         <dt><%= link_to t('settings.form_information.heading'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %></dt>
         <dd class="govuk-hint"><%= t('settings.form_information.lede') %></dd>
       </div>
+      <% if ENV['NAME_SLUG'] == 'enabled' %>
+        <div>
+          <dt><%= link_to t('settings.form_name.heading'), settings_form_name_url_index_path(service.service_id), class: 'govuk-link' %></dt>
+          <dd class="govuk-hint"><%= t('settings.form_information.lede') %></dd>
+        </div>
+      <% end %>
       <div>
         <dt><%= link_to t('settings.reference_payment.link'), settings_reference_payment_index_path(service.service_id), class: 'govuk-link' %></dt>
         <dd class="govuk-hint" ><%= t('settings.reference_payment.lede') %></dd>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,15 +1,14 @@
 <%= mojf_settings_screen(heading:t('settings.name')) do |c| %>
   <nav class="govuk-navigation" aria-labelledby="page-heading">
     <dl class="fb-settings-list">
-      <% unless( ENV['NAME_SLUG'].present? && ENV['NAME_SLUG'] == 'enabled' ) %>
-      <div>
-        <dt><%= link_to t('settings.form_information.heading'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %></dt>
-        <dd class="govuk-hint"><%= t('settings.form_information.lede') %></dd>
-      </div>
-    <% end %>
-      <% if ENV['NAME_SLUG'] == 'enabled' %>
+      <% if ENV['NAME_SLUG'] == 'enabled' && moj_forms_dev? %>
         <div>
           <dt><%= link_to t('settings.form_name.heading'), settings_form_name_url_index_path(service.service_id), class: 'govuk-link' %></dt>
+          <dd class="govuk-hint"><%= t('settings.form_information.lede') %></dd>
+        </div>
+      <% else %>
+        <div>
+          <dt><%= link_to t('settings.form_information.heading'), settings_form_information_index_path(service.service_id), class: 'govuk-link' %></dt>
           <dd class="govuk-hint"><%= t('settings.form_information.lede') %></dd>
         </div>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,7 +318,7 @@ en:
         href: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/settings" target="_blank" rel="noopener noreferrer">Learn more about naming a form</a>
       form_slug:
         label: 'URL'
-        lede: "This will be your form's web address when it goes live. The URL should be easy to read and closely resemble your form name. Words should be in lower case and separated with hyphens. %{href}.\r\n\r\nChanging a live form's URL can cause problems for users so this option is only available before a form has been published to Live."
+        lede: "This will be your form's web address when it goes live. The URL should be easy to read and closely resemble your form name. Words should be in lower case and separated with hyphens. %{href}.<br /><br />Changing a live form's URL can cause problems for users so this option is only available before a form has been published to Live."
         href: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/settings" target="_blank" rel="noopener noreferrer">Learn more about URL standards</a>
         hint: Maximum 57 characters. It cannot start with a number or include spaces or special characters except hyphens
         domain: .form.service.justice.gov.uk
@@ -479,6 +479,9 @@ en:
         service_name: 'Give your form a name'
       settings:
         service_name: 'Form name'
+      form_name_url_settings:
+        service_name: 'Form name'
+        service_slug: 'URL'
       form_analytics_settings:
         enabled_test: Enable analytics on Test
         enabled_live: Enable analytics on Live

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,7 +318,7 @@ en:
         href: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/settings" target="_blank" rel="noopener noreferrer">Learn more about naming a form</a>
       form_slug:
         label: 'URL'
-        lede: This will be your form's web address when it goes live. The URL should be easy to read and closely resemble your form name. Words should be in lower case and separated with hyphens. %{href}.
+        lede: "This will be your form's web address when it goes live. The URL should be easy to read and closely resemble your form name. Words should be in lower case and separated with hyphens. %{href}.\r\n\r\nChanging a live form's URL can cause problems for users so this option is only available before a form has been published to Live."
         href: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/settings" target="_blank" rel="noopener noreferrer">Learn more about URL standards</a>
         hint: Maximum 57 characters. It cannot start with a number or include spaces or special characters except hyphens
         domain: .form.service.justice.gov.uk
@@ -466,6 +466,7 @@ en:
     heading: 'Your forms'
     edit: 'Edit'
     form_name_hint: "Maximum %{max_length} characters, including spaces. It cannot start with a number or include special characters except ' - ( )"
+    form_name_change_hint: "You will be able to change this later in your form's settings"
     preview: 'Preview'
     create: 'Create a new form'
     cancel: 'Cancel'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -308,6 +308,20 @@ en:
       negative: 'No'
   settings:
     name: 'Settings'
+    form_name:
+      heading: 'Form name and URL'
+      lede: ''
+      help: Additional guidance for URL is available on
+      form_name:
+        label: 'Form name'
+        lede: This appears in the header of all your form pages and is what your form is liseted as in the MoJ Forms editor. A good name describes the task the form is designer for and starts with an action, such as "Get help with..." or "Apply for..." %{href}.
+        href: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/settings" target="_blank" rel="noopener noreferrer">Learn more about naming a form</a>
+      form_slug:
+        label: 'URL'
+        lede: This will be your form's web address when it goes live. The URL should be easy to read and closely resemble your form name. Words should be in lower case and separated with hyphens. %{href}.
+        href: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/settings" target="_blank" rel="noopener noreferrer">Learn more about URL standards</a>
+        hint: Maximum 57 characters. It cannot start with a number or include spaces or special characters except hyphens
+        domain: .form.service.justice.gov.uk
     form_information:
       heading: 'Form details'
       lede: "Set your form's name, URL and phase (e.g. Alpha, Beta)."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
       resources :settings, only: [:index]
       namespace :settings do
         resources :form_information, only: [:index, :create]
+        resources :form_name_url, only: [:index, :create]
         resources :form_analytics, only: [:index, :create]
         resources :reference_payment, only: [:index, :create]
         resources :save_and_return, only: [:index, :create]

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -284,6 +284,28 @@ RSpec.describe ApplicationController do
     end
   end
 
+  describe '#service_slug' do
+    before do
+      allow(controller).to receive(:service).and_return(service)
+    end
+
+    context 'when SERVICE_SLUG exists' do
+      before do
+        allow(controller).to receive(:service_slug_config).and_return('service-slug')
+      end
+
+      it 'returns service slug' do
+        expect(controller.service_slug).to eq('service-slug')
+      end
+    end
+
+    context 'when SERVICE_SLUG does not exists' do
+      it 'returns service slug' do
+        expect(controller.service_slug).to eq('version-fixture')
+      end
+    end
+  end
+
   describe '#service_slug_config' do
     before do
       allow(controller).to receive(:service).and_return(service)

--- a/spec/models/form_name_settings_spec.rb
+++ b/spec/models/form_name_settings_spec.rb
@@ -1,0 +1,105 @@
+RSpec.describe FormNameUrlSettings do
+  subject(:form_name_url_settings) do
+    described_class.new(
+      params.merge(
+        service_id: '24601',
+        latest_metadata:
+      )
+    )
+  end
+  let(:latest_metadata) do
+    { service_name: 'a service name' }
+  end
+
+  describe '#create' do
+    context 'when valid' do
+      let(:params) do
+        { service_name: 'another service name', service_slug: 'a-valid-slug' }
+      end
+      let(:service) do
+        double(id: '05e12a93-3978-4624-a875-e59893f2c262', errors?: false)
+      end
+
+      before do
+        expect(MetadataApiClient::Version).to receive(:create).with(
+          service_id: '24601',
+          payload: { service_name: 'another service name' }
+        ).and_return(service)
+      end
+
+      it 'returns true' do
+        expect(form_name_url_settings.create).to be_truthy
+      end
+    end
+
+    context 'when invalid' do
+      context 'service_name' do
+        context 'when blank' do
+          let(:params) { { service_name: '' } }
+
+          it 'returns false' do
+            expect(form_name_url_settings.create).to be_falsey
+          end
+        end
+
+        context 'when too long' do
+          let(:params) { { service_name: 'hi' * 160 } }
+
+          it 'returns false' do
+            expect(form_name_url_settings.create).to be_falsey
+          end
+        end
+
+        context 'when too short' do
+          let(:params) { { service_name: 'HI' } }
+
+          it 'returns false' do
+            expect(form_name_url_settings.create).to be_falsey
+          end
+        end
+      end
+
+      context 'service_slug' do
+        context 'when blank' do
+          let(:params) { { service_slug: '' } }
+
+          it 'returns false' do
+            expect(form_name_url_settings.create).to be_falsey
+          end
+        end
+
+        context 'when too long' do
+          let(:params) { { service_slug: 'hi' * 58 } }
+
+          it 'returns false' do
+            expect(form_name_url_settings.create).to be_falsey
+          end
+        end
+
+        context 'when too short' do
+          let(:params) { { service_slug: 'ss' } }
+
+          it 'returns false' do
+            expect(form_name_url_settings.create).to be_falsey
+          end
+        end
+
+        context 'when begins with a number' do
+          let(:params) { { service_slug: '001ss' } }
+
+          it 'returns false' do
+            expect(form_name_url_settings.create).to be_falsey
+          end
+        end
+
+        context 'when spaces' do
+          let(:params) { { service_slug: 'an invalid service slug' } }
+
+          it 'returns false' do
+            expect(form_name_url_settings.create).to be_falsey
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Adds the Form name and url settings screen template 
* Updates the settings index page
  * Adds form name and url 
  * Hides form details 
* Update the create new form modal

All changes are behind the NAME_SLUG feature flag, so this should be good to deploy.

Co-authored by @njseeto 


## With feature flag ENABLED
![image](https://github.com/ministryofjustice/fb-editor/assets/595564/f3266318-8642-4a85-a910-a0590f0ee9bb)

![image](https://github.com/ministryofjustice/fb-editor/assets/595564/928a0eb1-670e-45a9-a204-d5a99decd464)

![image](https://github.com/ministryofjustice/fb-editor/assets/595564/14ad8376-c19b-4a0b-822f-668a1e3860ee)

## Without feature flag
![image](https://github.com/ministryofjustice/fb-editor/assets/595564/1a1bc637-ee83-4f13-a26a-ff47c9653e60)

![image](https://github.com/ministryofjustice/fb-editor/assets/595564/81ebc9ed-6f92-4f93-bad3-e96399a6f025)
