### PR TITLE
Propagate request_id in MetadataApiClient

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
             echo "export BUILD_SHA=$CIRCLE_SHA1" >> $BASH_ENV
       - run: &deploy_scripts
           name: cloning deploy scripts
-          command: 'git clone --branch temporary-ecr-creds git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
+          command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
       - run:
           name: build testable editor web docker images
           environment:

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -12,8 +12,10 @@ module Admin
   end
 
   class ApplicationController < Administrate::ApplicationController
+    include SetCurrentRequestDetails
     include ApplicationHelper
     include Auth0Helper
+
     before_action :require_user!
     before_action :authenticate_admin
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include SetCurrentRequestDetails
   include Auth0Helper
 
   def service

--- a/app/controllers/concerns/set_current_request_details.rb
+++ b/app/controllers/concerns/set_current_request_details.rb
@@ -1,0 +1,9 @@
+module SetCurrentRequestDetails
+  extend ActiveSupport::Concern
+
+  included do
+    before_action do
+      Current.request_id = request.uuid
+    end
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,9 @@
+# `Current` class facilitates easy access to global, per-request attributes
+# without passing them deeply around everywhere.
+# `Current` should only be used for a few, top-level globals.
+#
+# https://edgeapi.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html
+#
+class Current < ActiveSupport::CurrentAttributes
+  attribute :request_id
+end

--- a/app/services/metadata_api_client/connection.rb
+++ b/app/services/metadata_api_client/connection.rb
@@ -1,24 +1,37 @@
 module MetadataApiClient
   class Connection
     SUBSCRIPTION = 'metadata_api.client'
-    OPEN_TIMEOUT = 60
-    TIMEOUT = 60
+    DEFAULT_OPEN_TIMEOUT = 10
+    DEFAULT_READ_TIMEOUT = 60
 
     attr_reader :connection
 
     delegate :get, :post, :put, :delete, to: :connection
 
     def initialize(root_url: ENV['METADATA_API_URL'])
-      @connection = Faraday.new(root_url) do |conn|
+      @connection = Faraday.new(root_url, headers:) do |conn|
         conn.request :json
         conn.response :json
         conn.response :raise_error
         conn.use :instrumentation, name: SUBSCRIPTION
-        conn.options[:open_timeout] = OPEN_TIMEOUT
-        conn.options[:timeout] = TIMEOUT
+
+        # Number of seconds to wait for the connection to open
+        conn.options.open_timeout = DEFAULT_OPEN_TIMEOUT
+
+        # Number of seconds to wait for one block to be read
+        conn.options.read_timeout = DEFAULT_READ_TIMEOUT
 
         conn.request :authorization, 'Bearer', service_access_token
       end
+    end
+
+    private
+
+    def headers
+      {
+        'User-Agent' => 'Editor',
+        'X-Request-Id' => Current.request_id
+      }.freeze
     end
 
     def service_access_token

--- a/app/validators/service_slug_validator.rb
+++ b/app/validators/service_slug_validator.rb
@@ -46,7 +46,7 @@ class ServiceSlugValidator < ActiveModel::EachValidator
       )
     end
 
-    unless value.match?(/^[a-zA-Z0-9- ]+$/)
+    unless value.match?(/^[a-zA-Z0-9\- ]+$/)
       record.errors.add attribute, (
         options[:message] ||
         I18n.t(

--- a/spec/requests/admin/admin_authorisation_spec.rb
+++ b/spec/requests/admin/admin_authorisation_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe 'Admin authorisation spec', type: :request do
     ).to receive(:current_user).and_return(current_user)
   end
 
+  it_behaves_like 'a controller that stores the current request details' do
+    let(:path) { admin_root_path }
+  end
+
   shared_examples 'an authorisation action' do
     context 'when admin user' do
       before do

--- a/spec/requests/authorisation_spec.rb
+++ b/spec/requests/authorisation_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe 'Authorisation spec', type: :request do
     allow(MetadataApiClient::Items).to receive(:all).and_return({})
   end
 
+  it_behaves_like 'a controller that stores the current request details' do
+    let(:path) { root_path }
+  end
+
   context 'all services page' do
     let(:request) { get '/services' }
 

--- a/spec/services/metadata_api_client/service_spec.rb
+++ b/spec/services/metadata_api_client/service_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe MetadataApiClient::Service do
       ]
     }
   end
