### PR TITLE
Add hotjar to CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,8 +12,14 @@ Rails.application.configure do
     policy.object_src  :none
     policy.script_src  :self,
                        "https://unpkg.com/alpinejs",
-                       "https://cdn.jsdelivr.net/npm/marked@2.1.3/marked.min.js"
-    policy.style_src   :self, :https
+                       "https://cdn.jsdelivr.net/npm/marked@2.1.3/marked.min.js",
+                       "https://*.hotjar.com"
+    policy.style_src   :self,
+                       "https://*.hotjar.com"
+    policy.connect_src :self,
+                       "https://*.hotjar.com",
+                       "https://*.hotjar.io",
+                       "wss://*.hotjar.com"
 
     # Specify URI for violation reports
     policy.report_uri "report-uri #{ENV['SENTRY_CSP_URL']}"


### PR DESCRIPTION
We use hotjar on the editor as to analyse user behaviour. We need to add these to our CSP to allow hotjar to function properly.