### PR TITLE
Conditional content - show error if user select a question form the same page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ gem 'delayed_job_active_record'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'conditional-content-fixture'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'conditional-content-fixture'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.2.9'
+# gem 'metadata_presenter', '3.2.9'
 
 gem 'aws-sdk-s3'
 gem 'aws-sdk-sesv2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 94c81663331fa53a05d36170243397f5d82c600f
+  branch: conditional-content-fixture
+  specs:
+    metadata_presenter (3.2.10)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -272,15 +287,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.2.9)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
@@ -742,7 +748,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.2.9)
+  metadata_presenter!
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/api/conditional_content_expressions_controller.rb
+++ b/app/controllers/api/conditional_content_expressions_controller.rb
@@ -7,8 +7,9 @@ module Api
 
     def show
       @expression = ComponentExpression.new(
-        component: params[:component_id],
-        page: page_with_component(params[:component_id])
+        component: params[:component_uuid],
+        page: page_with_component(params[:component_uuid]),
+        content_component_page: page_with_component(params[:content_component_uuid])
       )
 
       render partial: 'expression_condition',

--- a/app/controllers/api/conditional_contents_controller.rb
+++ b/app/controllers/api/conditional_contents_controller.rb
@@ -6,7 +6,7 @@ module Api
       @conditional_content = ConditionalContent.new(conditional_content_attributes.merge(ConditionalContent.from_json(component_params)))
 
       if @conditional_content.conditionals.blank?
-        @conditional_content.conditionals << ComponentConditional.new(expressions: [ComponentExpression.new])
+        @conditional_content.conditionals << ComponentConditional.new(expressions: [ComponentExpression.new(service: service)])
       end
 
       render 'edit', layout: false
@@ -14,7 +14,7 @@ module Api
 
     def update
       @conditional_content = ConditionalContent.new(conditional_content_params)
-
+      
       if @conditional_content.valid? && !@conditional_content.any_errors?
         render json: @conditional_content.to_metadata, status: :ok
       else
@@ -28,7 +28,7 @@ module Api
     helper_method :conditional_index
 
     def new_conditional_expression
-      @conditional_component.conditionals[params[:conditional_index]].expressions << ComponentExpression.new
+      @conditional_component.conditionals[params[:conditional_index]].expressions << ComponentExpression.new(service: service)
     end
 
     def require_user!

--- a/app/controllers/api/conditional_contents_controller.rb
+++ b/app/controllers/api/conditional_contents_controller.rb
@@ -6,7 +6,7 @@ module Api
       @conditional_content = ConditionalContent.new(conditional_content_attributes.merge(ConditionalContent.from_json(component_params)))
 
       if @conditional_content.conditionals.blank?
-        @conditional_content.conditionals << ComponentConditional.new(expressions: [ComponentExpression.new(service: service)])
+        @conditional_content.conditionals << ComponentConditional.new(expressions: [ComponentExpression.new(service:)])
       end
 
       render 'edit', layout: false
@@ -14,7 +14,7 @@ module Api
 
     def update
       @conditional_content = ConditionalContent.new(conditional_content_params)
-      
+
       if @conditional_content.valid? && !@conditional_content.any_errors?
         render json: @conditional_content.to_metadata, status: :ok
       else
@@ -28,7 +28,7 @@ module Api
     helper_method :conditional_index
 
     def new_conditional_expression
-      @conditional_component.conditionals[params[:conditional_index]].expressions << ComponentExpression.new(service: service)
+      @conditional_component.conditionals[params[:conditional_index]].expressions << ComponentExpression.new(service:)
     end
 
     def require_user!

