### PR TITLE
Inform form filler of the confirmation email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ gem 'delayed_job_active_record'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'multi-file-upload'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'confirmation-email-data-risk'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.2.7'
+# gem 'metadata_presenter', '3.0.11'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ gem 'delayed_job_active_record'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'confirmation-email-data-risk'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'confirmation-email-data-risk'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '3.0.11'
+gem 'metadata_presenter', '3.2.8'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: c7c53016367f75ee15064d4af469dd348d945cbc
+  revision: 7075370b4377a0ee4c818a2efc027eed7f578ba4
   branch: confirmation-email-data-risk
   specs:
     metadata_presenter (3.2.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 7075370b4377a0ee4c818a2efc027eed7f578ba4
+  revision: 9ad979bd5fb0a8817f2711c3fd51be3e279f7159
   branch: confirmation-email-data-risk
   specs:
     metadata_presenter (3.2.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 326277aa7e2d88d3349ec5e60d7e9df9a8a417e9
+  branch: confirmation-email-data-risk
+  specs:
+    metadata_presenter (3.0.11)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -270,15 +285,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.2.7)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
@@ -735,7 +741,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.2.7)
+  metadata_presenter!
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: ddcc67387982b5529df4e89fce89abfb836636eb
+  revision: c82fa3ef6bbabe49c9a46e07a3b5782eaa0db4ac
   branch: confirmation-email-data-risk
   specs:
     metadata_presenter (3.2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 326277aa7e2d88d3349ec5e60d7e9df9a8a417e9
+  revision: ddcc67387982b5529df4e89fce89abfb836636eb
   branch: confirmation-email-data-risk
   specs:
-    metadata_presenter (3.0.11)
+    metadata_presenter (3.2.3)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 9ad979bd5fb0a8817f2711c3fd51be3e279f7159
-  branch: confirmation-email-data-risk
-  specs:
-    metadata_presenter (3.2.6)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -285,6 +270,15 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    metadata_presenter (3.2.8)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
@@ -741,7 +735,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter!
+  metadata_presenter (= 3.2.8)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 0f1ed3a261c11d0d525a072666b6d89a59ce9694
+  revision: c7c53016367f75ee15064d4af469dd348d945cbc
   branch: confirmation-email-data-risk
   specs:
     metadata_presenter (3.2.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: c82fa3ef6bbabe49c9a46e07a3b5782eaa0db4ac
+  revision: 0f1ed3a261c11d0d525a072666b6d89a59ce9694
   branch: confirmation-email-data-risk
   specs:
-    metadata_presenter (3.2.3)
+    metadata_presenter (3.2.6)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -160,7 +160,7 @@ class ApplicationController < ActionController::Base
 
   def confirmation_email
     confirmation_email_component_id = ServiceConfiguration.find_by(service_id: service.service_id, name: 'CONFIRMATION_EMAIL_COMPONENT_ID')&.decrypt_value
-    @confirmation_email ||= session[@service.service_id]['user_data'][confirmation_email_component_id]
+    @confirmation_email ||= session[@service.service_id]['user_data'][confirmation_email_component_id] if confirmation_email_enabled?
   end
   helper_method :confirmation_email
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -165,6 +165,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :confirmation_email
 
+  def is_confirmation_email_question?
+    confirmation_email_config&.decrypt_value == @page.metadata.components[0]['_id']
+  end
+  helper_method :is_confirmation_email_question?
+
   def load_conditional_content
     @page.content_components.map(&:uuid)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -149,6 +149,15 @@ class ApplicationController < ActionController::Base
     )&.decrypt_value
   end
 
+  def confirmation_email_enabled?
+    confirmation_email_config.present?
+  end
+  helper_method :confirmation_email_enabled?
+
+  def confirmation_email_config
+    @confirmation_email_config ||= ServiceConfiguration.find_by(service_id: service.service_id, name: 'CONFIRMATION_EMAIL_COMPONENT_ID')
+  end
+
   def load_conditional_content
     @page.content_components.map(&:uuid)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -160,7 +160,8 @@ class ApplicationController < ActionController::Base
 
   def confirmation_email
     confirmation_email_component_id = ServiceConfiguration.find_by(service_id: service.service_id, name: 'CONFIRMATION_EMAIL_COMPONENT_ID')&.decrypt_value
-    @confirmation_email ||= session[@service.service_id]['user_data'][confirmation_email_component_id] if confirmation_email_enabled?
+    user_data = Preview::SessionDataAdapter.new(session, service.service_id).load_data
+    @confirmation_email ||= user_data[confirmation_email_component_id] if confirmation_email_enabled?
   end
   helper_method :confirmation_email
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -158,6 +158,11 @@ class ApplicationController < ActionController::Base
     @confirmation_email_config ||= ServiceConfiguration.find_by(service_id: service.service_id, name: 'CONFIRMATION_EMAIL_COMPONENT_ID')
   end
 
+  def confirmation_email
+    @confirmation_email ||= ServiceConfiguration.find_by(service_id: service.service_id, name: 'CONFIRMATION_EMAIL_COMPONENT_ID')&.decrypt_value
+  end
+  helper_method :confirmation_email
+
   def load_conditional_content
     @page.content_components.map(&:uuid)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -159,7 +159,8 @@ class ApplicationController < ActionController::Base
   end
 
   def confirmation_email
-    @confirmation_email ||= ServiceConfiguration.find_by(service_id: service.service_id, name: 'CONFIRMATION_EMAIL_COMPONENT_ID')&.decrypt_value
+    confirmation_email_component_id = ServiceConfiguration.find_by(service_id: service.service_id, name: 'CONFIRMATION_EMAIL_COMPONENT_ID')&.decrypt_value
+    @confirmation_email ||= session[@service.service_id]['user_data'][confirmation_email_component_id]
   end
   helper_method :confirmation_email
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -352,8 +352,19 @@ RSpec.describe ApplicationController do
         )
       end
 
