### PR TITLE
Revert "Revert "Rotate to short lived S3 credentials""

### DIFF
--- a/app/services/publisher/adapters/aws_s3_client.rb
+++ b/app/services/publisher/adapters/aws_s3_client.rb
@@ -3,12 +3,10 @@ require 'aws-sdk-s3'
 class Publisher
   module Adapters
     class AwsS3Client
-      attr_reader :bucket, :access_key_id, :secret_access_key
+      attr_reader :bucket
 
-      def initialize(bucket:, access_key_id:, secret_access_key:)
+      def initialize(bucket:)
         @bucket = bucket
-        @access_key_id = access_key_id
-        @secret_access_key = secret_access_key
       end
 
       REGION = 'eu-west-2'.freeze
@@ -25,11 +23,7 @@ class Publisher
       private
 
       def s3
-        @s3 ||= Aws::S3::Client.new(region: REGION, credentials:)
-      end
-
-      def credentials
-        Aws::Credentials.new(access_key_id, secret_access_key)
+        @s3 ||= Aws::S3::Client.new(region: REGION)
       end
     end
   end

--- a/app/services/publisher/adapters/cloud_platform.rb
+++ b/app/services/publisher/adapters/cloud_platform.rb
@@ -91,9 +91,7 @@ class Publisher
 
       def aws_s3_adapter
         Publisher::Adapters::AwsS3Client.new(
-          bucket: service_provisioner.aws_s3_bucket_name,
-          access_key_id: service_provisioner.aws_s3_access_key_id,
-          secret_access_key: service_provisioner.aws_s3_secret_access_key
+          bucket: service_provisioner.aws_s3_bucket_name
         )
       end
     end

--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -153,14 +153,6 @@ class Publisher
       service_configuration.select(&:secrets?)
     end
 
-    def aws_s3_access_key_id
-      ENV["AWS_S3_ACCESS_KEY_ID_#{deployment_environment_upcase}"]
-    end
-
-    def aws_s3_secret_access_key
-      ENV["AWS_S3_SECRET_ACCESS_KEY_#{deployment_environment_upcase}"]
-    end
-
     def aws_s3_bucket_name
       ENV["AWS_S3_BUCKET_#{deployment_environment_upcase}"]
     end

--- a/config/publisher/cloud_platform/deployment.yaml.erb
+++ b/config/publisher/cloud_platform/deployment.yaml.erb
@@ -57,10 +57,6 @@ spec:
             value: '<%= service_sentry_dsn %>'
           - name: SENTRY_CSP_URL
             value: '<%= service_sentry_csp_url %>'
-          - name: ACCESS_KEY_ID
-            value: <%= aws_s3_access_key_id %>
-          - name: SECRET_ACCESS_KEY
-            value: <%= aws_s3_secret_access_key %>
           - name: BUCKET_NAME
             value: <%= aws_s3_bucket_name %>
         <% secrets.each do |secret|  %>

--- a/deploy-eks/fb-editor-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-editor-chart/templates/deployment.yaml
@@ -291,31 +291,11 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: slack_publish_webhook
-          - name: AWS_S3_ACCESS_KEY_ID_DEV
-            valueFrom:
-              secretKeyRef:
-                name: fb-editor-secrets-{{ .Values.environmentName }}
-                key: aws_s3_access_key_id_dev
-          - name: AWS_S3_SECRET_ACCESS_KEY_DEV
-            valueFrom:
-              secretKeyRef:
-                name: fb-editor-secrets-{{ .Values.environmentName }}
-                key: aws_s3_secret_access_key_dev
           - name: AWS_S3_BUCKET_DEV
             valueFrom:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: aws_s3_bucket_dev
-          - name: AWS_S3_ACCESS_KEY_ID_PRODUCTION
-            valueFrom:
-              secretKeyRef:
-                name: fb-editor-secrets-{{ .Values.environmentName }}
-                key: aws_s3_access_key_id_production
-          - name: AWS_S3_SECRET_ACCESS_KEY_PRODUCTION
-            valueFrom:
-              secretKeyRef:
-                name: fb-editor-secrets-{{ .Values.environmentName }}
-                key: aws_s3_secret_access_key_production
           - name: AWS_S3_BUCKET_PRODUCTION
             valueFrom:
               secretKeyRef:

