### PR TITLE
Bump metadata presenter (accessibility copy change)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby '3.1.3'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'fix-extra-pointers-in-detached-flows'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.6'
+gem 'metadata_presenter', '3.3.7'
 
 gem 'activerecord-session_store'
 gem 'administrate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.3.6)
+    metadata_presenter (3.3.7)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (~> 4.1.1)
@@ -766,7 +766,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.3.6)
+  metadata_presenter (= 3.3.7)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
[Trello card](https://trello.com/c/6SqXklen)

Bump to the metadata presenter gem that includes a minor copy change in the accessibility page template.