### PR TITLE
Remove encode/decodeURI component

### DIFF
--- a/app/javascript/src/web-components/editable-content.js
+++ b/app/javascript/src/web-components/editable-content.js
@@ -44,7 +44,7 @@ class EditableContent extends HTMLElement {
       this.initialMarkup = this.innerHTML;
       this.initialContent = this.getAttribute('content')?.replace(/\\r\\n?|\\n/g, '\n') || '';
       this.defaultContent = this.getAttribute('default-content') || '';
-      this.config = (this.dataset.config ? JSON.parse(decodeURIComponent(this.dataset.config)) : undefined);
+      this.config = (this.dataset.config ? JSON.parse(this.dataset.config) : undefined);
       this.render();
     })
   }

--- a/test/web-components/editable-content/helpers.js
+++ b/test/web-components/editable-content/helpers.js
@@ -6,11 +6,14 @@ async function createComponent(element, html) {
 }
 
 function createTemplate(id, defaultContent='', markdown='', html='', config='') {
+  //N.B. the lack of quotes around the data-config attribute is deliberate.  It
+  //is valid HTML and adding them in breaks the tests, Works fine IRL with or
+  //without them. 
   return `
   <form id="${id}-form">
     <button type=submit>Save</button>
   </form>
-  <editable-content id="${id}" default-content="${defaultContent}" content="${markdown}" data-config="${config}" >
+  <editable-content id="${id}" default-content="${defaultContent}" content="${markdown}" data-config=${config}>
     ${html}
   </editable-content>`
 }

--- a/test/web-components/editable-content/methods_test.js
+++ b/test/web-components/editable-content/methods_test.js
@@ -61,7 +61,7 @@ describe('<editable-content>', function() {
         initialHTML = `<p>this is content</p>`
         initialMarkdown = 'this is content'
         const config = { _uuid: '1234567890' }
-        const html = createTemplate(ID, defaultContent, initialMarkdown, initialHTML, encodeURIComponent(JSON.stringify(config)) );
+        const html = createTemplate(ID, defaultContent, initialMarkdown, initialHTML, JSON.stringify(config) );
         await createComponent('editable-content', html)
         component = getElements();
         button = document.querySelector('button')

--- a/test/web-components/editable-content/properties_test.js
+++ b/test/web-components/editable-content/properties_test.js
@@ -73,7 +73,7 @@ describe('<editable-content>', function() {
       beforeEach( async function() {
         initialHTML = `<p>this is content</p>`
         initialMarkdown = 'this is content'
-        const html = createTemplate(ID, defaultContent, initialMarkdown, initialHTML, encodeURIComponent(JSON.stringify({"_uuid": "1234567890"})));
+        const html = createTemplate(ID, defaultContent, initialMarkdown, initialHTML, JSON.stringify({"_uuid": "1234567890"}));
         await createComponent('editable-content', html)
         component = getElements();
       })


### PR DESCRIPTION
This PR fixes a bug where using a `%` character within an editable content component would cause the editable preview to break in the editor.

This was caused by the use of `decodeURIComponent` on the `data-config` attribute.  This was only used as initially the only way I could get json config into the attribute from the tests was using `encodeURIComponent`. 

By removing the double quotes from around the attribute in the test helper that generates the template HTML resolves the JSON parsing issues, and remoives the need for the encode/decode operations.

Not using quotes is perfectly valid HTML, and outside of the tests using JSON in the attribute works perfectly fine. 