### PR TITLE
Add notification banner messages standalone pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ gem 'delayed_job_active_record'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'standalone-pages-notification-banners'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'standalone-pages-notification-banners'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '3.0.6'
+gem 'metadata_presenter', '3.0.11'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ gem 'delayed_job_active_record'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'component-default-value'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'standalone-pages-notification-banners'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.0.7'
+# gem 'metadata_presenter', '3.0.6'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 69ea4a5f3ddd1ce2865acfdabbeee4afaf5c5556
+  branch: standalone-pages-notification-banners
+  specs:
+    metadata_presenter (3.0.9)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -263,15 +278,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.0.7)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
@@ -532,7 +538,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.0.7)
+  metadata_presenter!
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 69ea4a5f3ddd1ce2865acfdabbeee4afaf5c5556
-  branch: standalone-pages-notification-banners
-  specs:
-    metadata_presenter (3.0.9)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -278,6 +263,15 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    metadata_presenter (3.0.11)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
@@ -538,7 +532,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter!
+  metadata_presenter (= 3.0.11)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,16 @@ en:
   notification_banners:
     important: Important
     success: Success
+    cookies:
+      heading:   "This page can’t be edited. You don’t need to do anything with it because we’ve taken care of it for you."
+    privacy:
+      heading: "You need to ensure you are following data protection requirements and complete this page before your form can go live. "
+      link_text: "Learn more about data protection and privacy"
+      link_href: "https://moj-forms.service.justice.gov.uk/data-protection/"
+    accessibility:
+      heading: "You need to ensure your form’s content is accessible and complete this page before your form can go live. "
+      link_text: "Learn more about accessibility"
+      link_href: "https://moj-forms.service.justice.gov.uk/accessibility/"
   dialogs:
     button_cancel: 'Cancel'
     button_delete: 'Delete'


### PR DESCRIPTION
Adds notification banners to the top of the accessibility and privacy standalone pages.

Bumps presenter to 3.0.11

![image](https://github.com/ministryofjustice/fb-editor/assets/595564/09adef43-b0c4-46a4-bbe7-b5a5b1232fd4)

![image](https://github.com/ministryofjustice/fb-editor/assets/595564/ee9b1945-b472-483e-81b5-4128bc6bfe74)
