### PR TITLE
Use localStorage to persist expander state

### DIFF
--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -1054,6 +1054,8 @@ function createExpanderComponents() {
       activator_source: $node.find('> h2').first(),
       wrap_content: true,
       auto_open: true,
+      persist: true,
+      id: 'flow-view-footer-expander'
     });
   });
 }

--- a/app/javascript/src/utilities.js
+++ b/app/javascript/src/utilities.js
@@ -396,6 +396,32 @@ function rangeIntersection(a,b) {
   }
 }
 
+function storageAvailable(type) {
+  let storage;
+  try {
+    storage = window[type];
+    const x = "__storage_test__";
+    storage.setItem(x, x);
+    storage.removeItem(x);
+    return true;
+  } catch (e) {
+    return (
+      e instanceof DOMException &&
+      // everything except Firefox
+      (e.code === 22 ||
+        // Firefox
+        e.code === 1014 ||
+        // test name field too, because code might not be present
+        // everything except Firefox
+        e.name === "QuotaExceededError" ||
+        // Firefox
+        e.name === "NS_ERROR_DOM_QUOTA_REACHED") &&
+      // acknowledge QuotaExceededError only if there's something already stored
+      storage &&
+      storage.length !== 0
+    );
+  }
+}
 
 
 // Make available for importing.
@@ -424,4 +450,5 @@ module.exports  = {
   snakeToPascalCase: snakeToPascalCase,
   intersects: intersects,
   overlaps: overlaps,
+  storageAvailable: storageAvailable,
 }


### PR DESCRIPTION
Adds functionality to the expander component to allow it to store its state within localStorage in the browser (if available)

This is the used in the footer expander oin the flow view to ensure it rememembers its previous state.

N.B. it is not possible to add Js unit tests for this functionality as it is not possible to navigate/reload within Mocha/JSDOM