### PR TITLE
Replace submitHandler.js with save-button component

### DIFF
--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -205,7 +205,7 @@ class AddContent {
     this.saveButton = config.view.saveButton;
 
     $button.on("click.AddContent", () => {
-      updateHiddenInputOnForm(config.$form, fieldname, "content");
+      updateHiddenInputOnForm(config.form, fieldname, "content");
       this.saveButton.save();
     });
 

--- a/app/javascript/src/web-components/save-button.js
+++ b/app/javascript/src/web-components/save-button.js
@@ -74,6 +74,10 @@ class SaveButton extends HTMLButtonElement {
   get describedBy() {
     return this.form.querySelector(`#${this.getAttribute('aria-describedby')}`);
   }
+  
+  get $form() {
+    return $(this.form)
+  }
 
   get preventUnload() {
     return this.hasAttribute('prevent-unload');
@@ -116,10 +120,10 @@ class SaveButton extends HTMLButtonElement {
 
   // Enables programatically submitting the form, regardless of the state of the
   // button, and bypassing unload prevention.
-  submit() {
+  save() {
     this.#enabled = true;
     this.#removeBeforeUnloadListener();
-    this.form.submit(); // Does not raise a `submit` event
+    this.form.submit();
   }
 
   #handleClick(event) {

--- a/app/javascript/src/web-components/save-button.js
+++ b/app/javascript/src/web-components/save-button.js
@@ -122,7 +122,7 @@ class SaveButton extends HTMLButtonElement {
   // button, and bypassing unload prevention.
   save() {
     this.#enabled = true;
-    this.#removeBeforeUnloadListener();
+    this.form.dispatchEvent(new Event('submit')) // Trigger submit event listeners
     this.form.submit();
   }
 

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -27,8 +27,9 @@
     <% end %>
   <% end %>
 
-  <%= f.submit t('actions.save'), class: 'govuk-button fb-govuk-button', id: 'fb-editor-save', 'aria-describedby': "save_description" %>
-  <span class="sr-only" id="save_description"></span>
+
+    <%= mojf_save_button(form: f, text: t('actions.save'), html_attributes: {id: 'fb-editor-save', 'prevent-unload': true}) %>
+
 <% end %>
 
 <% # app.page is initialised in partials/properties. %>

--- a/test/web-components/save-button/methods_test.js
+++ b/test/web-components/save-button/methods_test.js
@@ -92,7 +92,7 @@ describe('save-button', function() {
       });
     });
 
-    describe('submit()', function() {
+    describe('save()', function() {
       const sandbox = sinon.createSandbox();
 
       describe('when save required', function() {
@@ -113,7 +113,7 @@ describe('save-button', function() {
         it('submits the form', function() {
           const formSubmitSpy = sandbox.spy(form, 'submit')
 
-          saveButton.submit();
+          saveButton.save();
 
           expect(formSubmitSpy).to.have.been.calledOnce;
         })
@@ -121,9 +121,9 @@ describe('save-button', function() {
         it('removes the beforeunload listener', function() {
           const removeEventListenerSpy = sandbox.spy(window, 'removeEventListener')
 
-          saveButton.submit()
+          saveButton.save()
 
-          expect(removeEventListenerSpy).to.have.been.calledOnce
+          expect(removeEventListenerSpy).to.have.been.calledOnce;
         })
 
       })


### PR DESCRIPTION
This uses the new save-button custom element used on the settings screens onto the question/edit pages.

* Adds `$form` getter to save-button to return a jQuery object of the form, for compatibility
* Updates `submit()` method to `save()` for better readability.
* `save()` function triggers a submit event, to ensure listeners fire
* Updates pages-controller to replace submitHandler with save-button
* Update the button in the view template