### PR TITLE
Fix flow view confirmation thumbnail labels

### DIFF
--- a/acceptance/features/reference_payment_spec.rb
+++ b/acceptance/features/reference_payment_spec.rb
@@ -110,7 +110,7 @@ feature 'Reference Payment Page' do
     click_button(I18n.t('actions.save'))
 
     and_I_return_to_flow_page
-    given_I_edit_a_confirmation_page
+    given_I_edit_a_confirmation_page(text: I18n.t('presenter.confirmation.payment_enabled'))
     expect(page).to have_css('div.govuk-panel--confirmation-payment', text: confirmation_page_payment_text)
 
     editor.question_heading.first.set('You have to pay now')

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -142,8 +142,8 @@ module CommonSteps
     editor.add_confirmation.click
   end
 
-  def given_I_edit_a_confirmation_page
-    page.find('.govuk-link', text: 'Application complete').click
+  def given_I_edit_a_confirmation_page(text: 'Application complete' )
+    page.find('.govuk-link', text: text).click
   end
 
   def given_I_add_an_exit_page


### PR DESCRIPTION
Take 2 at this PR.  With fixed acceptance test!

Updates the labels on the confirmation page on the flow view when payments are enabled.

If payments are enabled and the confirmation page title is still default (Application complete) then show the default payment confirmation title (You still need to pay).

If the user has edited the title away from default, then that will display.

### Results

|               | Payment disabled | Payment enabled |
|---------------|------------------|-----------------|
| Default title | ![image](https://github.com/ministryofjustice/fb-editor/assets/595564/77e8088b-3983-45bb-af87-0559a34cb13c) | ![image](https://github.com/ministryofjustice/fb-editor/assets/595564/76365fab-777d-4a08-a1e4-749c542a44eb) |
| Custom title  | ![image](https://github.com/ministryofjustice/fb-editor/assets/595564/bbc8b0d4-3e03-4dfe-82e8-0270e6cce842) | ![image](https://github.com/ministryofjustice/fb-editor/assets/595564/63ea7d9b-8489-4d2a-9856-50a11c728ec0) | 


