### PR TITLE
Add Sentry CSP URL env vars

### DIFF
--- a/deploy-eks/fb-editor-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-editor-chart/templates/deployment.yaml
@@ -124,6 +124,16 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: service_sentry_dsn_live
+          - name: SERVICE_SENTRY_CSP_URL_TEST
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: service_sentry_csp_url_test
+          - name: SERVICE_SENTRY_CSP_URL_LIVE
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: service_sentry_csp_url_live
           - name: SLACK_PUBLISH_WEBHOOK
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
These env vars will be injected into each runner. We need the Sentry CSP URL to allow us to send alerts to Slack via Sentry whenever there is a CSP violation in our runners.