### PR TITLE
Fix component id collisions on multiquestion pages

### DIFF
--- a/app/generators/new_component_generator.rb
+++ b/app/generators/new_component_generator.rb
@@ -32,6 +32,19 @@ class NewComponentGenerator
   end
 
   def increment
-    components.select { |c| c['_type'] == component_type }.size + 1
+    existing_components = components_of_type(component_type)
+    if existing_components.empty?
+      1
+    else
+      component_index(existing_components.last).to_i + 1
+    end
+  end
+
+  def components_of_type(type)
+    components.select { |c| c['_type'] == type }
+  end
+
+  def component_index(component)
+    component['_id'].split('_').last
   end
 end

--- a/spec/generators/new_component_generator_spec.rb
+++ b/spec/generators/new_component_generator_spec.rb
@@ -97,6 +97,32 @@ RSpec.describe NewComponentGenerator do
         end
       end
 
+      context 'non collection input components after deletion' do
+        %w[text textarea email date number upload autocomplete].each do |component|
+          context "when #{component} component" do
+            let(:component_type) { component }
+            let(:components) do
+              [
+                {
+                  '_id' => "#{page_url}_#{component}_2",
+                  '_type' => component,
+                  'name' => "#{page_url}_#{component}_2"
+                },
+                {
+                  '_id' => "#{page_url}_#{component}_3",
+                  '_type' => component,
+                  'name' => "#{page_url}_#{component}_3"
+                }
+              ]
+            end
+
+            it 'should increment the newly created component id' do
+              expect(generator.to_metadata['_id']).to eq("#{page_url}_#{component}_4")
+            end
+          end
+        end
+      end
+
       context 'collection input components' do
         let(:components) { [] }
 

--- a/spec/services/page_updater_spec.rb
+++ b/spec/services/page_updater_spec.rb
@@ -266,12 +266,12 @@ RSpec.describe PageUpdater do
           let(:page_url) { 'check-answers' }
           let(:expected_created_component) do
             ActiveSupport::HashWithIndifferentAccess.new({
-              '_id': 'check-answers_content_3',
+              '_id': 'check-answers_content_2',
               '_type': 'content',
               '_uuid' => "Dead or alive you're coming with me",
               'content': '[Optional content]',
               'display': 'always',
-              'name': 'check-answers_content_3'
+              'name': 'check-answers_content_2'
             })
           end
           let(:expected_updated_page) do


### PR DESCRIPTION
This PR fixes an issue where if a multiquestion page has mutliple of the same component type on, and one of the earlier components is deleted, then the next component of that type added to the page would have a duplicate id, causing issues.

This was caused by a naive way of generating ids, where we just counted the number of components of the same type, and then incremented by one.  This obviously fails once a component is deleted.

Instead we now get the id of the last component of the type being created and increment that id. 