### PR TITLE
Remove report only mode to enforce CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -32,5 +32,5 @@ Rails.application.configure do
   config.content_security_policy_nonce_directives = %w(script-src)
 
   # Report violations without enforcing the policy.
-  config.content_security_policy_report_only = true
+  config.content_security_policy_report_only = false
 end


### PR DESCRIPTION
We haven't had any CSP violations over the last week so we can begin to enforce the CSP.