### PR TITLE
Confirmation Email Disclaimer for Multiple Components Page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ gem 'delayed_job_active_record'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'confirmation-email-data-risk'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'disclaimer-multiple-email'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.2.8'
+# gem 'metadata_presenter', '3.2.8'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ gem 'delayed_job_active_record'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'disclaimer-multiple-email'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'disclaimer-multiple-email'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '3.2.8'
+gem 'metadata_presenter', '3.2.9'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 0ea0a19ff67cf1a0ae6a6855b8cce0a73ada3da1
+  branch: disclaimer-multiple-email
+  specs:
+    metadata_presenter (3.2.8)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -270,15 +285,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.2.8)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
@@ -735,7 +741,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.2.8)
+  metadata_presenter!
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 0ea0a19ff67cf1a0ae6a6855b8cce0a73ada3da1
-  branch: disclaimer-multiple-email
-  specs:
-    metadata_presenter (3.2.8)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -285,6 +270,15 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    metadata_presenter (3.2.9)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
@@ -741,7 +735,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter!
+  metadata_presenter (= 3.2.9)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -165,8 +165,8 @@ class ApplicationController < ActionController::Base
   end
   helper_method :confirmation_email
 
-  def is_confirmation_email_question?
-    confirmation_email_config&.decrypt_value == @page.metadata.components[0]['_id']
+  def is_confirmation_email_question?(component_id)
+    confirmation_email_config&.decrypt_value == component_id
   end
   helper_method :is_confirmation_email_question?
 


### PR DESCRIPTION
[Trello](https://trello.com/c/ddAPdi9h/3667-confirmation-email-disclaimer-for-multiple-component-page)

We're using the last version of the metadata presenter and specify exactly what component id to display properly in a multiple component page.

<img width="857" alt="Screenshot 2023-08-24 at 15 42 04" src="https://github.com/ministryofjustice/fb-editor/assets/26165112/051fc950-929e-4cd8-9fde-684958cc6143">