--- a/app/javascript/src/controllers/expression-controller.js
+++ b/app/javascript/src/controllers/expression-controller.js
@@ -27,7 +27,13 @@ export default class extends Controller {
 
     if (option.dataset.supportsBranching == 'false') {
       this.conditionTarget.setAttribute('hidden', '')
-      this.showError()
+      this.showError('unsupported')
+      return
+    }
+
+    if (option.dataset.samePage == 'true') {
+      this.conditionTarget.setAttribute('hidden', '')
+      this.showError('samepage')
       return
     }
 
@@ -40,14 +46,15 @@ export default class extends Controller {
   }
 
 
-  showError() {
+  showError(errorType) {
     this.element.classList.add(this.errorClass)
-    this.errorMessageTarget.removeAttribute('hidden')
+    this.errorMessageTargets.filter((el) => el.dataset.errorType == errorType)
+                            .forEach((el) => el.removeAttribute('hidden') )
   }
 
   clearError() {
     this.element.classList.remove(this.errorClass)
-    this.errorMessageTarget.setAttribute('hidden', '')
+    this.errorMessageTargets.forEach((el) => el.setAttribute('hidden', ''))
   }
 
   hideDeleteButton(){

--- a/app/javascript/src/controllers/expression-controller.js
+++ b/app/javascript/src/controllers/expression-controller.js
@@ -38,6 +38,7 @@ export default class extends Controller {
     }
 
     this.conditionTarget.src = url
+    this.conditionTarget.reload()
     this.conditionTarget.removeAttribute('hidden')
   }
 

--- a/app/javascript/src/web-components/editable-content.js
+++ b/app/javascript/src/web-components/editable-content.js
@@ -233,6 +233,8 @@ class EditableContent extends HTMLElement {
     config = JSON.parse(value)
     if(config.display && config.display !== 'always') {
       this.setAttribute('conditional', '')
+    } else {
+      this.removeAttribute('conditional')
     }
   }
 

--- a/app/models/component_conditional.rb
+++ b/app/models/component_conditional.rb
@@ -1,6 +1,6 @@
 class ComponentConditional
   include ActiveModel::Model
-  attr_accessor :service
+  attr_accessor :service, :content_component
   attr_writer :expressions
 
   validate :expressions_validations
@@ -10,6 +10,7 @@ class ComponentConditional
 
   def initialize(attributes)
     @service = attributes.delete(:service)
+    @content_component = attributes.delete(:content_component)
     super
   end
 
@@ -40,7 +41,8 @@ class ComponentConditional
       expressions.push(
         ComponentExpression.new(
           expression_hash.merge(
-            page: service.page_with_component(expression_hash['component'])
+            page: service.page_with_component(expression_hash['component']),
+            content_component_page: service.page_with_component(content_component)
           )
         )
       )

--- a/app/models/component_expression.rb
+++ b/app/models/component_expression.rb
@@ -1,6 +1,7 @@
 class ComponentExpression
   include ActiveModel::Model
   attr_accessor :component, :operator, :field, :service, :page, :content_component_page
+
   validates :component, presence: true
   validates :component, supported_component: true
   validates :component, non_same_page: true
@@ -26,7 +27,6 @@ class ComponentExpression
   def initialize(attributes)
     @service = attributes.delete(:service)
     @page = attributes.delete(:page)
-    # @page = service.find_page_by_uuid(@page_uuid)
     @content_component_page = attributes.delete(:content_component_page)
     super
   end
@@ -69,13 +69,10 @@ class ComponentExpression
   def component_supported?
     component_object&.supports_branching?
   end
-  
+
   def component_on_different_page?
-    Rails.logger.info "SELECTED COMPONENT PAGE UUID: #{page.uuid}"
-    Rails.logger.info "CONTENT COMPONENT PAGE UUID: #{content_component_page.uuid}"
-    !(page.uuid == content_component_page.uuid)
+    page.uuid != content_component_page.uuid
   end
-  
 
   def name_attr(conditional_index:, expression_index:, attribute:)
     "conditional_content[conditionals_attributes][#{conditional_index}]" \
@@ -102,8 +99,6 @@ class ComponentExpression
   def component_object
     @component_object ||= page.find_component_by_uuid(component)
   end
-
-  
 
   def contains_operators
     @contains_operators ||= all_operators.select do |operator|

--- a/app/models/component_expression.rb
+++ b/app/models/component_expression.rb
@@ -1,10 +1,10 @@
 class ComponentExpression
   include ActiveModel::Model
-  attr_accessor :component, :operator, :field, :page
-
+  attr_accessor :component, :operator, :field, :service, :page, :content_component_page
   validates :component, presence: true
   validates :component, supported_component: true
-  validates :operator, presence: true, if: proc { |e| e.component && e.component_supported? }
+  validates :component, non_same_page: true
+  # validates :operator, presence: true, if: proc { |e| e.component && e.component_supported? && !e.component_on_same_page? }
   validates_each :field do |record, attribute, _value|
     if record.field_required? && record.field.nil?
       record.errors.add(
@@ -23,10 +23,18 @@ class ComponentExpression
     [I18n.t('operators.is_not_answered'), 'is_not_answered', { 'data-hide-answers': 'true' }]
   ].freeze
 
+  def initialize(attributes)
+    @service = attributes.delete(:service)
+    @page = attributes.delete(:page)
+    # @page = service.find_page_by_uuid(@page_uuid)
+    @content_component_page = attributes.delete(:content_component_page)
+    super
+  end
+
   def to_metadata
     {
       'operator' => operator,
-      'page' => @page&.uuid,
+      'page' => page.uuid,
       'component' => component,
       'field' => field_answer
     }
@@ -59,8 +67,15 @@ class ComponentExpression
   end
 
   def component_supported?
-    component && component_object&.supports_branching?
+    component_object&.supports_branching?
   end
+  
+  def component_on_different_page?
+    Rails.logger.info "SELECTED COMPONENT PAGE UUID: #{page.uuid}"
+    Rails.logger.info "CONTENT COMPONENT PAGE UUID: #{content_component_page.uuid}"
+    !(page.uuid == content_component_page.uuid)
+  end
+  
 
   def name_attr(conditional_index:, expression_index:, attribute:)
     "conditional_content[conditionals_attributes][#{conditional_index}]" \
@@ -76,7 +91,7 @@ class ComponentExpression
     operator == I18n.t('operators.is') || operator == I18n.t('operators.is_not')
   end
 
-  private
+  # private
 
   def field_answer
     return field.to_s unless field_required?
@@ -85,8 +100,10 @@ class ComponentExpression
   end
 
   def component_object
-    @component_object ||= page&.find_component_by_uuid(component)
+    @component_object ||= page.find_component_by_uuid(component)
   end
+
+  
 
   def contains_operators
     @contains_operators ||= all_operators.select do |operator|

--- a/app/models/conditional_content.rb
+++ b/app/models/conditional_content.rb
@@ -77,7 +77,10 @@ class ConditionalContent
         [
           component.humanised_title,
           component.uuid,
-          { 'data-supports-branching': component.supports_branching? }
+          { 
+            'data-supports-branching': component.supports_branching?,
+            'data-same-page': page.uuid == page_uuid,
+          }
         ]
       end
     end
@@ -89,6 +92,10 @@ class ConditionalContent
     return service.page_with_component(component_uuid)&.[](:_uuid) if previous_flow_uuid.blank?
 
     previous_flow_uuid
+  end
+
+  def page_uuid 
+    service.page_with_component(component_uuid)&.[](:_uuid)
   end
 
   def any_errors?

--- a/app/models/conditional_content.rb
+++ b/app/models/conditional_content.rb
@@ -44,7 +44,6 @@ class ConditionalContent
     conditional.expressions.each_with_index do |expression, expression_index|
       expressions_hash['expressions_attributes'][expression_index.to_s] = {
         'operator' => expression.operator,
-        'page' => expression.page,
         'component' => expression.component,
         'field' => expression.field
       }
@@ -67,7 +66,7 @@ class ConditionalContent
 
   def conditionals_attributes=(hash)
     hash.each do |_index, conditional_hash|
-      conditionals.push(ComponentConditional.new(conditional_hash.merge(service:)))
+      conditionals.push(ComponentConditional.new(conditional_hash.merge(service:, content_component: component_uuid)))
     end
   end
 
@@ -79,7 +78,7 @@ class ConditionalContent
           component.uuid,
           { 
             'data-supports-branching': component.supports_branching?,
-            'data-same-page': page.uuid == page_uuid,
+            'data-same-page': page.uuid == content_component_page_uuid,
           }
         ]
       end
@@ -94,7 +93,7 @@ class ConditionalContent
     previous_flow_uuid
   end
 
-  def page_uuid 
+  def content_component_page_uuid 
     service.page_with_component(component_uuid)&.[](:_uuid)
   end
 

--- a/app/models/conditional_content.rb
+++ b/app/models/conditional_content.rb
@@ -76,9 +76,9 @@ class ConditionalContent
         [
           component.humanised_title,
           component.uuid,
-          { 
+          {
             'data-supports-branching': component.supports_branching?,
-            'data-same-page': page.uuid == content_component_page_uuid,
+            'data-same-page': page.uuid == content_component_page_uuid
           }
         ]
       end
@@ -93,7 +93,7 @@ class ConditionalContent
     previous_flow_uuid
   end
 
-  def content_component_page_uuid 
+  def content_component_page_uuid
     service.page_with_component(component_uuid)&.[](:_uuid)
   end
 

--- a/app/validators/non_same_page_validator.rb
+++ b/app/validators/non_same_page_validator.rb
@@ -1,0 +1,12 @@
+
+class NonSamePageValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, _value)
+    # byebug
+    if record.component.present? && !record.component_on_different_page?
+      record.errors.add(
+        attribute,
+        I18n.t("activemodel.errors.models.#{record.model_name.singular}.same_page")
+      )
+    end
+  end
+end

--- a/app/validators/non_same_page_validator.rb
+++ b/app/validators/non_same_page_validator.rb
@@ -1,7 +1,5 @@
-
 class NonSamePageValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, _value)
