### PR TITLE
Create more granular error messages for form name and URL settings

### DIFF
--- a/acceptance/features/form_name_url_settings_spec.rb
+++ b/acceptance/features/form_name_url_settings_spec.rb
@@ -51,7 +51,7 @@ feature 'Form name URL settings page' do
 
   scenario 'validates the service slug' do
     given_I_update_the_service_slug('')
-    then_I_should_see_a_validation_message_for_required('URL')
+    then_I_should_see_a_validation_message('blank')
   end
 
   scenario 'validates the service slug min length' do
@@ -62,6 +62,26 @@ feature 'Form name URL settings page' do
   scenario 'validates the service slug max length' do
     given_I_update_the_service_slug('slug' * 15)
     then_I_should_see_a_validation_message_for_max_length('URL', 57)
+  end
+
+  scenario 'validates the service slug does not contain spaces' do
+    given_I_update_the_service_slug('slug with whitespace')
+    then_I_should_see_a_validation_message('whitespace')
+  end
+
+  scenario 'validates the service slug does not upper case characters' do
+    given_I_update_the_service_slug('slug with UpPer Case')
+    then_I_should_see_a_validation_message('contains_uppercase')
+  end
+
+  scenario 'validates the service slug does not special characters' do
+    given_I_update_the_service_slug('slug with sp£c!al chars')
+    then_I_should_see_a_validation_message('special_characters')
+  end
+
+  scenario 'validates the service slug does not start with a number' do
+    given_I_update_the_service_slug('123 slug')
+    then_I_should_see_a_validation_message('starts_with_number')
   end
 
   scenario 'updates the service slug in settings' do
@@ -133,6 +153,12 @@ feature 'Form name URL settings page' do
   def then_I_should_see_a_validation_message_for_max_length(attribute, count)
     expect(editor).to have_content(
       I18n.t('activemodel.errors.messages.too_long', attribute: attribute, count: count)
+    )
+  end
+
+  def then_I_should_see_a_validation_message(error)
+    expect(editor).to have_content(
+      I18n.t("activemodel.errors.models.service_slug.#{error}")
     )
   end
 

--- a/app/models/form_name_url_settings.rb
+++ b/app/models/form_name_url_settings.rb
@@ -9,8 +9,6 @@ class FormNameUrlSettings
   validates :service_name, legacy_service_name: true
   validates :service_name, length: { minimum: MINIMUM, maximum: 255 }, allow_blank: true
   validates :service_slug, length: { minimum: MINIMUM, maximum: 57 }, allow_blank: true
-  validates :service_slug, format: { with: /\A[a-zA-Z][\sa-z0-9-]*\z/ }, allow_blank: true
-  validates :service_slug, format: { with: /\A\S+\Z/ }, allow_blank: true
   validates_with ServiceSlugValidator
 
   def create

--- a/app/models/form_name_url_settings.rb
+++ b/app/models/form_name_url_settings.rb
@@ -9,7 +9,7 @@ class FormNameUrlSettings
   validates :service_name, legacy_service_name: true
   validates :service_name, length: { minimum: MINIMUM, maximum: 255 }, allow_blank: true
   validates :service_slug, length: { minimum: MINIMUM, maximum: 57 }, allow_blank: true
-  validates_with ServiceSlugValidator
+  validates_with ServiceSlugValidator, attributes: :service_slug
 
   def create
     return false if invalid?

--- a/app/models/form_name_url_settings.rb
+++ b/app/models/form_name_url_settings.rb
@@ -5,7 +5,7 @@ class FormNameUrlSettings
 
   MINIMUM = 3
 
-  validates :service_name, :service_slug, presence: true
+  validates :service_name, presence: true
   validates :service_name, legacy_service_name: true
   validates :service_name, length: { minimum: MINIMUM, maximum: 255 }, allow_blank: true
   validates :service_slug, length: { minimum: MINIMUM, maximum: 57 }, allow_blank: true

