### PR TITLE
Editable element placeholder and default text focus behaviour

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,9 @@ gem 'delayed_job_active_record'
 # one of these lines:
 # gem 'metadata_presenter',
 #     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'editable-content-web-component'
+#     branch: 'component-default-value'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.0.6'
+gem 'metadata_presenter', '3.0.7'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,7 +263,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.0.6)
+    metadata_presenter (3.0.7)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
@@ -532,7 +532,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.0.6)
+  metadata_presenter (= 3.0.7)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/acceptance/features/edit_single_checkboxes_question_page_spec.rb
+++ b/acceptance/features/edit_single_checkboxes_question_page_spec.rb
@@ -148,6 +148,7 @@ feature 'Edit single radios question page' do
   end
 
   def and_I_have_optional_section_heading_text
+    editor.service_name.click
     expect(page).to have_content(I18n.t('default_text.section_heading'))
   end
 
@@ -162,6 +163,7 @@ feature 'Edit single radios question page' do
   end
 
   def then_I_should_see_the_default_section_heading
+    editor.service_name.click
     expect(editor.section_heading_hint.text).to eq(default_section_heading)
   end
 

--- a/acceptance/features/edit_single_question_autocomplete_page_spec.rb
+++ b/acceptance/features/edit_single_question_autocomplete_page_spec.rb
@@ -83,6 +83,7 @@ feature 'Edit single question autocomplete page' do
   end
 
   def and_I_have_optional_section_heading_text
+    editor.service_name.click
     expect(page).to have_content(I18n.t('default_text.section_heading'))
   end
 
@@ -108,6 +109,7 @@ feature 'Edit single question autocomplete page' do
   end
 
   def then_I_should_see_the_default_section_heading
+    editor.service_name.click
     expect(editor.section_heading_hint.text).to eq(default_section_heading)
   end
 

--- a/acceptance/features/edit_single_question_page_spec.rb
+++ b/acceptance/features/edit_single_question_page_spec.rb
@@ -199,8 +199,6 @@ feature 'Edit single question page' do
   def and_I_have_optional_section_heading_text
     editor.service_name.click
     expect(page).to have_content(I18n.t('default_text.section_heading'))
-    # First EditablElement is focused on page load, which clears content
-    # expect(page).to have_selector('.fb-section_heading.EditableElement', text: '')
   end
 
 

--- a/acceptance/features/edit_single_question_page_spec.rb
+++ b/acceptance/features/edit_single_question_page_spec.rb
@@ -120,6 +120,7 @@ feature 'Edit single question page' do
   end
 
   def then_I_should_see_the_default_section_heading
+    editor.service_name.click
     expect(editor.section_heading_hint.text).to eq(default_section_heading)
   end
 
@@ -196,7 +197,10 @@ feature 'Edit single question page' do
   end
 
   def and_I_have_optional_section_heading_text
+    editor.service_name.click
     expect(page).to have_content(I18n.t('default_text.section_heading'))
+    # First EditablElement is focused on page load, which clears content
+    # expect(page).to have_selector('.fb-section_heading.EditableElement', text: '')
   end
 
 

--- a/acceptance/features/edit_single_radios_question_page_spec.rb
+++ b/acceptance/features/edit_single_radios_question_page_spec.rb
@@ -125,6 +125,7 @@ feature 'Edit single radios question page' do
   end
 
   def and_I_have_optional_section_heading_text
+    editor.service_name.click
     expect(page).to have_content(I18n.t('default_text.section_heading'))
   end
 
@@ -139,6 +140,7 @@ feature 'Edit single radios question page' do
   end
 
   def then_I_should_see_the_default_section_heading