-    # byebug
     if record.component.present? && !record.component_on_different_page?
       record.errors.add(
         attribute,

--- a/app/validators/supported_component_validator.rb
+++ b/app/validators/supported_component_validator.rb
@@ -3,7 +3,7 @@ class SupportedComponentValidator < ActiveModel::EachValidator
     if record.component.present? && !record.component_supported?
       record.errors.add(
         attribute,
-        I18n.t("activemodel.errors.models.#{record.model_name.singular}.unsupported_component")
+        I18n.t("activemodel.errors.models.#{record.model_name.singular}.unsupported")
       )
     end
   end

--- a/app/views/api/conditional_contents/_conditional_fields.html.erb
+++ b/app/views/api/conditional_contents/_conditional_fields.html.erb
@@ -4,12 +4,12 @@
 
     <div class="expressions" data-controller="dynamic-fields expressions">
       <%= conditional.fields_for :expressions do |expression| %>
-        <%= render 'expression_fields', conditional: conditional, expression: expression %>
+        <%= render 'expression_fields', conditional: conditional, expression: expression, component_uuid: component_uuid  %>
       <% end %>
 
       <template data-dynamic-fields-target="template">
-        <%= conditional.fields_for :expressions, ComponentExpression.new, child_index: "__CHILD_INDEX__" do |expression| %>
-          <%= render 'expression_fields', conditional: conditional, expression: expression %>
+        <%= conditional.fields_for :expressions, ComponentExpression.new(service: service), child_index: "__CHILD_INDEX__" do |expression| %>
+          <%= render 'expression_fields', conditional: conditional, expression: expression, component_uuid: component_uuid  %>
         <% end %>
       </template>
 

--- a/app/views/api/conditional_contents/_expression_condition.html.erb
+++ b/app/views/api/conditional_contents/_expression_condition.html.erb
@@ -1,5 +1,5 @@
 <turbo-frame id="conditional_<%= conditional_index %>_expression_<%= expression_index %>" data-expression-target="condition">
-  <% if expression.component.present? && expression.component_supported? %>
+  <% if expression.component.present? && expression.component_supported? && expression.component_on_different_page? %>
     <div class="expression__condition" data-controller="selection-reveal" data-selection-reveal-matches-value="<%= expression.answered_operator_values.to_json %>">
         <%= f.select :operators, expression.operators,
           {

--- a/app/views/api/conditional_contents/_expression_fields.html.erb
+++ b/app/views/api/conditional_contents/_expression_fields.html.erb
@@ -28,7 +28,8 @@
         },
       }
     %> 
