### PR TITLE
Presenter bump 3.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'multi-file-upload'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.1.0'
+gem 'metadata_presenter', '3.2.0'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.1.0)
+    metadata_presenter (3.2.0)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
@@ -735,7 +735,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.1.0)
+  metadata_presenter (= 3.2.0)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/acceptance/features/edit_confirmation_page_spec.rb
+++ b/acceptance/features/edit_confirmation_page_spec.rb
@@ -5,7 +5,10 @@ feature 'Edit confirmation pages' do
   let(:service_name) { generate_service_name }
   let(:confirmation_heading) { 'Updated confirmation heading' }
   let(:confirmation_lede) { 'Updated confirmation lede' }
-  let(:confirmation_body) { 'Updated confirmation body' }
+  let(:content_component) { 'Give me content' }
+  let(:optional_content) do
+    I18n.t('default_text.content')
+  end
 
   background do
     given_I_am_logged_in
@@ -16,14 +19,14 @@ feature 'Edit confirmation pages' do
     given_I_edit_a_confirmation_page
     and_I_change_the_page_heading(confirmation_heading)
     and_I_change_the_page_lede(confirmation_lede)
-    and_I_change_the_page_body(confirmation_body)
+    and_I_add_a_content_component(content: content_component)
     when_I_save_my_changes
     and_I_return_to_flow_page
     and_I_click_on_the_confirmation_page_three_dots
     and_I_click_edit_page
     then_I_should_see_the_confirmation_heading(confirmation_heading)
     then_I_should_see_the_confirmation_lede(confirmation_lede)
-    then_I_should_see_the_confirmation_body(confirmation_body)
+    then_I_should_see_the_content_component(content_component)
   end
 
   def and_I_change_the_page_body(body)
@@ -34,10 +37,6 @@ feature 'Edit confirmation pages' do
     expect(editor.page_lede.text).to eq(lede)
   end
 
-  def then_I_should_see_the_confirmation_body(body)
-    expect(editor.page_body.text).to eq(body)
-  end
-
   def and_I_click_on_the_confirmation_page_three_dots # confirmation page does not have 'img.body'
     page.find('.flow-thumbnail', text: confirmation_heading).hover
     and_I_click_on_the_three_dots
@@ -45,5 +44,24 @@ feature 'Edit confirmation pages' do
 
   def and_I_click_edit_page
     editor.edit_page_button.click
+  end
+
+  def and_I_add_a_content_component(content:)
+    editor.add_content_area_buttons.first.click
+    and_the_content_component_has_the_optional_content
+    when_I_change_editable_content(editor.first_component, content: content)
+  end
+
+  def and_the_content_component_has_the_optional_content
+    editor.service_name.click # click outside to close the editable component
+
+    # the output element p tag of a content component is the thing which has
+    # the actual text in it
+    output_component = editor.first_component.find('[data-element="editable-content-output"]', visible: false)
+    expect(output_component.text).to eq(optional_content)
+  end
+
+  def then_I_should_see_the_content_component(content)
+    expect(editor.first_component.text).to eq(content)
   end
 end


### PR DESCRIPTION
Bumping the presenter gem to 3.2.0 which introduces the change whereby the content page and confirmation page no longer have a 'body' attribute, forcing users to create a content component.
This is some groundwork to get us ready for implementing conditional content components.

### CircleCI run
https://app.circleci.com/pipelines/github/ministryofjustice/fb-editor/8747/workflows/910df2ee-3112-4ebf-bd96-58ceae1dea5d