### PR TITLE
Restore the flow view position after page editing

### DIFF
--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -396,7 +396,7 @@ module CommonSteps
     find('#main-content', visible: true)
     editor.connection_menu(page_title).click
     expect(editor).to have_content(page_link)
-    editor.flow_thumbnail(page_title).hover #hides the connection menu
+    editor.service_name.click #hides the connection menu
   end
 
   def then_I_should_see_default_service_pages

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,9 +45,9 @@ module ApplicationHelper
   def pages_url
     case controller_name
     when 'pages'
-      edit_service_path(service.service_id, anchor: @page.uuid)
+      edit_service_path(service.service_id, anchor: @page&.uuid)
     when 'branches'
-      edit_service_path(service.service_id, anchor: @branch.branch_uuid)
+      edit_service_path(service.service_id, anchor: @branch&.branch_uuid)
     else
       edit_service_path(service.service_id)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,6 +41,19 @@ module ApplicationHelper
     end
   end
 
+  # rubocop:disable Rails/HelperInstanceVariable
+  def pages_url
+    case controller_name
+    when 'pages'
+      edit_service_path(service.service_id, anchor: @page.uuid)
+    when 'branches'
+      edit_service_path(service.service_id, anchor: @branch.branch_uuid)
+    else
+      edit_service_path(service.service_id)
+    end
+  end
+  # rubocop:enable Rails/HelperInstanceVariable
+
   def strip_url(url)
     url.to_s.chomp('/').reverse.chomp('/').reverse.strip.downcase
   end

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -81,7 +81,9 @@ ServicesController.edit = function() {
   renderActivatedMenus(view);
 
   addServicesContentScrollContainer(view);
+  setScrollPosition(view);
   view.ready();
+
 
   const flowLayoutTime = performance.measure('flow-layout-time', 'flow-layout-start', 'flow-layout-end');
   const flowItemPositionTime = performance.measure('flow-item-position-time', 'flow-layout-start', 'flow-items-positioned');
@@ -212,30 +214,16 @@ function addEventListeners() {
   })
 
   document.body.addEventListener('click', function(event){
-    console.log('you clicked')
     if(!event.target.closest('.flow-item')) return;
-    console.log('you clicked something in a flow item');
-    console.log(event);
-    // event.preventDefault();
     if(!(event.target.closest('.flow-thumbnail') || event.target.closest('.govuk-link')) ) return;
-    console.log('you clicked a thumbnail or a link');
-    
     
     const id = event.target.closest('.flow-item').dataset.fbId 
-    console.log({id})
     const state = { flow_item_id: id };
     const url = new URL(location)
+
     url.hash = id;
-
-    history.pushState(state, "", `${url}`);
-    
+    history.replaceState(state, "", `${url}`);
   })
-
-  // window.addEventListener("popstate", (event) => {
-  //   console.log(
-  //     `LOCATION: ${DOCUMENT.LOCATION}, STATE: ${json.STRINGIFY(EVENT.STATE)}`
-  //   );
-  // });
 
 }
 
@@ -658,6 +646,28 @@ function adjustScrollDimensionsAndPositions($body, $container, $main, $header, $
     $nav.css("top", (y + navTop) + "px");
     $title.css("top", (y + titleTop) + "px");
   });
+}
+
+function setScrollPosition(view) {
+  if(!location.hash) return;
+
+  const id = location.hash.replace('#','');
+  console.log(id)
+  const flowItem = document.querySelector(`[data-fb-id="${id}"]`)
+  console.log(flowItem);
+  if(!flowItem) return;
+
+  const rect = flowItem.getBoundingClientRect()
+  const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+  const scrollLeft = window.pageXOfset || document.documentElement.scrollLeft;
+
+  const position = {
+    top: rect.top + scrollTop - window.innerHeight/2, 
+    left: rect.left + scrollLeft - window.innerWidth/2 
+  }
+  console.log(position)
+
+  window.scrollTo(position)
 }
 
 

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -211,6 +211,32 @@ function addEventListeners() {
     event.target.closest('.FlowConnectorPath').classList.remove('active')
   })
 
