### PR TITLE
Testable form stats in admin

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -28,10 +28,20 @@ module Admin
                     .select(&:published?)
     end
 
+    def ever_published(environment)
+      PublishService.where(deployment_environment: environment)
+                    .group_by(&:service_id)
+                    .map(&:last)
+                    .map { |p| p.select(&:published?) }
+                    .map(&:last)
+                    .compact
+    end
+
     # Override this value to specify the number of elements to display at a time
     # on index pages. Defaults to 20.
     # def records_per_page
     #   params[:per_page] || 20
     # end
+    #
   end
 end

--- a/app/controllers/admin/overviews_controller.rb
+++ b/app/controllers/admin/overviews_controller.rb
@@ -13,14 +13,6 @@ module Admin
           value: active_sessions
         },
         {
-          name: 'Pending jobs',
-          value: Delayed::Job.where('attempts = 0').count
-        },
-        {
-          name: 'Failed jobs',
-          value: Delayed::Job.where('attempts > 0').count
-        },
-        {
           name: 'Published to Live',
           value: published('production').count
         },

--- a/app/views/admin/overviews/index.html.erb
+++ b/app/views/admin/overviews/index.html.erb
@@ -47,7 +47,7 @@ It renders the `_table` partial to display details about the resources.
     <% end %>
   </dl>
 
-  <a href="<%= admin_export_services_path %>" data-disable-with="Exporting..." class="govuk-button fb-govuk-button">
+  <a href="<%= admin_export_services_path(format: :csv) %>" data-disable-with="Exporting..." class="govuk-button fb-govuk-button">
     Export Services
   </a>
 </section>


### PR DESCRIPTION
Update the stats in the overview section of the admin area to no include forms created by the team, and to split out forms currently published, and a total count of all forms published.

Also fixed the CSV download while I was there