### PR TITLE
Disable save and return on upload components

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'standalone-pages-notification-banners'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.0.13'
+gem 'metadata_presenter', '3.0.15'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,7 +264,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.0.13)
+    metadata_presenter (3.0.15)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
@@ -539,7 +539,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.0.13)
+  metadata_presenter (= 3.0.15)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -118,6 +118,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :save_and_return_enabled?
 
+  def show_save_and_return
+    @page.upload_components.none?
+  end
+  helper_method :show_save_and_return
+
   def save_and_return_config
     @save_and_return_config ||= ServiceConfiguration.find_by(service_id: service.service_id, name: 'SAVE_AND_RETURN')
   end


### PR DESCRIPTION
### Disable save and return on file upload components
This is a temporary measure to prevent a bug that allows files to be uploaded without a reference, which in turn creates an issue with the submission.

### Bump presenter 3.0.14