### PR TITLE
Increase read timeout

### DIFF
--- a/app/services/metadata_api_client/connection.rb
+++ b/app/services/metadata_api_client/connection.rb
@@ -1,8 +1,8 @@
 module MetadataApiClient
   class Connection
     SUBSCRIPTION = 'metadata_api.client'
-    OPEN_TIMEOUT = 10
-    TIMEOUT = 15
+    OPEN_TIMEOUT = 60
+    TIMEOUT = 60
 
     attr_reader :connection
 


### PR DESCRIPTION
We have an error which only affects the read timeout. This has occurred when a user has tried to publish a form unsuccessfully.

60 seconds is the maximum before rails defaults take over