### PR TITLE
Make flow view arrows selectable on click

### DIFF
--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -157,6 +157,11 @@ class FlowConnectorPath {
       flowConnectorPath.$node.removeClass("active");
     });
 
+    this.$node.find("path").on("click", function() {
+      $('.FlowConnectorPath').removeClass("selected")
+      flowConnectorPath.$node.toggleClass("selected");
+    });
+
     // Uncomment for developer helper code only
     //this.makeLinesVisibleForTesting();
   }

--- a/app/javascript/src/component_flow_connector_path.js
+++ b/app/javascript/src/component_flow_connector_path.js
@@ -147,21 +147,6 @@ class FlowConnectorPath {
 
     this.config.container.append(this.$node);
 
-    this.$node.find("path").on("mouseover", function() {
-      $(document).trigger("FlowConnectorPathOver", flowConnectorPath);
-      flowConnectorPath.$node.addClass("active");
-    });
-
-    this.$node.find("path").on("mouseout", function() {
-      $(document).trigger("FlowConnectorPathOut", flowConnectorPath);
-      flowConnectorPath.$node.removeClass("active");
-    });
-
-    this.$node.find("path").on("click", function() {
-      $('.FlowConnectorPath').removeClass("selected")
-      flowConnectorPath.$node.toggleClass("selected");
-    });
-
     // Uncomment for developer helper code only
     //this.makeLinesVisibleForTesting();
   }

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -76,6 +76,8 @@ ServicesController.edit = function() {
     layoutDetachedItemsOverview(view);
   }
 
+  addEventListeners()
+
   renderActivatedMenus(view);
 
   addServicesContentScrollContainer(view);
@@ -181,6 +183,35 @@ function setupUndoRedoButton(view) {
   });
 }
 
+function addEventListeners() {
+  document.body.addEventListener('click', function(event) {
+    const target = event.target;
+    const targetConnectorPath = target.closest('.FlowConnectorPath')
+    const flowConnectorPaths = document.querySelectorAll('.FlowConnectorPath')
+
+    flowConnectorPaths.forEach((path) => {
+      if( path != targetConnectorPath) {
+        path.classList.remove('selected')
+      } 
+    }) 
+    if(target.matches('path')) {
+      targetConnectorPath?.classList.toggle('selected')
+    }
+  })
+
+  document.body.addEventListener('mouseover', function(event) {
+    if(!event.target.matches('path')) return;
+    
+    event.target.closest('.FlowConnectorPath').classList.add('active')
+  })
+
+  document.body.addEventListener('mouseout', function(event) {
+    if(!event.target.matches('path')) return;
+    
+    event.target.closest('.FlowConnectorPath').classList.remove('active')
+  })
+
+}
 
 /* VIEW SETUP FUNCTION:
  * --------------------
@@ -218,6 +249,10 @@ function layoutFormFlowOverview(view) {
   renderFlowConnectorPaths($container);
   adjustOverviewHeight($container);
   adjustOverviewWidth($container);
+
+
+
+
   performance.mark('flow-layout-end')
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -682,7 +682,8 @@ editable-content,
     fill: #949494;
   }
 
-  &.active {
+  &.active,
+  &.selected {
     path {
       stroke-width:4px;
       stroke: $govuk-link-hover-colour;

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -610,10 +610,14 @@ editable-content,
     &.active {
       z-index: 1;
     }
+
+    &.selected {
+      z-index: 2;
+    }
   }
 
   .FlowItem {
-    z-index: 2
+    z-index: 3
   }
 
   .ConnectionMenuActivator {
@@ -686,6 +690,11 @@ editable-content,
   &.selected {
     path {
       stroke-width:4px;
+    }
+  }
+
+  &.active {
+    path {
       stroke: $govuk-link-hover-colour;
     }
 
@@ -693,6 +702,17 @@ editable-content,
       fill: $govuk-link-hover-colour;
     }
   }
+
+  &.selected {
+    path {
+      stroke: govuk-colour('orange');
+    }
+
+    .arrowPath {
+      fill: govuk-colour('orange');
+    }
+  }
+  
 }
 
 .PageMenuActivator {


### PR DESCRIPTION
In order to improve usability of large forms where arrows often go off screen, this PR adds the ability to click on a flow view arrow to highlight it to make finding its destination easier.

Clicking the arrow again will unselect it
Clicking anywhere in the flow view will unselect all arrows
Clicking another arrow, will unslect the current arrow and select the new one.

![image](https://github.com/ministryofjustice/fb-editor/assets/595564/55bbc8a4-cf91-4db2-b9ca-e8e6aa22e52b)

As part of this work, the event listeners have been moved from on every arrow, to being on the `<body>` element via delegation for greater efficiency.