+    editor.service_name.click
     expect(editor.section_heading_hint.text).to eq(default_section_heading)
   end
 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -517,7 +517,7 @@ function enhanceContent(view) {
       text: {
         default_content: view.text.defaults.content
       },
-
+      defaultLabelValue: $node.data('fb-default-value'),
       type: $node.data("fb-content-type")
     });
   });

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -495,8 +495,13 @@ function focusOnEditableComponent() {
     }
   }
   else {
-    // Standard editable page so find first editable item.
-    $(".fb-editable").eq(0).focus();
+    const pageTitle = $('h1.EditableElement').get(0)
+
+    if(pageTitle) {
+      pageTitle.focus();
+    } else {
+      $(".fb-editable").eq(0).focus();
+    }
   }
 }
 

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -115,11 +115,12 @@ class EditableElement extends EditableBase {
 
   set content(content) {
     var trimmedContent = content.trim();
+
     if(this._content != trimmedContent) {
       this._content = trimmedContent;
 
       // If something changed...
-      if(this._content != this._defaultContent && this._content != this._originalContent) {
+      if(this._content != this._defaultContent || this._content != this._originalContent) {
         this.emitSaveRequired();
       }
     }
@@ -136,7 +137,14 @@ class EditableElement extends EditableBase {
   }
 
   update() {
-    this.content = this.$node.text().trim();
+    const currentContent = this.$node.text();
+
+    if(currentContent == '' ){
+      this.content = (this._required ? this._originalContent : this._defaultContent);
+    } else {
+      this.content = currentContent
+    }
+
     this.$node.removeClass(this._config.editClassname);
   }
 

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -42,9 +42,6 @@ class EditableBase {
     this.type = config.type;
     this.$node = $node;
     $node.data("instance", this);
-    $node.on("click.editablecomponent focus.editablecomponent", (e) => {
-      e.preventDefault();
-    });
   }
 
   get config() {
@@ -91,7 +88,7 @@ class EditableElement extends EditableBase {
     var required = defaultContent === undefined;
 
     $node.on("blur.editablecomponent", this.update.bind(this));
-    $node.on("focus.editablecomponent", (e)  => { console.log(e); this.edit.bind(this) } );
+    $node.on("focus.editablecomponent", this.edit.bind(this) );
     $node.on("paste.editablecomponent", e => pasteAsPlainText(e) );
     $node.on("keydown.editablecomponent", e => singleLineInputRestrictions(e) );
 
@@ -132,7 +129,9 @@ class EditableElement extends EditableBase {
 
   edit() {
     this.removePlaceholder();
-    // this.moveCaretToEndOfContent();
+    if(this.$node.text().trim() == this.config.defaultLabelValue || this.$node.text().trim() == this.config.defaultItemLabelValue) {
+      this.selectContent();
+    }
     this.$node.addClass(this._config.editClassname);
   }
 

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -91,7 +91,7 @@ class EditableElement extends EditableBase {
     var required = defaultContent === undefined;
 
     $node.on("blur.editablecomponent", this.update.bind(this));
-    $node.on("focus.editablecomponent", this.edit.bind(this) );
+    $node.on("focus.editablecomponent", (e)  => { console.log(e); this.edit.bind(this) } );
     $node.on("paste.editablecomponent", e => pasteAsPlainText(e) );
     $node.on("keydown.editablecomponent", e => singleLineInputRestrictions(e) );
 
@@ -131,6 +131,8 @@ class EditableElement extends EditableBase {
   }
 
   edit() {
+    this.removePlaceholder();
+    // this.moveCaretToEndOfContent();
     this.$node.addClass(this._config.editClassname);
   }
 
@@ -147,6 +149,30 @@ class EditableElement extends EditableBase {
 
   focus() {
     this.$node.focus();
+  }
+
+  removePlaceholder() {
+    if(this.$node.text().trim() == this._defaultContent) {
+      this.$node.text('')
+    }
+  }
+
+  selectContent() {
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    const range = document.createRange();
+    range.selectNodeContents(this.$node.get(0));
+    selection.addRange(range);
+  }
+
+  moveCaretToEndOfContent() {
+    const range = document.createRange();//Create a range (a range is a like the selection but invisible)
+    const selection = window.getSelection();//get the selection object (allows you to change selection)
+
+    range.selectNodeContents(this.$node.get(0));//Select the entire contents of the element with the range
+    range.collapse(false);//collapse the range to the end point. false means collapse to end rather than the start
+    selection.removeAllRanges();//remove any selections already made
+    selection.addRange(range);//make the range you have just created the visible selection
   }
 }
 

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -39,6 +39,8 @@ class Question {
         // optionalFlag: Replaced with design requirement
       },
       type: $node.data("fb-content-type"),
+      defaultLabelValue: $node.data('fb-default-value'),
+      defaultItemLabelValue: $node.data('fb-default-item-value'),
       view: {}
     }, config);
 

--- a/test/editable_components/editable_element/events_test.js
+++ b/test/editable_components/editable_element/events_test.js
@@ -2,7 +2,7 @@ require('../../setup');
 
 describe('EditableElement', function() {
   const helpers = require('./helpers');
-  const COMPONENT_ID = 'editable-element-component-test';
+  const COMPONENT_ID = 'editable-element-events-test';
 
   describe('Events', function() {
     var created;

--- a/test/editable_components/editable_element/helpers.js
+++ b/test/editable_components/editable_element/helpers.js
@@ -9,12 +9,12 @@ const constants = {
 }
 
 function createEditableElement(id, config, content) {
-    var text = content ? content : constants.EDITABLE_RAW_CONTENT;
-    var html = `<form id="${id}-form">
+  var text = content == undefined ? constants.EDITABLE_RAW_CONTENT : content;
+  var html = `<form id="${id}-form">
       </form>
       <div id="${id}" data-default-text="${constants.EDITABLE_DEFAULT_CONTENT}">${text}</div>`;
 
-    $(document.body).append(html);
+    $(document).find('body').append(html);
 
     $node = $(document).find('#'+id);
     $form = $(document).find('#'+id+'-form');
@@ -47,8 +47,10 @@ function createEditableElement(id, config, content) {
 }
 
 function teardownView(id) {
-    $("#" + id).remove();
-    $("#" + id + "-form").remove();
+    var nodes = document.querySelectorAll(`#${id}, #${id}-form`);
+    if(nodes) {
+      nodes.forEach( (node) => node.remove() )
+    }
 }
 
 module.exports = {

--- a/test/editable_components/editable_element/methods_test.js
+++ b/test/editable_components/editable_element/methods_test.js
@@ -4,7 +4,7 @@ describe('EditableElement', function() {
 
   const helpers = require('./helpers');
   const c = helpers.constants;
-  const COMPONENT_ID = 'editable-element-methods-test';
+  const COMPONENT_ID = 'editable-element-methods-testsvdb';
 
   describe('Methods', function() {
     var created;
@@ -138,31 +138,35 @@ describe('EditableElement', function() {
       })
 
       it('doesn\'t trigger saveRequired when content is original', function() {
-        created.instance.content = 'More new content';
+        //reset
+        helpers.teardownView(COMPONENT_ID);
+        created = undefined;
+        //new instance with default text
+        created = helpers.createEditableElement(COMPONENT_ID, {}, c.EDITABLE_TRIMMED_CONTENT);
         var eventCount = 0;
 
         $(document).on('SaveRequired', function() {
           eventCount++;
         });
+
         created.instance.content = c.EDITABLE_TRIMMED_CONTENT;
         expect(eventCount).to.equal(0);
       });
 
       it('doesn\'t trigger saveRequired when content is default', function() {
         //reset
-        helpers.teardownView();
+        helpers.teardownView(COMPONENT_ID);
         created = undefined;
         //new instance with default text
         created = helpers.createEditableElement(COMPONENT_ID, {
-            attributeDefaultText: 'defaultText',
-        });
-        created.instance.content = 'More new content';
+            attributeDefaultText: c.EDITABLE_DEFAULT_CONTENT,
+        }, ' ');
         var eventCount = 0;
 
         $(document).on('SaveRequired', function() {
           eventCount++;
         });
-        created.instance.content = c.EDITABLE_DEFAULT_CONTENT;
+        created.instance.content = '';
         expect(eventCount).to.equal(0);
       });
     });


### PR DESCRIPTION
For the sake of clarity, some definitions:
* Placeholder Text - optional default content that is not stored in metadata e.g. '[Optional section heading]' (referred to in the code as default text)
* Default Text - The default values for fields that are saved to the metadata e.g. 'Question' is the deafult title for questions.  (referred to in the code as default value)

This PR adjusts the focus behaviour of placeholders and default text.

If an EditableElement:
* contains placeholder text, that text will be cleared on focus.
* contains default text, that text will be highlighted on focus.
* contains user entered text, then on focus the text will not be highlighted and the cursor will be placed at the start of the field (browser default behaviour)

We also now focus on the page title on page load rather than just the first EditableElement.  this is because that element often contains placeholder text, which is now cleared on focus - and that resulted in an empty yellow box on page load.  

<img width="1054" alt="image" src="https://github.com/ministryofjustice/fb-editor/assets/595564/d9bbf8b0-0a4e-4ac2-ab61-467b0551978a">
Screenshot showing question page after load
