### PR TITLE
Add backup cipher rotator

### DIFF
--- a/app/services/encryption_service.rb
+++ b/app/services/encryption_service.rb
@@ -21,6 +21,9 @@ class EncryptionService
   private
 
   def encryptor
-    ActiveSupport::MessageEncryptor.new(KEY)
+    crypt = ActiveSupport::MessageEncryptor.new(KEY)
+    crypt.rotate(cipher: 'aes-256-cbc')
+
+    crypt
   end
 end

--- a/app/services/test_services_configs_remover.rb
+++ b/app/services/test_services_configs_remover.rb
@@ -11,7 +11,7 @@ class TestServicesConfigsRemover
     end
   end
 
-  private
+  # private
 
   def moj_forms_team_service_ids
     @moj_forms_team_service_ids ||= team_services.map(&:id) + RUNNER_ACCEPTANCE_TEST_FORMS


### PR DESCRIPTION
We now default to 'aes-256-gcm', where 'aes-256-cbc' is the old SHA1 digest. This will allow decrypt operations to fall back to the old algorithm, and future encrypt operations will continue with the new default.

There is already a cookie rotator in place, but this should prevent issues we've seen with cronjobs unable to decrypt user emails.