--- a/app/validators/service_slug_validator.rb
+++ b/app/validators/service_slug_validator.rb
@@ -46,7 +46,7 @@ class ServiceSlugValidator < ActiveModel::EachValidator
       )
     end
 
-    unless value.match?(/^[a-zA-Z0-9-]+$/)
+    unless value.match?(/^[a-zA-Z0-9- ]+$/)
       record.errors.add attribute, (
         options[:message] ||
         I18n.t(

--- a/app/validators/service_slug_validator.rb
+++ b/app/validators/service_slug_validator.rb
@@ -1,56 +1,54 @@
-class ServiceSlugValidator < ActiveModel::Validator
-  def validate(record)
-    if record.service_slug.blank?
-      return record.errors.add(
-        :base,
-        I18n.t(
-          'activemodel.errors.models.service_slug.blank'
-        )
+class ServiceSlugValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value.blank?
+      return record.errors.add attribute, (
+        options[:message] ||
+        I18n.t('activemodel.errors.models.service_slug.blank')
       )
     end
 
     current_service_slug = current_service_slug_config(service_id: record.service_id)
     valid_service_slugs = all_service_slugs - [current_service_slug]
 
-    unless valid_service_slugs.exclude?(record.service_slug)
-      record.errors.add(
-        :base,
+    unless valid_service_slugs.exclude?(value)
+      record.errors.add attribute, (
+        options[:message] ||
         I18n.t(
           'activemodel.errors.models.service_slug.exists'
         )
       )
     end
 
-    if record.service_slug.include?(' ')
-      record.errors.add(
-        :base,
+    if value.include?(' ')
+      record.errors.add attribute, (
+        options[:message] ||
         I18n.t(
           'activemodel.errors.models.service_slug.whitespace'
         )
       )
     end
 
-    if record.service_slug.start_with?(/[0-9]/)
-      record.errors.add(
-        :base,
+    if value.start_with?(/[0-9]/)
+      record.errors.add attribute, (
+        options[:message] ||
         I18n.t(
           'activemodel.errors.models.service_slug.starts_with_number'
         )
       )
     end
 
-    if record.service_slug.match?(/[A-Z]/)
-      record.errors.add(
-        :base,
+    if value.match?(/[A-Z]/)
+      record.errors.add attribute, (
+        options[:message] ||
         I18n.t(
           'activemodel.errors.models.service_slug.contains_uppercase'
         )
       )
     end
 
-    unless record.service_slug.match?(/^[a-zA-Z0-9-]+$/)
-      record.errors.add(
-        :base,
+    unless value.match?(/^[a-zA-Z0-9-]+$/)
+      record.errors.add attribute, (
+        options[:message] ||
         I18n.t(
           'activemodel.errors.models.service_slug.special_characters'
         )

--- a/app/validators/service_slug_validator.rb
+++ b/app/validators/service_slug_validator.rb
@@ -1,5 +1,14 @@
 class ServiceSlugValidator < ActiveModel::Validator
   def validate(record)
+    if record.service_slug.blank?
+      return record.errors.add(
+        :base,
+        I18n.t(
+          'activemodel.errors.models.service_slug.blank'
+        )
+      )
+    end
+
     current_service_slug = current_service_slug_config(service_id: record.service_id)
     valid_service_slugs = all_service_slugs - [current_service_slug]
 

--- a/app/validators/service_slug_validator.rb
+++ b/app/validators/service_slug_validator.rb
@@ -11,6 +11,42 @@ class ServiceSlugValidator < ActiveModel::Validator
         )
       )
     end
+
+    if record.service_slug.include?(' ')
+      record.errors.add(
+        :base,
+        I18n.t(
+          'activemodel.errors.models.service_slug.whitespace'
+        )
+      )
+    end
+
+    if record.service_slug.start_with?(/[0-9]/)
+      record.errors.add(
+        :base,
+        I18n.t(
+          'activemodel.errors.models.service_slug.starts_with_number'
+        )
+      )
+    end
+
+    if record.service_slug.match?(/[A-Z]/)
+      record.errors.add(
+        :base,
+        I18n.t(
+          'activemodel.errors.models.service_slug.contains_uppercase'
+        )
+      )
+    end
+
+    unless record.service_slug.match?(/^[a-zA-Z0-9-]+$/)
+      record.errors.add(
+        :base,
+        I18n.t(
+          'activemodel.errors.models.service_slug.special_characters'
+        )
+      )
+    end
   end
 
   private

--- a/app/views/settings/form_name_url/index.html.erb
+++ b/app/views/settings/form_name_url/index.html.erb
@@ -18,7 +18,7 @@
       </h2>
         <div class="govuk-error-summary__body">
           <ul class="govuk-list govuk-error-summary__list govuk-error-message" id="form-name-url-settings-field-error" >
-            <% f.object.errors.full_messages.each_with_index do |error_message, index| %>
+            <% f.object.errors.messages.values.flatten.each_with_index do |error_message, index| %>
             <li>
               <a href="#form-name-url-settings-field-error-<%= index %>">
                 <%= error_message %>
@@ -56,30 +56,30 @@
       <p><%= t('settings.form_name.form_slug.lede', href:  t('settings.form_name.form_slug.href')).html_safe %></p>
       <div class="fb-domain-input">
         <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="<%= Editor::Service::URL_MAXIMUM %>" data-threshold="75">
+
           <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.present? ? 'govuk-form-group--error' : '' %>">
-            <% if f.object.errors.present? %>
-              <% f.object.errors.full_messages.each_with_index do |error_message, index| %>
-                <% if error_message.include?('URL') %>
-                  <p id="form-name-url-settings-field-error-<%= index %>" class="govuk-error-message">
-                    <span class="govuk-visually-hidden">Error:</span> <%= error_message %>
-                  </p>
+              <div id="service-service-slug-hint" class="govuk-hint govuk-!-margin-bottom-4">
+                <%= t('settings.form_name.form_slug.hint') %>
+              </div>
+
+              <% if f.object.errors.present? %>
+                <% f.object.errors[:service_slug].each_with_index do |error_message, index| %>
+                  <% if error_message.include?('URL') %>
+                    <p id="form-name-url-settings-field-error-<%= index %>" class="govuk-error-message">
+                      <span class="govuk-visually-hidden">Error:</span> <%= error_message %>
+                    </p>
+                  <% end %>
                 <% end %>
               <% end %>
-            <% end %>
 
-            <%= f.govuk_text_field :service_slug,
-              label: -> {},
-              hint: { text: t('settings.form_name.form_slug.hint'), class: 'govuk-!-margin-bottom-4' },
-              class: "govuk-input  govuk-js-character-count",
-              value: f.object.saved_service_slug,
-              'aria-labelledby': 'form-url-legend'
-            %>
-          </div>
-        <div id="<%= f.object.errors[:service_slug].any? ? 'service-service-slug-field-error-info' : 'service-service-slug-field-info' %>" class="govuk-hint govuk-character-count__message">
-            You can enter up to <%= Editor::Service::URL_MAXIMUM %> characters
-          </div>
-          <div class="fb-domain-input__suffix" aria-hidden="true">
-            <%= t('settings.form_name.form_slug.domain') %>
+            <input class="govuk-input govuk-js-character-count" id="service-service-slug-field" name="service[service_slug]" type="text" aria-labelledby="form-url-legend" value="<%= f.object.saved_service_slug %>">
+
+            <div id="<%= f.object.errors[:service_slug].any? ? 'service-service-slug-field-error-info' : 'service-service-slug-field-info' %>" class="govuk-hint govuk-character-count__message">
+                You can enter up to <%= Editor::Service::URL_MAXIMUM %> characters
+              <div class="fb-domain-input__suffix" aria-hidden="true">
+                <%= t('settings.form_name.form_slug.domain') %>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/settings/form_name_url/index.html.erb
+++ b/app/views/settings/form_name_url/index.html.erb
@@ -1,45 +1,47 @@
 <%= mojf_settings_screen(
   heading:t('settings.form_name.heading')
-  ) do |c| %>
+) do |c| %>
 
-  <% c .with_back_link(href: settings_path) %>
+<% c .with_back_link(href: settings_path) %>
 
-  <%= form_for @form_name_url_settings,
-    as: :service,
-    url: settings_form_name_url_index_path(service.service_id),
-    html: { id: 'form-name-url-settings' },
-    builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+<%= form_for @form_name_url_settings,
+  as: :service,
+  url: settings_form_name_url_index_path(service.service_id),
+  html: { id: 'form-name-url-settings' },
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
 
   <% if f.object.errors.present? %>
     <div class="govuk-error-summary" data-module="govuk-error-summary">
       <div role="alert">
-      <h2 class="govuk-error-summary__title">
-        <%= t('activemodel.errors.summary_title') %>
-      </h2>
+        <h2 class="govuk-error-summary__title">
+          <%= t('activemodel.errors.summary_title') %>
+        </h2>
         <div class="govuk-error-summary__body">
           <ul class="govuk-list govuk-error-summary__list govuk-error-message" id="form-name-url-settings-field-error" >
-            <% f.object.errors.messages.values.flatten.each_with_index do |error_message, index| %>
-            <li>
-              <a href="#form-name-url-settings-field-error-<%= index %>">
-                <%= error_message %>
-              </a>
-            </li>
-          <% end %>
+            <% f.object.errors.messages.each do |attribute, messages| %>
+              <% messages.each do |message| %>
+                <li>
+                  <a href="#service-<%= attribute.to_s.dasherize %>-field-error">
+                    <%= message %>
+                  </a>
+                </li>
+              <% end %>
+            <% end %>
           </ul>
         </div>
       </div>
     </div>
   <% end %>
 
-    <%= f.govuk_fieldset legend: { text:t('settings.form_name.form_name.label'), size: 's', id: 'form-name-legend' }, class:"govuk-!-margin-bottom-6" do %>
-        <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-6"><%= t('settings.form_name.form_name.lede', href:  t('settings.form_name.form_name.href') ).html_safe %></p>
+  <%= f.govuk_fieldset legend: { text:t('settings.form_name.form_name.label'), size: 's', id: 'form-name-legend' }, class:"govuk-!-margin-bottom-6" do %>
+    <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-6"><%= t('settings.form_name.form_name.lede', href:  t('settings.form_name.form_name.href') ).html_safe %></p>
 
-        <%= f.govuk_text_field :service_name,
-          label: ->  {},
-          class: "govuk-input width-responsive-two-thirds",
-          value: f.object.saved_service_name,
-          'aria-labelledby': 'form-name-legend' %>
-    <% end %>
+    <%= f.govuk_text_field :service_name,
+      label: ->  {},
+      class: "govuk-input width-responsive-two-thirds",
+      value: f.object.saved_service_name,
+      'aria-labelledby': 'form-name-legend' %>
+  <% end %>
 
   <% if f.object.published_to_live? %>
     <%= f.govuk_fieldset legend: { text: t('settings.form_name.form_slug.label'), size: 's', id: 'form-url-legend' } do %>
@@ -57,36 +59,38 @@
       <div class="fb-domain-input">
         <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="<%= Editor::Service::URL_MAXIMUM %>" data-threshold="75">
 
-          <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.present? ? 'govuk-form-group--error' : '' %>">
-              <div id="service-service-slug-hint" class="govuk-hint govuk-!-margin-bottom-4">
-                <%= t('settings.form_name.form_slug.hint') %>
-              </div>
-
-              <% if f.object.errors.present? %>
-                <% f.object.errors[:service_slug].each_with_index do |error_message, index| %>
-                  <% if error_message.include?('URL') %>
-                    <p id="form-name-url-settings-field-error-<%= index %>" class="govuk-error-message">
-                      <span class="govuk-visually-hidden">Error:</span> <%= error_message %>
-                    </p>
-                  <% end %>
-                <% end %>
-              <% end %>
-
-            <input class="govuk-input govuk-js-character-count" id="service-service-slug-field" name="service[service_slug]" type="text" aria-labelledby="form-url-legend" value="<%= f.object.saved_service_slug %>">
-
-            <div id="<%= f.object.errors[:service_slug].any? ? 'service-service-slug-field-error-info' : 'service-service-slug-field-info' %>" class="govuk-hint govuk-character-count__message">
-                You can enter up to <%= Editor::Service::URL_MAXIMUM %> characters
-              <div class="fb-domain-input__suffix" aria-hidden="true">
-                <%= t('settings.form_name.form_slug.domain') %>
-              </div>
+          <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors[:service_slug].any? ? 'govuk-form-group--error' : '' %>">
+            <div id="service-service-slug-hint" class="govuk-hint govuk-!-margin-bottom-4">
+              <%= t('settings.form_name.form_slug.hint') %>
             </div>
+
+            <% f.object.errors[:service_slug]&.each_with_index do |error_message, index| %>
+              <p id="service-service-slug-field-error-<%=index%>" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span> <%= error_message %>
+              </p>
+            <% end %>
+
+            <input class="govuk-input govuk-js-character-count" 
+                   id="service-service-slug-field<%= f.object.errors[:service_slug].any? ? '-error' : '' %>" 
+                   name="service[service_slug]" 
+                   type="text" 
+                   aria-labelledby="form-url-legend" 
+                   aria-describedby="<%= f.object.errors[:service_slug].any? ? f.object.errors[:service_slug]&.map.with_index {|_,index| "service-service-slug-field-error-#{index}"}.join(' ') : 'service-service-slug-hint'  %>"
+                   value="<%= f.object.saved_service_slug %>">
+
+                   <div id="<%= f.object.errors[:service_slug].any? ? 'service-service-slug-field-error-info' : 'service-service-slug-field-info' %>" class="govuk-hint govuk-character-count__message">
+                     You can enter up to <%= Editor::Service::URL_MAXIMUM %> characters
+                     <div class="fb-domain-input__suffix" aria-hidden="true">
+                       <%= t('settings.form_name.form_slug.domain') %>
+                     </div>
+                   </div>
           </div>
         </div>
       </div>
     <% end %>
   <% end %>
-    <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
-      <%= t('actions.save') %>
-    </button>
-  <% end %>
+  <button type="submit" class="govuk-button fb-govuk-button" data-module="govuk-button">
+    <%= t('actions.save') %>
+  </button>
+<% end %>
 <% end %>

--- a/app/views/settings/form_name_url/index.html.erb
+++ b/app/views/settings/form_name_url/index.html.erb
@@ -10,7 +10,26 @@
     html: { id: 'form-name-url-settings' },
     builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
 
-    <%= f.govuk_error_summary %>
+  <% if f.object.errors.present? %>
+    <div class="govuk-error-summary" data-module="govuk-error-summary">
+      <div role="alert">
+      <h2 class="govuk-error-summary__title">
+        <%= t('activemodel.errors.summary_title') %>
+      </h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list govuk-error-message" id="form-name-url-settings-field-error" >
+            <% f.object.errors.full_messages.each_with_index do |error_message, index| %>
+            <li>
+              <a href="#form-name-url-settings-field-error-<%= index %>">
+                <%= error_message %>
+              </a>
+            </li>
+          <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  <% end %>
 
     <%= f.govuk_fieldset legend: { text:t('settings.form_name.form_name.label'), size: 's', id: 'form-name-legend' }, class:"govuk-!-margin-bottom-6" do %>
         <p class="govuk-!-margin-top-2 govuk-!-margin-bottom-6"><%= t('settings.form_name.form_name.lede', href:  t('settings.form_name.form_name.href') ).html_safe %></p>
@@ -37,13 +56,25 @@
       <p><%= t('settings.form_name.form_slug.lede', href:  t('settings.form_name.form_slug.href')).html_safe %></p>
       <div class="fb-domain-input">
         <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="<%= Editor::Service::URL_MAXIMUM %>" data-threshold="75">
-          <%= f.govuk_text_field :service_slug,
-            label: -> {},
-            hint: { text: t('settings.form_name.form_slug.hint'), class: 'govuk-!-margin-bottom-4' },
-            class: "govuk-input  govuk-js-character-count",
-            value: f.object.saved_service_slug,
-            'aria-labelledby': 'form-url-legend'
-          %>
+          <div class="govuk-form-group govuk-!-margin-left-1 <%= f.object.errors.present? ? 'govuk-form-group--error' : '' %>">
+            <% if f.object.errors.present? %>
+              <% f.object.errors.full_messages.each_with_index do |error_message, index| %>
+                <% if error_message.include?('URL') %>
+                  <p id="form-name-url-settings-field-error-<%= index %>" class="govuk-error-message">
+                    <span class="govuk-visually-hidden">Error:</span> <%= error_message %>
+                  </p>
+                <% end %>
+              <% end %>
+            <% end %>
+
+            <%= f.govuk_text_field :service_slug,
+              label: -> {},
+              hint: { text: t('settings.form_name.form_slug.hint'), class: 'govuk-!-margin-bottom-4' },
+              class: "govuk-input  govuk-js-character-count",
+              value: f.object.saved_service_slug,
+              'aria-labelledby': 'form-url-legend'
+            %>
+          </div>
         <div id="<%= f.object.errors[:service_slug].any? ? 'service-service-slug-field-error-info' : 'service-service-slug-field-info' %>" class="govuk-hint govuk-character-count__message">
             You can enter up to <%= Editor::Service::URL_MAXIMUM %> characters
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -611,6 +611,7 @@ en:
           starts_with_number: Your URL cannot start with a number
           contains_uppercase: Your URL cannot include upper-case letters
           special_characters: Your URL cannot include special characters except hyphens
+          blank: Your URL cannot be blank
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."
         too_short: "%{attribute} must be %{count} characters or more"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -607,6 +607,10 @@ en:
           blank: Enter a reply email address
         service_slug:
           exists: The URL entered already exists, please try another URL
+          whitespace: Your URL cannot include spaces - use hyphens to separate words
+          starts_with_number: Your URL cannot start with a number
+          contains_uppercase: Your URL cannot include upper-case letters
+          special_characters: Your URL cannot include special characters except hyphens
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."
         too_short: "%{attribute} must be %{count} characters or more"

--- a/spec/validators/service_slug_validator_spec.rb
+++ b/spec/validators/service_slug_validator_spec.rb
@@ -8,46 +8,148 @@ RSpec.describe ServiceSlugValidator do
     end
 
     context 'SERVICE_SLUG' do
-      context 'when service slug already exists' do
-        let!(:existing_service_configuration) do
-          create(
-            :service_configuration,
-            :dev,
-            :service_slug,
-            service_id: SecureRandom.uuid
-          )
+      context 'when invalid' do
+        context 'when service slug already exists' do
+          let!(:existing_service_configuration) do
+            create(
+              :service_configuration,
+              :dev,
+              :service_slug,
+              service_id: SecureRandom.uuid
+            )
+          end
+
+          before do
+            allow_any_instance_of(
+              ServiceSlugValidator
+            ).to receive(:all_service_slugs).and_return(
+              [existing_service_configuration.decrypt_value]
+            )
+          end
+
+          let(:params) do
+            {
+              service_slug: 'eat-slugs-malfoy',
+              service_name: 'Form name'
+            }
+          end
+
+          it 'returns invalid' do
+            expect(subject).to_not be_valid
+          end
         end
 
-        before do
-          allow_any_instance_of(
-            ServiceSlugValidator
-          ).to receive(:all_service_slugs).and_return(
-            [existing_service_configuration.decrypt_value]
-          )
+        context 'when service slug submitted is empty' do
+          let(:params) do
+            {
+              service_slug: '',
+              service_name: 'Form name'
+            }
+          end
+
+          it 'returns invalid' do
+            expect(subject).to_not be_valid
+          end
+
+          it 'returns an error message' do
+            expect(subject.errors.full_messages).to include(/#{I18n.t('activemodel.errors.models.service_slug.blank')}/)
+          end
         end
 
-        let(:params) do
-          {
-            service_slug: 'eat-slugs-malfoy',
-            service_name: 'Form name'
-          }
+        context 'when service slug submitted is begins with a number' do
+          let(:params) do
+            {
+              service_slug: '123slug',
+              service_name: 'Form name'
+            }
+          end
+
+          it 'returns invalid' do
+            expect(subject).to_not be_valid
+          end
+
+          it 'returns an error message' do
+            expect(subject.errors.full_messages).to include(/#{I18n.t('activemodel.errors.models.service_slug.starts_with_number')}/)
+          end
         end
 
-        it 'returns invalid' do
-          expect(subject).to_not be_valid
+        context 'when service slug submitted has spaces' do
+          let(:params) do
+            {
+              service_slug: 's l u g',
+              service_name: 'Form name'
+            }
+          end
+
+          it 'returns invalid' do
+            expect(subject).to_not be_valid
+          end
+
+          it 'returns an error message' do
+            expect(subject.errors.full_messages).to include(/#{I18n.t('activemodel.errors.models.service_slug.whitespace')}/)
+          end
+        end
+
+        context 'when service slug submitted has uppercase chars' do
+          let(:params) do
+            {
+              service_slug: 'Slug',
+              service_name: 'Form name'
+            }
+          end
+
+          it 'returns invalid' do
+            expect(subject).to_not be_valid
+          end
+
+          it 'returns an error message' do
+            expect(subject.errors.full_messages).to include(/#{I18n.t('activemodel.errors.models.service_slug.contains_uppercase')}/)
+          end
+        end
+
+        context 'when service slug submitted has special characters' do
+          let(:params) do
+            {
+              service_slug: 's|!&"@?',
+              service_name: 'Form name'
+            }
+          end
+
+          it 'returns invalid' do
+            expect(subject).to_not be_valid
+          end
+
+          it 'returns an error message' do
+            expect(subject.errors.full_messages).to include(/#{I18n.t('activemodel.errors.models.service_slug.special_characters')}/)
+          end
         end
       end
 
-      context 'when service slug does not exist' do
-        let(:params) do
-          {
-            service_slug: 'eat-slugs-malfoy',
-            service_name: 'Form name'
-          }
+      context 'when valid' do
+        context 'when service slug does not exist' do
+          let(:params) do
+            {
+              service_slug: 'eat-slugs-malfoy',
+              service_name: 'Form name'
+            }
+          end
+
+          it 'returns valid' do
+            expect(subject).to be_valid
+          end
         end
 
-        it 'returns valid' do
-          expect(subject).to be_valid
+        context 'when service slug has numbers' do
+          let(:params) do
+            {
+              service_slug: 'eat1-slugs2-malfoy3',
+              service_name: 'Form name'
+            }
+          end
+
+          it 'returns valid' do
+            expect(subject).to be_valid
+          end
         end
       end
     end


### PR DESCRIPTION
### Before
![Screenshot 2023-07-07 at 17 13 45](https://github.com/ministryofjustice/fb-editor/assets/29227502/186dd317-07a1-473d-aa95-a7236aff144f)

### After
![Screenshot 2023-07-10 at 12 25 34](https://github.com/ministryofjustice/fb-editor/assets/29227502/8fb14932-d546-408c-945b-377415e36c52)
