### PR TITLE
Change Form Name and URL settings template when form is Live

### DIFF
--- a/app/models/form_name_url_settings.rb
+++ b/app/models/form_name_url_settings.rb
@@ -37,6 +37,10 @@ class FormNameUrlSettings
     service_slug
   end
 
+  def published_to_live?
+    published_production&.last&.published?
+  end
+
   private
 
   def params(setting_name)
@@ -45,5 +49,11 @@ class FormNameUrlSettings
 
   def metadata
     latest_metadata.merge(service_name:)
+  end
+
+  def published_production
+    @published_production ||= PublishService.where(
+      service_id:
+    ).production
   end
 end

--- a/app/views/settings/form_name_url/index.html.erb
+++ b/app/views/settings/form_name_url/index.html.erb
@@ -12,7 +12,7 @@
 
     <%= f.govuk_error_summary %>
 
-    <%= f.govuk_fieldset legend: { text:t('settings.form_name.form_name.label'), size: 's', id: 'form-name-legend' }, class:"govuk-!-margin-bottom-6" do %>   
+    <%= f.govuk_fieldset legend: { text:t('settings.form_name.form_name.label'), size: 's', id: 'form-name-legend' }, class:"govuk-!-margin-bottom-6" do %>
         <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-6"><%= t('settings.form_name.form_name.lede', href:  t('settings.form_name.form_name.href') ).html_safe %></p>
 
         <%= f.govuk_text_field :service_name,
@@ -22,8 +22,18 @@
           'aria-labelledby': 'form-name-legend' %>
     <% end %>
 
-
-    <%= f.govuk_fieldset legend: { text: t('settings.form_name.form_slug.label'), size: 's', id: 'form-url-legend' } do %>   
+  <% if f.object.published_to_live? %>
+    <%= f.govuk_fieldset legend: { text: t('settings.form_name.form_slug.label'), size: 's', id: 'form-url-legend' } do %>
+      <p><%= t('settings.form_name.form_slug.lede_live', href: t('settings.form_name.form_slug.href'), contact_us: t('settings.form_name.form_slug.contact_us')).html_safe %></p>
+      <div class="fb-domain-input">
+        <div aria-hidden="true">
+          <p><strong><%= f.object.service_slug %></strong><%= t('settings.form_name.form_slug.domain') %></p>
+          <%= f.hidden_field :service_slug, value: f.object.service_slug %>
+        </div>
+      </div>
+    <% end %>
+  <% else %>
+    <%= f.govuk_fieldset legend: { text: t('settings.form_name.form_slug.label'), size: 's', id: 'form-url-legend' } do %>
       <p><%= t('settings.form_name.form_slug.lede', href:  t('settings.form_name.form_slug.href')).html_safe %></p>
       <div class="fb-domain-input">
         <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="<%= Editor::Service::URL_MAXIMUM %>">
@@ -43,7 +53,7 @@
         </div>
       </div>
     <% end %>
-
+  <% end %>
     <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
       <%= t('actions.save') %>
     </button>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -319,6 +319,8 @@ en:
       form_slug:
         label: 'URL'
         lede: "This will be your form's web address when it goes live. The URL should be easy to read and closely resemble your form name. Words should be in lower case and separated with hyphens. %{href}.<br /><br />Changing a live form's URL can cause problems for users so this option is only available before a form has been published to Live."
+        lede_live: "This is your form's live web address. The URL should be easy to read and closely resemble your form name. Words should be in lower case and separated with hyphens. %{href}.<br /><br />As your form is now live, you cannot change your URL here. %{contact_us} to discuss changing your URL."
+        contact_us: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/contact" target="_blank" rel="noopener noreferrer">Contact us</a>
         href: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/settings" target="_blank" rel="noopener noreferrer">Learn more about URL standards</a>
         hint: Maximum 57 characters. It cannot start with a number or include spaces or special characters except hyphens
         domain: .form.service.justice.gov.uk


### PR DESCRIPTION
Once a form has been published to live, we do not allow users to change their URL.
Remove the URL input on the template and show the current live URL instead.
We need to include the hidden field, so as not to trigger the URL validation on save.

### When not Live
![Screenshot 2023-06-01 at 11 18 01](https://github.com/ministryofjustice/fb-editor/assets/29227502/f3e9546d-4b3d-45b1-9aee-140e4ce78d54)

### When Live
![Screenshot 2023-06-01 at 12 45 55](https://github.com/ministryofjustice/fb-editor/assets/29227502/05d7d21d-f2f8-459d-987d-b816904b1011)