+      let(:dummy_session) { { service.service_id => { 'user_data' => { 'email_question_1' => dummy_email } } } }
+      let(:dummy_email) { 'em@il.com' }
+
+      before do
+        allow_any_instance_of(Preview::SessionDataAdapter).to receive(:session).and_return(dummy_session)
+      end
+
       it 'confirmation_email_enabled? returns true' do
         expect(controller.confirmation_email_enabled?).to be_truthy
+      end
+
+      it 'confirmation_email returns the email in session' do
+        expect(controller.confirmation_email).to eq(dummy_email)
       end
     end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -335,4 +335,38 @@ RSpec.describe ApplicationController do
       end
     end
   end
+
+  describe '#confirmation_email' do
+    before do
+      allow(controller).to receive(:service).and_return(service)
+      allow(ServiceConfiguration).to receive(:find_by).and_return(service_configuration)
+    end
+
+    context 'when CONFIRMATION_EMAIL_COMPONENT_ID is present' do
+      let!(:service_configuration) do
+        create(
+          :service_configuration,
+          :dev,
+          :confirmation_email_component_id,
+          service_id: service.service_id
+        )
+      end
+
+      it 'confirmation_email_enabled? returns true' do
+        expect(controller.confirmation_email_enabled?).to be_truthy
+      end
+    end
+
+    context 'when CONFIRMATION_EMAIL_COMPONENT_ID is not present' do
+      let!(:service_configuration) { nil }
+
+      it 'confirmation_email_enabled? returns false' do
+        expect(controller.confirmation_email_enabled?).to be_falsey
+      end
+
+      it 'confirmation_email doesn\'t return anything' do
+        expect(controller.confirmation_email).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/SzV8RNaW/3524-inform-form-filler-of-the-confirmation-email)

This PR simply pulls the last metadata presenter for informing the user of the confirmation email. It also implement how to pull the confirmation email set for the editor preview mode.