### PR TITLE
Conditional content expressions and conditionals

### DIFF
--- a/app/models/component_conditional.rb
+++ b/app/models/component_conditional.rb
@@ -1,0 +1,56 @@
+class ComponentConditional
+  include ActiveModel::Model
+  attr_accessor :service
+  attr_writer :expressions
+
+  validate :expressions_validations
+
+  IF = 'if'.freeze
+  AND = 'and'.freeze
+
+  def initialize(attributes)
+    @service = attributes.delete(:service)
+    super
+  end
+
+  def to_metadata
+    {
+      '_uuid' => generate_uuid,
+      '_type' => conditional_type,
+      'expressions' => expressions.map(&:to_metadata)
+    }
+  end
+
+  def expressions
+    @expressions ||= []
+  end
+
+  def expressions_validations
+    expressions.map(&:invalid?)
+  end
+
+  # this is tested in the ConditionalComponent model
+  def expressions_attributes=(hash)
+    hash.each do |_index, expression_hash|
+      expressions.push(
+        ComponentExpression.new(
+          expression_hash.merge(
+            page: service.page_with_component(expression_hash['component'])
+          )
+        )
+      )
+    end
+  end
+
+  private
+
+  def conditional_type
+    # The UI currently only supports IF and AND. The runner can also cater for
+    # an OR but for the moment we have not surfaced that functionality
+    expressions.count == 1 ? IF : AND
+  end
+
+  def generate_uuid
+    SecureRandom.uuid
+  end
+end

--- a/app/models/component_expression.rb
+++ b/app/models/component_expression.rb
@@ -1,0 +1,101 @@
+class ComponentExpression
+  include ActiveModel::Model
+  attr_accessor :component, :operator, :field, :page
+
+  validates :component, :operator, :page, presence: true
+  validate :unsupported_component, :blank_field
+
+  OPERATORS = [
+    [I18n.t('operators.is'), 'is', { 'data-hide-answers': 'false' }],
+    [I18n.t('operators.is_not'), 'is_not', { 'data-hide-answers': 'false' }],
+    [I18n.t('operators.contains'), 'contains', { 'data-hide-answers': 'false' }],
+    [I18n.t('operators.does_not_contain'), 'does_not_contain', { 'data-hide-answers': 'false' }],
+    [I18n.t('operators.is_answered'), 'is_answered', { 'data-hide-answers': 'true' }],
+    [I18n.t('operators.is_not_answered'), 'is_not_answered', { 'data-hide-answers': 'true' }]
+  ].freeze
+
+  def to_metadata
+    {
+      'operator' => operator,
+      'page' => page&.uuid,
+      'component' => component,
+      'field' => field_answer
+    }
+  end
+
+  def answers
+    component_object.items.map { |item| [item.label, item.uuid] }
+  end
+
+  def all_operators
+    OPERATORS
+  end
+
+  def operators
+    return contains_operators if is_checkbox?
+
+    is_operators
+  end
+
+  def component_type
+    component_object.type
+  end
+
+  def name_attr(conditional_index:, expression_index:, attribute:)
+    "conditional_component[conditionals_attributes][#{conditional_index}]" \
+    "[expressions_attributes][#{expression_index}][#{attribute}]"
+  end
+
+  def id_attr(conditional_index:, expression_index:, attribute:)
+    "conditional_component_conditionals_attributes_#{conditional_index}_" \
+    "expressions_attributes_#{expression_index}_#{attribute}"
+  end
+
+  private
+
+  def field_answer
+    return field.to_s unless field_required?
+
+    field
+  end
+
+  def field_required?
+    operator == I18n.t('operators.is') || operator == I18n.t('operators.is_not')
+  end
+
+  def component_object
+    @component_object ||= page.find_component_by_uuid(component)
+  end
+
+  def contains_operators
+    @contains_operators ||= all_operators.select do |operator|
+      operator.exclude?(I18n.t('operators.is')) && operator.exclude?(I18n.t('operators.is_not'))
+    end
+  end
+
+  def is_operators
+    @is_operators ||= all_operators.select do |operator|
+      operator.exclude?(I18n.t('operators.contains')) && operator.exclude?(I18n.t('operators.does_not_contain'))
+    end
+  end
+
+  def is_checkbox?
+    component_type == 'checkboxes'
+  end
+
+  def unsupported_component
+    if page.present? && component.present? && !component_object.supports_branching?
+      errors.add(:component, message: I18n.t(
+        'activemodel.errors.messages.unsupported_component'
+      ))
+    end
+  end
+
+  def blank_field
+    if field_required? && field.nil?
+      errors.add(:operator, message: I18n.t(
+        'activemodel.errors.messages.blank'
+      ))
+    end
+  end
+end

