### PR TITLE
Temporary fix for browser-tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   slack: circleci/slack@3.4.2
   ruby: circleci/ruby@1.4.0
   node: circleci/node@5.1.0
-  browser-tools: circleci/browser-tools@1.2.4
+  browser-tools: circleci/browser-tools@1.4.1
   kubernetes: circleci/kubernetes@0.12.0
 
 jobs:
@@ -240,8 +240,8 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
+      - browser-tools/install-browser-tools:
+          chrome-version: 114.0.5735.90 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - run:
           name: Check browser tools install
           command: |
@@ -279,8 +279,8 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
+      - browser-tools/install-browser-tools:
+          chrome-version: 114.0.5735.90 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - run:
           name: Check browser tools install
           command: |


### PR DESCRIPTION
The CircleCI team are currently working on a fix to make browser-tools compatible with the latest Chromedriver version (115).

Use v114 for now to ensure the pipeline is not blocked.