### PR TITLE
Save and return email link

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
     reference_number_subject: ", reference number: {{reference_number}}"
     reference_number: '123-ABCD-456'
     reference_payment_sentence: "Your reference number is: {{reference_number}}.\n\r\nTo complete your submission, you now need to make the required payment at {{payment_link}}."
-    save_and_return_email: "You have saved your progress with the form '%{service_name}'.<br /><br /><a href=\"{{save_and_return_link}}\">Continue with your form</a><br /><br />This link will only work once. If you want to save your progress again after resuming the form, you will need to repeat the save process and generate another link.<br /><br />The link is valid for 28 days. After that time, your saved information will be deleted."
+    save_and_return_email: 'You have saved your progress with the form ''%{service_name}''.<br /><br /><a href="{{save_and_return_link}}">Continue with your form</a><br /><br />This link will only work once. If you want to save your progress again after resuming the form, you will need to repeat the save process and generate another link.<br /><br />The link is valid for 28 days. After that time, your saved information will be deleted.'
     service_output_json_endpoint: 'Enter the endpoint URL here'
     service_output_json_key: 'Enter the endpoint key here'
   notification_banners:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
     reference_number_subject: ", reference number: {{reference_number}}"
     reference_number: '123-ABCD-456'
     reference_payment_sentence: "Your reference number is: {{reference_number}}.\n\r\nTo complete your submission, you now need to make the required payment at {{payment_link}}."
-    save_and_return_email: "You have saved your progress with the form '%{service_name}'.<br /><br />Use this link to return to your form:<br />{{save_and_return_link}}<br /><br />This link will only work once. If you want to save your progress again after resuming the form, you will need to repeat the save process and generate another link.<br /><br />The link is valid for 28 days. After that time, your saved information will be deleted."
+    save_and_return_email: "You have saved your progress with the form '%{service_name}'.<br /><br /><a href=\"{{save_and_return_link}}\">Continue with your form</a><br /><br />This link will only work once. If you want to save your progress again after resuming the form, you will need to repeat the save process and generate another link.<br /><br />The link is valid for 28 days. After that time, your saved information will be deleted."
     service_output_json_endpoint: 'Enter the endpoint URL here'
     service_output_json_key: 'Enter the endpoint key here'
   notification_banners:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
     reference_number_subject: ", reference number: {{reference_number}}"
     reference_number: '123-ABCD-456'
     reference_payment_sentence: "Your reference number is: {{reference_number}}.\n\r\nTo complete your submission, you now need to make the required payment at {{payment_link}}."
-    save_and_return_email: 'You have saved your progress with the form ''%{service_name}''.<br /><br /><a href="{{save_and_return_link}}">Continue with your form</a><br /><br />This link will only work once. If you want to save your progress again after resuming the form, you will need to repeat the save process and generate another link.<br /><br />The link is valid for 28 days. After that time, your saved information will be deleted.'
+    save_and_return_email: "You have saved your progress with the form '%{service_name}'.<br /><br /><a href={{save_and_return_link}}>Continue with your form</a><br /><br />This link will only work once. If you want to save your progress again after resuming the form, you will need to repeat the save process and generate another link.<br /><br />The link is valid for 28 days. After that time, your saved information will be deleted."
     service_output_json_endpoint: 'Enter the endpoint URL here'
     service_output_json_key: 'Enter the endpoint key here'
   notification_banners:


### PR DESCRIPTION
Updates the link in the save and return email to be a link with nice readable copy.

![image](https://github.com/ministryofjustice/fb-editor/assets/595564/54d0b367-ecfe-436f-95de-ddddc8e29015)
