### PR TITLE
Attempts to fix flaky tests

### DIFF
--- a/acceptance/features/edit_branch_page_spec.rb
+++ b/acceptance/features/edit_branch_page_spec.rb
@@ -34,9 +34,9 @@ feature 'New branch page' do
       'Which flavours of ice cream have you eaten?'
     )
 
-    when_I_save_my_changes
     sleep(1)
-    expect(page).not_to have_selector('.govuk-error-summary')
+    when_I_save_my_changes
+    then_I_should_see_no_errors
     then_I_can_add_conditionals_and_expressions
 
     editor.branches.conditional(0).expression(1).component_select.select('What is your favourite hobby?')

--- a/acceptance/features/edit_single_question_autocomplete_page_spec.rb
+++ b/acceptance/features/edit_single_question_autocomplete_page_spec.rb
@@ -77,8 +77,7 @@ feature 'Edit single question autocomplete page' do
   def then_I_should_see_my_changes_in_the_form(preview_form, change)
     within_window(preview_form) do
       page.find('.autocomplete__input').click
-      sleep(5) # allow time for page to load
-      expect(page).to have_content(change)
+      expect(page).to have_css('.autocomplete__menu', text: change, visible: :all)
     end
   end
 


### PR DESCRIPTION
A quick attemopt to fix a couple of persistently flaky tests

1) Edit Branch spec.
The failure is because it is expecting not to have any errors, but the errors are present. This implies one of the select options has failed to set.  I have moved the `sleep` to after the optioon set, and before save. As I suspect that maybe the save button was being pressed before the option setting had completed.

2)Autocomplete page spec
The failure was because it was failing to find the option in the page when clicking on the autocomplete input.  The element being clicked was the JS enhanced autocomplete select so the issue wasn't JS realted.

The "fix" I have applied here is just to test that the option text we want is present within the list of autocomplete options *regardless of if that option has been made visible* 

While this feels a bit controversial, all this specific test is trying to validate is that reuploading a new csv replaces the options available for selection.  There are other tests that check the funcioning of the actual autocomplete itself.

