### PR TITLE
Remove first publish alert

### DIFF
--- a/app/services/publisher/adapters/cloud_platform.rb
+++ b/app/services/publisher/adapters/cloud_platform.rb
@@ -54,11 +54,7 @@ class Publisher
         )
       end
 
-      def completed
-        if live_production? && first_published?
-          NotificationService.notify(message)
-        end
-      end
+      def completed; end
 
       private
 
@@ -68,10 +64,6 @@ class Publisher
           service_id:,
           deployment_environment:
         ).count == 1
-      end
-
-      def message
-        "#{service_name} has been published to #{namespace}.\n#{hostname}"
       end
 
       def create_config_dir

--- a/spec/services/publisher/adapters/cloud_platform_spec.rb
+++ b/spec/services/publisher/adapters/cloud_platform_spec.rb
@@ -129,15 +129,15 @@ RSpec.describe Publisher::Adapters::CloudPlatform do
             create(:publish_service, :completed, :dev, service_id:)
           end
 
-          it 'sends a notification to the slack channel' do
-            expect(NotificationService).to receive(:notify).with("sam-or-frodo has been published to formbuilder-services-live-production.\nsam-or-frodo.service.justice.gov.uk")
+          it 'no longer sends a notification to the slack channel' do
+            expect(NotificationService).to_not receive(:notify)
             cloud_platform.completed
           end
         end
 
         context 'when publish directly to live production' do
-          it 'sends a notification to the slack channel' do
-            expect(NotificationService).to receive(:notify).with("sam-or-frodo has been published to formbuilder-services-live-production.\nsam-or-frodo.service.justice.gov.uk")
+          it 'no longer sends a notification to the slack channel' do
+            expect(NotificationService).to_not receive(:notify)
             cloud_platform.completed
           end
         end


### PR DESCRIPTION
We now get an alert on publishing for review, which also triggers this alert. Removing for now as it's not useful.

I've left the empty completed definition as I believe it needs to be implemented by the adapter, but it's just a hook that was used to send the notification.