### PR TITLE
Add required dummy env variables

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -45,7 +45,16 @@ ENV GOVUK_APP_DOMAIN ''
 ENV GOVUK_WEBSITE_ROOT '' 
 
 ARG RAILS_ENV=production
+
 RUN yarn install --production --check-files
 RUN ./bin/webpack
-RUN RAILS_ENV=${RAILS_ENV} SECRET_KEY_BASE=$(bin/rake secret) bundle exec rake assets:precompile --trace
+
+# Note some ENV vars here are just dummies needed to be present to build the image.
+# The real ones in the kubernetes pods are injected into the environment.
+RUN RAILS_ENV=${RAILS_ENV} \
+    SECRET_KEY_BASE=needed_for_assets_precompile \
+    ENCRYPTION_KEY=needed_for_assets_precompile \
+    ENCRYPTION_SALT=needed_for_assets_precompile \
+    rails assets:precompile --trace
+
 CMD bundle exec rake db:migrate:ignore_concurrent && bundle exec rails s -e ${RAILS_ENV} -p ${APP_PORT} --binding=0.0.0.0


### PR DESCRIPTION
As a side effect of the previous PR #2535, the assets precompile rake task that runs as part of the docker image build process requires the encryption env variables to be present, however just dummies.

All real env variables are injected into the kubernetes pod environment so shouldn't have any other effect to the best of my understanding.