### PR TITLE
Bump to presenter 3.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'delayed_job_active_record'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'multi-file-upload'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.2.0'
+gem 'metadata_presenter', '3.2.1'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.2.0)
+    metadata_presenter (3.2.1)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
@@ -735,7 +735,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.2.0)
+  metadata_presenter (= 3.2.1)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -148,4 +148,9 @@ class ApplicationController < ActionController::Base
       name: 'SERVICE_SLUG'
     )&.decrypt_value
   end
+
+  def load_conditional_content
+    @page.content_components.map(&:uuid)
+  end
+  helper_method :load_conditional_content
 end


### PR DESCRIPTION
This version of the presenter adds logic to evaluate the content conditionals. 
We want to load all content components in the editor for now, so the `load_conditional_content` method gives us all the content component uuids on a page to be shown.

### CircleCI run
https://app.circleci.com/pipelines/github/ministryofjustice/fb-editor/8767/workflows/12ebb034-f8d3-479e-80fc-c58492cc9ca6