### PR TITLE
Filter allowed govspeak components

### DIFF
--- a/app/javascript/src/web-components/editable-content.js
+++ b/app/javascript/src/web-components/editable-content.js
@@ -33,13 +33,6 @@ class EditableContent extends HTMLElement {
 
         return markdown
       },
-      // removeButtons: (markdown) => {
-      //   console.log('removing buttons')
-      //   markdown = markdown.replace(/{button\s?(?:start)?}(?:.*?){\/button}/gi, '')
-
-      //   return markdown
-      // },
-
     }
 
     const allowedGovspeakComponents = [
@@ -119,6 +112,10 @@ class EditableContent extends HTMLElement {
     return val
   }
 
+  set value(value) {
+    this.input.value = value
+  }
+
   // The form containing the element that will be updated on save
   set form(element) {
     this.submissionForm = element;
@@ -151,7 +148,6 @@ class EditableContent extends HTMLElement {
 
       this.root.addEventListener('click', () => this.state.mode = 'edit' )
       this.root.addEventListener('focus', () => this.state.mode = 'edit' )
-      // this.input.addEventListener('blur', () => this.state.mode = 'read' )
       this.addEventListener('focusout', (event) => {
         if(this.contains(event.relatedTarget)) return
         this.state.mode = 'read'
@@ -170,7 +166,7 @@ class EditableContent extends HTMLElement {
 
     switch(this.state.mode) {
       case 'edit':
-        this._contentBeforeEditing = this.value.trim();
+        this._contentBeforeEditing = this.input.value.trim();
         this.show(this.input)
         this.hide(this.output)
         this.classList.add('active')

--- a/app/javascript/styles/shared/_content.scss
+++ b/app/javascript/styles/shared/_content.scss
@@ -41,6 +41,25 @@
   }
 }
 
+.govspeak-info-notice,
+.info-notice {
+  @include govuk-font($size: 19);
+  @include govuk-text-colour;
+  @include govuk-responsive-margin(6, "top");
+  @include govuk-responsive-margin(6, "bottom");
+  border-left: $govuk-border-width-wide solid $govuk-border-colour;
+  padding: govuk-spacing(3);
+
+  > :first-child {
+    margin-top: 0;
+  }
+
+  > :only-child,
+  > :last-child {
+    margin-bottom: 0;
+  }
+}
+
 .govspeak-address,
 .govspeak-contact,
 .address,
@@ -53,6 +72,7 @@
   margin-top: 0;
   padding-left: govuk-spacing(3);
 }
+
 
 // Apply GOVUk link styles to all links in editable content areas
 editable-content {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@rails/webpacker": "^5.4.4",
     "@sentry/browser": "^7.28.1",
     "@ungap/custom-elements": "^1.3.0",
-    "@x-govuk/marked-govspeak": "^0.1.0",
+    "@x-govuk/marked-govspeak": "^0.2.0",
     "accessible-autocomplete": "^2.0.4",
     "chai-dom": "^1.11.0",
     "dompurify": "^3.0.3",

--- a/test/web-components/editable-content/syntax_test.js
+++ b/test/web-components/editable-content/syntax_test.js
@@ -204,7 +204,7 @@ $CTA`
           component.root.focus();
           button.focus();
 
-          expect(component.output).to.contain.html(`<div class="govspeak-call-to-action">
+          expect(component.output).to.contain.html(`<div class="call-to-action">
   <p class="govuk-body">Call to action</p>
 
 </div>`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,10 +1158,10 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@x-govuk/marked-govspeak@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@x-govuk/marked-govspeak/-/marked-govspeak-0.1.0.tgz#e67ad9f1a1dd0e38ddc62726de10cb8f6a29f9d5"
-  integrity sha512-TzYVTHlsXAo9mqW2vaIGDSRZ+ZqK8ZABoKdHR2FgPlFclzHYGuhz+A3fxFFg1tjvmq3kE1geD94pVBCP7yG5tg==
+"@x-govuk/marked-govspeak@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@x-govuk/marked-govspeak/-/marked-govspeak-0.2.0.tgz#0e500cc0cd591e4746a7ffaa78363e0f8761fa91"
+  integrity sha512-+hikT3RpIWefMn2BBLS+jlk72EjvQUU3WRJ4TAtK3oJoENR6vckAM2sv9quc+lIqFyR+Jy2a8pqODmPA3Go6tA==
   dependencies:
     marked "^4.3.0"
 


### PR DESCRIPTION
This PR limits our support for Govspeak to only this components we want form editors to be able to use.

We do this by only importing the extensions we want from marked-govspeak.

However, editors can still enter valid govspeak syntax into our contenteditable areas - they won't be parsed and rendered by marked however the syntax will remain and could be saved to the DB.  Then the runner **will** be able to render them as it uses the govspeak gem - which we have no control over.  This is fine for most things with the exception of buttons.  **We do not want to allow form editors to add buttons into content**

We have opted to downgrade any button syntax entered into a simple link.

So
```
{button}[I'm a button](http://google.com){/button}
```
will be converted into
```
[I'm a button](http://google.com)
```

To do this we apply filters to both the markdown parsed by marked using the preprocess filter so the preview renders correctly.  

We also use the same filters to pass the content through when saving the content to the backend.

