### PR TITLE
Always reference the same deployment env version of the SERVICE_SLUG 

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -248,7 +248,8 @@ module Admin
     def service_slug_config(service_id)
       ServiceConfiguration.find_by(
         service_id:,
-        name: 'SERVICE_SLUG'
+        name: 'SERVICE_SLUG',
+        deployment_environment: 'dev'
       )&.decrypt_value
     end
 

--- a/app/controllers/admin/uptime_checks_controller.rb
+++ b/app/controllers/admin/uptime_checks_controller.rb
@@ -90,7 +90,7 @@ module Admin
     def service_slug_config(service_id)
       ServiceConfiguration.find_by(
         service_id:,
-        deployment_environment: 'production',
+        deployment_environment: 'dev',
         name: 'SERVICE_SLUG'
       )&.decrypt_value
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -152,7 +152,8 @@ class ApplicationController < ActionController::Base
   def service_slug_config
     ServiceConfiguration.find_by(
       service_id: service.service_id,
-      name: 'SERVICE_SLUG'
+      name: 'SERVICE_SLUG',
+      deployment_environment: 'dev'
     )&.decrypt_value
   end
 

--- a/app/models/form_url_updater.rb
+++ b/app/models/form_url_updater.rb
@@ -63,14 +63,16 @@ class FormUrlUpdater
   def existing_service_slug_config
     ServiceConfiguration.find_by(
       service_id:,
-      name: 'SERVICE_SLUG'
+      name: 'SERVICE_SLUG',
+      deployment_environment: 'dev'
     )&.decrypt_value
   end
 
   def previous_service_slug
     ServiceConfiguration.find_by(
       service_id:,
-      name: 'PREVIOUS_SERVICE_SLUG'
+      name: 'PREVIOUS_SERVICE_SLUG',
+      deployment_environment: 'dev'
     )
   end
 

--- a/app/presenters/publish_service_presenter.rb
+++ b/app/presenters/publish_service_presenter.rb
@@ -40,7 +40,8 @@ class PublishServicePresenter
   def service_slug_config
     ServiceConfiguration.find_by(
       service_id: service.service_id,
-      name: 'SERVICE_SLUG'
+      name: 'SERVICE_SLUG',
+      deployment_environment: 'dev'
     )&.decrypt_value
   end
 

--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -201,7 +201,8 @@ class Publisher
     def service_slug_config
       ServiceConfiguration.find_by(
         service_id:,
-        name: 'SERVICE_SLUG'
+        name: 'SERVICE_SLUG',
+        deployment_environment: 'dev'
       )&.decrypt_value
     end
   end

--- a/app/services/unpublish_dev_services.rb
+++ b/app/services/unpublish_dev_services.rb
@@ -33,7 +33,8 @@ class UnpublishDevServices
   def service_slug_config(service_id)
     ServiceConfiguration.find_by(
       service_id:,
-      name: 'SERVICE_SLUG'
+      name: 'SERVICE_SLUG',
+      deployment_environment: 'dev'
     )&.decrypt_value
   end
 

--- a/app/services/unpublish_test_services.rb
+++ b/app/services/unpublish_test_services.rb
@@ -41,7 +41,8 @@ class UnpublishTestServices
   def service_slug_config(service_id)
     ServiceConfiguration.find_by(
       service_id:,
-      name: 'SERVICE_SLUG'
+      name: 'SERVICE_SLUG',
+      deployment_environment: 'dev'
     )&.decrypt_value
   end
 

--- a/app/validators/service_slug_validator.rb
+++ b/app/validators/service_slug_validator.rb
@@ -73,7 +73,8 @@ class ServiceSlugValidator < ActiveModel::EachValidator
   def current_service_slug_config(service_id:)
     ServiceConfiguration.find_by(
       service_id:,
-      name: 'SERVICE_SLUG'
+      name: 'SERVICE_SLUG',
+      deployment_environment: 'dev'
     )&.decrypt_value
   end
 end


### PR DESCRIPTION
When we create or update in the settings we always do both dev and production
<img width="1123" alt="image" src="https://github.com/ministryofjustice/fb-editor/assets/7647632/4463a632-00b1-4672-a4ca-7f6aeeb67198">

But we don't consistently reference a specific one when we reference this config, which leads to a rare edge case when you've changed the slug value and republished but then attempt to create a pingdom alert.