### PR TITLE
Allow inline style-src

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,7 +16,8 @@ Rails.application.configure do
                        "https://*.hotjar.com"
     policy.style_src   :self,
                        "https://*.hotjar.com",
-                       'unsafe-inline'
+                       'unsafe-inline',
+                       'inline'
     policy.connect_src :self,
                        "*.sentry.io",
                        "https://*.hotjar.com",

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -22,11 +22,9 @@ Rails.application.configure do
                        "https://*.hotjar.com",
                        "https://*.hotjar.io",
                        "wss://*.hotjar.com"
-    policy.style_src_attr 'unsafe-inline'
-    policy.style_src_elem 'unsafe-inline'
 
     # Specify URI for violation reports
-    policy.report_uri "report-uri #{ENV['SENTRY_CSP_URL']}"
+    # policy.report_uri "report-uri #{ENV['SENTRY_CSP_URL']}"
   end
 
   # Generate session nonces for permitted importmap and inline scripts

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -15,8 +15,8 @@ Rails.application.configure do
                        "https://cdn.jsdelivr.net/npm/marked@2.1.3/marked.min.js",
                        "https://*.hotjar.com"
     policy.style_src   :self,
-                       "https://*.hotjar.com",
-                       'unsafe-inline'
+                       :unsafe_inline,
+                       "https://*.hotjar.com"
     policy.connect_src :self,
                        "*.sentry.io",
                        "https://*.hotjar.com",
@@ -24,7 +24,7 @@ Rails.application.configure do
                        "wss://*.hotjar.com"
 
     # Specify URI for violation reports
-    # policy.report_uri "report-uri #{ENV['SENTRY_CSP_URL']}"
+    policy.report_uri "report-uri #{ENV['SENTRY_CSP_URL']}"
   end
 
   # Generate session nonces for permitted importmap and inline scripts

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,13 +16,14 @@ Rails.application.configure do
                        "https://*.hotjar.com"
     policy.style_src   :self,
                        "https://*.hotjar.com",
-                       'unsafe-inline',
-                       'inline'
+                       'unsafe-inline'
     policy.connect_src :self,
                        "*.sentry.io",
                        "https://*.hotjar.com",
                        "https://*.hotjar.io",
                        "wss://*.hotjar.com"
+    policy.style_src_attr 'unsafe-inline'
+    policy.style_src_elem 'unsafe-inline'
 
     # Specify URI for violation reports
     policy.report_uri "report-uri #{ENV['SENTRY_CSP_URL']}"


### PR DESCRIPTION
Determined that style-src: inline is minimal risk and so allowing these to cut down on unnecessary sentry alerting
**We actually had unsafe-inline style-src enabled already but it was being blocked as it was _incorrectly enabled_ because the rails helper only properly applies if you use the symbol**

@chrispymm research
@danielglen-moj & @mattempty for info + threat modelling