### PR TITLE
Do not create SERVICE_SLUG config if user is Acceptance Tests

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,6 +1,7 @@
 class ServicesController < PermissionsController
   layout 'form', only: :edit
   skip_before_action :authorised_access, only: %i[index create]
+  ACCEPTANCE_TEST_USER = 'Acceptance Tests'.freeze
 
   def index
     @service_creation = ServiceCreation.new
@@ -10,8 +11,7 @@ class ServicesController < PermissionsController
     @service_creation = ServiceCreation.new(service_creation_params)
 
     if @service_creation.create
-
-      if ENV['NAME_SLUG'] == 'enabled'
+      if ENV['NAME_SLUG'] == 'enabled' && current_user.name != ACCEPTANCE_TEST_USER
         FormNameUpdater.new(
           service_id: @service_creation.service_id,
           service_name: @service_creation.service_name


### PR DESCRIPTION
We have many `SERVICE_SLUG` records in our ServiceConfig table. This is because our acceptance tests create new forms on every run, so adding this little caveat to prevent the creation of a SERVICE_SLUG record for acceptance tests.

We use the service name as the service slug by default if there is no `SERVICE_SLUG` record.