### PR TITLE
Fix generated component id to always be the max

### DIFF
--- a/app/generators/new_component_generator.rb
+++ b/app/generators/new_component_generator.rb
@@ -32,11 +32,11 @@ class NewComponentGenerator
   end
 
   def increment
-    existing_components = components_of_type(component_type)
-    if existing_components.empty?
+    components = components_of_type(component_type)
+    if components.empty?
       1
     else
-      component_index(existing_components.last).to_i + 1
+      max_component_index(components) + 1
     end
   end
 
@@ -44,7 +44,11 @@ class NewComponentGenerator
     components.select { |c| c['_type'] == type }
   end
 
+  def max_component_index(components)
+    components.map { |c| component_index(c) }.max
+  end
+
   def component_index(component)
-    component['_id'].split('_').last
+    component['_id'].split('_').last.to_i
   end
 end

--- a/spec/services/page_updater_spec.rb
+++ b/spec/services/page_updater_spec.rb
@@ -266,12 +266,12 @@ RSpec.describe PageUpdater do
           let(:page_url) { 'check-answers' }
           let(:expected_created_component) do
             ActiveSupport::HashWithIndifferentAccess.new({
-              '_id': 'check-answers_content_2',
+              '_id': 'check-answers_content_3',
               '_type': 'content',
               '_uuid' => "Dead or alive you're coming with me",
               'content': '[Optional content]',
               'display': 'always',
-              'name': 'check-answers_content_2'
+              'name': 'check-answers_content_3'
             })
           end
           let(:expected_updated_page) do


### PR DESCRIPTION
When generating the next component id we simply incremented the id of the last component on the page.  While this works fine for new forms, for older forms that have ids that are non-sequential then the last id on the page may not be the highest, and thus incrementing it could cause a conflicting id.

This PR makes the adjustment to fionding the max id for that component type on the page and incrementing that, this should mean there should be no collisions on either new or old forms.