### PR TITLE
Fix failing periodic rake tasks

### DIFF
--- a/app/services/test_services_configs_remover.rb
+++ b/app/services/test_services_configs_remover.rb
@@ -7,7 +7,7 @@ class TestServicesConfigsRemover
 
   def call
     models.each do |model|
-      model.where.not(service_id: moj_forms_team_service_ids).destroy_all
+      model.where.not(service_id: moj_forms_team_service_ids).in_batches.destroy_all
     end
   end
 
@@ -22,11 +22,11 @@ class TestServicesConfigsRemover
   end
 
   def user_ids
-    User.all.map { |user| user.id if user.email.in?(team_emails) }.compact
+    User.all.filter_map { |user| user.id if user.email.in?(team_emails) }
   end
 
   def team_emails
-    @team_emails ||= Rails.application.config.moj_forms_team
+    Rails.application.config.moj_forms_team
   end
 
   def models

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,6 +11,7 @@ Rails.application.configure do
   # and those relying on copy on write to perform better.
   # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
+  config.rake_eager_load = true
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false

--- a/deploy-eks/fb-editor-chart/templates/remove_test_services_configs.yaml
+++ b/deploy-eks/fb-editor-chart/templates/remove_test_services_configs.yaml
@@ -10,6 +10,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 120
       template:
         metadata:
           labels:
@@ -18,10 +19,7 @@ spec:
           containers:
           - name: "fb-editor-workers-{{ .Values.environmentName }}"
             image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-editor-workers:{{ .Values.circleSha1 }}"
-            args:
-            - /bin/sh
-            - -c
-            - bundle exec rake remove:test_services_configs
+            command: ['bin/rails', 'remove:test_services_configs']
             securityContext:
               runAsUser: 1001
             imagePullPolicy: Always

--- a/deploy-eks/fb-editor-chart/templates/unpublish_test_services.yaml
+++ b/deploy-eks/fb-editor-chart/templates/unpublish_test_services.yaml
@@ -10,6 +10,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 120
       template:
         metadata:
           labels:
@@ -18,10 +19,7 @@ spec:
           containers:
           - name: "fb-editor-workers-{{ .Values.environmentName }}"
             image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-editor-workers:{{ .Values.circleSha1 }}"
-            args:
-            - /bin/sh
-            - -c
-            - bundle exec rake unpublish:test_services
+            command: ['bin/rails', 'unpublish:test_services']
             securityContext:
               runAsUser: 1001
             imagePullPolicy: Always


### PR DESCRIPTION
There were a couple issues.

First one, these rake tasks for some reason require eager loading for the decryption to work correctly. By default rake tasks will not do eager loading. Console (in production) does eager loading, and that's why the tasks were working when invoked in the console.

The other issue was a performance issue. One rake task (`remove:test_services_configs`) has not been run successfully in such a long time that it accumulated thousands of records (well over 700k+) and the query to return them was not doing it in batches, which killed the process due to memory constraints.

The query has been optimised to use batches.

Both tasks have been run already so next time they run should finish fairly quick.