-    <p class="expression__error" data-expression-target="errorMessage" hidden><%= t('activemodel.errors.messages.unsupported') %></p> 
+    <p class="expression__error" data-expression-target="errorMessage" data-error-type='unsupported' hidden><%= t('activemodel.errors.models.component_expression.unsupported') %></p> 
+    <p class="expression__error" data-expression-target="errorMessage" data-error-type='samepage' hidden><%= t('activemodel.errors.models.component_expression.same_page') %></p> 
   </div>
     
     <%= render partial: 'expression_condition',

--- a/app/views/api/conditional_contents/_expression_fields.html.erb
+++ b/app/views/api/conditional_contents/_expression_fields.html.erb
@@ -24,7 +24,7 @@
         data: {
           action: 'change->expression#getCondition',
           expression_target: 'question',
-          expression_url_param: api_service_conditional_content_expressions_path(service.service_id, '--componentId--', conditional.options[:child_index], expression.options[:child_index]),
+          expression_url_param: api_service_conditional_content_expressions_path(service.service_id, component_uuid, conditional.options[:child_index], expression.options[:child_index], '--componentId--'),
         },
       }
     %> 

--- a/app/views/api/conditional_contents/_form.html.erb
+++ b/app/views/api/conditional_contents/_form.html.erb
@@ -35,12 +35,12 @@
 
     <fieldset class="govuk-fieldset conditionals" data-controller="dynamic-fields conditionals" data-selection-reveal-target="reveal">
       <%= f.fields_for :conditionals, child_index: conditional_index do |conditional| %>
