### PR TITLE
Add link to feedback form

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -9,7 +9,7 @@
           </strong>
           <span class="govuk-phase-banner__text">
             <%= t('.phase_banner',
-              feedback_link: govuk_link_to( t('.feedback_link_text'), 'mailto:moj-forms@digital.justice.gov.uk')
+              feedback_link: govuk_link_to( t('.feedback_link_text'), ENV['FEEDBACK_FORM_URL'] )
                  ).html_safe %>
           </span>
         </p>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -2,19 +2,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <div class="govuk-phase-banner govuk-!-margin-bottom-6">
-        <p class="govuk-phase-banner__content">
-          <strong class="govuk-tag govuk-phase-banner__content__tag">
-            <%= t('.phase') %>
-          </strong>
-          <span class="govuk-phase-banner__text">
-            <%= t('.phase_banner',
-              feedback_link: govuk_link_to( t('.feedback_link_text'), ENV['FEEDBACK_FORM_URL'] )
-                 ).html_safe %>
-          </span>
-        </p>
-      </div>
-
       <h1 class="govuk-panel__title govuk-heading-xl" data-block-id="title" data-block-property="heading">
         <%= t('.title') %>
       </h1>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -20,12 +20,13 @@
           <li>
             <%= link_to t('.user_guide'), t('.user_guide_url'), target: :_blank, noreferrer: true, nofollow: true %>
           </li>
-          <li>
-            <%= link_to t('.send_feedback'), ENV['FEEDBACK_FORM_URL'], target: :_blank, noreferrer: true, nofollow: true %>
-          </li>
           <% if moj_forms_dev? || moj_forms_admin? %>
             <li>
               <%= link_to t('.admin'), admin_root_path %>
+            </li>
+          <% else %>
+            <li>
+              <%= link_to t('.send_feedback'), t('.feedback_form_url'), target: :_blank, noreferrer: true, nofollow: true %>
             </li>
           <% end %>
           <li>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -18,7 +18,10 @@
             <%= link_to t('.forms'), services_path %>
           </li>
           <li>
-            <%= link_to t('.user_guide'), t('.user_guide_url'), target: :_blank %>
+            <%= link_to t('.user_guide'), t('.user_guide_url'), target: :_blank, noreferrer: true, nofollow: true %>
+          </li>
+          <li>
+            <%= link_to t('.send_feedback'), ENV['FEEDBACK_FORM_URL'], target: :_blank, noreferrer: true, nofollow: true %>
           </li>
           <% if moj_forms_dev? || moj_forms_admin? %>
             <li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,7 +147,8 @@ en:
       admin: Admin
       forms: Your forms
       sign_out: Sign out %{user_name}
-      user_guide: "User guide"
+      user_guide: "Support"
+      send_feedback: "Send feedback"
       home_url: "https://moj-forms.service.justice.gov.uk/"
       user_guide_url: "https://moj-forms.service.justice.gov.uk/user-guide/"
       user_guide_check_confirm_url: 'https://moj-forms.service.justice.gov.uk/building-and-editing/#check-confirm'
@@ -241,8 +242,8 @@ en:
   conditional_content:
     heading: Show this content...
     show_if_button_label: Shows if...
-    hidden_button_label: Hidden 
-    display: 
+    hidden_button_label: Hidden
+    display:
       always: 'Always'
       conditional: 'Only if...'
       never: 'Never'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,10 +148,11 @@ en:
       forms: Your forms
       sign_out: Sign out %{user_name}
       user_guide: "Support"
-      send_feedback: "Send feedback"
+      send_feedback: "Feedback"
       home_url: "https://moj-forms.service.justice.gov.uk/"
       user_guide_url: "https://moj-forms.service.justice.gov.uk/user-guide/"
       user_guide_check_confirm_url: 'https://moj-forms.service.justice.gov.uk/building-and-editing/#check-confirm'
+      feedback_form_url: "https://mojf-in-service-feedback-form.form.service.justice.gov.uk"
   home:
     show:
       phase: beta


### PR DESCRIPTION
PR adds a link to MOJ Forms feedback form into the main nav.

**Only visible if you are not a dev or an admin**

Also removes the phase/feedback banner from the start page.

![image](https://github.com/ministryofjustice/fb-editor/assets/595564/1395eab9-7cb2-41df-b505-6668130ef2aa)
