### PR TITLE
Try different approach for the encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ yarn-debug.log*
 .env
 .env.acceptance_tests
 
+coverage
+
 # Visual Studio Code #
 **/.vscode/
 

--- a/app/services/encryption_service.rb
+++ b/app/services/encryption_service.rb
@@ -1,13 +1,4 @@
 class EncryptionService
-  KEY = ActiveSupport::KeyGenerator.new(
-    ENV.fetch('ENCRYPTION_KEY')
-  ).generate_key(
-    ENV.fetch('ENCRYPTION_SALT'),
-    ActiveSupport::MessageEncryptor.key_len
-  ).freeze
-
-  private_constant :KEY
-
   delegate :encrypt_and_sign, :decrypt_and_verify, to: :encryptor
 
   def encrypt(value)
@@ -21,6 +12,15 @@ class EncryptionService
   private
 
   def encryptor
-    ActiveSupport::MessageEncryptor.new(KEY)
+    @encryptor ||= ActiveSupport::MessageEncryptor.new(key)
+  end
+
+  def key
+    ActiveSupport::KeyGenerator.new(
+      ENV.fetch('ENCRYPTION_KEY')
+    ).generate_key(
+      ENV.fetch('ENCRYPTION_SALT'),
+      ActiveSupport::MessageEncryptor.key_len
+    ).freeze
   end
 end

--- a/app/services/encryption_service.rb
+++ b/app/services/encryption_service.rb
@@ -1,4 +1,13 @@
 class EncryptionService
+  KEY = ActiveSupport::KeyGenerator.new(
+    ENV.fetch('ENCRYPTION_KEY', '')
+  ).generate_key(
+    ENV.fetch('ENCRYPTION_SALT', ''),
+    ActiveSupport::MessageEncryptor.key_len
+  ).freeze
+
+  private_constant :KEY
+
   delegate :encrypt_and_sign, :decrypt_and_verify, to: :encryptor
 
   def encrypt(value)
@@ -12,15 +21,6 @@ class EncryptionService
   private
 
   def encryptor
-    @encryptor ||= ActiveSupport::MessageEncryptor.new(key)
-  end
-
-  def key
-    ActiveSupport::KeyGenerator.new(
-      ENV.fetch('ENCRYPTION_KEY')
-    ).generate_key(
-      ENV.fetch('ENCRYPTION_SALT'),
-      ActiveSupport::MessageEncryptor.key_len
-    ).freeze
+    @encryptor ||= ActiveSupport::MessageEncryptor.new(KEY)
   end
 end

--- a/deploy-eks/fb-editor-chart/templates/remove_test_services_configs.yaml
+++ b/deploy-eks/fb-editor-chart/templates/remove_test_services_configs.yaml
@@ -42,11 +42,6 @@ spec:
                   secretKeyRef:
                     name: rds-instance-formbuilder-editor-{{ .Values.environmentName }}
                     key: url
-              - name: EDITOR_SERVICE_ACCOUNT_TOKEN
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ .Values.bearer_token }}
-                    key: token
               - name: ENCODED_PRIVATE_KEY
                 valueFrom:
                   secretKeyRef:

--- a/deploy-eks/fb-editor-chart/templates/sessions_trim.yaml
+++ b/deploy-eks/fb-editor-chart/templates/sessions_trim.yaml
@@ -9,6 +9,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 120
       template:
         metadata:
           labels:
@@ -17,10 +18,7 @@ spec:
           containers:
           - name: "fb-editor-workers-{{ .Values.environmentName }}"
             image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-editor-workers:{{ .Values.circleSha1 }}"
-            args:
-            - /bin/sh
-            - -c
-            - rake db:sessions:trim
+            command: ['bin/rails', 'db:sessions:trim']
             securityContext:
               runAsUser: 1001
             imagePullPolicy: Always
@@ -43,9 +41,4 @@ spec:
                   secretKeyRef:
                     name: rds-instance-formbuilder-editor-{{ .Values.environmentName }}
                     key: url
-              - name: EDITOR_SERVICE_ACCOUNT_TOKEN
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ .Values.bearer_token }}
-                    key: token
           restartPolicy: Never

--- a/deploy-eks/fb-editor-chart/templates/unpublish_test_services.yaml
+++ b/deploy-eks/fb-editor-chart/templates/unpublish_test_services.yaml
@@ -42,11 +42,6 @@ spec:
                   secretKeyRef:
                     name: rds-instance-formbuilder-editor-{{ .Values.environmentName }}
                     key: url
-              - name: EDITOR_SERVICE_ACCOUNT_TOKEN
-                valueFrom:
-                  secretKeyRef:
-                    name: {{ .Values.bearer_token }}
-                    key: token
               - name: ENCODED_PRIVATE_KEY
                 valueFrom:
                   secretKeyRef:

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -53,8 +53,6 @@ RUN ./bin/webpack
 # The real ones in the kubernetes pods are injected into the environment.
 RUN RAILS_ENV=${RAILS_ENV} \
     SECRET_KEY_BASE=needed_for_assets_precompile \
-    ENCRYPTION_KEY=needed_for_assets_precompile \
-    ENCRYPTION_SALT=needed_for_assets_precompile \
     rails assets:precompile --trace
 
 CMD bundle exec rake db:migrate:ignore_concurrent && bundle exec rails s -e ${RAILS_ENV} -p ${APP_PORT} --binding=0.0.0.0


### PR DESCRIPTION
~Trying to avoid having to declare encryption variables when they are not necessary (some cronjobs don't need them) by moving from using a constant to a method.~

It seems we must continue using a constant, as for some reason doing lazy assignment (via a method) produces the infamous `ActiveSupport::MessageEncryptor::InvalidMessage` again.

To minimise having to declare these encryption env variables in places where they are not even needed (because no encryption/decryption operations take place) I've resorted to a fetch with fallback.
The rake eager loading is still needed tho.

Tested each of the cronjobs and are working fine, included the sessions trimmer.
Should have no effect on the web containers either.