### PR TITLE
Configure this alert to no longer fire as it is not necessary

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,6 @@ module FbEditor
     config.autoload_paths << "#{root}/app/models/component_validations"
 
     config.active_model.i18n_customize_full_message = true
+    config.action_dispatch.ip_spoofing_check = false
   end
 end


### PR DESCRIPTION
https://trello.com/c/hoYWHZFn/3768-investigate-actiondispatchremoteipipspoofarrackerror-errors

@danielglen-moj to update threat model, this alert is not useful and the mismatched IP in headers is not something we need to use sentry credits on.