### PR TITLE
Service slug for un-publish services and uptime checks

### DIFF
--- a/app/controllers/admin/uptime_checks_controller.rb
+++ b/app/controllers/admin/uptime_checks_controller.rb
@@ -87,12 +87,16 @@ module Admin
       Uptime::Adapters::Pingdom
     end
 
-    def service_slug(service_id)
+    def service_slug_config(service_id)
       ServiceConfiguration.find_by(
         service_id:,
         deployment_environment: 'production',
         name: 'SERVICE_SLUG'
       )&.decrypt_value
+    end
+
+    def service_slug(service_id)
+      service_slug_config(service_id).presence? || service.service_slug
     end
     helper_method :service_slug
   end

--- a/app/helpers/metadata_version_helper.rb
+++ b/app/helpers/metadata_version_helper.rb
@@ -17,4 +17,9 @@ module MetadataVersionHelper
   def latest_version(service_id)
     MetadataApiClient::Service.latest_version(service_id)
   end
+
+  def service_slug_from_name(version_metadata)
+    service = MetadataPresenter::Service.new(version_metadata, editor: true)
+    service.service_slug
+  end
 end

--- a/spec/services/unpublish_dev_services_spec.rb
+++ b/spec/services/unpublish_dev_services_spec.rb
@@ -4,72 +4,90 @@ RSpec.describe UnpublishDevServices do
   subject(:unpublish_dev_services) { described_class.new }
 
   describe '#call' do
-    let(:version_metadata) { metadata_fixture(:version) }
-    let(:service_configuration) do
-      ServiceConfiguration.find_by(
-        service_id: service.service_id,
-        name: 'SERVICE_SLUG'
-      )
-    end
-    let(:params) do
-      {
-        publish_service_id: published_services.id,
-        service_slug: service_configuration
-      }
-    end
-
-    before do
-      allow(UnpublishServiceJob).to receive(:perform_later).and_call_original
-      allow(UnpublishServiceJob).to receive(:perform_later).with(params)
-
-      unpublish_dev_services.call
-    end
-
-    context 'when service is in dev' do
-      let(:published_services) do
-        create(
-          :publish_service,
-          :dev,
-          service_id: SecureRandom.uuid,
-          status: 'completed'
-        )
+    RSpec.shared_examples 'call' do
+      let(:version_metadata) { metadata_fixture(:version) }
+      let(:params) do
+        {
+          publish_service_id: published_services.id,
+          service_slug: service_slug_config
+        }
       end
 
-      it 'should unpublish the service' do
-        expect(UnpublishServiceJob).to have_received(:perform_later).with(params)
-      end
-    end
+      before do
+        allow(unpublish_dev_services).to receive(:get_version_metadata).and_return(version_metadata)
+        allow(UnpublishServiceJob).to receive(:perform_later).and_call_original
+        allow(UnpublishServiceJob).to receive(:perform_later).with(params)
 
-    context 'when service is in production' do
-      let(:published_services) do
-        create(
-          :publish_service,
-          :production,
-          service_id: SecureRandom.uuid,
-          status: 'completed'
-        )
+        unpublish_dev_services.call
       end
 
-      it 'should not unpublish the service' do
-        expect(UnpublishServiceJob).to_not have_received(:perform_later).with(params)
-      end
-    end
-
-    context 'when service is in an automated test service' do
-      UnpublishDevServices::AUTOMATED_TEST_SERVICES.each do |service_id|
+      context 'when service is in dev' do
         let(:published_services) do
           create(
             :publish_service,
             :dev,
-            service_id:,
+            service_id: SecureRandom.uuid,
             status: 'completed'
           )
         end
 
-        it 'should not unpublish the automated test service' do
+        it 'should unpublish the service' do
+          expect(UnpublishServiceJob).to have_received(:perform_later).with(params)
+        end
+      end
+
+      context 'when service is in production' do
+        let(:published_services) do
+          create(
+            :publish_service,
+            :production,
+            service_id: SecureRandom.uuid,
+            status: 'completed'
+          )
+        end
+
+        it 'should not unpublish the service' do
           expect(UnpublishServiceJob).to_not have_received(:perform_later).with(params)
         end
       end
+
+      context 'when service is in an automated test service' do
+        UnpublishDevServices::AUTOMATED_TEST_SERVICES.each do |service_id|
+          let(:published_services) do
+            create(
+              :publish_service,
+              :dev,
+              service_id:,
+              status: 'completed'
+            )
+          end
+
+          it 'should not unpublish the automated test service' do
+            expect(UnpublishServiceJob).to_not have_received(:perform_later).with(params)
+          end
+        end
+      end
+    end
+
+    context 'when service slug is from service config' do
+      let(:service_slug_config) do
+        ServiceConfiguration.find_by(
+          service_id: service.service_id,
+          name: 'SERVICE_SLUG'
+        )
+      end
+      before do
+        allow(subject).to receive(:service_slug).and_return(service_slug_config)
+      end
+      it_behaves_like 'call'
+    end
+
+    context 'when service slug is from service name' do
+      let(:service_slug_config) { 'version-fixture' }
+      before do
+        allow(subject).to receive(:service_slug).and_return(service_slug_config)
+      end
+      it_behaves_like 'call'
     end
   end
 end


### PR DESCRIPTION
Some older forms may not have a SERVICE_SLUG service config saved, in these instances we need to fallback and use the service name when showing the uptime check admin page or un-publishing services via the admin page.

Add tests to check for when service slug is from the service config or derived from the service name.