### PR TITLE
Remove hotjar script and references to hotjar in CSP

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -91,10 +91,4 @@ module ApplicationHelper
 
     response.metadata['items'].present?
   end
-
-  # Remove once hotjar testing is complete
-  def live_platform?
-    ENV['PLATFORM_ENV'] == 'live'
-  end
-  # Remove once hotjar testing is complete
 end

--- a/app/views/partials/_footer.html.erb
+++ b/app/views/partials/_footer.html.erb
@@ -16,19 +16,4 @@
       </div>
     </div>
   </div>
-
-  <% if live_platform? %>
-    <!-- Hotjar Tracking Code for Private Beta Research Study -->
-      <script nonce=<%= request.content_security_policy_nonce %>>
-        (function(h,o,t,j,a,r){
-          h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-          h._hjSettings={hjid:2316310,hjsv:6};
-          a=o.getElementsByTagName('head')[0];
-          r=o.createElement('script');r.async=1;
-          r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-          a.appendChild(r);
-        })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-      </script>
-    <!-- Hotjar Tracking Code for Private Beta Research Study -->
-    <% end %>
 </footer>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,11 +12,11 @@ Rails.application.configure do
     policy.object_src  :none
     policy.script_src  :self,
                        "https://unpkg.com/alpinejs",
-                       "https://cdn.jsdelivr.net/npm/marked@2.1.3/marked.min.js",
+                       "https://cdn.jsdelivr.net/npm/marked@2.1.3/marked.min.js"
     policy.style_src   :self,
-                       :unsafe_inline,
+                       :unsafe_inline
     policy.connect_src :self,
-                       "*.sentry.io",
+                       "*.sentry.io"
 
     # Specify URI for violation reports
     policy.report_uri "report-uri #{ENV['SENTRY_CSP_URL']}"

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,15 +13,10 @@ Rails.application.configure do
     policy.script_src  :self,
                        "https://unpkg.com/alpinejs",
                        "https://cdn.jsdelivr.net/npm/marked@2.1.3/marked.min.js",
-                       "https://*.hotjar.com"
     policy.style_src   :self,
                        :unsafe_inline,
-                       "https://*.hotjar.com"
     policy.connect_src :self,
                        "*.sentry.io",
-                       "https://*.hotjar.com",
-                       "https://*.hotjar.io",
-                       "wss://*.hotjar.com"
 
     # Specify URI for violation reports
     policy.report_uri "report-uri #{ENV['SENTRY_CSP_URL']}"


### PR DESCRIPTION
Occasionally provokes (handled) alerts when the script loads and tries to references something undefined. We're not using it anyway, so tear it out!