### PR TITLE
Ensure content areas get focused when added to multiquestion pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby '3.1.3'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'bump-json-schema'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.0'
+gem 'metadata_presenter', '3.3.1'
 
 gem 'activerecord-session_store'
 gem 'administrate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.3.0)
+    metadata_presenter (3.3.1)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (~> 4.1.1)
@@ -761,7 +761,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.3.0)
+  metadata_presenter (= 3.3.1)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -264,6 +264,7 @@ module CommonSteps
   end
 
   def when_I_want_to_edit_content_component_properties(component)
+    editor.service_name.click #in case component is already focused
     element_output(component).click
     component.find('.ActivatedMenuActivator', visible: true).click
   end
@@ -321,6 +322,8 @@ module CommonSteps
   end
 
   def when_I_change_editable_content(element, content:)
+    editor.service_name.click #in case component is already focused
+
     # activate the input element for the content component by clicking on the
     # output element tag first
     element_output(element).click
@@ -351,7 +354,7 @@ module CommonSteps
     else
       and_I_add_a_multiple_page_content_component
     end
-      
+
     component = editor.editable_content_areas.last
     and_the_content_component_has_the_optional_content(component)
     when_I_change_editable_content(component, content: content)

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -13,10 +13,10 @@
  **/
 
 
-const  {
+const {
   updateHiddenInputOnForm,
   stringInject,
-}  = require('./utilities');
+} = require('./utilities');
 
 const {
   htmlAdjustment,
@@ -51,7 +51,7 @@ class PagesController extends DefaultController {
   constructor(app) {
     super(app);
 
-    switch(app.page.action) {
+    switch (app.page.action) {
       case "edit":
         PagesController.edit.call(this);
         break;
@@ -86,27 +86,27 @@ PagesController.edit = function() {
   enhanceQuestions(view);
 
   // Handle page-specific view customisations here.
-  switch(view.type) {
+  switch (view.type) {
     case "page.multiplequestions":
-         editPageMultipleQuestionsViewCustomisations.call(view);
-         break;
+      editPageMultipleQuestionsViewCustomisations.call(view);
+      break;
 
     case "page.singlequestion":
-         editPageSingleQuestionViewCustomisations.call(view);
-         break;
+      editPageSingleQuestionViewCustomisations.call(view);
+      break;
 
     case "page.content":
-         editPageContentViewCustomisations.call(view);
-         break;
+      editPageContentViewCustomisations.call(view);
+      break;
 
     case "page.confirmation":
-         // No customisations required for this view.
-         editPageConfirmationViewCustomisations(view);
-         break;
+      // No customisations required for this view.
+      editPageConfirmationViewCustomisations(view);
+      break;
 
     case "page.checkanswers":
-         editPageCheckAnswersViewCustomisations.call(view);
-         break;
+      editPageCheckAnswersViewCustomisations.call(view);
+      break;
   }
 
   // Enhance any Add Content buttons
@@ -116,7 +116,7 @@ PagesController.edit = function() {
   });
 
   // Enhance any Add Component buttons.
-  view.$document.on("AddComponentMenuSelection", AddComponent.MenuSelection.bind(view) );
+  view.$document.on("AddComponentMenuSelection", AddComponent.MenuSelection.bind(view));
   $("[data-component=add-component]").each(function() {
     var $node = $(this);
     new AddComponent($node, { form: view.saveButton.$form });
@@ -133,9 +133,9 @@ PagesController.edit = function() {
   addContentMenuListeners(view);
   addEditableComponentItemMenuListeners(view);
 
-  this.$document.on("SaveRequired", () => this.saveButton.saveRequired = true );
-  this.$document.on("MaxFilesSave", () => this.saveButton.save() );
-  this.saveButton.$form.on("submit", () => this.updateComponents() );
+  this.$document.on("SaveRequired", () => this.saveButton.saveRequired = true);
+  this.$document.on("MaxFilesSave", () => this.saveButton.save());
+  this.saveButton.$form.on("submit", () => this.updateComponents());
 
   // Bit hacky: Cookies page is going through this controller but content is static.
   // The static content is wrapped in [fb-content-type=static] to help identify it.
@@ -187,7 +187,7 @@ class AddComponent {
  **/
 AddComponent.MenuSelection = function(event, data) {
   var action = data.activator.data("action");
-  if( action != "none" ) {
+  if (action != "none") {
     updateHiddenInputOnForm(this.saveButton.$form, "page[add_component]", action);
     this.saveButton.save();
   }
@@ -236,14 +236,14 @@ function addQuestionMenuListeners(view) {
         // Find and correct (make work!) any method:delete links
         dialog.$node.find("[data-method=delete]").on("click", function(e) {
           e.preventDefault();
-      // Workaround solution that doesn't require extra backend work
-      // 1. First remove component from view
+          // Workaround solution that doesn't require extra backend work
+          // 1. First remove component from view
           question.$node.hide();
-      // 2. Update form (in case anything else has changed)
+          // 2. Update form (in case anything else has changed)
           view.updateComponents();
-      // 3. Remove corresponding component from form
+          // 3. Remove corresponding component from form
           question.remove();
-      // 4. Trigger save required (to enable Save button)
+          // 4. Trigger save required (to enable Save button)
           view.saveButton.saveRequired = true;
         });
       }
@@ -258,12 +258,12 @@ function addQuestionMenuListeners(view) {
     html = html.replace(regex, "$1 checked=\"true\"");
     view.dialogConfiguration.onConfirm = (dialog) => { question.required = dialog.content.content };
     view.dialogConfiguration.open({
-        content: html
-      });
+      content: html
+    });
   });
 
   view.$document.on("QuestionMenuSelectionValidation", function(event, details) {
-    const {question, validation} = details;
+    const { question, validation } = details;
     var apiUrl = question.menu.selectedItem.data('apiPath');
 
     new DialogForm(apiUrl, {
@@ -271,12 +271,12 @@ function addQuestionMenuListeners(view) {
       remote: true,
       autoOpen: true,
       /*
-       * Function runs after the modal content has been returned by the api
-       * as it is possible to open and edit the validations multiple times
-       * before saving.  We need to load the current validation state from the
-       * question data and apply it to the form.  As the values from the api
-       * could be out of date
-       */
+                   * Function runs after the modal content has been returned by the api
+                   * as it is possible to open and edit the validations multiple times
+                   * before saving.  We need to load the current validation state from the
+                   * question data and apply it to the form.  As the values from the api
+                   * could be out of date
+                   */
       onLoad: function(dialog) {
         // Find fields that may be in the dialog
         var $statusField = dialog.$node.find('input[name="component_validation[status]"]');
@@ -287,12 +287,12 @@ function addQuestionMenuListeners(view) {
         var $charsRadio = dialog.$node.find('input[id="component_validation_characters"]');
         var $wordsRadio = dialog.$node.find('input[id="component_validation_words"]');
 
-        switch(validation) {
+        switch (validation) {
           case 'date_before':
           case 'date_after':
             // Destructure date value and use to populate or clear date fields in modal
             var currentValue = question.data.validation[validation];
-            if(currentValue) {
+            if (currentValue) {
               let [currentYear, currentMonth, currentDay] = currentValue.split('-');
               $dayField.val(currentDay);
               $monthField.val(currentMonth);
@@ -306,20 +306,20 @@ function addQuestionMenuListeners(view) {
           case 'min_string_length':
             // Check the appropriate radio in the modal based on the validation type
             var currentValue = question.data.validation['min_length'] || question.data.validation['min_word'];
-            if( question.data.validation.hasOwnProperty('min_length')) {
+            if (question.data.validation.hasOwnProperty('min_length')) {
               $charsRadio.prop('checked', true);
             }
-            if( question.data.validation.hasOwnProperty('min_word')) {
+            if (question.data.validation.hasOwnProperty('min_word')) {
               $wordsRadio.prop('checked', true);
             }
             break;
           case 'max_string_length':
             // Check the appropriate radio in the modal based on the validation type
             var currentValue = question.data.validation['max_length'] || question.data.validation['max_word'];
-            if( question.data.validation.hasOwnProperty('max_length')) {
+            if (question.data.validation.hasOwnProperty('max_length')) {
               $charsRadio.prop('checked', true);
             }
-            if( question.data.validation.hasOwnProperty('max_word')) {
+            if (question.data.validation.hasOwnProperty('max_word')) {
               $wordsRadio.prop('checked', true);
             }
             break;
@@ -329,12 +329,12 @@ function addQuestionMenuListeners(view) {
         }
 
         // If its a standard validationl just set the value filed to the current value
-        if($valueField) {
-          $valueField.val( currentValue ?? '');
+        if ($valueField) {
+          $valueField.val(currentValue ?? '');
         }
 
         // Presence of current value indicates whether the validation is enabled/disabled
-        if(currentValue) {
+        if (currentValue) {
           $statusField.prop('checked', true);
         } else {
           $statusField.prop('checked', false);
@@ -355,8 +355,8 @@ function addQuestionMenuListeners(view) {
         var $statusInput = dialog.$node.find('input[name="component_validation[status]"]');
         var $resettableInputs = dialog.$node.find('.Expander input').not('input[name*="string_length"]');
         $statusInput.on('change', () => {
-          if(!$statusInput.prop('checked')) {
-            $resettableInputs.each( function() {
+          if (!$statusInput.prop('checked')) {
+            $resettableInputs.each(function() {
               $(this).value = '';
             })
           }
@@ -386,7 +386,7 @@ function addQuestionMenuListeners(view) {
       disableOnSubmit: view.text.dialogs.autocomplete.button_disabled,
       onSuccess: function() {
         var $success = question.$node.find('[data-fb-status="autocomplete-success"]');
-        var $warning =  question.$node.find('[data-fb-status="autocomplete-warning"]');
+        var $warning = question.$node.find('[data-fb-status="autocomplete-warning"]');
         var $successMessage = question.$node.find('[data-fb-template="autocomplete-success-message"]').first().html();
         $success.html($successMessage);
         $warning.remove();
@@ -418,19 +418,19 @@ function addEditableComponentItemMenuListeners(view) {
     var dialog = view.dialog;
     var path = selectedItem.data('api-path');
 
-    var questionUuid =  collectionItem.component.data._uuid;
-    var optionUuid =  collectionItem.data._uuid;
+    var questionUuid = collectionItem.component.data._uuid;
+    var optionUuid = collectionItem.data._uuid;
 
     var url = stringInject(path, {
       'question_uuid': questionUuid,
       'option_uuid': optionUuid ?? 'new',
     });
 
-    if( !optionUuid ) {
-      url = url + '&label=' + encodeURIComponent( collectionItem.$node.find('label').text() );
+    if (!optionUuid) {
+      url = url + '&label=' + encodeURIComponent(collectionItem.$node.find('label').text());
     }
 
-    if( collectionItem.component.canHaveItemsRemoved() ) {
+    if (collectionItem.component.canHaveItemsRemoved()) {
       new DialogApiRequest(url, {
         activator: selectedItem,
         closeOnClickSelector: ".govuk-button",
@@ -482,39 +482,39 @@ function addContentMenuListeners(view) {
   });
 
   view.$document.on("ContentMenuSelectionConditionalContent", function(event, details) {
-    const {component, selectedItem } = details;
+    const { component, selectedItem } = details;
     openConditionalContentDialog(component, selectedItem, view)
   });
 }
 
 function openConditionalContentDialog(component, activator, view) {
-    const url = component.dataset.conditionalApiPath;
-    const data = {
-      component: JSON.stringify( component.config || {} )
-    }
-    if(url) {
-      new DialogForm(url, {
-        activator: activator,
-        remote: true,
-        requestMethod: 'POST',
-        requestData: data,
-        autoOpen: true,
-        closeOnClickSelector: 'button[type="button"]:not(.prevent-modal-close)',
-        onReady: (dialog) => {
-        },
-        onSuccess: (data, dialog) => {
-          component.config = Object.assign(component.config, data)
-          view.saveButton.saveRequired = true; // 4. Trigger save required (to enable Save button)
-        },
-        onError: (data, dialog) => {
-          var responseHtml = $.parseHTML(data.responseText);
-          var $newHtml = $(responseHtml[0]).html();
-          dialog.$node.html($newHtml);
-          dialog.refresh();
-        }
+  const url = component.dataset.conditionalApiPath;
+  const data = {
+    component: JSON.stringify(component.config || {})
+  }
+  if (url) {
+    new DialogForm(url, {
+      activator: activator,
+      remote: true,
+      requestMethod: 'POST',
+      requestData: data,
+      autoOpen: true,
+      closeOnClickSelector: 'button[type="button"]:not(.prevent-modal-close)',
+      onReady: (dialog) => {
+      },
+      onSuccess: (data, dialog) => {
+        component.config = Object.assign(component.config, data)
+        view.saveButton.saveRequired = true; // 4. Trigger save required (to enable Save button)
+      },
+      onError: (data, dialog) => {
+        var responseHtml = $.parseHTML(data.responseText);
+        var $newHtml = $(responseHtml[0]).html();
+        dialog.$node.html($newHtml);
+        dialog.refresh();
+      }
 
-      });
-    }
+    });
+  }
 }
 
 
@@ -522,24 +522,31 @@ function openConditionalContentDialog(component, activator, view) {
  * added, the first element with that new component.
  **/
 function focusOnEditableComponent() {
-  var target = location.hash;
-  if(target)
-  if(target.match(/^[#\w\d_]+$/)) {
-    // Newly added component with fragment identifier so find first
-    // first editable item of last component.
-    let $newComponent = $(target);
-    if($newComponent.length) {
-      $newComponent.data("instance").focus();
-    }
-  }
-  else {
-    const pageTitle = $('h1.EditableElement').get(0)
-    if(pageTitle) {
-      pageTitle.focus();
+  const target = location.hash
+  setTimeout(() => {
+    if (target && target.match(/^[#\w\d_]+$/)) {
+      console.log(target)
+      // Newly added component with fragment identifier so find first
+      // first editable item of last component.
+      let $newComponent = $(target);
+      if ($newComponent.length) {
+        console.log($newComponent)
+        if ($newComponent.prop('tagName').toLowerCase() == 'editable-content') {
+          console.log('you added editable content');
+          $newComponent.get(0).root.focus();
+        } else {
+          $newComponent.data("instance").focus();
+        }
+      }
     } else {
-      $(".fb-editable").eq(0).focus();
+      const pageTitle = $('h1.EditableElement').get(0)
+      if (pageTitle) {
+        pageTitle.focus();
+      } else {
+        $(".fb-editable").eq(0).focus();
+      }
     }
-  }
+  })
 }
 
 
@@ -567,18 +574,18 @@ function enhanceContent(view) {
   const form = document.querySelector('#editContentForm');
   document.querySelectorAll('editable-content').forEach((element) => {
     element.form = form
-    if(element.isComponent) {
+    if (element.isComponent) {
       createContentMenu(element)
-        createConditionalContentButton(view, {
-          component: element,
-          label: view.text.content_visibility.label_show_if,
-          className: 'show-if-button'
-        })
-        createConditionalContentButton(view, {
-          component: element,
-          label: view.text.content_visibility.label_hidden,
-          className: 'hidden-button'
-        })
+      createConditionalContentButton(view, {
+        component: element,
+        label: view.text.content_visibility.label_show_if,
+        className: 'show-if-button'
+      })
+      createConditionalContentButton(view, {
+        component: element,
+        label: view.text.content_visibility.label_hidden,
+        className: 'hidden-button'
+      })
     }
   });
 }
@@ -601,7 +608,7 @@ function createContentMenu(component) {
   });
 }
 
-function createConditionalContentButton(view, config ) {
+function createConditionalContentButton(view, config) {
   const { component, className, label } = config
 
   const button = document.createElement('button')
@@ -681,8 +688,8 @@ function enhanceQuestions(view) {
         // with onItemAdd (provides an opportunity for clean up).
         view.dialogConfirmationDelete.onConfirm = () => { item.component.removeItem(item) };
         view.dialogConfirmationDelete.open({
-            heading: view.text.dialogs.heading_delete_option.replace(/%{option label}/, item._elements.label.$node.text()),
-            confirm: view.text.dialogs.button_delete_option
+          heading: view.text.dialogs.heading_delete_option.replace(/%{option label}/, item._elements.label.$node.text()),
+          confirm: view.text.dialogs.button_delete_option
         });
       }
     });
@@ -711,8 +718,8 @@ function enhanceQuestions(view) {
         // with onItemAdd (provides an opportunity for clean up).
         view.dialogconfirmationDelete.onConfirm = () => { item.component.removeItem(item) };
         view.dialogConfirmationDelete.open({
-            heading: view.text.dialogs.heading_delete_option.replace(/%{option label}/, item._elements.label.$node.text()),
-            confirm: view.text.dialogs.button_delete_option
+          heading: view.text.dialogs.heading_delete_option.replace(/%{option label}/, item._elements.label.$node.text()),
+          confirm: view.text.dialogs.button_delete_option
         });
       }
 
@@ -781,7 +788,7 @@ function editPageCheckAnswersViewCustomisations() {
 function editPageConfirmationViewCustomisations() {
   var $payButton = $('[data-component="pay-button"]');
   var $addContentButton = $('[data-component="add-content"]');
-  if($payButton && $addContentButton) {
+  if ($payButton && $addContentButton) {
     $addContentButton.after($payButton);
     $payButton.attr('disabled', 'disabled');
     $payButton.attr('tabindex', '-1');
@@ -824,7 +831,7 @@ function accessibilityQuestionViewEnhancements(view) {
  **/
 function supportGovUkStaticContent() {
   var content = document.querySelectorAll("[data-fb-content-type=static]");
-  for( var c=0; c<content.length; ++c) {
+  for (var c = 0; c < content.length; ++c) {
     content[c].innerHTML = htmlAdjustment(content[c].innerHTML);
   }
 }

--- a/app/javascript/src/web-components/editable-content.js
+++ b/app/javascript/src/web-components/editable-content.js
@@ -4,12 +4,12 @@ const GovukHTMLRenderer = require('govuk-markdown')
 const DOMPurify = require('dompurify')
 
 class EditableContent extends HTMLElement {
-  static get observedAttributes() { 
+  static get observedAttributes() {
     return ['data-config']
   }
 
   constructor() {
-    super() 
+    super()
 
     const self = this
 
@@ -58,8 +58,8 @@ class EditableContent extends HTMLElement {
       govspeakGemCompatibility: true
     })
 
-    marked.use({ 
-      extensions: govspeak.filter((component) => allowedGovspeakComponents.includes(component.name) ),
+    marked.use({
+      extensions: govspeak.filter((component) => allowedGovspeakComponents.includes(component.name)),
       hooks: { preprocess }
     })
   }
@@ -77,9 +77,9 @@ class EditableContent extends HTMLElement {
   }
 
   attributeChangedCallback(name, oldValue, newValue) {
-    switch(name) {
+    switch (name) {
       case 'data-config':
-        if(newValue != oldValue) {
+        if (newValue != oldValue) {
           this.processConfigChange(newValue);
         }
         break
@@ -90,7 +90,7 @@ class EditableContent extends HTMLElement {
   // If content area is part of page components we need to return compontn json
   // as a string otherwise we return the content string
   get content() {
-    if(this.isComponent) {
+    if (this.isComponent) {
       // Need to reassign config completely to trigger the 'setter' and the observed attributes
       this.config = Object.assign(this.config, { content: this.value })
       return JSON.stringify(this.config);
@@ -105,7 +105,7 @@ class EditableContent extends HTMLElement {
     return this.sanitize(unsafeHTML)
   }
 
-  // Is the content area part of the page components 
+  // Is the content area part of the page components
   get isComponent() {
     return !!this.config;
   }
@@ -115,8 +115,12 @@ class EditableContent extends HTMLElement {
   }
 
   get uuid() {
-    if(!this.isComponent) return
+    if (!this.isComponent) return
     return this.config._uuid
+  }
+
+  get componentId() {
+    return this.dataset.fbContentId
   }
 
   get config() {
@@ -124,13 +128,13 @@ class EditableContent extends HTMLElement {
 
     return JSON.parse(this.dataset.config)
   }
-  
+
   // returns the markdown content of the input after filtering it through any
   // configured filters
   get value() {
     let val = this.input.value
 
-    for( const [key, filterFunction] of Object.entries(this.markdownFilters)) {
+    for (const [key, filterFunction] of Object.entries(this.markdownFilters)) {
       val = filterFunction(val)
     }
 
@@ -154,13 +158,13 @@ class EditableContent extends HTMLElement {
     const initialContent = this.initialContent || this.defaultContent;
     const initialMarkup = (this.initialMarkup.trim() != '' ? this.sanitize(this.initialMarkup) : this.defaultContent);
     this.innerHTML = `
-    <div class="editable-content" data-element="editable-content-root">
-      <elastic-textarea>
-        <textarea class="" data-element="editable-content-input" rows="8" hidden>${initialContent}</textarea>
-      </elastic-textarea>
-      <div data-element="editable-content-output">${initialMarkup}</div>
-    </div>`
-    
+<div class="editable-content" data-element="editable-content-root">
+  <elastic-textarea>
+    <textarea class="" data-element="editable-content-input" rows="8" hidden>${initialContent}</textarea>
+  </elastic-textarea>
+  <div data-element="editable-content-output">${initialMarkup}</div>
+</div>`
+
     this.afterRender()
   }
 
@@ -169,22 +173,22 @@ class EditableContent extends HTMLElement {
     this.input = this.querySelector('[data-element="editable-content-input"]')
     this.output = this.querySelector('[data-element="editable-content-output"]')
 
-    if(this.input && this.output) {
+    if (this.input && this.output) {
       this.root.setAttribute('tabindex', '0');
       this.root.setAttribute('mode', this.state.mode)
 
       this.input.dataset.minRows = this.input.rows || 5;
 
-      this.root.addEventListener('click', () => this.state.mode = 'edit' )
-      this.root.addEventListener('focus', () => this.state.mode = 'edit' )
+      this.root.addEventListener('click', () => this.state.mode = 'edit')
+      this.root.addEventListener('focus', () => this.state.mode = 'edit')
       this.addEventListener('focusout', (event) => {
-        if(this.contains(event.relatedTarget)) return
+        if (this.contains(event.relatedTarget)) return
         this.state.mode = 'read'
       })
 
       return
     }
-    
+
     // If we don't have input and output elements, bail and just restore the
     // initial markup
     this.innerHTML = this.initialMarkup;
@@ -193,7 +197,7 @@ class EditableContent extends HTMLElement {
   processStateChange() {
     this.root.setAttribute('mode', this.state.mode)
 
-    switch(this.state.mode) {
+    switch (this.state.mode) {
       case 'edit':
         this._contentBeforeEditing = this.input.value.trim();
         this.show(this.input)
@@ -201,37 +205,37 @@ class EditableContent extends HTMLElement {
         this.classList.add('active')
         this.input.focus({ preventScroll: true });
 
-        if(this.valueIsDefault()) this.value = '';
-        // Move cursor to end of content 
+        if (this.valueIsDefault()) this.value = '';
+        // Move cursor to end of content
         this.input.selectionStart = this.value.length;
         break;
       case 'read':
       case 'initial':
-        if(this.valueIsDefault()) this.value = '';
+        if (this.valueIsDefault()) this.value = '';
         this.updateOutput();
-        
+
         this.hide(this.input);
         this.show(this.output);
         this.classList.remove('active')
 
-        if(this.valueHasChanged()) {
+        if (this.valueHasChanged()) {
           this.save();
-          document.dispatchEvent( 
-            new CustomEvent( 
-              'SaveRequired', 
-              { 
-                bubbles: true, 
+          document.dispatchEvent(
+            new CustomEvent(
+              'SaveRequired',
+              {
+                bubbles: true,
               }
             )
           );
-        } 
+        }
         break;
     }
   }
 
   processConfigChange(value) {
     config = JSON.parse(value)
-    if(config.display && config.display !== 'always') {
+    if (config.display && config.display !== 'always') {
       this.setAttribute('conditional', config.display)
     } else {
       this.removeAttribute('conditional')
@@ -246,8 +250,8 @@ class EditableContent extends HTMLElement {
     element.removeAttribute('hidden');
   }
 
-  updateOutput(){
-    this.output.innerHTML = this.html   
+  updateOutput() {
+    this.output.innerHTML = this.html
   }
 
   valueIsDefault() {
@@ -255,40 +259,40 @@ class EditableContent extends HTMLElement {
   }
 
   valueHasChanged() {
-    return this.value.trim() !== this._contentBeforeEditing 
+    return this.value.trim() !== this._contentBeforeEditing
   }
 
   save() {
-    if(!this.submissionForm) return
-    const hiddenInput = this.submissionForm.querySelector(`input[name="${this.id}"]`);
-    if(hiddenInput) {
+    if (!this.submissionForm) return
+    const hiddenInput = this.submissionForm.querySelector(`input[name="${this.componentId}"]`);
+    if (hiddenInput) {
       hiddenInput.value = this.content;
     } else {
       const button = this.submissionForm.querySelector('button[type="submit"], input[type="submit"]');
-      const newInputHTML = `<input type="hidden" name="${this.id}" value="${this.content}" />`
+      const newInputHTML = `<input type="hidden" name="${this.componentId}" value="${this.content}" />`
       button.insertAdjacentHTML('beforebegin', newInputHTML);
     }
   }
 
   destroy() {
-    if(!this.submissionForm) return
+    if (!this.submissionForm) return
     const hiddenInput = this.submissionForm.querySelector(`input[name="${this.id}"]`);
     const button = this.submissionForm.querySelector('button[type="submit"], input[type="submit"]');
 
-    if(hiddenInput) {
+    if (hiddenInput) {
       hiddenInput.remove()
     }
-    
+
     const deleteInputHTML = `<input type="hidden" name="delete_components[]" value="${this.config._uuid}" />`
     button.insertAdjacentHTML('beforebegin', deleteInputHTML);
     this.remove()
   }
 
   // Run the markdown through all configured filter functions
-  // called by marked in the preprocess hook 
+  // called by marked in the preprocess hook
   // called in the value() getter
   filterMarkdown(markdown) {
-    for( const [key, filterFunction] of Object.entries(this.markdownFilters)) {
+    for (const [key, filterFunction] of Object.entries(this.markdownFilters)) {
       markdown = filterFunction(markdown)
     }
     return markdown
@@ -296,9 +300,9 @@ class EditableContent extends HTMLElement {
 
   sanitize(unsafeHTML) {
     return DOMPurify.sanitize(unsafeHTML, {
-        USE_PROFILES: {html: true}, 
-        FORBID_TAGS: ['style', 'button']
-    })  
+      USE_PROFILES: { html: true },
+      FORBID_TAGS: ['style', 'button']
+    })
   }
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -438,6 +438,10 @@ a[disabled] {
 
 /* Editable components
  * ------------------- */
+[data-component=add-component] ul {
+    display: none;
+}
+
 .AddComponent,
 .AddContent {
   margin: govuk-spacing(9) 0;
@@ -492,21 +496,21 @@ editable-content {
         outline: 1px dashed $govuk-link-colour;
         outline-offset: 16px;
     }
- 
+
   &[conditional="conditional"] .show-if-button {
       display: inline-block;
       position: absolute;
       top: -10px;
       right: -6px;
   }
-  
+
   &[conditional="never"] .hidden-button {
       display: inline-block;
       position: absolute;
       top: -10px;
       right: -6px;
   }
-  
+
 }
 
 .EditableCollectionFieldComponent,

--- a/test/web-components/editable-content/helpers.js
+++ b/test/web-components/editable-content/helpers.js
@@ -5,15 +5,15 @@ async function createComponent(element, html) {
   await new Promise(resolve => setTimeout(resolve, 0));
 }
 
-function createTemplate(id, defaultContent='', markdown='', html='', config='') {
+function createTemplate(id, defaultContent = '', markdown = '', html = '', config = '') {
   //N.B. the lack of quotes around the data-config attribute is deliberate.  It
   //is valid HTML and adding them in breaks the tests, Works fine IRL with or
-  //without them. 
+  //without them.
   return `
   <form id="${id}-form">
     <button type=submit>Save</button>
   </form>
-  <editable-content id="${id}" default-content="${defaultContent}" content="${markdown}" data-config=${config}>
+  <editable-content id="${id}" default-content="${defaultContent}" content="${markdown}" data-fb-content-id="${id}" data-config=${config} >
     ${html}
   </editable-content>`
 }


### PR DESCRIPTION
Fixes a bug where new comntent areas wouldn't receive focus after being added to a multiquestion page.

On long pages this was annoying, and some users struggled identifying that content areas had been added / how to edit them.