-        <%= render 'conditional_fields', conditional: conditional, f: f %>
+        <%= render 'conditional_fields', conditional: conditional, f: f, component_uuid: f.object.component_uuid %>
       <% end %>
 
       <template data-dynamic-fields-target="template">
-        <%= f.fields_for :conditionals, ComponentConditional.new(expressions: [ComponentExpression.new]), child_index: "__CHILD_INDEX__" do |conditional| %>
-          <%= render 'conditional_fields', conditional: conditional, f: f %>
+        <%= f.fields_for :conditionals, ComponentConditional.new(expressions: [ComponentExpression.new(service: service)]), child_index: "__CHILD_INDEX__" do |conditional| %>
+          <%= render 'conditional_fields', conditional: conditional, f: f, component_uuid: f.object.component_uuid %>
         <% end %>
       </template>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -633,7 +633,8 @@ en:
           special_characters: Your URL cannot include special characters except hyphens
           blank: Your URL cannot be blank
         component_expression:
-          unsupported_component: "This type of question is not currently supported to create a content rule. Please select a radio button or checkbox question."
+          unsupported: "This type of question is not currently supported to create a content rule. Please select a radio button or checkbox question."
+          same_page: "Only questions on other pages are supported."
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."
         too_short: "%{attribute} must be %{count} characters or more"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,7 +98,7 @@ Rails.application.routes.draw do
 
       post 'conditional_content/components/:component_uuid/edit', to: 'conditional_contents#edit', as: 'edit_conditional_content'
       put 'conditional_content/components/:component_uuid', to: 'conditional_contents#update', as: 'update_conditional_content'
-      get 'conditional_content/components/:component_id/conditionals/:conditional_index/expressions/:expression_index', to: 'conditional_content_expressions#show', as: 'conditional_content_expressions'
+      get 'conditional_content/components/:content_component_uuid/conditionals/:conditional_index/expressions/:expression_index/component/:component_uuid', to: 'conditional_content_expressions#show', as: 'conditional_content_expressions'
 
       get '/components/:component_id/autocomplete', to: 'autocomplete#show', as: :autocomplete
       post '/components/:component_id/autocomplete', to: 'autocomplete#create'

--- a/spec/models/component_expression_spec.rb
+++ b/spec/models/component_expression_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ComponentExpression do
         {
           'operator': 'is',
           'page': double(uuid: 'some-page-uuid'),
+          'content_component_page': double(uuid: 'another-page-uuid'),
           'component': 'some-component-uuid',
           'field': 'some-field-uuid'
         }
@@ -33,6 +34,7 @@ RSpec.describe ComponentExpression do
         {
           'operator': 'is_answered',
           'page': double(uuid: 'some-page-uuid'),
+          'content_component_page': double(uuid: 'another-page-uuid'),
           'component': 'some-component-uuid',
           'field': nil
         }
@@ -202,6 +204,7 @@ RSpec.describe ComponentExpression do
         {
           'operator': 'is',
           'page': page,
+          'content_component_page': double(uuid: 'some-other-uuid'),
           'component': page.components.first.uuid,
           'field': 'c5571937-9388-4411-b5fa-34ddf9bc4ca0'
         }
@@ -219,6 +222,7 @@ RSpec.describe ComponentExpression do
           'operator': 'is',
           'page': page,
           'component': page.components.first.uuid,
+          'content_component_page': double(uuid: 'some-other-uuid'),
           'field': '27d377a2-6828-44ca-87d1-b83ddac98284'
         }
       end
@@ -228,7 +232,7 @@ RSpec.describe ComponentExpression do
         expect(errors).to be_present
         expect(errors.values.first).to include(
           I18n.t(
-            'activemodel.errors.models.component_expression.unsupported_component'
+            'activemodel.errors.models.component_expression.unsupported'
           )
         )
       end
@@ -240,6 +244,7 @@ RSpec.describe ComponentExpression do
         {
           'operator': 'is',
           'page': page,
+          'content_component_page': double(uuid: 'some-other-uuid'),
           'component': page.components.first.uuid,
           'field': nil
         }
