### PR TITLE
Enable CSP and set to reporting mode only

### DIFF
--- a/app/javascript/styles/_utilities.scss
+++ b/app/javascript/styles/_utilities.scss
@@ -5,3 +5,15 @@
 .text-success {
   color: govuk-colour('green');
 }
+
+.flex {
+  display: flex;
+}
+
+.align-items-center {
+  align-items: center;
+}
+
+.justify-content-between {
+  justify-content: space-between;
+}

--- a/app/javascript/styles/_utilities.scss
+++ b/app/javascript/styles/_utilities.scss
@@ -17,3 +17,10 @@
 .justify-content-between {
   justify-content: space-between;
 }
+.white-space-pre-wrap {
+  white-space: pre-wrap;
+}
+
+.clear-both {
+  clear: both;
+}

--- a/app/views/admin/application/show.html.erb
+++ b/app/views/admin/application/show.html.erb
@@ -36,7 +36,7 @@ as well as a link to its edit page.
 
   <dl>
     <% page.attributes.each do |attribute| %>
-      <dt class="attribute-label" id="<%= attribute.name %>" style="margin-top: 0;">
+      <dt class="govuk-!-margin-top-0 attribute-label" id="<%= attribute.name %>">
       <%= t(
         "helpers.label.#{resource_name}.#{attribute.name}",
         default: page.resource.class.human_attribute_name(attribute.name),
@@ -51,7 +51,7 @@ as well as a link to its edit page.
 
 <% if @user_services.present? %>
 
-  <div style="clear: both;">
+  <div class="clear-both">
     <h2>Forms</h2>
       <ul class="fb-editor-list fb-editor-form-list">
           <% @user_services.each do |service| %>

--- a/app/views/admin/services/edit.html.erb
+++ b/app/views/admin/services/edit.html.erb
@@ -32,7 +32,8 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
                url: admin_service_path(@service.service_id),
                method: :put,
                builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |f| %>
-<div class="govuk-!-margin-bottom-5" style="display: flex; justify-content: space-between; align-items: center;">
+
+<div class="govuk-!-margin-bottom-5 flex align-items-center justify-content-between">
     <a href="<%= admin_services_path %>" class="govuk-back-link govuk-!-margin-top-0 govuk-!-margin-bottom-0">
       Back to services
     </a>

--- a/app/views/admin/services/show.html.erb
+++ b/app/views/admin/services/show.html.erb
@@ -169,7 +169,7 @@
 
     <a href="<%= edit_admin_service_version_path(@service.service_id, @latest_metadata['version_id']) %>" class="govuk-button fb-govuk-button">Edit</a>
 
-    <pre class="govuk-!-padding-right-5" style="white-space:pre-wrap;">
+    <pre class="govuk-!-padding-right-5 white-space-pre-wrap">
       <%= JSON.pretty_generate(@latest_metadata) %>
     </pre>
 

--- a/app/views/admin/versions/show.html.erb
+++ b/app/views/admin/versions/show.html.erb
@@ -34,7 +34,7 @@
         </dd>
       </div>
     </dl>
-    <pre class="govuk-!-padding-right-5" style="white-space:pre-wrap;">
+    <pre class="govuk-!-padding-right-5 white-space-pre-wrap">
       <%= JSON.pretty_generate(@version.metadata) %>
     </pre>
   </div>

--- a/app/views/api/component_validations/_string_length_validation.html.erb
+++ b/app/views/api/component_validations/_string_length_validation.html.erb
@@ -1,4 +1,4 @@
-<div style="display: flex; align-items:center;">
+<div class="flex align-items-center">
   <label class="govuk-label govuk-label--m govuk-visually-hidden" for="component_validation_value">
     <%= @component_validation.label %>
   </label>

--- a/app/views/partials/_footer.html.erb
+++ b/app/views/partials/_footer.html.erb
@@ -19,7 +19,7 @@
 
   <% if live_platform? %>
     <!-- Hotjar Tracking Code for Private Beta Research Study -->
-      <script>
+      <script nonce=<%= request.content_security_policy_nonce %>>
         (function(h,o,t,j,a,r){
           h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
           h._hjSettings={hjid:2316310,hjsv:6};

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -1,4 +1,4 @@
-<script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+<script nonce=<%= request.content_security_policy_nonce %>>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 <header class="govuk-header govuk-header__container" role="banner" data-module="govuk-header">
   <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -1,4 +1,4 @@
-<script>
+<script nonce=<%= request.content_security_policy_nonce %>>
   var SENTRY_DSN = "<%= ENV['SENTRY_DSN'] %>";
   var PLATFORM_ENV =  "<%= ENV['PLATFORM_ENV'] %>";
   var app = {

--- a/app/views/publish/_first_publish_message.html.erb
+++ b/app/views/publish/_first_publish_message.html.erb
@@ -7,7 +7,7 @@
 
 </p>
 
-<script type="module">
+<script nonce=<%= request.content_security_policy_nonce %> type="module">
   /*
   * This script is reponsible for checking if the published service is live and
   * updating the first publish message accordingly.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
                        "'sha256-g0/XswAmA05eJqlbjX+QanYdtwQs9NJHFaBXC9/dmm8='", # style tag on admin service page
                        "'sha256-NN3cxOpkbkk3bTeAp9eF4SiKghXfcmGXX+G8ICEuZtQ='" # hash for component validation
     # Specify URI for violation reports
-    # policy.report_uri "/csp-violation-report-endpoint"
+    policy.report_uri "report-uri #{ENV['SENTRY_CSP_URL']}"
   end
 
   # Generate session nonces for permitted importmap and inline scripts

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,10 +13,8 @@ Rails.application.configure do
     policy.script_src  :self,
                        "https://unpkg.com/alpinejs",
                        "https://cdn.jsdelivr.net/npm/marked@2.1.3/marked.min.js"
-    policy.style_src   :self,
-                       "'unsafe-hashes'",
-                       "'sha256-g0/XswAmA05eJqlbjX+QanYdtwQs9NJHFaBXC9/dmm8='", # style tag on admin service page
-                       "'sha256-NN3cxOpkbkk3bTeAp9eF4SiKghXfcmGXX+G8ICEuZtQ='" # hash for component validation
+    policy.style_src   :self, :https
+
     # Specify URI for violation reports
     policy.report_uri "report-uri #{ENV['SENTRY_CSP_URL']}"
   end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,27 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self,
+                       "https://unpkg.com/alpinejs",
+                       "https://cdn.jsdelivr.net/npm/marked@2.1.3/marked.min.js"
+    policy.style_src   :self,
+                       "'unsafe-hashes'",
+                       "'sha256-g0/XswAmA05eJqlbjX+QanYdtwQs9NJHFaBXC9/dmm8='", # style tag on admin service page
+                       "'sha256-NN3cxOpkbkk3bTeAp9eF4SiKghXfcmGXX+G8ICEuZtQ='" # hash for component validation
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Generate session nonces for permitted importmap and inline scripts
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w(script-src)
+
+  # Report violations without enforcing the policy.
+  config.content_security_policy_report_only = true
+end

--- a/deploy-eks/fb-editor-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-editor-chart/templates/deployment.yaml
@@ -74,6 +74,11 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: sentry_dsn
+          - name: SENTRY_CSP_URL
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: sentry_csp_url
           - name: AUTH0_CLIENT_ID
             valueFrom:
               secretKeyRef:
@@ -216,6 +221,11 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: sentry_dsn
+          - name: SENTRY_CSP_URL
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: sentry_csp_url
           - name: AUTH0_CLIENT_ID
             valueFrom:
               secretKeyRef:

--- a/deploy-eks/fb-editor-chart/templates/secrets.yaml
+++ b/deploy-eks/fb-editor-chart/templates/secrets.yaml
@@ -7,6 +7,7 @@ type: Opaque
 data:
   secret_key_base: {{ .Values.secret_key_base }}
   sentry_dsn: {{ .Values.sentry_dsn }}
+  sentry_csp_url: {{ .Values.sentry_csp_url }}
   auth0_client_id: {{ .Values.auth0_client_id }}
   auth0_client_secret: {{ .Values.auth0_client_secret }}
   encoded_private_key: {{ .Values.encoded_private_key}}


### PR DESCRIPTION
As part of the recommendations from a recent pen test, we are enabling a CSP. For now, the policy will be on report mode only. We have a Sentry CSP URL that will report any CSP violations. Once we are happy that we have resolved all CSP violations, we can enforce the CSP.

Most of the inline JS scripts have had a nonce added, all inline styles have been moved into a utility class.