### PR TITLE
Add Sentry CSP URL env vars

### DIFF
--- a/deploy-eks/fb-editor-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-editor-chart/templates/deployment.yaml
@@ -266,6 +266,16 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: service_sentry_dsn_live
+          - name: SERVICE_SENTRY_CSP_URL_TEST
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: service_sentry_csp_url_test
+          - name: SERVICE_SENTRY_CSP_URL_LIVE
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: service_sentry_csp_url_live
           - name: SLACK_PUBLISH_WEBHOOK
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
They need to be added twice in this file. Once for the workers and again for the web deployment - I left out the web deployment env vars in the previous PR 🤦 