### PR TITLE
Add failureThreshold to deployment config

### DIFF
--- a/deploy-eks/fb-editor-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-editor-chart/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
           initialDelaySeconds: {{ .Values.livenessProbe.web.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.web.periodSeconds }}
           successThreshold: {{ .Values.livenessProbe.web.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.web.failureThreshold }}
         readinessProbe:
           httpGet:
             path: /readiness


### PR DESCRIPTION
This should allow the newer 30 second liveness probe to fail once before restarting the pod.

Locked or failing pods will still restart and alert within a minute.