@@ -252,6 +257,29 @@ RSpec.describe ComponentExpression do
           I18n.t(
             'activemodel.errors.messages.blank',
             attribute: ComponentExpression.human_attribute_name(:field)
+          )
+        )
+      end
+    end
+
+    context 'component on same page' do
+      let(:page) { service.find_page_by_url('star-wars-knowledge') }
+      let(:component_expression_hash) do
+        {
+          'operator': 'is',
+          'page': page,
+          'content_component_page': page,
+          'component': page.find_component_by_uuid('51efe2ca-fc47-4584-8129-e91589a46b9e'),
+          'field': '1b6c5734-04bf-49fa-928a-2e9bbbb09f8c'
+        }
+      end
+
+      it 'returns the error message' do
+        errors = component_expression.errors.messages
+        expect(errors).to be_present
+        expect(errors.values.first).to include(
+          I18n.t(
+            'activemodel.errors.models.component_expression.same_page'
           )
         )
       end

--- a/spec/models/conditional_content_spec.rb
+++ b/spec/models/conditional_content_spec.rb
@@ -11,16 +11,47 @@ RSpec.describe ConditionalContent do
     }.merge(attributes)
   end
   let(:previous_page) do
-    service.find_page_by_url('pets')
+    service.find_page_by_url('multiple')
   end
   let(:previous_flow_uuid) do
     previous_page.uuid
   end
   let(:current_page) do
-    service.find_page_by_url('furry')
+    service.find_page_by_url('best-content')
   end
-  let(:component_uuid) { '46a49bb2-349d-47f2-bb75-eaed3892d5d7' }
+  let(:component_uuid) { 'f7208ed7-ed10-4c53-9271-ab075f6d3e3c' }
   let(:latest_metadata) { metadata_fixture(:conditional) }
+  let(:component_json) do
+    '{
+      "display": "conditional",
+      "conditionals": [
+        {
+          "_uuid":"6b1dea31-abbd-4053-8e6f-6211534dcd3b",
+          "_type":"if",
+          "expressions":[
+            {
+              "operator":"is",
+              "page":"00cc353e-51c5-4462-88bc-c357e344cd4d",
+              "component":"db99d122-17e4-47b1-b5a4-d6e8bf70fa86",
+              "field":"38492ffc-b18c-4b0b-94fe-c1addd854738"
+            }
+          ]
+        },
+        {
+          "_uuid":"291df640-16b0-4b7d-876e-92662d95e7a5",
+          "_type":"if",
+          "expressions":[
+            {
+              "operator":"is",
+              "page":"00cc353e-51c5-4462-88bc-c357e344cd4d",
+              "component":"db99d122-17e4-47b1-b5a4-d6e8bf70fa86",
+              "field":"f0c1585e-7b23-461a-8644-4da3b2e1ebc4"
+            }
+          ]
+        }
+      ]
+    }'
+  end
   let(:service) do
     MetadataPresenter::Service.new(latest_metadata)
   end
@@ -35,50 +66,110 @@ RSpec.describe ConditionalContent do
           '0' => {
             'expressions_attributes' => {
               '0' => {
-                'page' => '07635f6d-34a8-45c8-884f-87696eba6a1f',
-                'field' => '46c218d5-018a-482a-a66d-0d84be80f543',
-                'operator' => 'is_not',
-                'component' => '612f5bc2-8766-4296-9b9c-47f92bdc4b62'
+                'field' => '38492ffc-b18c-4b0b-94fe-c1addd854738',
+                'operator' => 'is',
+                'component' => 'db99d122-17e4-47b1-b5a4-d6e8bf70fa86'
+              }
+            }
+          },
+          '1' => {
+            'expressions_attributes' => {
+              '0' => {
+                'field' => 'f0c1585e-7b23-461a-8644-4da3b2e1ebc4',
+                'operator' => 'is',
+                'component' => 'db99d122-17e4-47b1-b5a4-d6e8bf70fa86'
               }
             }
           }
         },
-        'display' => nil
+        'display' => 'conditional'
       }
     end
 
     it 'serialises the component objects metadata' do
-      pending('Conditional content presenter update') unless ENV['CONDITONAL_CONTENT'] == 'enabled'
+      skip('Conditional content presenter update') unless ENV['CONDITIONAL_CONTENT'] == 'enabled'
       expect(ConditionalContent.from_metadata(component)).to eq(expected_metadata)
     end
   end
 
   describe '.from_json' do
