### PR TITLE
Add HotJar and Sentry to CSP allow list

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -18,6 +18,7 @@ Rails.application.configure do
                        "https://*.hotjar.com",
                        'unsafe-inline'
     policy.connect_src :self,
+                       "*.sentry.io",
                        "https://*.hotjar.com",
                        "https://*.hotjar.io",
                        "wss://*.hotjar.com"

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -15,7 +15,8 @@ Rails.application.configure do
                        "https://cdn.jsdelivr.net/npm/marked@2.1.3/marked.min.js",
                        "https://*.hotjar.com"
     policy.style_src   :self,
-                       "https://*.hotjar.com"
+                       "https://*.hotjar.com",
+                       'unsafe-inline'
     policy.connect_src :self,
                        "https://*.hotjar.com",
                        "https://*.hotjar.io",


### PR DESCRIPTION
### Add HotJar and Sentry to CSP allow list
As per the [HotJar docs](https://help.hotjar.com/hc/en-us/articles/115011640307-Content-Security-Policies), we need to enable `unsafe-inline` to allow hotjar to run properly.

Adding sentry url as per [sentry docs](https://docs.sentry.io/platforms/javascript/install/loader/#content-security-policy)