+  document.body.addEventListener('click', function(event){
+    console.log('you clicked')
+    if(!event.target.closest('.flow-item')) return;
+    console.log('you clicked something in a flow item');
+    console.log(event);
+    // event.preventDefault();
+    if(!(event.target.closest('.flow-thumbnail') || event.target.closest('.govuk-link')) ) return;
+    console.log('you clicked a thumbnail or a link');
+    
+    
+    const id = event.target.closest('.flow-item').dataset.fbId 
+    console.log({id})
+    const state = { flow_item_id: id };
+    const url = new URL(location)
+    url.hash = id;
+
+    history.pushState(state, "", `${url}`);
+    
+  })
+
+  // window.addEventListener("popstate", (event) => {
+  //   console.log(
+  //     `LOCATION: ${DOCUMENT.LOCATION}, STATE: ${json.STRINGIFY(EVENT.STATE)}`
+  //   );
+  // });
+
 }
 
 /* VIEW SETUP FUNCTION:

--- a/app/views/partials/_form_navigation.html.erb
+++ b/app/views/partials/_form_navigation.html.erb
@@ -6,7 +6,7 @@
 
     <ul class="govuk-navigation">
       <li class="<%= controller_name == 'services' ? 'current' : '' %>">
-        <%= link_to t('pages.name'), edit_service_path(service.service_id) %>
+        <%= link_to t('pages.name'), pages_url %>
       </li>
 
       <li class="<%= controller_name == 'settings' ? 'current' : '' %>">

--- a/app/views/services/_flow_layout.html.erb
+++ b/app/views/services/_flow_layout.html.erb
@@ -23,7 +23,7 @@
     <% else %>
 
       <% if item[:type] == 'flow.branch' %>
-        <article class="flow-item flow-branch" data-fb-id="<%= item[:uuid] %>">
+        <article id="<%= item[:uuid] %>" class="flow-item flow-branch" data-fb-id="<%= item[:uuid] %>">
           <%= image_pack_tag "diamond.svg",  usemap: "#thumbnail-#{item[:uuid]}", alt: "", role: "presentation" %>
           <map name="thumbnail-<%= item[:uuid] %>" aria-hidden="true">
             <area shape="poly" coords="0,72.5 100,0 200,72.5 100,145" alt="<%= item[:title]-%>" role="presentation" href="<%= edit_branch_path(service.service_id, item[:uuid]) %>" tabindex="-1">
@@ -60,7 +60,7 @@
 
         <% if item[:next].empty? %>
           <%# Likely to be items like the end of a path (e.g. Confirmation page) %>
-          <article class="flow-item flow-page" aria-label="<%= item[:title] %>" data-fb-id="<%= item[:uuid] %>" <%= !(item[:type] =~ /page.(confirmation|exit)/) ? 'data-next=trailing-route' : ''  -%> >
+          <article id="<%= item[:uuid] %>" class="flow-item flow-page" aria-label="<%= item[:title] %>" data-fb-id="<%= item[:uuid] %>" <%= !(item[:type] =~ /page.(confirmation|exit)/) ? 'data-next=trailing-route' : ''  -%> >
             <%= flow_thumbnail_link(item) %>
             <%= flow_text_link(item) %>
             <%= render partial: 'services/flow_page_menu', locals: { item: item } %>
@@ -69,7 +69,7 @@
             <% end %>
           </article>
         <% else %>
-          <article class="flow-item flow-page" aria-label="<%= item[:title] %>" data-fb-id="<%= item[:uuid] %>" data-next="<%= item[:next] %>">
+          <article id="<%= item[:uuid] %>" class="flow-item flow-page" aria-label="<%= item[:title] %>" data-fb-id="<%= item[:uuid] %>" data-next="<%= item[:next] %>">
             <%= flow_thumbnail_link(item) %>
             <%= flow_text_link(item) %>
             <%= render partial: 'services/flow_page_menu', locals: { item: item } %>


### PR DESCRIPTION
Allows form editors to visit a page from the flow view, and then when they click the browser back button or the 'pages' navigation url they are returned to the flow view, with the relevant item roughtly cntered in their viewport.

We do this by using the history API to replace the current url when you click a flowItem.  This means if the user presses 'back' the url they return to includes a hash anchor with the items id.

We also modify the code that generates the url for the form navigation to append an anchor hash to the 'pages' link if the controller is 'pages' or 'branches'

There is then a bit of JS on the flow view to pick up the hash from the url and ensure the item is scrolled into view.