--- a/spec/models/component_conditional_spec.rb
+++ b/spec/models/component_conditional_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe ComponentConditional do
+  subject(:component_conditional) do
+    described_class.new(component_conditional_hash)
+  end
+  let(:component_conditional_hash) do
+    {
+      'expressions' => [
+        ComponentExpression.new(
+          {
+            'operator' => 'is',
+            'component' => '67890',
+            'page' => double(uuid: 'some-page-uuid'),
+            'field' => 'some-field-uuid'
+          }
+        )
+      ]
+    }.merge(service:)
+  end
+  let(:expected_component_conditional) do
+    {
+      '_uuid' => 'til-its-done',
+      '_type' => 'if',
+      'expressions' => [
+        {
+          'operator' => 'is',
+          'component' => '67890',
+          'page' => 'some-page-uuid',
+          'field' => 'some-field-uuid'
+        }
+      ]
+    }
+  end
+
+  describe '#to_metadata' do
+    before do
+      allow(component_conditional).to receive(:generate_uuid).and_return('til-its-done')
+    end
+
+    context 'with a single expression' do
+      it 'returns the correct metadata' do
+        expect(component_conditional.to_metadata).to eq(expected_component_conditional)
+      end
+    end
+
+    context 'with multiple expressions' do
+      before do
+        component_conditional_hash['expressions'].push(
+          ComponentExpression.new('component' => '0987', 'page' => double(uuid: 'another-page-uuid'))
+        )
+      end
+
+      it 'returns and as the condition type' do
+        expect(component_conditional.to_metadata['_type']).to eq('and')
+      end
+    end
+  end
+
+  describe '#expressions' do
+    let(:page) { service.find_page_by_url('do-you-like-star-wars') }
+    let(:component) { page.components.first }
+    let(:component_conditional_hash) do
+      {
+        'expressions' => [component_expression]
+      }.merge(service:)
+    end
+    let(:component_expression) do
+      ComponentExpression.new(
+        {
+          'operator' => 'is',
+          'component' => component.uuid,
+          'page' => page,
+          'field' => 'some-field-id'
+        }
+      )
+    end
+
+    it 'returns an array of expressions' do
+      expect(component_conditional.expressions).to eq([component_expression])
+    end
+  end
+
+  describe '#component_expressions' do
+    before do
+      component_conditional.valid?
+    end
+
+    context 'when blank component expressions' do
+      let(:component_conditional_hash) do
+        {
+          'expressions' => [
+            ComponentExpression.new(
+              {
+                'operator' => '',
+                'component' => '',
+                'page' => 'some-page-uuid',
+                'field' => ''
+              }
+            )
+          ]
+        }
+      end
+
+      it 'does not accept blank component expressions' do
+        expect(component_conditional.expressions_validations).to be_present
+      end
+
+      it 'adds an error to the expression object' do
+        errors = component_conditional.expressions.first.errors
+        expect(errors).to be_present
+        expect(errors.of_kind?(:component, :blank)).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/models/component_expression_spec.rb
+++ b/spec/models/component_expression_spec.rb
@@ -1,0 +1,260 @@
+RSpec.describe ComponentExpression do
+  subject(:component_expression) do
+    described_class.new(component_expression_hash)
+  end
+  let(:component_expression_hash) { {} }
+
+  describe '#to_metadata' do
+    context 'when a field has an answer' do
+      let(:component_expression_hash) do
+        {
+          'operator': 'is',
+          'page': double(uuid: 'some-page-uuid'),
+          'component': 'some-component-uuid',
+          'field': 'some-field-uuid'
+        }
+      end
+      let(:expected_component_expression) do
+        {
+          'operator' => 'is',
+          'page' => 'some-page-uuid',
+          'component' => 'some-component-uuid',
+          'field' => 'some-field-uuid'
+        }
+      end
+
+      it 'returns the correct structure' do
+        expect(component_expression.to_metadata).to eq(expected_component_expression)
+      end
+    end
+
+    context 'when the field is nil' do
+      let(:component_expression_hash) do
+        {
+          'operator': 'is_answered',
+          'page': double(uuid: 'some-page-uuid'),
+          'component': 'some-component-uuid',
+          'field': nil
+        }
+      end
+      let(:expected_component_expression) do
+        {
+          'operator' => 'is_answered',
+          'page' => 'some-page-uuid',
+          'component' => 'some-component-uuid',
+          'field' => ''
+        }
+      end
+
+      it 'returns the correct structure' do
+        expect(component_expression.to_metadata).to eq(expected_component_expression)
+      end
+    end
+  end
+
+  describe '#answers' do
+    let(:metadata) { metadata_fixture(:branching) }
+    let(:service) { MetadataPresenter::Service.new(metadata) }
+    let(:page) { service.find_page_by_url('do-you-like-star-wars') }
+
+    let(:component_expression_hash) do
+      {
+        'operator': 'is',
+        'page': page,
+        'component': page.components.first.uuid,
+        'field': ''
+      }
+    end
+    let(:answers) do
+      [
+        ['Only on weekends', 'c5571937-9388-4411-b5fa-34ddf9bc4ca0'],
+        ['Hell no!', '67160ff1-6f7c-43a8-8bf6-49b3d5f450f6']
+      ]
+    end
+
+    it 'returns a list of answers' do
+      expect(component_expression.answers).to eq(answers)
+    end
+  end
+
+  describe '#all_operators' do
+    let(:expected_operators) { ComponentExpression::OPERATORS }
+
+    it 'returns all the operators' do
+      expect(component_expression.all_operators).to eq(expected_operators)
+    end
+  end
+
+  describe '#operators' do
+    context 'when component type is checkboxes' do
+      let(:metadata) { metadata_fixture(:branching) }
+      let(:service) { MetadataPresenter::Service.new(metadata) }
+      let(:page) { service.find_page_by_url('burgers') }
+      let(:component) { page.components.find { |component| component.type == 'checkboxes' } }
+      let(:component_expression_hash) do
+        {
+          'operator': 'contains',
+          'page': page,
+          'component': component.uuid,
+          'field': 'some-field-uuid'
+        }
+      end
+      let(:expected_operators) do
+        [
+          [I18n.t('operators.contains'), 'contains', { 'data-hide-answers': 'false' }],
+          [I18n.t('operators.does_not_contain'), 'does_not_contain', { 'data-hide-answers': 'false' }],
+          [I18n.t('operators.is_answered'), 'is_answered', { 'data-hide-answers': 'true' }],
+          [I18n.t('operators.is_not_answered'), 'is_not_answered', { 'data-hide-answers': 'true' }]
+        ]
+      end
+
+      it 'returns the expected operators' do
+        expect(component_expression.operators).to eq(expected_operators)
+      end
+    end
+
+    context 'when component type is radios' do
+      let(:page) { service.find_page_by_url('star-wars-knowledge') }
+      let(:component) { page.components.find { |component| component.type == 'radios' } }
+      let(:component_expression_hash) do
+        {
+          'operator': 'contains',
+          'page': page,
+          'component': component.uuid,
+          'field': 'some-field-uuid'
+        }
+      end
+      let(:expected_operators) do
+        [
+          [I18n.t('operators.is'), 'is', { 'data-hide-answers': 'false' }],
+          [I18n.t('operators.is_not'), 'is_not', { 'data-hide-answers': 'false' }],
+          [I18n.t('operators.is_answered'), 'is_answered', { 'data-hide-answers': 'true' }],
+          [I18n.t('operators.is_not_answered'), 'is_not_answered', { 'data-hide-answers': 'true' }]
+        ]
+      end
+
+      it 'returns the expected operators' do
+        expect(component_expression.operators).to eq(expected_operators)
+      end
+    end
+  end
+
+  describe '#component_type' do
+    let(:page) { service.find_page_by_url('star-wars-knowledge') }
+    let(:component) { page.components.find { |component| component.type == 'radios' } }
+    let(:component_expression_hash) do
+      {
+        'operator': 'is',
+        'page': page,
+        'component': component.uuid,
+        'field': 'some-field-uuid'
+      }
+    end
+
+    it 'returns the the type of the component' do
+      expect(component_expression.component_type).to eq('radios')
+    end
+  end
+
+  describe '#name_attr' do
+    let(:attributes) { %w[answer component operator field] }
+
+    it 'constructs the correct name attribute' do
+      attributes.each do |attribute|
+        expect(
+          component_expression.name_attr(
+            conditional_index: 1,
+            expression_index: 0,
+            attribute:
+          )
+        ).to eq("conditional_component[conditionals_attributes][1][expressions_attributes][0][#{attribute}]")
+      end
+    end
+  end
+
+  describe '#id_attr' do
+    let(:attributes) { %w[component operator field] }
+
+    it 'constructs the correct id attribute' do
+      attributes.each do |attribute|
+        expect(
+          component_expression.id_attr(
+            conditional_index: 0,
+            expression_index: 1,
+            attribute:
+          )
+        ).to eq("conditional_component_conditionals_attributes_0_expressions_attributes_1_#{attribute}")
+      end
+    end
+  end
+
+  describe 'conditional content support' do
+    before do
+      component_expression.valid?
+    end
+
+    context 'supported component' do
+      let(:metadata) { metadata_fixture(:branching) }
+      let(:service) { MetadataPresenter::Service.new(metadata) }
+      let(:page) { service.find_page_by_url('do-you-like-star-wars') }
+
+      let(:component_expression_hash) do
+        {
+          'operator': 'is',
+          'page': page,
+          'component': page.components.first.uuid,
+          'field': 'c5571937-9388-4411-b5fa-34ddf9bc4ca0'
+        }
+      end
+
+      it 'saves the metadata' do
+        expect(component_expression.errors.messages).to be_empty
+      end
+    end
+
+    context 'unsupported component' do
+      let(:page) { service.find_page_by_url('name') }
+      let(:component_expression_hash) do
+        {
+          'operator': 'is',
+          'page': page,
+          'component': page.components.first.uuid,
+          'field': '27d377a2-6828-44ca-87d1-b83ddac98284'
+        }
+      end
+
+      it 'returns the error message' do
+        errors = component_expression.errors.messages
+        expect(errors).to be_present
+        expect(errors.values.first).to include(
+          I18n.t(
+            'activemodel.errors.messages.unsupported_component'
+          )
+        )
+      end
+    end
+
+    context '#blank_field' do
+      let(:page) { service.find_page_by_url('do-you-like-star-wars') }
+      let(:component_expression_hash) do
+        {
+          'operator': 'is',
+          'page': page,
+          'component': page.components.first.uuid,
+          'field': nil
+        }
+      end
+
+      it 'returns the error message' do
+        errors = component_expression.errors.messages
+        expect(errors).to be_present
+        expect(errors.values.first).to include(
+          I18n.t(
+            'activemodel.errors.messages.blank',
+            attribute: Expression.human_attribute_name(:operator)
+          )
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### `ComponentExpression` model
This model ensures we return the correct expressions and expression answers, when a question is selected on the conditional content modal.

For now, we only support radios and checkboxes in conditional content, and these are the only questions that should return expressions and expression answers.

Since this is similar to branching, we have re-used the `supports_branching?` method, to check the component type is either radio or checkbox.

We also have different operators depending on whether it is radio or checkbox - this is addressed in the `operators` method.

We also do not return any expression answers if the chosen operator is `answered` or `not_answered`.

This class is largely similar to the `Expression` model used for branching - we can look at refactoring once we have the feature in place.

### `ComponentConditional` model
The ComponentConditional is an object that can have 'n' number of ComponentExpressions.

A ComponentConditional uses an 'if' or and 'and' conditional type. If there is more than one ComponentExpression in the ComponentConditional, we would use the 'and' type.

Each ComponentConditional has a uuid, this is to allow us to modify/update and delete the ComponentConditional.

### Example metadata
```
"conditionals": [
            {
              "_type": "if",
              "_uuid": "a52d0656-bf9e-4d3d-a472-ac8f9de9356e",
              "expressions": [
                {
                  "page": "be656508-ffa1-4c40-815e-ca1859c9514f",
                  "field": "d14b0d78-3977-4c58-8c05-2c2853d4dbbb",
                  "operator": "does_not_contain",
                  "component": "ea13126a-7ae2-45a5-a08f-949bd1953877"
                }
              ]
            }
          ]
```