### PR TITLE
Publish / un-publish services in Test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'editable-content-web-component'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.0'
+gem 'metadata_presenter', '3.0.2'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.0)
+    metadata_presenter (3.0.2)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -484,7 +484,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.0)
+  metadata_presenter (= 3.0.2)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -134,7 +134,7 @@ class ApplicationController < ActionController::Base
   end
 
   def service_slug_config
-    @service_slug_config ||= ServiceConfiguration.find_by(
+    ServiceConfiguration.find_by(
       service_id: service.service_id,
       name: 'SERVICE_SLUG'
     )&.decrypt_value

--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -84,21 +84,21 @@ class PublishController < FormController
   end
 
   def published_service
-    @published_service ||= PublishService.where(
+    PublishService.where(
       service_id: service.service_id,
       deployment_environment: 'dev'
     ).completed.desc.first
   end
 
   def previous_service_slug
-    @previous_service_slug ||= ServiceConfiguration.find_by(
+    ServiceConfiguration.find_by(
       service_id: service.service_id,
       name: 'PREVIOUS_SERVICE_SLUG'
     )
   end
 
   def all_previous_service_slugs
-    @all_previous_service_slugs ||= ServiceConfiguration.where(
+    ServiceConfiguration.where(
       service_id: service.service_id,
       name: 'PREVIOUS_SERVICE_SLUG'
     )

--- a/app/controllers/publish_controller.rb
+++ b/app/controllers/publish_controller.rb
@@ -7,26 +7,13 @@ class PublishController < FormController
   end
 
   def create
-    if published_form_uses_previous_slug?(publish_service_params[:deployment_environment])
-      unpublish_service = published(publish_service_params[:deployment_environment])
-      version_metadata = get_version_metadata(unpublish_service)
-
-      unpublish_service_creation = PublishServiceCreation.new(
-        service_id: service.service_id,
-        version_id: version_metadata['version_id'],
-        deployment_environment: publish_service_params[:deployment_environment],
-        user_id: current_user.id
-      )
-
-      UnpublishServiceJob.perform_later(
-        publish_service_id: unpublish_service_creation.publish_service_id,
-        service_slug: previous_service_slug
-      )
-    end
-
     @publish_service_creation = PublishServiceCreation.new(publish_service_params)
 
     if @publish_service_creation.save
+      if previous_service_slug.present?
+        all_previous_service_slugs.destroy_all
+      end
+
       PublishServiceJob.perform_later(
         publish_service_id: @publish_service_creation.publish_service_id
       )
@@ -91,23 +78,17 @@ class PublishController < FormController
     end
   end
 
-  def published(deployment_environment)
-    return if previous_service_slug.nil?
-
-    PublishService.where(
-      service_id: @service.service_id,
-      deployment_environment:
-    ).completed.desc.first
-  end
-
   def previous_service_slug
     @previous_service_slug ||= ServiceConfiguration.find_by(
       service_id: service.service_id,
       name: 'PREVIOUS_SERVICE_SLUG'
-    )&.decrypt_value
+    )
   end
 
-  def published_form_uses_previous_slug?(deployment_environment)
-    published(deployment_environment).present? && previous_service_slug.present?
+  def all_previous_service_slugs
+    @all_previous_service_slugs ||= ServiceConfiguration.where(
+      service_id: service.service_id,
+      name: 'PREVIOUS_SERVICE_SLUG'
+    )
   end
 end

--- a/app/controllers/settings/form_name_url_controller.rb
+++ b/app/controllers/settings/form_name_url_controller.rb
@@ -38,7 +38,7 @@ class Settings::FormNameUrlController < FormController
   end
 
   def service_slug_config
-    @service_slug_config ||= ServiceConfiguration.find_by(
+    ServiceConfiguration.find_by(
       service_id: service.service_id,
       name: 'SERVICE_SLUG',
       deployment_environment: 'dev'

--- a/app/controllers/settings/form_name_url_controller.rb
+++ b/app/controllers/settings/form_name_url_controller.rb
@@ -1,5 +1,6 @@
 class Settings::FormNameUrlController < FormController
   before_action :assign_form_object, only: :index
+  before_action :create_service_slug_config, only: :index
 
   def index; end
 
@@ -34,5 +35,22 @@ class Settings::FormNameUrlController < FormController
       service_name: service.service_name,
       service_slug:
     )
+  end
+
+  def service_slug_config
+    @service_slug_config ||= ServiceConfiguration.find_by(
+      service_id: service.service_id,
+      name: 'SERVICE_SLUG',
+      deployment_environment: 'dev'
+    )&.decrypt_value
+  end
+
+  def create_service_slug_config
+    if service_slug_config.blank?
+      FormUrlUpdater.new(
+        service_id: service.service_id,
+        service_slug:
+      ).create_or_update!
+    end
   end
 end

--- a/app/models/form_url_updater.rb
+++ b/app/models/form_url_updater.rb
@@ -8,6 +8,10 @@ class FormUrlUpdater
 
   def create_or_update!
     ActiveRecord::Base.transaction do
+      if existing_service_slug_config.nil?
+        save_config_service_slug
+      end
+
       if previous_service_slug.nil? && currently_published?
         save_config_previous_service_slug
       end

--- a/app/models/form_url_updater.rb
+++ b/app/models/form_url_updater.rb
@@ -61,17 +61,15 @@ class FormUrlUpdater
   end
 
   def new_service_slug
-    @new_service_slug ||= begin
-      return parameterized_service_slug if unique_service_slug?
+    return parameterized_service_slug if unique_service_slug?
 
-      # Replace the last 3 chars with random 3 alpha-numric chars
-      parameterized_service_slug.gsub(/.{3}$/, SecureRandom.alphanumeric(3)).downcase
-    end
+    # Replace the last 3 chars with random 3 alpha-numric chars
+    parameterized_service_slug.gsub(/.{3}$/, SecureRandom.alphanumeric(3)).downcase
   end
 
   def parameterized_service_slug
     # parameterize, use first non-numeric char and limit to 57 chars
-    @parameterized_service_slug ||= service_slug.parameterize.slice(service_slug.index(/\D/), 57)
+    service_slug.parameterize.slice(service_slug.index(/\D/), 57)
   end
 
   def unique_service_slug?
@@ -79,26 +77,26 @@ class FormUrlUpdater
   end
 
   def all_service_slugs
-    @all_service_slugs ||= all_existing_service_slugs.concat(all_previous_service_slugs)
+    all_existing_service_slugs.concat(all_previous_service_slugs)
   end
 
   def all_existing_service_slugs
-    @all_existing_service_slugs ||= ServiceConfiguration.where(name: 'SERVICE_SLUG').map(&:decrypt_value) - [existing_service_slug_config]
+    ServiceConfiguration.where(name: 'SERVICE_SLUG').map(&:decrypt_value) - [existing_service_slug_config]
   end
 
   def all_previous_service_slugs
-    @all_previous_service_slugs ||= ServiceConfiguration.where(name: 'PREVIOUS_SERVICE_SLUG').map(&:decrypt_value)
+    ServiceConfiguration.where(name: 'PREVIOUS_SERVICE_SLUG').map(&:decrypt_value)
   end
 
   def existing_service_slug_config
-    @existing_service_slug_config ||= ServiceConfiguration.find_by(
+    ServiceConfiguration.find_by(
       service_id:,
       name: 'SERVICE_SLUG'
     )&.decrypt_value
   end
 
   def previous_service_slug
-    @previous_service_slug ||= ServiceConfiguration.find_by(
+    ServiceConfiguration.find_by(
       service_id:,
       name: 'PREVIOUS_SERVICE_SLUG'
     )

--- a/app/presenters/publish_service_presenter.rb
+++ b/app/presenters/publish_service_presenter.rb
@@ -3,12 +3,15 @@ class PublishServicePresenter
   attr_reader :service, :publish_service
 
   delegate :deployment_environment, to: :publish_service
-  delegate :service_slug, to: :service
 
   def initialize(publish_service_query, service)
     @publishes = publish_service_query
     @publish_service = latest
     @service = service
+  end
+
+  def service_slug
+    service_slug_config || service.service_slug
   end
 
   def latest
@@ -30,5 +33,14 @@ class PublishServicePresenter
 
   def url
     "https://#{hostname}" if published?
+  end
+
+  private
+
+  def service_slug_config
+    @service_slug_config ||= ServiceConfiguration.find_by(
+      service_id: service.service_id,
+      name: 'SERVICE_SLUG'
+    )&.decrypt_value
   end
 end

--- a/app/presenters/publish_service_presenter.rb
+++ b/app/presenters/publish_service_presenter.rb
@@ -38,14 +38,14 @@ class PublishServicePresenter
   private
 
   def service_slug_config
-    @service_slug_config ||= ServiceConfiguration.find_by(
+    ServiceConfiguration.find_by(
       service_id: service.service_id,
       name: 'SERVICE_SLUG'
     )&.decrypt_value
   end
 
   def previous_service_slug
-    @previous_service_slug ||= ServiceConfiguration.find_by(
+    ServiceConfiguration.find_by(
       service_id: service.service_id,
       name: 'PREVIOUS_SERVICE_SLUG'
     )&.decrypt_value

--- a/app/presenters/publish_service_presenter.rb
+++ b/app/presenters/publish_service_presenter.rb
@@ -11,7 +11,7 @@ class PublishServicePresenter
   end
 
   def service_slug
-    service_slug_config || service.service_slug
+    (previous_service_slug.presence || service_slug_config.presence || service.service_slug)
   end
 
   def latest
@@ -41,6 +41,13 @@ class PublishServicePresenter
     @service_slug_config ||= ServiceConfiguration.find_by(
       service_id: service.service_id,
       name: 'SERVICE_SLUG'
+    )&.decrypt_value
+  end
+
+  def previous_service_slug
+    @previous_service_slug ||= ServiceConfiguration.find_by(
+      service_id: service.service_id,
+      name: 'PREVIOUS_SERVICE_SLUG'
     )&.decrypt_value
   end
 end

--- a/app/services/publisher/adapters/cloud_platform.rb
+++ b/app/services/publisher/adapters/cloud_platform.rb
@@ -78,7 +78,7 @@ class Publisher
       end
 
       def config_dir
-        Rails.root.join('tmp', 'publisher', service_id)
+        Rails.root.join('tmp', 'publisher', "#{service_id}-#{service_slug}")
       end
 
       def config_dir?

--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -40,9 +40,11 @@ class Publisher
       binding
     end
 
-    delegate :service_slug, to: :service
-
     delegate :service_name, to: :service
+
+    def service_slug
+      (service_slug_config.presence || service.service_slug)
+    end
 
     def container_port
       Rails.application.config.platform_environments[:common][:container_port]
@@ -193,6 +195,13 @@ class Publisher
 
     def deployment_environment_upcase
       @deployment_environment_upcase ||= deployment_environment.upcase
+    end
+
+    def service_slug_config
+      ServiceConfiguration.find_by(
+        service_id:,
+        name: 'SERVICE_SLUG'
+      )&.decrypt_value
     end
   end
 end

--- a/app/services/publisher/utils/kubernetes_configuration.rb
+++ b/app/services/publisher/utils/kubernetes_configuration.rb
@@ -31,6 +31,10 @@ class Publisher
           erb = ERB.new(template_content)
           content = erb.result(service_provisioner.get_binding)
 
+          Rails.logger.debug('***** writing to config *****')
+          Rails.logger.debug("erb: #{erb}")
+          Rails.logger.debug("content: #{content}")
+
           write_config_file(
             file: File.expand_path(File.join(destination, "#{template}.yaml")),
             content:

--- a/spec/models/form_url_updater_spec.rb
+++ b/spec/models/form_url_updater_spec.rb
@@ -267,5 +267,18 @@ RSpec.describe FormUrlUpdater do
         end
       end
     end
+
+    context 'when SERVICE_CONFIG does not exist' do
+      let(:params) { 'I am a unique service' }
+      let(:expected_service_slug) { 'i-am-a-unique-service' }
+
+      it 'creates a SERVICE_CONFIG' do
+        form_name_updater.create_or_update!
+        service_configuration.reload
+        expect(
+          service_configuration.decrypt_value
+        ).to eq(expected_service_slug)
+      end
+    end
   end
 end

--- a/spec/services/publisher/adapters/cloud_platform_spec.rb
+++ b/spec/services/publisher/adapters/cloud_platform_spec.rb
@@ -10,14 +10,13 @@ RSpec.describe Publisher::Adapters::CloudPlatform do
       deployment_environment: 'dev'
     )
   end
-
   let(:config_dir) do
-    Rails.root.join('tmp', 'publisher', service_provisioner.service_id)
+    Rails.root.join('tmp', 'publisher', "#{service_provisioner.service_id}-#{service_provisioner.service_slug}")
   end
 
   before do
-    allow(cloud_platform).to receive(:create_config_dir).and_return(config_dir)
     allow(service_provisioner).to receive(:service_slug).and_return('obi-wan')
+    allow(cloud_platform).to receive(:create_config_dir).and_return(config_dir)
   end
 
   describe '#pre_publishing' do
@@ -46,7 +45,6 @@ RSpec.describe Publisher::Adapters::CloudPlatform do
 
       context 'when config files exist' do
         let(:config_files?) { true }
-
         it 'calls kubecontrol' do
           expect(
             ::Publisher::Utils::KubeControl


### PR DESCRIPTION
## Managing service slug and previous service slugs
A `SERVICE_SLUG` config is created when a user visits the Form name and URL settings page, if the form does not have the config.
A `PREVIOUS_SERVICE_SLUG` is created if there is a a service currently published to test and a newly saved `SERVICE_SLUG` is different to the currently saved `SERVICE_SLUG`.
The `PREVIOUS_SERVICE_SLUG` is deleted when publishing, as we will be using the `SERVICE_SLUG` config, which on subsequent saves will need to become the `PREVIOUS_SERVICE_SLUG`.
 
## Publishing
We always publish the value that is saved in the `SERVICE_SLUG` config.

We have added a Rails logger during the creation of the erb files that are used in creating the kubernetes config files - the addition of these files have allowed the pods to successfully use the most recent `SERVICE_SLUG` config.

We have also prefixed the kubernetes config directory with the service slug, this is again to ensure we create new files for a new url and to assist in un-publishing the correct files.

There was a small bug in which on first publish we would always use the parameterized service name, rather than the saved `SERVICE_SLUG` - this was fixed by removing the memoization of the `SERVICE_SLUG`.

# Test Cases
This branch was used to test the following scenarios:

## A new form called `the-newest-form`.
- Created and published the form on this testable branch, this has a `SERVICE_SLUG` config on service creation
![first-publish](https://github.com/ministryofjustice/fb-editor/assets/29227502/55cc2647-d47a-4611-a7c2-55d902cf60f1)

- Published with a slug changed
![subsequent-publish](https://github.com/ministryofjustice/fb-editor/assets/29227502/bc0d390c-51c1-4acd-bf49-8bad49c555a5)

## Old form that has not been published called `branching point test`
- This form was created last year, and does not have a `SERVICE_SLUG` config
- Published on this testable editor without `SERVICE_SLUG` config
![first-publish-no-config](https://github.com/ministryofjustice/fb-editor/assets/29227502/b72c03ca-f6c7-46bd-a69d-b9c91851e3bc)
- Publish with slug changed
![Screenshot 2023-06-09 at 17 31 35](https://github.com/ministryofjustice/fb-editor/assets/29227502/c153c313-9480-4ab1-b703-b5a6f521d8e8)

## Old form that has been published previously, named `acceptance test test`
- Published the form in the Test Editor without a `SERVICE_SLUG` config
![acceptance-test-test-publish-test-editor](https://github.com/ministryofjustice/fb-editor/assets/29227502/f5d0880a-6840-4528-af53-ebe8d68f7d3f)

- Re-publish the form on this testable editor without changing the slug or visiting the settings page
![acceptance-test-test-first-publish-testable](https://github.com/ministryofjustice/fb-editor/assets/29227502/44fd5f96-ab56-4826-9aba-51960d447a5c)

- Publish again with a `SERVICE_SLUG` config
![acceptance-test-one](https://github.com/ministryofjustice/fb-editor/assets/29227502/3a32dc64-9aa3-4d6e-885f-a3be10fb9335)