+    skip('Conditional content presenter update') unless ENV['CONDITIONAL_CONTENT'] == 'enabled'
+    let(:component) do
+      current_page.find_component_by_uuid(component_uuid)
+    end
+    let(:expected_metadata) do
+      {
+        'conditionals_attributes' => {
+          '0' => {
+            'expressions_attributes' => {
+              '0' => {
+                'field' => '38492ffc-b18c-4b0b-94fe-c1addd854738',
+                'operator' => 'is',
+                'component' => 'db99d122-17e4-47b1-b5a4-d6e8bf70fa86'
+              }
+            }
+          },
+          '1' => {
+            'expressions_attributes' => {
+              '0' => {
+                'field' => 'f0c1585e-7b23-461a-8644-4da3b2e1ebc4',
+                'operator' => 'is',
+                'component' => 'db99d122-17e4-47b1-b5a4-d6e8bf70fa86'
+              }
+            }
+          }
+        },
+        'display' => 'conditional'
+      }
+    end
+
+    it 'seriualizes the component metadat from json' do
+      expect(ConditionalContent.from_json(component_json)).to eq(expected_metadata)
+    end
   end
 
   describe '#previous_questions' do
     it 'returns all questions for single and mulitiple questions pages' do
-      pending('Conditional content presenter update') unless ENV['CONDITONAL_CONTENT'] == 'enabled'
+      skip('Conditional content presenter update') unless ENV['CONDITIONAL_CONTENT'] == 'enabled'
       expect(conditional_content.previous_questions.map { |question| question[0] }).to eq(
         [
-          'Checkbox',
-          'Colours',
-          'Pet choice',
-          'Email address question'
+          'Single Radios',
+          'radio',
+          'checkbox (optional)',
+          'name'
         ]
       )
     end
 
     it 'injects the data-supports-branching attribute' do
-      pending('Conditional content presenter update') unless ENV['CONDITONAL_CONTENT'] == 'enabled'
+      skip('Conditional content presenter update') unless ENV['CONDITIONAL_CONTENT'] == 'enabled'
       expect(conditional_content.previous_questions.map { |question| question[2] }).to eq(
         [
-          { 'data-supports-branching': true },
-          { 'data-supports-branching': true },
-          { 'data-supports-branching': true },
-          { 'data-supports-branching': false }
+          { 'data-supports-branching': true, 'data-same-page': false },
+          { 'data-supports-branching': true, 'data-same-page': false },
+          { 'data-supports-branching': true, 'data-same-page': false },
+          { 'data-supports-branching': false, 'data-same-page': false }
         ]
       )
+    end
+
+    context 'content component on same page' do
+      let(:current_page) do
+        service.find_page_by_url('multiple')
+      end
+      let(:component_uuid) { '73869807-f82f-4000-8204-fcb3f62718a2' }
+
+      it 'injects the data-same-page attribute' do
+        skip('Conditional content presenter update') unless ENV['CONDITIONAL_CONTENT'] == 'enabled'
+        expect(conditional_content.previous_questions.map { |question| question[2] }).to eq(
+          [
+            { 'data-supports-branching': true, 'data-same-page': false },
+            { 'data-supports-branching': true, 'data-same-page': true },
+            { 'data-supports-branching': true, 'data-same-page': true },
+            { 'data-supports-branching': false, 'data-same-page': true }
+          ]
+        )
+      end
     end
   end
 
@@ -109,7 +200,7 @@ RSpec.describe ConditionalContent do
     end
 
     it 'assigns conditionals' do
