### PR TITLE
Testable editabe components optional fix

### DIFF
--- a/acceptance/features/mark_questions_as_optional_spec.rb
+++ b/acceptance/features/mark_questions_as_optional_spec.rb
@@ -35,7 +35,7 @@ feature 'Mark question as optional' do
     within_window(preview_form) do
       expect(page).to have_content('Service name goes here')
       page.click_button 'Start now'
-      expect(page).to have_content('Full name (Optional)')
+      expect(page).to have_content('Full name (optional)')
       page.click_button 'Continue'
       expect(page.text).to_not include('Full name')
       expect(page).to have_content('Option')

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -110,21 +110,24 @@ class Question {
    * This function is to handle the adding the extra element.
    **/
   setRequiredFlag() {
-    var $target = this.$heading;
     var text = this._config.text.optionalFlag;
-    var regExpTextWithSpace = " " + text.replace(/(\(|\))/mig, "\\$1"); // Need to escape parenthesis for RegExp
-    var textWithSpace =  " " + text;
-    var re = new RegExp(regExpTextWithSpace + "$");
+    // Escape the parentheses
+    var escapedTextWithSpace = " " + text.replace(/(\(|\))/mig, "\\$1");
+    // $ - must be at the end of the string
+    // i - case insensitive
+    var regex = new RegExp(escapedTextWithSpace + "$", "i"); 
 
-    // Since we always remove first we can add knowing duplicates should not happen.
-    $target.text($target.text().replace(re, ""));
-    if(!this.required) {
-      $target.text($target.text() + textWithSpace);
+    if(this.required) {
+      this.$heading.text(this.$heading.text().replace(regex, ''))
+    } else {
+      if(!this.$heading.text().match(regex)) {
+        this.$heading.text(`${this.$heading.text()} ${text}`);
+      }
     }
 
-    // If we've changed the $target content, or the eitor has, we
+    // If we've changed the this.$heading content, or the editor has, we
     // need to check whether required flag needs to show, or not.
-    $target.data("instance").update();
+    this.$heading.data("instance").update();
   }
 
   focus() {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -289,7 +289,7 @@ en:
       affirmative: 'Yes'
       negative: 'No'
   question:
-    optional_flag: '(Optional)'
+    optional_flag: '(optional)'
     menu:
       activator: 'Properties'
       remove: 'Delete...'


### PR DESCRIPTION
Small fix to change the 'optional' text appended to question titles to be lower case, and to prevent it being duplicated if the user adjust the capitalisation of it.