--- a/deploy-eks/fb-editor-chart/templates/secrets.yaml
+++ b/deploy-eks/fb-editor-chart/templates/secrets.yaml
@@ -24,8 +24,4 @@ data:
   aws_ses_access_key_id: {{ .Values.aws_ses_access_key_id }}
   aws_ses_secret_access_key: {{ .Values.aws_ses_secret_access_key }}
   aws_s3_bucket_dev: {{ .Values.aws_s3_bucket_dev }}
-  aws_s3_access_key_id_dev: {{ .Values.aws_s3_access_key_id_dev }}
-  aws_s3_secret_access_key_dev: {{ .Values.aws_s3_secret_access_key_dev }}
   aws_s3_bucket_production: {{ .Values.aws_s3_bucket_production }}
-  aws_s3_access_key_id_production: {{ .Values.aws_s3_access_key_id_production }}
-  aws_s3_secret_access_key_production: {{ .Values.aws_s3_secret_access_key_production }}

--- a/spec/fixtures/kubernetes_configuration/deployment.yaml
+++ b/spec/fixtures/kubernetes_configuration/deployment.yaml
@@ -57,10 +57,6 @@ spec:
             value: 'sentry-dsn-test'
           - name: SENTRY_CSP_URL
             value: 'sentry-csp-url-test'
-          - name: ACCESS_KEY_ID
-            value: access-key-id
-          - name: SECRET_ACCESS_KEY
-            value: secret-access-key
           - name: BUCKET_NAME
             value: bucket-name
           - name: ENCODED_PRIVATE_KEY

--- a/spec/services/publisher/adapters/aws_s3_client_spec.rb
+++ b/spec/services/publisher/adapters/aws_s3_client_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe Publisher::Adapters::AwsS3Client do
   subject(:aws_s3_client) do
     described_class.new(
-      bucket:,
-      access_key_id: 'some-access-key_id',
-      secret_access_key: 'some-secret-access-key'
+      bucket:
     )
   end
 
@@ -13,6 +11,27 @@ RSpec.describe Publisher::Adapters::AwsS3Client do
     let(:object_key) { 'some-object-key' }
 
     it 'should upload an object to s3' do
+      # stub the token requests that the pod service account makes
+      stub_request(:put, 'http://169.254.169.254/latest/api/token')
+      .with(
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent' => 'aws-sdk-ruby3/3.181.0',
+          'X-Aws-Ec2-Metadata-Token-Ttl-Seconds' => '21600'
+        }
+      )
+      .to_return(status: 200, body: '', headers: {})
+      stub_request(:get, 'http://169.254.169.254/latest/meta-data/iam/security-credentials/')
+      .with(
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent' => 'aws-sdk-ruby3/3.181.0'
+        }
+      )
+      .to_return(status: 200, body: '', headers: {})
+
       expect_any_instance_of(Aws::S3::Client).to receive(:put_object).with(
         body:,
         bucket:,

--- a/spec/services/publisher/utils/kubernetes_configuration_spec.rb
+++ b/spec/services/publisher/utils/kubernetes_configuration_spec.rb
@@ -71,12 +71,6 @@ RSpec.describe Publisher::Utils::KubernetesConfiguration do
       .with(service_id: '0da69306-cafd-4d32-bbee-fff98cac74ce')
       .and_return(MetadataApiClient::Items.new(autocomplete_items))
     allow(ENV).to receive(:[])
-      .with('AWS_S3_ACCESS_KEY_ID_DEV')
-      .and_return('access-key-id')
-    allow(ENV).to receive(:[])
-      .with('AWS_S3_SECRET_ACCESS_KEY_DEV')
-      .and_return('secret-access-key')
-    allow(ENV).to receive(:[])
       .with('AWS_S3_BUCKET_DEV')
       .and_return('bucket-name')
   end


### PR DESCRIPTION
Reverts ministryofjustice/fb-editor#2411

Revert the revert - strip long lived aws creds from published pods (now that everything has been republished with the service account)