### PR TITLE
Revert "Adding waf to runner ingress"

### DIFF
--- a/config/publisher/cloud_platform/ingress.yaml.erb
+++ b/config/publisher/cloud_platform/ingress.yaml.erb
@@ -14,12 +14,8 @@ metadata:
       }
     external-dns.alpha.kubernetes.io/set-identifier: <%= service_slug %>-ingress-<%= namespace %>-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-    nginx.ingress.kubernetes.io/modsecurity-snippet: |
-      SecRuleEngine On
-      SecDefaultAction "phase:2,pass,log,tag:github_team=form-builder"
 spec:
-  ingressClassName: modsec
+  ingressClassName: default
   tls:
     - hosts:
       - <%= hostname %>

--- a/spec/fixtures/kubernetes_configuration/ingress.yaml
+++ b/spec/fixtures/kubernetes_configuration/ingress.yaml
@@ -14,12 +14,8 @@ metadata:
       }
     external-dns.alpha.kubernetes.io/set-identifier: acceptance-tests-date-ingress-formbuilder-services-test-dev-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-    nginx.ingress.kubernetes.io/modsecurity-snippet: |
-      SecRuleEngine On
-      SecDefaultAction "phase:2,pass,log,tag:github_team=form-builder"
 spec:
-  ingressClassName: modsec
+  ingressClassName: default
   tls:
     - hosts:
       - acceptance-tests-date.dev.test.form.service.justice.gov.uk


### PR DESCRIPTION
Reverts ministryofjustice/fb-editor#2405

Once published with the WAF applied, behaviour changes when injecting scripts into inputs which breaks some acceptance tests (we test the prevention measures we have). This isn't obvious until the acceptance test form is republished.

Reverting for now, we will re-open this with an AT update.