### PR TITLE
Node 16.20.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ jobs:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-            nvm install v16.20.0
-            nvm alias default 16.20.0
+            nvm install v16.20.1
+            nvm alias default 16.20.1
 
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ New editor for MoJ Forms.
 
 ## Prerequisites
 * Docker
-* Node (version 16.20.0 LTS)
+* Node (version 16.20.1 LTS)
 * Ruby v2.7.7
 * Postgresql
 * Yarn
 
 ## Setup
-Ensure you are running Node version 16.20.0 LTS. Easiest is to install [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) and then:
-`nvm install 16.20.0`
-`nvm use 16.20.0`
+Ensure you are running Node version 16.20.1 LTS. Easiest is to install [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) and then:
+`nvm install 16.20.1`
+`nvm use 16.20.1`
 
 Install gems:
 `bundle`

--- a/acceptance/Dockerfile
+++ b/acceptance/Dockerfile
@@ -5,7 +5,7 @@ ARG UID=1001
 RUN apk add git yarn build-base postgresql-contrib postgresql-dev bash libcurl
 RUN apk add build-base bash tzdata chromium-chromedriver chromium zlib-dev xorg-server
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=16.20.0-r0 npm
+RUN apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.16/main/ nodejs
 
 WORKDIR /usr/src/app
 

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update
 RUN apk add git yarn build-base postgresql-contrib postgresql-dev \
       bash libcurl curl
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=16.20.0-r0 npm
+RUN apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.16/main/ nodejs
 RUN apk add clamav-daemon
 RUN apk add --no-cache gcompat
 

--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -4,7 +4,7 @@ ARG UID=1001
 
 RUN apk add git yarn build-base postgresql-contrib postgresql-dev bash libcurl curl
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=16.20.0-r0 npm
+RUN apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.16/main/ nodejs
 
 ARG KUBE_VERSION="1.21.0"
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v$KUBE_VERSION/bin/linux/amd64/kubectl

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fb_editor",
   "private": true,
   "engines": {
-    "node": "16.20.0"
+    "node": "16.20.1"
   },
   "scripts": {
     "jstest": "mocha --recursive"


### PR DESCRIPTION
CircleCI deployments are failing due to Node apk 16.20.0 being pulled. Use Node v16.20.1 instead.

Also, stop using 'edge' repo for builds as this is the development repo and changes frequently.

CircleCI: https://app.circleci.com/pipelines/github/ministryofjustice/fb-editor/8443/workflows/d481e6db-bf8e-4430-bf06-f63c910b8639