### PR TITLE
Update browser-tools to v1.4.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   slack: circleci/slack@3.4.2
   ruby: circleci/ruby@1.4.0
   node: circleci/node@5.1.0
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.3
   kubernetes: circleci/kubernetes@0.12.0
 
 jobs:
@@ -240,8 +240,8 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - browser-tools/install-browser-tools:
-          chrome-version: 114.0.5735.90 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install
           command: |
@@ -279,8 +279,8 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - browser-tools/install-browser-tools:
-          chrome-version: 114.0.5735.90 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install
           command: |


### PR DESCRIPTION
### Update browser-tools to 1.4.3
Our pipeline was failing due to browser tools unsuccessfully downloading the latest chromedriver, so we pushed a temporary fix.

The maintainers have released now a new browser-tools version that successfully installs Chromedriver v115, this PR updates our pipeline to use that version.

#### CircleCI
https://app.circleci.com/pipelines/github/ministryofjustice/fb-editor?branch=chromedriver