### PR TITLE
Add CSP URL and GOVUK_APP_DOMAIN env vars

### DIFF
--- a/deploy-eks/fb-editor-chart/templates/secrets.yaml
+++ b/deploy-eks/fb-editor-chart/templates/secrets.yaml
@@ -15,6 +15,8 @@ data:
   submission_encryption_key: {{ .Values.submission_encryption_key }}
   service_sentry_dsn_test: {{ .Values.service_sentry_dsn_test }}
   service_sentry_dsn_live: {{ .Values.service_sentry_dsn_live }}
+  service_sentry_csp_url_test: {{ .Values.service_sentry_csp_url_test }}
+  service_sentry_csp_url_live: {{ .Values.service_sentry_csp_url_live }}
   slack_publish_webhook: {{ .Values.slack_publish_webhook }}
   pingdom_token: {{ .Values.pingdom_token }}
   pingdom_alert_integration_id: {{ .Values.pingdom_alert_integration_id }}

--- a/docker/workers/Dockerfile
+++ b/docker/workers/Dockerfile
@@ -38,5 +38,10 @@ COPY --chown=appuser:appgroup . .
 
 USER ${UID}
 
+# Govuk Publishing Components gem requires these env vars to be set, however we
+# do not actually need to use them.
+ENV GOVUK_APP_DOMAIN ''
+ENV GOVUK_WEBSITE_ROOT ''
+
 ARG RAILS_ENV=production
 CMD bin/delayed_job run

--- a/spec/services/publisher/service_provisioner_spec.rb
+++ b/spec/services/publisher/service_provisioner_spec.rb
@@ -615,4 +615,40 @@ RSpec.describe Publisher::ServiceProvisioner do
       end
     end
   end
+
+  describe '#service_sentry_csp_url' do
+    before do
+      allow(ENV).to receive(:[])
+      allow(ENV).to receive(:[]).with('SERVICE_SENTRY_CSP_URL_TEST').and_return('test')
+      allow(ENV).to receive(:[]).with('SERVICE_SENTRY_CSP_URL_LIVE').and_return('live')
+    end
+
+    context 'not live production' do
+      not_live_production = [
+        { platform_environment: 'test', deployment_environment: 'dev' },
+        { platform_environment: 'test', deployment_environment: 'production' },
+        { platform_environment: 'live', deployment_environment: 'dev' }
+      ]
+
+      not_live_production.each do |platform_deployment|
+        context "#{platform_deployment[:platform_environment]}-#{platform_deployment[:deployment_environment]}" do
+          let(:attributes) { platform_deployment }
+
+          it 'creates the correct platform deployment' do
+            expect(service_provisioner.service_sentry_csp_url).to eq('test')
+          end
+        end
+      end
+    end
+
+    context 'live production' do
+      let(:attributes) do
+        { platform_environment: 'live', deployment_environment: 'production' }
+      end
+
+      it 'creates the correct platform deployment' do
+        expect(service_provisioner.service_sentry_csp_url).to eq('live')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Add CSP URL and GOVUK_APP_DOMAIN env vars
CSP URL env var is needed for reporting purposes of CSP violations.

GOVUK APP DOMAIN env var is require by the Govuk Publishing Components but we do not use them.

### CircleCI run
https://app.circleci.com/pipelines/github/ministryofjustice/fb-editor/8498/workflows/b2aba526-b08b-48e3-b65c-7232cd161c5a