### PR TITLE
Use correct service slug for pingdom alerts

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -100,7 +100,7 @@ module Admin
         if publish_service_creation.save
           UnpublishServiceJob.perform_later(
             publish_service_id: publish_service_creation.publish_service_id,
-            service_slug: service_slug(version_metadata)
+            service_slug: service_slug(publish_service.service_id)
           )
           flash[:success] = "Service queued for unpublishing from #{params[:deployment_environment]}. Refresh in a minute"
         else
@@ -217,11 +217,6 @@ module Admin
       ).last&.unpublished?
     end
 
-    def service_slug(version_metadata)
-      service = MetadataPresenter::Service.new(version_metadata, editor: true)
-      service.service_slug
-    end
-
     def maintenance_mode_params
       params.require(:maintenance_mode_settings).permit(
         :maintenance_mode,
@@ -248,6 +243,13 @@ module Admin
 
     def require_authentication
       password.present? && username.present? ? '1' : '0'
+    end
+
+    def service_slug(service_id)
+      ServiceConfiguration.find_by(
+        service_id:,
+        name: 'SERVICE_SLUG'
+      )&.decrypt_value
     end
   end
 end

--- a/app/controllers/admin/uptime_checks_controller.rb
+++ b/app/controllers/admin/uptime_checks_controller.rb
@@ -15,7 +15,7 @@ module Admin
       Uptime.new(
         service_id: service.service_id,
         service_name: service.service_name,
-        host: "#{service.service_slug}.#{url_root}",
+        host: "#{service_slug(service.service_id)}.#{url_root}",
         adapter:
       ).create
 
@@ -85,6 +85,14 @@ module Admin
 
     def adapter
       Uptime::Adapters::Pingdom
+    end
+
+    def service_slug(service_id)
+      ServiceConfiguration.find_by(
+        service_id:,
+        deployment_environment: 'production',
+        name: 'SERVICE_SLUG'
+      )&.decrypt_value
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -132,6 +132,7 @@ class ApplicationController < ActionController::Base
 
     service.service_slug
   end
+  helper_method :service_slug
 
   def service_slug_config
     ServiceConfiguration.find_by(

--- a/app/helpers/metadata_version_helper.rb
+++ b/app/helpers/metadata_version_helper.rb
@@ -17,9 +17,4 @@ module MetadataVersionHelper
   def latest_version(service_id)
     MetadataApiClient::Service.latest_version(service_id)
   end
-
-  def service_slug(version_metadata)
-    service = MetadataPresenter::Service.new(version_metadata, editor: true)
-    service.service_slug
-  end
 end

--- a/app/services/unpublish_dev_services.rb
+++ b/app/services/unpublish_dev_services.rb
@@ -1,6 +1,4 @@
 class UnpublishDevServices
-  include MetadataVersionHelper
-
   AUTOMATED_TEST_SERVICES = [
     'cd75ad76-1d4b-4ce5-8a9e-035262cd2683', # New Runner Service
     'e68dca75-20b8-468e-9436-e97791a914c5', # Branching Fixture 10 Service
@@ -10,10 +8,9 @@ class UnpublishDevServices
 
   def call
     published_dev_services.each do |publish_service|
-      version_metadata = get_version_metadata(publish_service)
       UnpublishServiceJob.perform_later(
         publish_service_id: publish_service.id,
-        service_slug: service_slug(version_metadata)
+        service_slug: service_slug(publish_service.service_id)
       )
     end
   end
@@ -29,5 +26,12 @@ class UnpublishDevServices
 
   def published_dev_services
     published_services.select { |ps| ps.deployment_environment == 'dev' }
+  end
+
+  def service_slug(service_id)
+    ServiceConfiguration.find_by(
+      service_id:,
+      name: 'SERVICE_SLUG'
+    )&.decrypt_value
   end
 end

--- a/app/services/unpublish_test_services.rb
+++ b/app/services/unpublish_test_services.rb
@@ -1,6 +1,4 @@
 class UnpublishTestServices
-  include MetadataVersionHelper
-
   ACCEPTANCE_TEST_SERVICES = [
     'cd75ad76-1d4b-4ce5-8a9e-035262cd2683', # New Runner Service
     'e68dca75-20b8-468e-9436-e97791a914c5', # Branching Fixture 10 Service
@@ -13,10 +11,9 @@ class UnpublishTestServices
   def call
     ENVIRONMENTS.each do |environment|
       send(environment).each do |publish_service|
-        version_metadata = get_version_metadata(publish_service)
         UnpublishServiceJob.perform_later(
           publish_service_id: publish_service.id,
-          service_slug: service_slug(version_metadata)
+          service_slug: service_slug(publish_service.service_id)
         )
       end
     end
@@ -37,5 +34,12 @@ class UnpublishTestServices
 
   def production
     published_services.select { |ps| ps.deployment_environment == 'production' }
+  end
+
+  def service_slug(service_id)
+    ServiceConfiguration.find_by(
+      service_id:,
+      name: 'SERVICE_SLUG'
+    )&.decrypt_value
   end
 end

--- a/app/views/admin/uptime_checks/index.html.erb
+++ b/app/views/admin/uptime_checks/index.html.erb
@@ -33,7 +33,7 @@
               <%= service.service_id %>
             </td>
             <td class="govuk-table__cell"  id="service-slug">
-              <%= service.service_slug %>
+              <%= service_slug %>
             </td>
             <td class="govuk-table__cell">
               <%= form_with url: admin_uptime_checks_path,

--- a/spec/services/unpublish_dev_services_spec.rb
+++ b/spec/services/unpublish_dev_services_spec.rb
@@ -5,15 +5,20 @@ RSpec.describe UnpublishDevServices do
 
   describe '#call' do
     let(:version_metadata) { metadata_fixture(:version) }
+    let(:service_configuration) do
+      ServiceConfiguration.find_by(
+        service_id: service.service_id,
+        name: 'SERVICE_SLUG'
+      )
+    end
     let(:params) do
       {
         publish_service_id: published_services.id,
-        service_slug: 'version-fixture'
+        service_slug: service_configuration
       }
     end
 
     before do
-      allow(unpublish_dev_services).to receive(:get_version_metadata).and_return(version_metadata)
       allow(UnpublishServiceJob).to receive(:perform_later).and_call_original
       allow(UnpublishServiceJob).to receive(:perform_later).with(params)
 

--- a/spec/services/uptime_spec.rb
+++ b/spec/services/uptime_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Uptime do
   subject(:uptime) { described_class.new(**attributes) }
   let(:service_id) { SecureRandom.uuid }
   let(:service_name) { 'Apply To Use An Apply For Service' }
-  let(:host) { 'apply-to-use-an-apply-for-service' }
+  let(:host) { 'a-different-url' }
   let(:attributes) do
     {
       service_id:,


### PR DESCRIPTION
### Use the service slug in service configuration to create Pingdom alerts
When creating a pingdom alert, we need to use the service slug saved in the service configuration rather than using the service name.

### Use service configuration when un-publishing services
We now have the service slug saved in the service configuration. We should use this rather than the service name to identify the correct service slug to be unpublished.

Both these mechanisms are only reachable via the Admin dashboard.