### PR TITLE
Fix issues with url field character counter 

### DIFF
--- a/app/views/settings/form_name_url/index.html.erb
+++ b/app/views/settings/form_name_url/index.html.erb
@@ -36,7 +36,7 @@
     <%= f.govuk_fieldset legend: { text: t('settings.form_name.form_slug.label'), size: 's', id: 'form-url-legend' } do %>
       <p><%= t('settings.form_name.form_slug.lede', href:  t('settings.form_name.form_slug.href')).html_safe %></p>
       <div class="fb-domain-input">
-        <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="<%= Editor::Service::URL_MAXIMUM %>">
+        <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="<%= Editor::Service::URL_MAXIMUM %>" data-threshold="75">
           <%= f.govuk_text_field :service_slug,
             label: -> {},
             hint: { text: t('settings.form_name.form_slug.hint'), class: 'govuk-!-margin-bottom-4' },
@@ -44,7 +44,7 @@
             value: f.object.saved_service_slug,
             'aria-labelledby': 'form-url-legend'
           %>
-          <div id="service-service-slug-field-info" class="govuk-hint govuk-character-count__message">
+        <div id="<%= f.object.errors[:service_slug] ? 'service-service-slug-field-error-info' : 'service-service-slug-field-info' %>" class="govuk-hint govuk-character-count__message">
             You can enter up to <%= Editor::Service::URL_MAXIMUM %> characters
           </div>
           <div class="fb-domain-input__suffix" aria-hidden="true">


### PR DESCRIPTION
This PR fixes 2 issue with the character counter on the Form and and URL settings screen:

* The count is now only shown at a threshold of 75% of the max length*
* The count still works if the field ahs a validation error

* Ticket requested a 90% threshold, but in conversation with team it was deiced that was a bit low (only 5 chars left when warning displayed) so decreased it to 75%