### PR TITLE
Add `unsafe-inline` for hotjar inline scripts

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,7 +13,8 @@ Rails.application.configure do
     policy.script_src  :self,
                        "https://unpkg.com/alpinejs",
                        "https://cdn.jsdelivr.net/npm/marked@2.1.3/marked.min.js",
-                       "https://*.hotjar.com"
+                       "https://*.hotjar.com",
+                       'unsafe-inline'
     policy.style_src   :self,
                        "https://*.hotjar.com",
                        'unsafe-inline'


### PR DESCRIPTION
As per hotjar docs, we need to add the `unsafe-inline` keyword for hotjar inline scripts to work.
[HotJar docs](https://help.hotjar.com/hc/en-us/articles/115011640307-Content-Security-Policies)