### PR TITLE
testable: Use metadata_presenter v3.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ ruby '3.1.3'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'conditional-content-fixture'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'bump-json-schema'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.2.11'
+# gem 'metadata_presenter', '3.3.0'
 
 gem 'activerecord-session_store'
 gem 'administrate'

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ ruby '3.1.3'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'bump-json-schema'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'bump-json-schema'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '3.3.0'
+gem 'metadata_presenter', '3.3.0'
 
 gem 'activerecord-session_store'
 gem 'administrate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 29a5f1394e6df5ae17e6d97b6655e9db895e9adc
+  revision: 01eb4d88b2acdb2e8ed4d7eba917ef7677b3dbeb
   branch: bump-json-schema
   specs:
     metadata_presenter (3.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 01eb4d88b2acdb2e8ed4d7eba917ef7677b3dbeb
-  branch: bump-json-schema
-  specs:
-    metadata_presenter (3.3.0)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (~> 4.1.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -289,6 +274,15 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    metadata_presenter (3.3.0)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (~> 4.1.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
@@ -767,7 +761,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter!
+  metadata_presenter (= 3.3.0)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 29a5f1394e6df5ae17e6d97b6655e9db895e9adc
+  branch: bump-json-schema
+  specs:
+    metadata_presenter (3.3.0)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (~> 4.1.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -180,9 +195,9 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (3.24.4)
-    google-protobuf (3.24.4-x86_64-darwin)
-    google-protobuf (3.24.4-x86_64-linux)
+    google-protobuf (3.25.0)
+    google-protobuf (3.25.0-x86_64-darwin)
+    google-protobuf (3.25.0-x86_64-linux)
     googleapis-common-protos-types (1.9.0)
       google-protobuf (~> 3.18)
     govspeak (7.1.1)
@@ -240,8 +255,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.6.3)
-    json-schema (2.8.1)
-      addressable (>= 2.4)
+    json-schema (4.1.1)
+      addressable (>= 2.8)
     jwt (2.7.1)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -274,15 +289,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.2.11)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
@@ -356,7 +362,7 @@ GEM
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
       ruby2_keywords
-    opentelemetry-instrumentation-active_support (0.4.3)
+    opentelemetry-instrumentation-active_support (0.4.4)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
     opentelemetry-instrumentation-all (0.50.1)
@@ -424,7 +430,7 @@ GEM
       opentelemetry-api (~> 1.0)
       opentelemetry-common (~> 0.20.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
-    opentelemetry-instrumentation-grape (0.1.4)
+    opentelemetry-instrumentation-grape (0.1.5)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
       opentelemetry-instrumentation-rack (~> 0.21)
@@ -515,7 +521,7 @@ GEM
       opentelemetry-semantic_conventions (>= 1.8.0)
     opentelemetry-registry (0.3.0)
       opentelemetry-api (~> 1.1)
-    opentelemetry-sdk (1.3.0)
+    opentelemetry-sdk (1.3.1)
       opentelemetry-api (~> 1.1)
       opentelemetry-common (~> 0.20)
       opentelemetry-registry (~> 0.2)
@@ -761,7 +767,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.2.11)
+  metadata_presenter!
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/spec/generators/new_component_generator_spec.rb
+++ b/spec/generators/new_component_generator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe NewComponentGenerator do
       components:
     )
   end
-  input_components = %w[text textarea email number radios checkboxes upload autocomplete]
+  input_components = %w[text textarea email number radios checkboxes date upload autocomplete]
   non_input_components = %w[content]
 
   before do

--- a/spec/generators/new_service_generator_spec.rb
+++ b/spec/generators/new_service_generator_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe NewServiceGenerator do
   describe '#to_metadata' do
+    let(:valid) { true }
+
     context 'valid service metadata' do
-      let(:valid) { true }
       let(:service_name) { 'Razorback' }
       let(:current_user) { double(id: '1234') }
       let(:service_metadata) do
@@ -88,6 +89,61 @@ RSpec.describe NewServiceGenerator do
           expect(
             MetadataPresenter::ValidateSchema.validate(page, page['_type'])
           ).to be(valid)
+        end
+      end
+    end
+
+    context 'validation of page types in the flow' do
+      context 'when an invalid page type is used' do
+        let(:test_metadata) do
+          service_metadata.dup.merge(
+            'pages' => [
+              {
+                '_type' => 'page.foobar',
+                '_id' => 'page.foobar',
+                '_uuid' => SecureRandom.uuid,
+                'url' => '/something'
+              }
+            ]
+          )
+        end
+
+        it 'raises a schema validation error' do
+          expect {
+            MetadataPresenter::ValidateSchema.validate(test_metadata, 'service.base')
+          }.to raise_error(JSON::Schema::ValidationError)
+        end
+      end
+
+      %w[
+        start exit checkanswers confirmation content singlequestion multiplequestions
+      ].each do |page_type|
+        context "when a page of type 'page.#{page_type}' is used" do
+          let(:test_metadata) do
+            service_metadata.dup.merge(
+              'pages' => [
+                {
+                  '_type' => "page.#{page_type}",
+                  '_id' => "page.#{page_type}_foobar",
+                  '_uuid' => SecureRandom.uuid,
+                  'url' => '/something',
+                  # NOTE: some pages does not require some or all of the following
+                  # but for the sake of this test, we add them. This test is really about
+                  # validating the types of pages allowed in the `pages` metadata attribute.
+                  'heading' => 'Hello world',
+                  'send_heading' => 'anything',
+                  'send_body' => 'anything',
+                  'components' => []
+                }
+              ]
+            )
+          end
+
+          it 'validates the service.base' do
+            expect(
+              MetadataPresenter::ValidateSchema.validate(test_metadata, 'service.base')
+            ).to be(valid)
+          end
         end
       end
     end


### PR DESCRIPTION
New version of the `metadata_presenter` gem has an updated `json-schema` gem and some minor fixes.

Add `date` component to the test suite. Wasn't there before.

Add some test coverage for the different allowed page types in the "pages" object of the metadata.