### PR TITLE
Pin chrome version to latest with matching chromedriver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,9 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          # TODO remove following line when fixed https://github.com/CircleCI-Public/browser-tools-orb/issues/90
+          chrome-version: 116.0.5845.96
       - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install


### PR DESCRIPTION
Google released a new stable version of Chrome without a matching version
of ChromeDriver. This causes Circle CIs browser-tools orb to fail trying to download a version of ChromeDriver that doesn't exist!

Hopefully pinning the chrome version at the previous stable version that has a chromedriver version will solve the issue.

Associated issue:
https://github.com/CircleCI-Public/browser-tools-orb/issues/90