### PR TITLE
Revert "Bump selenium-webdriver from 4.8.0 to 4.12.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rspec_junit_formatter'
   gem 'rspec-rails'
-  gem 'selenium-webdriver', '4.12.0'
+  gem 'selenium-webdriver', '4.8.0'
   gem 'shoulda-matchers'
   gem 'site_prism'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -640,7 +640,7 @@ GEM
       sprockets-rails
       tilt
     selectize-rails (0.12.6)
-    selenium-webdriver (4.12.0)
+    selenium-webdriver (4.8.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -748,7 +748,7 @@ DEPENDENCIES
   rubocop (~> 1.55.0)
   rubocop-govuk
   sass-rails (>= 6)
-  selenium-webdriver (= 4.12.0)
+  selenium-webdriver (= 4.8.0)
   sentry-delayed_job (~> 5.11.0)
   sentry-rails (~> 5.11.0)
   sentry-ruby (~> 5.11.0)


### PR DESCRIPTION
Reverts ministryofjustice/fb-editor#2396

This is not passing acceptance tests: 
[circle](https://app.circleci.com/pipelines/github/ministryofjustice/fb-editor/9101/workflows/f416381e-7529-4ef6-8a43-357b8ca9b2ee/jobs/52883/steps)