+  let(:expected_headers) do
+    {
+      'User-Agent' => 'Editor',
+      'X-Request-Id' => '12345'
+    }
+  end
   let(:service_attributes) do
     {
       "service_name": 'basset',
@@ -17,6 +23,7 @@ RSpec.describe MetadataApiClient::Service do
   before do
     allow(ENV).to receive(:[])
     allow(ENV).to receive(:[]).with('METADATA_API_URL').and_return(metadata_api_url)
+    allow(Current).to receive(:request_id).and_return('12345')
   end
 
   describe '.all_services' do
@@ -38,6 +45,7 @@ RSpec.describe MetadataApiClient::Service do
 
     before do
       stub_request(:get, expected_url)
+        .with(headers: expected_headers)
         .to_return(status: 200, body: expected_body.to_json, headers: {})
     end
 
@@ -52,6 +60,7 @@ RSpec.describe MetadataApiClient::Service do
 
     before do
       stub_request(:get, expected_url)
+        .with(headers: expected_headers)
         .to_return(status: 200, body: expected_body.to_json, headers: {})
     end
 
@@ -72,6 +81,7 @@ RSpec.describe MetadataApiClient::Service do
     context 'when created' do
       before do
         stub_request(:post, expected_url)
+          .with(headers: expected_headers)
           .to_return(status: 201, body: expected_body.to_json, headers: {})
       end
 
@@ -93,6 +103,7 @@ RSpec.describe MetadataApiClient::Service do
 
       before do
         stub_request(:post, expected_url)
+          .with(headers: expected_headers)
           .to_return(status: 422, body: expected_body.to_json, headers: {})
       end
 
@@ -116,6 +127,7 @@ RSpec.describe MetadataApiClient::Service do
 
     before do
       stub_request(:get, expected_url)
+        .with(headers: expected_headers)
         .to_return(status: 200, body: expected_body.to_json, headers: {})
     end
 

--- a/spec/services/metadata_api_client/version_spec.rb
+++ b/spec/services/metadata_api_client/version_spec.rb
@@ -1,10 +1,18 @@
 RSpec.describe MetadataApiClient::Version do
   let(:metadata_api_url) { 'http://metadata-api' }
+  let(:service_id) { SecureRandom.uuid }
+  let(:expected_headers) do
+    {
+      'User-Agent' => 'Editor',
+      'X-Request-Id' => '12345'
+    }
+  end
+
   before do
     allow(ENV).to receive(:[])
     allow(ENV).to receive(:[]).with('METADATA_API_URL').and_return(metadata_api_url)
+    allow(Current).to receive(:request_id).and_return('12345')
   end
-  let(:service_id) { SecureRandom.uuid }
 
   describe '.create' do
     let(:expected_url) { "#{metadata_api_url}/services/#{service_id}/versions" }
@@ -16,6 +24,7 @@ RSpec.describe MetadataApiClient::Version do
 
       before do
         stub_request(:post, expected_url)
+          .with(headers: expected_headers)
           .to_return(status: 201, body: expected_body.to_json, headers: {})
       end
 
@@ -35,6 +44,7 @@ RSpec.describe MetadataApiClient::Version do
 
       before do
         stub_request(:post, expected_url)
+          .with(headers: expected_headers)
           .to_return(status: 422, body: expected_body.to_json, headers: {})
       end
 
@@ -76,6 +86,7 @@ RSpec.describe MetadataApiClient::Version do
 
     before do
       stub_request(:get, expected_url)
+        .with(headers: expected_headers)
         .to_return(status: 200, body: expected_body.to_json, headers: {})
     end
 
@@ -99,6 +110,7 @@ RSpec.describe MetadataApiClient::Version do
 
     before do
       stub_request(:get, expected_url)
+        .with(headers: expected_headers)
         .to_return(status: 200, body: version_attributes.to_json, headers: {})
     end
 
@@ -140,6 +152,7 @@ RSpec.describe MetadataApiClient::Version do
     context 'if the metadata api service is working fine' do
       before do
         stub_request(:get, expected_url)
+          .with(headers: expected_headers)
           .to_return(status: 200, body: version_attributes.to_json, headers: {})
       end
 
@@ -156,6 +169,7 @@ RSpec.describe MetadataApiClient::Version do
 
       before do
         stub_request(:get, expected_url)
+          .with(headers: expected_headers)
           .to_return(status: 400, body: expected_body.to_json, headers: {})
       end
 

--- a/spec/support/shared_examples/current_request_details_examples.rb
+++ b/spec/support/shared_examples/current_request_details_examples.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples 'a controller that stores the current request details' do
+  let(:headers) { { 'X-Request-Id' => request_id } }
+  let(:request_id) { '12345' }
+
+  it 'stores the current `request_id`' do
+    expect(Current).to receive(:request_id=).with(request_id)
+    get path, headers:
+  end
+end


### PR DESCRIPTION
Same work we've been doing in the rest of services.

Note however because the way this Faraday client is setup, and to limit the scope of changes, instead of passing around a `request_id` argument to many methods and classes, I'm using `ActiveSupport::CurrentAttributes` as a global object. I think in this case the pros outweighs the cons.