### PR TITLE
Add hint text prompt into validation modals

### DIFF
--- a/app/views/api/component_validations/_date_after_before_validations.html.erb
+++ b/app/views/api/component_validations/_date_after_before_validations.html.erb
@@ -11,9 +11,10 @@
                  name="component_validation[<%=field%>]"
                  pattern="[0-9]*"
                  inputmode="numeric"
-                 aria-describedby="<%= has_error ? "component_validation_#{field}_error" : ""%>"
+                 aria-describedby="<%= has_error ? "component_validation_#{field}_error" : ""%> hint-text-prompt"
                  value="<%= @component_validation.send("answered_#{field}") %>">
         </div>
       </div>
     <% end %>
 </div>
+<p id="hint-text-prompt"><%= t('dialogs.component_validations.hint_text_prompt') %></p>

--- a/app/views/api/component_validations/_minimum_maximum_validations.html.erb
+++ b/app/views/api/component_validations/_minimum_maximum_validations.html.erb
@@ -8,5 +8,6 @@
        inputmode="numeric"
        spellcheck="false"
        autocomplete=""
-       aria-describedby="<%= @component_validation.errors.present? ? 'component_validation_value_error' : '' %>"
+       aria-describedby="<%= @component_validation.errors.present? ? 'component_validation_value_error' : '' %> hint-text-prompt"
        value="<%= @component_validation.main_value %>">
+<p id="hint-text-prompt"><%= t('dialogs.component_validations.hint_text_prompt') %></p>

--- a/app/views/api/component_validations/_string_length_validation.html.erb
+++ b/app/views/api/component_validations/_string_length_validation.html.erb
@@ -9,7 +9,7 @@
          inputmode="numeric"
          spellcheck="false"
          autocomplete=""
-         aria-describedby="<%= @component_validation.errors.present? ? 'component_validation_value_error' : '' %>"
+         aria-describedby="<%= @component_validation.errors.present? ? 'component_validation_value_error' : '' %> hint-text-prompt"
          <%=   @component_validation.errors.present? ? 'aria-invalid=true' : '' %>
          value="<%= @component_validation.main_value %>">
 
@@ -35,3 +35,4 @@
       </div>
   </fieldset>
 </div>
+<p id="hint-text-prompt"><%= t('dialogs.component_validations.hint_text_prompt') %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,7 @@ en:
       redo:
         content: We were unable to redo your last action.
     component_validations:
+      hint_text_prompt: You may want to mention this requirement in the question's hint text to help users with their answer
       date:
         day: Day
         month: Month


### PR DESCRIPTION
When form inputs have validations, it is helpful for form fillers to be informed of this in the hint text for the field.  This is hard to do correctly automatically, so we are adding a prompt to form editors when they add validation to suggest that they add hint text.

![image](https://github.com/ministryofjustice/fb-editor/assets/595564/5c2c4f8b-1f13-49d2-a57b-f955e75ef88f)
