### PR TITLE
Update approval buttons to have a confirmation

### DIFF
--- a/app/views/admin/services/show.html.erb
+++ b/app/views/admin/services/show.html.erb
@@ -22,13 +22,13 @@
         Already approved to go live
       </a>
     <% else %>
-      <a href="<%= admin_service_approve_path(:service_id => @service.service_id) %>" class="govuk-button fb-govuk-button">
-        Approve to go live
-      </a>
+      <%= link_to 'Approve to go live', admin_service_approve_path(:service_id => @service.service_id),
+          method: :get, class: "govuk-button fb-govuk-button" ,
+          data: { confirm: 'Approving will unpublish any live forms, are you sure?' }  %>
     <% end %>
-    <a href="<%= admin_service_revoke_approval_path(:service_id => @service.service_id) %>" class="govuk-button fb-govuk-button">
-      Revoke approval to go live
-    </a>
+    <%= link_to 'Revoke approval to go live', admin_service_revoke_approval_path(:service_id => @service.service_id),
+      method: :get, class: "govuk-button fb-govuk-button" ,
+      data: { confirm: 'Revoking approval will unpublish any live forms, are you sure?' }  %>
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
   editor-service-token-cache-app:
     container_name: editor-service-token-cache-app
     build:
-      context: https://github.com/ministryofjustice/fb-service-token-cache.git
+      context: https://github.com/ministryofjustice/fb-service-token-cache.git#main
     environment:
       SENTRY_DSN: sentry-dsn
       RAILS_ENV: test


### PR DESCRIPTION
Also added the explicit main branch in the reference to the service token cache git repo in the docker compose, as this has now been renamed to main and was erroring for me if not explicit.

<img width="1845" alt="image" src="https://github.com/ministryofjustice/fb-editor/assets/7647632/9623557c-399c-4aaa-a934-b7cb712c114a">
