### PR TITLE
Update labels for confirmation page thumbnail when pay is enabled

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,14 +6,14 @@ module ApplicationHelper
   end
 
   # Used on service flow page
-  def flow_thumbnail_link(args)
+  def flow_thumbnail_link(item)
     link_to edit_page_path(
-      service.service_id, args[:uuid]
-    ), class: "flow-thumbnail #{args[:thumbnail]} #{payment_link_enabled? ? 'payment-enabled' : ''}", 'aria-hidden': true, tabindex: -1 do
+      service.service_id, item[:uuid]
+    ), class: "flow-thumbnail #{item[:thumbnail]} #{payment_link_enabled? ? 'payment-enabled' : ''}", 'aria-hidden': true, tabindex: -1 do
       concat image_pack_tag('thumbnails/thumbs_header.png', class: 'header', alt: '')
       concat tag.span("#{t('actions.edit')}: ", class: 'govuk-visually-hidden')
-      concat tag.span(args[:title], class: 'text')
-      concat image_pack_tag("thumbnails/thumbs_#{args[:thumbnail]}.jpg", class: 'body', alt: '')
+      concat tag.span(flow_item_title(item), class: 'text')
+      concat image_pack_tag("thumbnails/thumbs_#{item[:thumbnail]}.jpg", class: 'body', alt: '')
     end
   end
 
@@ -25,8 +25,16 @@ module ApplicationHelper
                edit_page_path(service.service_id, item[:uuid])
              end), class: 'govuk-link flow-item__title' do
       concat tag.span("#{t('actions.edit')}: ", class: 'govuk-visually-hidden')
-      concat tag.span(item[:title], class: 'text')
+      concat tag.span(flow_item_title(item), class: 'text')
     end
+  end
+
+  def flow_item_title(item)
+    return item[:title] unless item[:type] == 'page.confirmation'
+    return item[:title] unless payment_link_enabled?
+    return item[:title] unless item[:title] == I18n.t('presenter.confirmation.application_complete')
+
+    I18n.t('presenter.confirmation.payment_enabled')
   end
 
   def flow_branch_link(item)


### PR DESCRIPTION
Updates the labels on the confirmation page on the flow view when payments are enabled.

If payments are enabled and the confirmation page title is still default (Application complete) then show the default payment confirmation title (You still need to pay).

If the user has edited the title away from default, then that will display.

### Results

|               | Payment disabled | Payment enabled |
|---------------|------------------|-----------------|
| Default title | ![image](https://github.com/ministryofjustice/fb-editor/assets/595564/77e8088b-3983-45bb-af87-0559a34cb13c) | ![image](https://github.com/ministryofjustice/fb-editor/assets/595564/76365fab-777d-4a08-a1e4-749c542a44eb) |
| Custom title  | ![image](https://github.com/ministryofjustice/fb-editor/assets/595564/bbc8b0d4-3e03-4dfe-82e8-0270e6cce842) | ![image](https://github.com/ministryofjustice/fb-editor/assets/595564/63ea7d9b-8489-4d2a-9856-50a11c728ec0) | 