-      pending('Conditional content presenter update') unless ENV['CONDITONAL_CONTENT'] == 'enabled'
+      skip('Conditional content presenter update') unless ENV['CONDITIONAL_CONTENT'] == 'enabled'
       expect(conditional_content.conditionals).to eq(
         [
           expected_conditional
@@ -121,7 +212,7 @@ RSpec.describe ConditionalContent do
   describe '#previous_flow_uuid' do
     context 'previous flow uuid is present' do
       it 'returns the previous flow uuid' do
-        pending('Conditional content presenter update') unless ENV['CONDITONAL_CONTENT'] == 'enabled'
+        skip('Conditional content presenter update') unless ENV['CONDITIONAL_CONTENT'] == 'enabled'
         expect(conditional_content.flow_uuid).to eq(previous_flow_uuid)
       end
     end
@@ -130,16 +221,16 @@ RSpec.describe ConditionalContent do
       let(:previous_flow_uuid) { nil }
 
       it 'returns the current page in the flow' do
-        pending('Conditional content presenter update') unless ENV['CONDITONAL_CONTENT'] == 'enabled'
+        skip('Conditional content presenter update') unless ENV['CONDITIONAL_CONTENT'] == 'enabled'
         expect(conditional_content.flow_uuid).to eq(current_page[:_uuid])
       end
     end
   end
 
   describe '#validations' do
-    skip('Conditional content presenter update') unless ENV['CONDITONAL_CONTENT'] == 'enabled'
+    skip('Conditional content presenter update') unless ENV['CONDITIONAL_CONTENT'] == 'enabled'
     before do
-      conditional_content.valid? if ENV['CONDITONAL_CONTENT'] == 'enabled'
+      conditional_content.valid? if ENV['CONDITIONAL_CONTENT'] == 'enabled'
     end
 
     context 'when blank conditionals' do
@@ -156,12 +247,12 @@ RSpec.describe ConditionalContent do
       end
 
       it 'does not accept blank conditionals' do
-        skip('Conditional content presenter update') unless ENV['CONDITONAL_CONTENT'] == 'enabled'
+        skip('Conditional content presenter update') unless ENV['CONDITIONAL_CONTENT'] == 'enabled'
         expect(conditional_content.conditionals_validations).to be_present
       end
 
       it 'adds error to conditionals object' do
-        skip('Conditional content presenter update') unless ENV['CONDITONAL_CONTENT'] == 'enabled'
+        skip('Conditional content presenter update') unless ENV['CONDITIONAL_CONTENT'] == 'enabled'
         errors = conditional_content.conditionals.first.errors
         expect(errors).to be_present
         expect(errors.of_kind?(:expressions, :invalid_expression)).to be_truthy
@@ -175,10 +266,9 @@ RSpec.describe ConditionalContent do
             '0' => {
               'expressions_attributes' => {
                 '0' => {
-                  'page' => '07635f6d-34a8-45c8-884f-87696eba6a1f',
-                  'field' => '46c218d5-018a-482a-a66d-0d84be80f543',
+                  'field' => '63dce510-a641-4649-906c-334262c37673',
                   'operator' => 'is_not',
-                  'component' => '612f5bc2-8766-4296-9b9c-47f92bdc4b62'
+                  'component' => 'db99d122-17e4-47b1-b5a4-d6e8bf70fa86'
                 }
               }
             }
@@ -187,12 +277,12 @@ RSpec.describe ConditionalContent do
       end
 
       it 'no errors on conditional_content' do
-        skip('Conditional content presenter update') unless ENV['CONDITONAL_CONTENT'] == 'enabled'
+        skip('Conditional content presenter update') unless ENV['CONDITIONAL_CONTENT'] == 'enabled'
         expect(conditional_content.errors).to be_blank
       end
 
       it 'no errors on conditionals' do
-        skip('Conditional content presenter update') unless ENV['CONDITONAL_CONTENT'] == 'enabled'
+        skip('Conditional content presenter update') unless ENV['CONDITIONAL_CONTENT'] == 'enabled'
         errors = conditional_content.conditionals.first.errors
         expect(errors).to be_blank
       end

--- a/spec/services/page_updater_spec.rb
+++ b/spec/services/page_updater_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe PageUpdater do
               '_type': 'content',
               '_uuid': "Dead or alive you're coming with me",
               'content': '[Optional content]',
+              'display': 'always',
               'name': 'confirmation_content_1'
             })
           end
@@ -269,6 +270,7 @@ RSpec.describe PageUpdater do
               '_type': 'content',
               '_uuid' => "Dead or alive you're coming with me",
               'content': '[Optional content]',
+              'display': 'always',
               'name': 'check-answers_content_3'
             })
           end


### PR DESCRIPTION
When configuring conditional content on multiple question pages it will be possible to select questions that are on the same page as the content component.

Handling this in the runner is out of scope and would rely on front-end javascript which we don't want to do.

So we will show an error informing the user they need to chiise a question from a different page.

![image](https://github.com/ministryofjustice/fb-editor/assets/595564/c0e82345-7082-4802-ac31-2397598469c2)

<img width="758" alt="image" src="https://github.com/ministryofjustice/fb-editor/assets/595564/7f8cc710-a7e7-4e8a-8418-bcb49aeb83ed">

