### PR TITLE
Branch edit screen accessible labelling

### DIFF
--- a/acceptance/sections/conditional_section.rb
+++ b/acceptance/sections/conditional_section.rb
@@ -2,7 +2,7 @@ require_relative './expression_section'
 
 class ConditionalSection < SitePrism::Section
     sections :expressions, ExpressionSection, '[data-controller="expression"]'
-    element :title, 'h3'
+    element :title, '[data-conditional-target="title"]'
     element :add_condition, :button, I18n.t('conditional_content.add_condition')
     element :delete_button, '.conditional__remover'
     element :destination_select, '.conditional__destination'

--- a/acceptance/sections/expression_section.rb
+++ b/acceptance/sections/expression_section.rb
@@ -1,11 +1,11 @@
 class ExpressionSection < SitePrism::Section
-      element :question_label, '.conditional__question label'
+      element :question_label, '[data-expression-target="label"]'
       element :component_select, '.expression__component'
       element :operator_select, '.expression__operator'
       elements :operator_select_options, '.expression__operator option'
       element :answer_select, '.expression__answer'
       elements :answer_select_options, '.expression__answer option'
-      element :delete_button, '.expression__remover'
+      element :delete_button, '[data-expression-target="deleteButton"]'
       element :unsupported_error, '.expression__error[data-error-type="unsupported"]'
       element :same_page_error, '.expression__error[data-error-type="samepage"]'
 

--- a/acceptance/support/branching_steps.rb
+++ b/acceptance/support/branching_steps.rb
@@ -44,7 +44,7 @@ module BranchingSteps
     then_I_should_see_the_branch_title(index: 1, title: 'Branch 2')
 
     and_I_delete_the_branch(1)
-    then_I_should_not_see_text('Branch 2')
+    expect( editor.branches ).to have_conditionals(count: 1)
   end
 
   def when_I_update_the_question_name(question_name)
@@ -157,7 +157,7 @@ module BranchingSteps
   end
 
   def then_I_should_see_the_operator(text)
-    page_with_css('.expression .conditional__question label', text)
+    page_with_css('.expression [data-expression-target="label"]', text)
   end
 
   def page_with_css(element, text)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,6 +13,7 @@ import "@hotwired/turbo-rails"
 import { Application } from "@hotwired/stimulus"
 
 import DynamicFieldsController from '../src/controllers/dynamic-fields-controller.js'
+import BranchStatusController from '../src/controllers/branch-status-controller.js'
 import ConditionalController from '../src/controllers/conditional-controller.js'
 import ConditionalsController from '../src/controllers/conditionals-controller.js'
 import ExpressionController from '../src/controllers/expression-controller.js'
@@ -22,6 +23,7 @@ import SelectionRevealController from '../src/controllers/selection-reveal-contr
 Turbo.session.drive = false
 window.Stimulus = Application.start()
 Stimulus.register("dynamic-fields", DynamicFieldsController)
+Stimulus.register("branch-status", BranchStatusController)
 Stimulus.register("conditional", ConditionalController)
 Stimulus.register("conditionals", ConditionalsController)
 Stimulus.register("expression", ExpressionController)
@@ -33,9 +35,9 @@ const { ElasticTextarea } = require('../src/web-components/elastic-textarea');
 const { SaveButton } = require('../src/web-components/save-button');
 
 if ('customElements' in window) {
-  customElements.define('elastic-textarea', ElasticTextarea);
-  customElements.define('editable-content', EditableContent);
-  customElements.define('save-button', SaveButton, { extends: 'button'});
+    customElements.define('elastic-textarea', ElasticTextarea);
+    customElements.define('editable-content', EditableContent);
+    customElements.define('save-button', SaveButton, { extends: 'button' });
 }
 
 // Entry point for fb-editor stylesheets

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,49 +4,48 @@
 // that code so it'll be compiled.
 
 // Scripts called by javascript_pack_tag
-require('@ungap/custom-elements'); // required until safari supports customizing native elements using `is`
-require("jquery")
-require("jquery-ui")
-require("../src/index")
+require("@ungap/custom-elements"); // required until safari supports customizing native elements using `is`
+require("jquery");
+require("jquery-ui");
+require("../src/index");
 
-import "@hotwired/turbo-rails"
-import { Application } from "@hotwired/stimulus"
+import "@hotwired/turbo-rails";
+import { Application } from "@hotwired/stimulus";
 
-import DynamicFieldsController from '../src/controllers/dynamic-fields-controller.js'
-import BranchStatusController from '../src/controllers/branch-status-controller.js'
-import ConditionalController from '../src/controllers/conditional-controller.js'
-import ConditionalsController from '../src/controllers/conditionals-controller.js'
-import ExpressionController from '../src/controllers/expression-controller.js'
-import ExpressionsController from '../src/controllers/expressions-controller.js'
-import SelectionRevealController from '../src/controllers/selection-reveal-controller.js'
+import DynamicFieldsController from "../src/controllers/dynamic-fields-controller.js";
+import ConditionalsStatusController from "../src/controllers/conditionals-status-controller.js";
+import ConditionalController from "../src/controllers/conditional-controller.js";
+import ConditionalsController from "../src/controllers/conditionals-controller.js";
+import ExpressionController from "../src/controllers/expression-controller.js";
+import ExpressionsController from "../src/controllers/expressions-controller.js";
+import SelectionRevealController from "../src/controllers/selection-reveal-controller.js";
 
-Turbo.session.drive = false
-window.Stimulus = Application.start()
-Stimulus.register("dynamic-fields", DynamicFieldsController)
-Stimulus.register("branch-status", BranchStatusController)
-Stimulus.register("conditional", ConditionalController)
-Stimulus.register("conditionals", ConditionalsController)
-Stimulus.register("expression", ExpressionController)
-Stimulus.register("expressions", ExpressionsController)
-Stimulus.register("selection-reveal", SelectionRevealController)
+Turbo.session.drive = false;
+window.Stimulus = Application.start();
+Stimulus.register("dynamic-fields", DynamicFieldsController);
+Stimulus.register("conditionals-status", ConditionalsStatusController);
+Stimulus.register("conditional", ConditionalController);
+Stimulus.register("conditionals", ConditionalsController);
+Stimulus.register("expression", ExpressionController);
+Stimulus.register("expressions", ExpressionsController);
+Stimulus.register("selection-reveal", SelectionRevealController);
 
-const { EditableContent } = require('../src/web-components/editable-content');
-const { ElasticTextarea } = require('../src/web-components/elastic-textarea');
-const { SaveButton } = require('../src/web-components/save-button');
+const { EditableContent } = require("../src/web-components/editable-content");
+const { ElasticTextarea } = require("../src/web-components/elastic-textarea");
+const { SaveButton } = require("../src/web-components/save-button");
 
-if ('customElements' in window) {
-    customElements.define('elastic-textarea', ElasticTextarea);
-    customElements.define('editable-content', EditableContent);
-    customElements.define('save-button', SaveButton, { extends: 'button' });
+if ("customElements" in window) {
+  customElements.define("elastic-textarea", ElasticTextarea);
+  customElements.define("editable-content", EditableContent);
+  customElements.define("save-button", SaveButton, { extends: "button" });
 }
 
 // Entry point for fb-editor stylesheets
-import "../styles/application.scss"
-
+import "../styles/application.scss";
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
 // or the `imagePath` JavaScript helper below.
 //
-global.images = require.context('../images', true)
-global.imagePath = (name) => images(name, true)
+global.images = require.context("../images", true);
+global.imagePath = (name) => images(name, true);

--- a/app/javascript/src/controllers/branch-status-controller.js
+++ b/app/javascript/src/controllers/branch-status-controller.js
@@ -1,8 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-
-  update(status) {
-    this.element.innerText = status
-  }
-}

--- a/app/javascript/src/controllers/branch-status-controller.js
+++ b/app/javascript/src/controllers/branch-status-controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+
+  update(status) {
+    this.element.innerText = status
+  }
+}

--- a/app/javascript/src/controllers/conditional-controller.js
+++ b/app/javascript/src/controllers/conditional-controller.js
@@ -30,7 +30,9 @@ export default class extends Controller {
     if (newValue !== oldValue) {
       this.updateTitle()
       this.updateDeleteButtonLabel()
-      this.updateDestinationLabel()
+      if (this.hasDestinationTarget) {
+        this.updateDestinationLabel()
+      }
       Promise.resolve().then(() => {
         this.updateFieldLabelsForExpressions()
       })

--- a/app/javascript/src/controllers/conditional-controller.js
+++ b/app/javascript/src/controllers/conditional-controller.js
@@ -1,11 +1,12 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ['title', 'deleteButton', 'expression']
+  static targets = ['title', 'deleteButton', 'expression', 'destination']
   static values = {
     index: Number,
     title: String,
-    deleteLabel: String
+    deleteLabel: String,
+    destinationLabel: String,
   }
 
   connect() {
@@ -13,12 +14,22 @@ export default class extends Controller {
     this.element[`${this.identifier}Controller`] = this
   }
 
-  indexValueChanged() {
-    this.updateTitle()
-    this.updateDeleteButtonLabel()
-    setTimeout(() => {
-      this.updateFieldLabelsForExpressions()
+  focusNewExpression(event) {
+    const element = event.detail.element
+    Promise.resolve().then(() => {
+      element.expressionController.questionTarget.focus()
     })
+  }
+
+  indexValueChanged(newValue, oldValue) {
+    if (newValue !== oldValue) {
+      this.updateTitle()
+      this.updateDeleteButtonLabel()
+      this.updateDestinationLabel()
+      Promise.resolve().then(() => {
+        this.updateFieldLabelsForExpressions()
+      })
+    }
   }
 
   get title() {
@@ -53,9 +64,13 @@ export default class extends Controller {
     this.deleteButtonTarget.innerText = `${this.deleteLabelValue} ${this.title}`
   }
 
+  updateDestinationLabel() {
+    this.destinationTarget.setAttribute('aria-label', `${this.destinationLabelValue} ${this.title}`)
+  }
+
   updateFieldLabelsForExpressions() {
     this.expressionTargets.forEach((element) => {
-      element.expressionController.updateFieldLabels()
+      element.expressionController.updateLabels()
     })
   }
 }

--- a/app/javascript/src/controllers/conditional-controller.js
+++ b/app/javascript/src/controllers/conditional-controller.js
@@ -32,6 +32,7 @@ export default class extends Controller {
   }
 
   focusNewExpression(event) {
+    if (event.detail.additionType != 'expression') return
     const element = event.detail.element
     Promise.resolve().then(() => {
       element.expressionController.questionTarget.focus()

--- a/app/javascript/src/controllers/conditional-controller.js
+++ b/app/javascript/src/controllers/conditional-controller.js
@@ -1,106 +1,111 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   static targets = [
-    'fieldset',
-    'title',
-    'deleteButton',
-    'expression',
-    'destination'
-  ]
+    "fieldset",
+    "title",
+    "deleteButton",
+    "expression",
+    "destination",
+  ];
 
-  static outlets = [
-    'branch-status',
-  ]
+  static outlets = ["conditionals-status"];
 
   static values = {
     index: Number,
     title: String,
     deleteLabel: String,
     destinationLabel: String,
-  }
+  };
 
   connect() {
     // Attach a reference to the controller to the element
-    this.element[`${this.identifier}Controller`] = this
+    this.element[`${this.identifier}Controller`] = this;
   }
 
   expressionTargetConnected() {
     Promise.resolve().then(() => {
-      this.updateFieldLabelsForExpressions()
-    })
+      this.updateFieldLabelsForExpressions();
+    });
   }
 
   expressionTargetDisconnected(element) {
-    this.fieldsetTarget.focus()
+    this.fieldsetTarget.focus();
   }
 
   indexValueChanged(newValue, oldValue) {
     if (newValue !== oldValue) {
-      this.updateTitle()
-      this.updateDeleteButtonLabel()
+      this.updateTitle();
+      this.updateDeleteButtonLabel();
       if (this.hasDestinationTarget) {
-        this.updateDestinationLabel()
+        this.updateDestinationLabel();
       }
       Promise.resolve().then(() => {
-        this.updateFieldLabelsForExpressions()
-      })
+        this.updateFieldLabelsForExpressions();
+      });
     }
   }
 
   focusNewExpression(event) {
-    if (event.detail.additionType != 'expression') return
+    if (event.detail.additionType != "expression") return;
 
-    const element = event.detail.element
+    const element = event.detail.element;
     Promise.resolve().then(() => {
-      element.expressionController.questionTarget.focus()
-    })
+      element.expressionController.questionTarget.focus();
+    });
   }
 
   get title() {
-    return `${this.titleValue} ${this.indexValue}`
+    return `${this.titleValue} ${this.indexValue}`;
   }
 
   delete() {
-    this.#destroy()
+    this.#destroy();
   }
 
   deleteWithConfirmation() {
-    document.dispatchEvent(new CustomEvent('ConfirmBranchConditionalRemoval', {
-      detail: {
-        action: () => { this.#destroy() }
-      }
-    }))
+    document.dispatchEvent(
+      new CustomEvent("ConfirmBranchConditionalRemoval", {
+        detail: {
+          action: () => {
+            this.#destroy();
+          },
+        },
+      }),
+    );
   }
 
   hideDeleteButton() {
-    this.deleteButtonTarget.setAttribute('hidden', '')
+    this.deleteButtonTarget.setAttribute("hidden", "");
   }
 
   showDeleteButton() {
-    this.deleteButtonTarget.removeAttribute('hidden')
+    this.deleteButtonTarget.removeAttribute("hidden");
   }
 
   updateTitle() {
-    this.titleTarget.innerText = this.title
+    this.titleTarget.innerText = this.title;
   }
 
   updateDeleteButtonLabel() {
-    this.deleteButtonTarget.innerText = `${this.deleteLabelValue} ${this.title}`
+    this.deleteButtonTarget.innerText = `${this.deleteLabelValue} ${this.title}`;
   }
 
   updateDestinationLabel() {
-    this.destinationTarget.setAttribute('aria-label', `${this.destinationLabelValue} ${this.title}`)
+    this.destinationTarget.setAttribute(
+      "aria-label",
+      `${this.destinationLabelValue} ${this.title}`,
+    );
   }
 
   updateFieldLabelsForExpressions() {
     this.expressionTargets.forEach((element) => {
-      element.expressionController.updateLabels()
-    })
+      element.expressionController.updateLabels();
+    });
   }
 
   #destroy() {
-    this.branchStatusOutlet.update(`${this.title} removed`)
-    this.element.remove()
+    this.conditionalsStatusOutlet.update(`${this.title} removed`);
+    this.element.remove();
   }
 }

--- a/app/javascript/src/controllers/conditional-controller.js
+++ b/app/javascript/src/controllers/conditional-controller.js
@@ -3,12 +3,23 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ['title', 'deleteButton']
   static values = {
-    title: String
+    index: Number,
+    title: String,
+    deleteLabel: String
   }
 
   connect() {
     // Attach a reference to the controller to the element
     this.element[`${this.identifier}Controller`] = this
+  }
+
+  indexValueChanged() {
+    this.updateTitle()
+    this.updateDeleteButtonLabel()
+  }
+
+  get title() {
+    return `${this.titleValue} ${this.indexValue}`
   }
 
   delete(event) {
@@ -31,7 +42,11 @@ export default class extends Controller {
     this.deleteButtonTarget.removeAttribute('hidden')
   }
 
-  setTitle(index) {
-    this.titleTarget.innerText = `${this.titleValue} ${index}`
+  updateTitle() {
+    this.titleTarget.innerText = this.title
+  }
+
+  updateDeleteButtonLabel() {
+    this.deleteButtonTarget.innerText = `${this.deleteLabelValue} ${this.title}`
   }
 }

--- a/app/javascript/src/controllers/conditional-controller.js
+++ b/app/javascript/src/controllers/conditional-controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ['title', 'deleteButton']
+  static targets = ['title', 'deleteButton', 'expression']
   static values = {
     index: Number,
     title: String,
@@ -16,6 +16,9 @@ export default class extends Controller {
   indexValueChanged() {
     this.updateTitle()
     this.updateDeleteButtonLabel()
+    setTimeout(() => {
+      this.updateFieldLabelsForExpressions()
+    })
   }
 
   get title() {
@@ -48,5 +51,11 @@ export default class extends Controller {
 
   updateDeleteButtonLabel() {
     this.deleteButtonTarget.innerText = `${this.deleteLabelValue} ${this.title}`
+  }
+
+  updateFieldLabelsForExpressions() {
+    this.expressionTargets.forEach((element) => {
+      element.expressionController.updateFieldLabels()
+    })
   }
 }

--- a/app/javascript/src/controllers/conditional-controller.js
+++ b/app/javascript/src/controllers/conditional-controller.js
@@ -14,10 +14,9 @@ export default class extends Controller {
     this.element[`${this.identifier}Controller`] = this
   }
 
-  focusNewExpression(event) {
-    const element = event.detail.element
+  expressionTargetConnected() {
     Promise.resolve().then(() => {
-      element.expressionController.questionTarget.focus()
+      this.updateFieldLabelsForExpressions()
     })
   }
 
@@ -30,6 +29,13 @@ export default class extends Controller {
         this.updateFieldLabelsForExpressions()
       })
     }
+  }
+
+  focusNewExpression(event) {
+    const element = event.detail.element
+    Promise.resolve().then(() => {
+      element.expressionController.questionTarget.focus()
+    })
   }
 
   get title() {

--- a/app/javascript/src/controllers/conditional-controller.js
+++ b/app/javascript/src/controllers/conditional-controller.js
@@ -2,10 +2,15 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = [
+    'fieldset',
     'title',
     'deleteButton',
     'expression',
     'destination'
+  ]
+
+  static outlets = [
+    'branch-status',
   ]
 
   static values = {
@@ -24,6 +29,10 @@ export default class extends Controller {
     Promise.resolve().then(() => {
       this.updateFieldLabelsForExpressions()
     })
+  }
+
+  expressionTargetDisconnected(element) {
+    this.fieldsetTarget.focus()
   }
 
   indexValueChanged(newValue, oldValue) {
@@ -52,14 +61,14 @@ export default class extends Controller {
     return `${this.titleValue} ${this.indexValue}`
   }
 
-  delete(event) {
-    this.element.remove()
+  delete() {
+    this.#destroy()
   }
 
-  deleteWithConfirmation(event) {
+  deleteWithConfirmation() {
     document.dispatchEvent(new CustomEvent('ConfirmBranchConditionalRemoval', {
       detail: {
-        action: () => { this.element.remove() }
+        action: () => { this.#destroy() }
       }
     }))
   }
@@ -88,5 +97,10 @@ export default class extends Controller {
     this.expressionTargets.forEach((element) => {
       element.expressionController.updateLabels()
     })
+  }
+
+  #destroy() {
+    this.branchStatusOutlet.update(`${this.title} removed`)
+    this.element.remove()
   }
 }

--- a/app/javascript/src/controllers/conditional-controller.js
+++ b/app/javascript/src/controllers/conditional-controller.js
@@ -1,7 +1,13 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ['title', 'deleteButton', 'expression', 'destination']
+  static targets = [
+    'title',
+    'deleteButton',
+    'expression',
+    'destination'
+  ]
+
   static values = {
     index: Number,
     title: String,
@@ -33,6 +39,7 @@ export default class extends Controller {
 
   focusNewExpression(event) {
     if (event.detail.additionType != 'expression') return
+
     const element = event.detail.element
     Promise.resolve().then(() => {
       element.expressionController.questionTarget.focus()

--- a/app/javascript/src/controllers/conditionals-controller.js
+++ b/app/javascript/src/controllers/conditionals-controller.js
@@ -12,20 +12,20 @@ export default class extends Controller {
       this.connected = true
       this.ensureFirstConditionalCannotBeDeleted();
       this.allowFirstConditionalToBeDeleted();
-      this.updateTitles();
+      this.updateConditionalIndices();
     })
   }
 
   conditionalTargetDisconnected(element) {
     this.ensureFirstConditionalCannotBeDeleted();
-    this.updateTitles();
+    this.updateConditionalIndices();
   }
 
   conditionalTargetConnected(element) {
     if (!this.connected) return;
 
     this.allowFirstConditionalToBeDeleted();
-    this.updateTitles();
+    this.updateConditionalIndices();
   }
 
   ensureFirstConditionalCannotBeDeleted() {
@@ -40,9 +40,10 @@ export default class extends Controller {
     }
   }
 
-  updateTitles() {
+  updateConditionalIndices() {
     this.conditionalTargets.forEach((conditional, index) => {
-      conditional.conditionalController.setTitle(index + 1)
+      console.log(index)
+      conditional.conditionalController.indexValue = index + 1
     })
   }
 }

--- a/app/javascript/src/controllers/conditionals-controller.js
+++ b/app/javascript/src/controllers/conditionals-controller.js
@@ -10,31 +10,33 @@ export default class extends Controller {
   connect() {
     Promise.resolve().then(() => {
       this.connected = true
-      this.ensureFirstConditionalCannotBeDeleted();
-      this.allowFirstConditionalToBeDeleted();
+      this.preventFirstConditionalDeletion();
+      this.allowFirstConditionalDeletion();
       this.updateConditionalIndices();
     })
   }
 
-  conditionalTargetDisconnected(element) {
-    this.ensureFirstConditionalCannotBeDeleted();
+  conditionalTargetDisconnected() {
+    this.preventFirstConditionalDeletion();
     this.updateConditionalIndices();
   }
 
-  conditionalTargetConnected(element) {
-    if (!this.connected) return;
+  update(event) {
+    if (event.detail.additionType != 'conditional') return
 
-    this.allowFirstConditionalToBeDeleted();
-    this.updateConditionalIndices();
+    Promise.resolve().then(() => {
+      this.allowFirstConditionalDeletion();
+      this.updateConditionalIndices();
+    })
   }
 
-  ensureFirstConditionalCannotBeDeleted() {
+  preventFirstConditionalDeletion() {
     if (this.conditionalTargets.length == 1) {
       this.conditionalTargets[0].conditionalController.hideDeleteButton()
     }
   }
 
-  allowFirstConditionalToBeDeleted() {
+  allowFirstConditionalDeletion() {
     if (this.conditionalTargets.length > 1) {
       this.conditionalTargets[0].conditionalController.showDeleteButton()
     }

--- a/app/javascript/src/controllers/conditionals-controller.js
+++ b/app/javascript/src/controllers/conditionals-controller.js
@@ -42,7 +42,6 @@ export default class extends Controller {
 
   updateConditionalIndices() {
     this.conditionalTargets.forEach((conditional, index) => {
-      console.log(index)
       conditional.conditionalController.indexValue = index + 1
     })
   }

--- a/app/javascript/src/controllers/conditionals-controller.js
+++ b/app/javascript/src/controllers/conditionals-controller.js
@@ -19,14 +19,17 @@ export default class extends Controller {
   conditionalTargetDisconnected() {
     this.preventFirstConditionalDeletion();
     this.updateConditionalIndices();
+    this.element.focus()
   }
 
-  update(event) {
+  newConditionalAdded(event) {
     if (event.detail.additionType != 'conditional') return
 
     Promise.resolve().then(() => {
       this.allowFirstConditionalDeletion();
       this.updateConditionalIndices();
+      // place focus on the newly added conditional fieldset
+      this.conditionalTargets[this.conditionalTargets.length - 1].conditionalController.fieldsetTarget.focus()
     })
   }
 

--- a/app/javascript/src/controllers/conditionals-status-controller.js
+++ b/app/javascript/src/controllers/conditionals-status-controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  update(status) {
+    this.element.innerText = status;
+  }
+}

--- a/app/javascript/src/controllers/dynamic-fields-controller.js
+++ b/app/javascript/src/controllers/dynamic-fields-controller.js
@@ -5,7 +5,7 @@ export default class extends Controller {
 
   add(event) {
     event.preventDefault();
-    console.log(event.params)
+
     this.templateTarget.insertAdjacentHTML(
       "beforebegin",
       this.templateTarget.innerHTML.replace(
@@ -13,10 +13,11 @@ export default class extends Controller {
         new Date().getTime().toString()
       )
     )
+
     this.dispatch('fieldsAdded', {
       detail: {
         element: this.templateTarget.previousElementSibling,
-        additionType: event.params.type
+        additionType: event.params.type ?? ''
       }
     })
   }

--- a/app/javascript/src/controllers/dynamic-fields-controller.js
+++ b/app/javascript/src/controllers/dynamic-fields-controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = [ 'template' ]
+  static targets = ['template']
 
   add(event) {
     event.preventDefault();
@@ -12,5 +12,6 @@ export default class extends Controller {
         new Date().getTime().toString()
       )
     )
+    this.dispatch('fieldsAdded', { detail: { element: this.templateTarget.previousElementSibling } })
   }
 }

--- a/app/javascript/src/controllers/dynamic-fields-controller.js
+++ b/app/javascript/src/controllers/dynamic-fields-controller.js
@@ -5,6 +5,7 @@ export default class extends Controller {
 
   add(event) {
     event.preventDefault();
+    console.log(event.params)
     this.templateTarget.insertAdjacentHTML(
       "beforebegin",
       this.templateTarget.innerHTML.replace(
@@ -12,6 +13,11 @@ export default class extends Controller {
         new Date().getTime().toString()
       )
     )
-    this.dispatch('fieldsAdded', { detail: { element: this.templateTarget.previousElementSibling } })
+    this.dispatch('fieldsAdded', {
+      detail: {
+        element: this.templateTarget.previousElementSibling,
+        additionType: event.params.type
+      }
+    })
   }
 }

--- a/app/javascript/src/controllers/expression-controller.js
+++ b/app/javascript/src/controllers/expression-controller.js
@@ -1,92 +1,92 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   static targets = [
-    'question',
-    'condition',
-    'operator',
-    'answer',
-    'deleteButton',
-    'label',
-    'fieldsetLabel',
-    'errorMessage'
-  ]
+    "question",
+    "condition",
+    "operator",
+    "answer",
+    "deleteButton",
+    "label",
+    "fieldsetLabel",
+    "errorMessage",
+  ];
 
-  static outlets = [
-    'branch-status'
-  ]
+  static outlets = ["conditionals-status"];
 
-  static classes = ['error']
+  static classes = ["error"];
 
   static values = {
     index: Number,
     title: String,
     firstLabel: String,
-    otherLabel: String
-  }
+    otherLabel: String,
+  };
 
   // A reference to the parent conditional stimulus controller
   get conditionalController() {
-    return this.element.closest('[data-controller~=conditional]').conditionalController
+    return this.element.closest("[data-controller~=conditional]")
+      .conditionalController;
   }
 
   // the title attribute for the parent conditional e.g. 'branch'
   get conditionalTitle() {
-    return `${this.conditionalController.title.toLowerCase()}`
+    return `${this.conditionalController.title.toLowerCase()}`;
   }
 
   // the title for this expression including its index e.g. 'condition 1'
   get title() {
-    return `${this.titleValue} ${this.indexValue}`
+    return `${this.titleValue} ${this.indexValue}`;
   }
 
   connect() {
     // Attach a reference to this controller to the element
-    this.element[`${this.identifier}Controller`] = this
+    this.element[`${this.identifier}Controller`] = this;
   }
 
   operatorTargetConnected(element) {
-    this.#updateFieldLabel(element)
+    this.#updateFieldLabel(element);
   }
 
   answerTargetConnected(element) {
-    this.#updateFieldLabel(element)
+    this.#updateFieldLabel(element);
   }
-
 
   indexValueChanged(newValue, oldValue) {
     if (newValue !== oldValue) {
-      this.updateLabels()
+      this.updateLabels();
     }
   }
 
   getCondition(event) {
-    const value = event.currentTarget.value
-    const option = event.currentTarget.querySelector(`option[value="${value}"]`)
-    const url = event.params.url.replace('--componentId--', value)
+    const value = event.currentTarget.value;
+    const option = event.currentTarget.querySelector(
+      `option[value="${value}"]`,
+    );
+    const url = event.params.url.replace("--componentId--", value);
 
-    this.clearErrors()
+    this.clearErrors();
 
-    if (value == '') {
-      this.#hide(this.conditionTarget)
-      return
+    if (value == "") {
+      this.#hide(this.conditionTarget);
+      return;
     }
 
-    if (option.dataset.supportsBranching == 'false') {
-      this.#hide(this.conditionTarget)
-      this.showError('unsupported')
-      return
+    if (option.dataset.supportsBranching == "false") {
+      this.#hide(this.conditionTarget);
+      this.showError("unsupported");
+      return;
     }
 
-    if (option.dataset.samePage == 'true') {
-      this.#hide(this.conditionTarget)
-      this.showError('samepage')
-      return
+    if (option.dataset.samePage == "true") {
+      this.#hide(this.conditionTarget);
+      this.showError("samepage");
+      return;
     }
 
-    this.conditionTarget.src = url
-    this.conditionTarget.reload()
-    this.#show(this.conditionTarget)
+    this.conditionTarget.src = url;
+    this.conditionTarget.reload();
+    this.#show(this.conditionTarget);
   }
 
   delete() {
@@ -94,81 +94,90 @@ export default class extends Controller {
   }
 
   deleteWithConfirmation() {
-    document.dispatchEvent(new CustomEvent('ConfirmBranchExpressionRemoval', {
-      detail: {
-        action: () => { this.#destroy() }
-      }
-    }))
+    document.dispatchEvent(
+      new CustomEvent("ConfirmBranchExpressionRemoval", {
+        detail: {
+          action: () => {
+            this.#destroy();
+          },
+        },
+      }),
+    );
   }
 
   hideDeleteButton() {
-    this.#hide(this.deleteButtonTarget)
+    this.#hide(this.deleteButtonTarget);
   }
 
   showDeleteButton() {
-    this.#show(this.deleteButtonTarget)
+    this.#show(this.deleteButtonTarget);
   }
 
   clearErrors() {
-    this.element.classList.remove(this.errorClass)
-    this.errorMessageTargets.forEach((el) => this.#hide(el))
+    this.element.classList.remove(this.errorClass);
+    this.errorMessageTargets.forEach((el) => this.#hide(el));
   }
 
   showError(errorType) {
-    this.element.classList.add(this.errorClass)
-    this.errorMessageTargets.filter((el) => el.dataset.errorType == errorType)
-      .forEach((el) => this.#show(el))
+    this.element.classList.add(this.errorClass);
+    this.errorMessageTargets
+      .filter((el) => el.dataset.errorType == errorType)
+      .forEach((el) => this.#show(el));
   }
 
   updateLabels() {
-    this.updateLabel()
-    this.updateDeleteButtonLabel()
-    this.updateFieldLabels()
+    this.updateLabel();
+    this.updateDeleteButtonLabel();
+    this.updateFieldLabels();
   }
 
   updateLabel() {
-    this.labelTarget.innerText = this.indexValue == 1 ? this.firstLabelValue : this.otherLabelValue
+    this.labelTarget.innerText =
+      this.indexValue == 1 ? this.firstLabelValue : this.otherLabelValue;
   }
 
   updateDeleteButtonLabel() {
-    this.deleteButtonTarget.innerText = `${this.conditionalController.deleteLabelValue} ${this.conditionalTitle} ${this.title}`
+    this.deleteButtonTarget.innerText = `${this.conditionalController.deleteLabelValue} ${this.conditionalTitle} ${this.title}`;
   }
 
   updateFieldLabels() {
-    if (this.hasQuestionTarget) this.#updateFieldLabel(this.questionTarget)
-    if (this.hasOperatorTarget) this.#updateFieldLabel(this.operatorTarget)
-    if (this.hasAnswerTarget) this.#updateFieldLabel(this.answerTarget)
+    if (this.hasQuestionTarget) this.#updateFieldLabel(this.questionTarget);
+    if (this.hasOperatorTarget) this.#updateFieldLabel(this.operatorTarget);
+    if (this.hasAnswerTarget) this.#updateFieldLabel(this.answerTarget);
   }
 
   #updateFieldLabel(element) {
-    const currentValue = element.getAttribute('aria-label')
-    let newValue = ''
-    if (!currentValue.includes('condition')) {
-      newValue = `${currentValue} for ${this.conditionalTitle} ${this.title}`
+    const currentValue = element.getAttribute("aria-label");
+    let newValue = "";
+    if (!currentValue.includes("condition")) {
+      newValue = `${currentValue} for ${this.conditionalTitle} ${this.title}`;
     } else {
       // just update the numbers in the string with new values
-      const replacements = [this.conditionalController.indexValue, this.indexValue]
-      let idx = 0
+      const replacements = [
+        this.conditionalController.indexValue,
+        this.indexValue,
+      ];
+      let idx = 0;
       newValue = currentValue.replace(/\d+/g, () => {
-        const replacement = replacements[idx]
-        idx++
-        return replacement
-      })
+        const replacement = replacements[idx];
+        idx++;
+        return replacement;
+      });
     }
-    element.setAttribute('aria-label', newValue)
+    element.setAttribute("aria-label", newValue);
   }
 
   #hide(element) {
-    element.setAttribute('hidden', '')
+    element.setAttribute("hidden", "");
   }
 
   #show(element) {
-    element.removeAttribute('hidden')
+    element.removeAttribute("hidden");
   }
 
   // Due to ordering, we cannot update the status from a disconnected() observer
   #destroy() {
-    this.branchStatusOutlet.update(`${this.title} removed`)
+    this.conditionalsStatusOutlet.update(`${this.title} removed`);
     this.element.remove();
   }
 }

--- a/app/javascript/src/controllers/expression-controller.js
+++ b/app/javascript/src/controllers/expression-controller.js
@@ -1,166 +1,174 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-    static targets = [
-        'question',
-        'condition',
-        'operator',
-        'answer',
-        'deleteButton',
-        'label',
-        'fieldsetLabel',
-        'errorMessage'
-    ]
+  static targets = [
+    'question',
+    'condition',
+    'operator',
+    'answer',
+    'deleteButton',
+    'label',
+    'fieldsetLabel',
+    'errorMessage'
+  ]
 
-    static classes = ['error']
+  static outlets = [
+    'branch-status'
+  ]
 
-    static values = {
-        index: Number,
-        title: String,
-        firstLabel: String,
-        otherLabel: String
+  static classes = ['error']
+
+  static values = {
+    index: Number,
+    title: String,
+    firstLabel: String,
+    otherLabel: String
+  }
+
+  // A reference to the parent conditional stimulus controller
+  get conditionalController() {
+    return this.element.closest('[data-controller~=conditional]').conditionalController
+  }
+
+  // the title attribute for the parent conditional e.g. 'branch'
+  get conditionalTitle() {
+    return `${this.conditionalController.title.toLowerCase()}`
+  }
+
+  // the title for this expression including its index e.g. 'condition 1'
+  get title() {
+    return `${this.titleValue} ${this.indexValue}`
+  }
+
+  connect() {
+    // Attach a reference to this controller to the element
+    this.element[`${this.identifier}Controller`] = this
+  }
+
+  operatorTargetConnected(element) {
+    this.#updateFieldLabel(element)
+  }
+
+  answerTargetConnected(element) {
+    this.#updateFieldLabel(element)
+  }
+
+
+  indexValueChanged(newValue, oldValue) {
+    if (newValue !== oldValue) {
+      this.updateLabels()
+    }
+  }
+
+  getCondition(event) {
+    const value = event.currentTarget.value
+    const option = event.currentTarget.querySelector(`option[value="${value}"]`)
+    const url = event.params.url.replace('--componentId--', value)
+
+    this.clearErrors()
+
+    if (value == '') {
+      this.#hide(this.conditionTarget)
+      return
     }
 
-    // A reference to the parent conditional stimulus controller
-    get conditionalController() {
-        return this.element.closest('[data-controller~=conditional]').conditionalController
+    if (option.dataset.supportsBranching == 'false') {
+      this.#hide(this.conditionTarget)
+      this.showError('unsupported')
+      return
     }
 
-    // the title attribute for the parent conditional
-    // e.g. 'branch'
-    get conditionalTitle() {
-        return `${this.conditionalController.title.toLowerCase()}`
+    if (option.dataset.samePage == 'true') {
+      this.#hide(this.conditionTarget)
+      this.showError('samepage')
+      return
     }
 
-    // the title for this expression including its index
-    // e.g. 'condition 1'
-    get title() {
-        return `${this.titleValue} ${this.indexValue}`
+    this.conditionTarget.src = url
+    this.conditionTarget.reload()
+    this.#show(this.conditionTarget)
+  }
+
+  delete() {
+    this.#destroy();
+  }
+
+  deleteWithConfirmation() {
+    document.dispatchEvent(new CustomEvent('ConfirmBranchExpressionRemoval', {
+      detail: {
+        action: () => { this.#destroy() }
+      }
+    }))
+  }
+
+  hideDeleteButton() {
+    this.#hide(this.deleteButtonTarget)
+  }
+
+  showDeleteButton() {
+    this.#show(this.deleteButtonTarget)
+  }
+
+  clearErrors() {
+    this.element.classList.remove(this.errorClass)
+    this.errorMessageTargets.forEach((el) => this.#hide(el))
+  }
+
+  showError(errorType) {
+    this.element.classList.add(this.errorClass)
+    this.errorMessageTargets.filter((el) => el.dataset.errorType == errorType)
+      .forEach((el) => this.#show(el))
+  }
+
+  updateLabels() {
+    this.updateLabel()
+    this.updateDeleteButtonLabel()
+    this.updateFieldLabels()
+  }
+
+  updateLabel() {
+    this.labelTarget.innerText = this.indexValue == 1 ? this.firstLabelValue : this.otherLabelValue
+  }
+
+  updateDeleteButtonLabel() {
+    this.deleteButtonTarget.innerText = `${this.conditionalController.deleteLabelValue} ${this.conditionalTitle} ${this.title}`
+  }
+
+  updateFieldLabels() {
+    if (this.hasQuestionTarget) this.#updateFieldLabel(this.questionTarget)
+    if (this.hasOperatorTarget) this.#updateFieldLabel(this.operatorTarget)
+    if (this.hasAnswerTarget) this.#updateFieldLabel(this.answerTarget)
+  }
+
+  #updateFieldLabel(element) {
+    const currentValue = element.getAttribute('aria-label')
+    let newValue = ''
+    if (!currentValue.includes('condition')) {
+      newValue = `${currentValue} for ${this.conditionalTitle} ${this.title}`
+    } else {
+      // just update the numbers in the string with new values
+      const replacements = [this.conditionalController.indexValue, this.indexValue]
+      let idx = 0
+      newValue = currentValue.replace(/\d+/g, () => {
+        const replacement = replacements[idx]
+        idx++
+        return replacement
+      })
     }
+    element.setAttribute('aria-label', newValue)
+  }
 
-    connect() {
-        // Attach a reference to this controller to the element
-        this.element[`${this.identifier}Controller`] = this
-    }
+  #hide(element) {
+    element.setAttribute('hidden', '')
+  }
 
-    operatorTargetConnected(element) {
-        this.updateFieldLabel(element)
-    }
+  #show(element) {
+    element.removeAttribute('hidden')
+  }
 
-    answerTargetConnected(element) {
-        this.updateFieldLabel(element)
-    }
-
-
-    indexValueChanged(newValue, oldValue) {
-        if (newValue !== oldValue) {
-            this.updateLabels()
-        }
-    }
-
-    getCondition(event) {
-        const value = event.currentTarget.value
-        const option = event.currentTarget.querySelector(`option[value="${value}"]`)
-        const url = event.params.url.replace('--componentId--', value)
-
-        this.clearErrors()
-
-        if (value == '') {
-            this.hide(this.conditionTarget)
-            return
-        }
-
-        if (option.dataset.supportsBranching == 'false') {
-            this.hide(this.conditionTarget)
-            this.showError('unsupported')
-            return
-        }
-
-        if (option.dataset.samePage == 'true') {
-            this.hide(this.conditionTarget)
-            this.showError('samepage')
-            return
-        }
-
-        this.conditionTarget.src = url
-        this.conditionTarget.reload()
-        this.show(this.conditionTarget)
-    }
-
-    delete() {
-        this.element.remove();
-    }
-
-    deleteWithConfirmation() {
-        document.dispatchEvent(new CustomEvent('ConfirmBranchExpressionRemoval', {
-            detail: {
-                action: () => { this.element.remove() }
-            }
-        }))
-    }
-
-    hide(element) {
-        element.setAttribute('hidden', '')
-    }
-
-    show(element) {
-        element.removeAttribute('hidden')
-    }
-
-    hideDeleteButton() {
-        this.deleteButtonTarget.setAttribute('hidden', '')
-    }
-
-    showDeleteButton() {
-        this.deleteButtonTarget.removeAttribute('hidden')
-    }
-
-    clearErrors() {
-        this.element.classList.remove(this.errorClass)
-        this.errorMessageTargets.forEach((el) => this.hide(el))
-    }
-
-    showError(errorType) {
-        this.element.classList.add(this.errorClass)
-        this.errorMessageTargets.filter((el) => el.dataset.errorType == errorType)
-            .forEach((el) => this.show(el))
-    }
-
-    updateLabels() {
-        this.updateLabel()
-        this.updateDeleteButtonLabel()
-        this.updateFieldLabels()
-    }
-
-    updateLabel() {
-        this.labelTarget.innerText = this.indexValue == 1 ? this.firstLabelValue : this.otherLabelValue
-    }
-
-    updateDeleteButtonLabel() {
-        this.deleteButtonTarget.innerText = `${this.conditionalController.deleteLabelValue} ${this.conditionalTitle} ${this.title}`
-    }
-
-    updateFieldLabels() {
-        if (this.hasQuestionTarget) this.updateFieldLabel(this.questionTarget)
-        if (this.hasOperatorTarget) this.updateFieldLabel(this.operatorTarget)
-        if (this.hasAnswerTarget) this.updateFieldLabel(this.answerTarget)
-    }
-
-    updateFieldLabel(element) {
-        const currentValue = element.getAttribute('aria-label')
-        let newValue = ''
-        if (!currentValue.includes('condition')) {
-            newValue = `${currentValue} for ${this.conditionalTitle} ${this.title}`
-        } else {
-            // just update the numbers in the string with new values
-            const replacements = [this.conditionalController.indexValue, this.indexValue]
-            let idx = 0
-            newValue = currentValue.replace(/\d+/g, () => {
-                const replacement = replacements[idx]
-                idx++
-                return replacement
-            })
-        }
-        element.setAttribute('aria-label', newValue)
-    }
+  // Due to ordering, we cannot update the status from a disconnected() observer
+  #destroy() {
+    this.branchStatusOutlet.update(`${this.title} removed`)
+    this.element.remove();
+  }
 }

--- a/app/javascript/src/controllers/expression-controller.js
+++ b/app/javascript/src/controllers/expression-controller.js
@@ -1,80 +1,127 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ['question', 'condition', 'deleteButton', 'label', 'errorMessage']
-  static classes = ['error']
-  static values = {
-    firstLabel: String,
-    otherLabel: String
-  }
-
-  connect() {
-    // Attach a reference to the controller to the element
-    this.element[`${this.identifier}Controller`] = this
-  }
-
-  getCondition(event) {
-    const value = event.currentTarget.value
-    const option = event.currentTarget.querySelector(`option[value="${value}"]`)
-    const url = event.params.url.replace('--componentId--', value)
-
-    this.clearError()
-
-    if (value == '') {
-      this.conditionTarget.setAttribute('hidden', '')
-      return
+    static targets = ['question', 'condition', 'operator', 'answer', 'deleteButton', 'label', 'errorMessage']
+    static classes = ['error']
+    static values = {
+        index: Number,
+        firstLabel: String,
+        otherLabel: String
     }
 
-    if (option.dataset.supportsBranching == 'false') {
-      this.conditionTarget.setAttribute('hidden', '')
-      this.showError('unsupported')
-      return
+    connect() {
+        // Attach a reference to the controller to the element
+        this.element[`${this.identifier}Controller`] = this
     }
 
-    if (option.dataset.samePage == 'true') {
-      this.conditionTarget.setAttribute('hidden', '')
-      this.showError('samepage')
-      return
+    indexValueChanged(value, previous) {
+        this.updateLabel()
+        this.updateFieldLabels()
     }
 
-    this.conditionTarget.src = url
-    this.conditionTarget.reload()
-    this.conditionTarget.removeAttribute('hidden')
-  }
+    operatorTargetConnected() {
+        this.updateFieldLabels()
+    }
 
-  delete(event) {
-    this.element.remove();
-  }
+    answerTargetConnected() {
+        this.updateFieldLabels()
+    }
 
-  deleteWithConfirmation() {
-    document.dispatchEvent(new CustomEvent('ConfirmBranchExpressionRemoval', {
-      detail: {
-        action: () => { this.element.remove() }
-      }
-    }))
-  }
+    get conditionalController() {
+        return this.element.closest('[data-controller~=conditional]').conditionalController
+    }
+
+    getCondition(event) {
+        const value = event.currentTarget.value
+        const option = event.currentTarget.querySelector(`option[value="${value}"]`)
+        const url = event.params.url.replace('--componentId--', value)
+
+        this.clearError()
+
+        if (value == '') {
+            this.conditionTarget.setAttribute('hidden', '')
+            return
+        }
+
+        if (option.dataset.supportsBranching == 'false') {
+            this.conditionTarget.setAttribute('hidden', '')
+            this.showError('unsupported')
+            return
+        }
+
+        if (option.dataset.samePage == 'true') {
+            this.conditionTarget.setAttribute('hidden', '')
+            this.showError('samepage')
+            return
+        }
+
+        this.conditionTarget.src = url
+        this.conditionTarget.reload()
+        this.conditionTarget.removeAttribute('hidden')
+    }
+
+    delete() {
+        this.element.remove();
+    }
+
+    deleteWithConfirmation() {
+        document.dispatchEvent(new CustomEvent('ConfirmBranchExpressionRemoval', {
+            detail: {
+                action: () => { this.element.remove() }
+            }
+        }))
+    }
 
 
-  showError(errorType) {
-    this.element.classList.add(this.errorClass)
-    this.errorMessageTargets.filter((el) => el.dataset.errorType == errorType)
-      .forEach((el) => el.removeAttribute('hidden'))
-  }
+    showError(errorType) {
+        this.element.classList.add(this.errorClass)
+        this.errorMessageTargets.filter((el) => el.dataset.errorType == errorType)
+            .forEach((el) => el.removeAttribute('hidden'))
+    }
 
-  clearError() {
-    this.element.classList.remove(this.errorClass)
-    this.errorMessageTargets.forEach((el) => el.setAttribute('hidden', ''))
-  }
+    clearError() {
+        this.element.classList.remove(this.errorClass)
+        this.errorMessageTargets.forEach((el) => el.setAttribute('hidden', ''))
+    }
 
-  hideDeleteButton() {
-    this.deleteButtonTarget.setAttribute('hidden', '')
-  }
+    hideDeleteButton() {
+        this.deleteButtonTarget.setAttribute('hidden', '')
+    }
 
-  showDeleteButton() {
-    this.deleteButtonTarget.removeAttribute('hidden')
-  }
+    showDeleteButton() {
+        this.deleteButtonTarget.removeAttribute('hidden')
+    }
 
-  setLabelText(value) {
-    this.labelTarget.innerText = value
-  }
+    updateLabel() {
+        this.labelTarget.innerText = this.indexValue == 1 ? this.firstLabelValue : this.otherLabelValue
+    }
+
+    updateFieldLabels() {
+        this.updateFieldLabel(this.questionTarget)
+        if (this.hasOperatorTarget) {
+            this.updateFieldLabel(this.operatorTarget)
+        }
+        if (this.hasAnswerTarget) {
+            this.updateFieldLabel(this.answerTarget)
+        }
+    }
+
+    updateFieldLabel(field) {
+        const currentValue = field.getAttribute('aria-label')
+        let newValue = ''
+        if (!currentValue.includes('condition')) {
+            // We've not updated this before, update the whole string
+            newValue = `${currentValue} for branch ${this.conditionalController.indexValue} condition ${this.indexValue}`
+        } else {
+            // just update the numbers in the string with new values
+            const replacements = [this.conditionalController.indexValue, this.indexValue]
+            let idx = 0
+            newValue = currentValue.replace(/\d+/g, () => {
+                const replacement = replacements[idx]
+                idx++
+                return replacement
+            })
+        }
+        field.setAttribute('aria-label', `${newValue}`)
+    }
 }

--- a/app/javascript/src/controllers/expression-controller.js
+++ b/app/javascript/src/controllers/expression-controller.js
@@ -1,8 +1,19 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-    static targets = ['question', 'condition', 'operator', 'answer', 'deleteButton', 'label', 'fieldsetLabel', 'errorMessage']
+    static targets = [
+        'question',
+        'condition',
+        'operator',
+        'answer',
+        'deleteButton',
+        'label',
+        'fieldsetLabel',
+        'errorMessage'
+    ]
+
     static classes = ['error']
+
     static values = {
         index: Number,
         title: String,
@@ -55,25 +66,25 @@ export default class extends Controller {
         this.clearErrors()
 
         if (value == '') {
-            this.hideCondition()
+            this.hide(this.conditionTarget)
             return
         }
 
         if (option.dataset.supportsBranching == 'false') {
-            this.hideCondition()
+            this.hide(this.conditionTarget)
             this.showError('unsupported')
             return
         }
 
         if (option.dataset.samePage == 'true') {
-            this.hideCondition()
+            this.hide(this.conditionTarget)
             this.showError('samepage')
             return
         }
 
         this.conditionTarget.src = url
         this.conditionTarget.reload()
-        this.showCondition()
+        this.show(this.conditionTarget)
     }
 
     delete() {
@@ -88,12 +99,12 @@ export default class extends Controller {
         }))
     }
 
-    hideCondition() {
-        this.conditionTarget.setAttribute('hidden', '')
+    hide(element) {
+        element.setAttribute('hidden', '')
     }
 
-    showCondition() {
-        this.conditionTarget.removeAttribute('hidden')
+    show(element) {
+        element.removeAttribute('hidden')
     }
 
     hideDeleteButton() {
@@ -106,13 +117,13 @@ export default class extends Controller {
 
     clearErrors() {
         this.element.classList.remove(this.errorClass)
-        this.errorMessageTargets.forEach((el) => el.setAttribute('hidden', ''))
+        this.errorMessageTargets.forEach((el) => this.hide(el))
     }
 
     showError(errorType) {
         this.element.classList.add(this.errorClass)
         this.errorMessageTargets.filter((el) => el.dataset.errorType == errorType)
-            .forEach((el) => el.removeAttribute('hidden'))
+            .forEach((el) => this.show(el))
     }
 
     updateLabels() {
@@ -136,7 +147,6 @@ export default class extends Controller {
     }
 
     updateFieldLabel(element) {
-        console.log(element)
         const currentValue = element.getAttribute('aria-label')
         let newValue = ''
         if (!currentValue.includes('condition')) {

--- a/app/javascript/src/controllers/expression-controller.js
+++ b/app/javascript/src/controllers/expression-controller.js
@@ -32,6 +32,15 @@ export default class extends Controller {
         this.element[`${this.identifier}Controller`] = this
     }
 
+    operatorTargetConnected(element) {
+        this.updateFieldLabel(element)
+    }
+
+    answerTargetConnected(element) {
+        this.updateFieldLabel(element)
+    }
+
+
     indexValueChanged(newValue, oldValue) {
         if (newValue !== oldValue) {
             this.updateLabels()
@@ -109,7 +118,7 @@ export default class extends Controller {
     updateLabels() {
         this.updateLabel()
         this.updateDeleteButtonLabel()
-        this.updateFieldsetLabel()
+        this.updateFieldLabels()
     }
 
     updateLabel() {
@@ -120,17 +129,28 @@ export default class extends Controller {
         this.deleteButtonTarget.innerText = `${this.conditionalController.deleteLabelValue} ${this.conditionalTitle} ${this.title}`
     }
 
-    updateFieldsetLabel() {
-        const currentValue = this.fieldsetLabelTarget.innerText
+    updateFieldLabels() {
+        if (this.hasQuestionTarget) this.updateFieldLabel(this.questionTarget)
+        if (this.hasOperatorTarget) this.updateFieldLabel(this.operatorTarget)
+        if (this.hasAnswerTarget) this.updateFieldLabel(this.answerTarget)
+    }
+
+    updateFieldLabel(element) {
+        console.log(element)
+        const currentValue = element.getAttribute('aria-label')
         let newValue = ''
-        // just update the numbers in the string with new values
-        const replacements = [this.indexValue, this.conditionalController.indexValue]
-        let idx = 0
-        newValue = currentValue.replace(/\d+/g, () => {
-            const replacement = replacements[idx]
-            idx++
-            return replacement
-        })
-        this.fieldsetLabelTarget.innerText = newValue
+        if (!currentValue.includes('condition')) {
+            newValue = `${currentValue} for ${this.conditionalTitle} ${this.title}`
+        } else {
+            // just update the numbers in the string with new values
+            const replacements = [this.conditionalController.indexValue, this.indexValue]
+            let idx = 0
+            newValue = currentValue.replace(/\d+/g, () => {
+                const replacement = replacements[idx]
+                idx++
+                return replacement
+            })
+        }
+        element.setAttribute('aria-label', newValue)
     }
 }

--- a/app/javascript/src/controllers/expression-controller.js
+++ b/app/javascript/src/controllers/expression-controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-    static targets = ['question', 'condition', 'operator', 'answer', 'deleteButton', 'label', 'heading', 'errorMessage']
+    static targets = ['question', 'condition', 'operator', 'answer', 'deleteButton', 'label', 'fieldsetLabel', 'errorMessage']
     static classes = ['error']
     static values = {
         index: Number,
@@ -34,10 +34,7 @@ export default class extends Controller {
 
     indexValueChanged(newValue, oldValue) {
         if (newValue !== oldValue) {
-            this.updateLabel()
-            this.updateDeleteButtonLabel()
-            // this.updateFieldLabels()
-            this.updateHeading()
+            this.updateLabels()
         }
     }
 
@@ -109,20 +106,23 @@ export default class extends Controller {
             .forEach((el) => el.removeAttribute('hidden'))
     }
 
+    updateLabels() {
+        this.updateLabel()
+        this.updateDeleteButtonLabel()
+        this.updateFieldsetLabel()
+    }
+
     updateLabel() {
-        console.log(this.indexValue)
         this.labelTarget.innerText = this.indexValue == 1 ? this.firstLabelValue : this.otherLabelValue
     }
 
     updateDeleteButtonLabel() {
-        console.log('updating delete button label')
         this.deleteButtonTarget.innerText = `${this.conditionalController.deleteLabelValue} ${this.conditionalTitle} ${this.title}`
     }
 
-    updateHeading() {
-        const currentValue = this.headingTarget.innerText
+    updateFieldsetLabel() {
+        const currentValue = this.fieldsetLabelTarget.innerText
         let newValue = ''
-        console.log(currentValue)
         // just update the numbers in the string with new values
         const replacements = [this.indexValue, this.conditionalController.indexValue]
         let idx = 0
@@ -131,6 +131,6 @@ export default class extends Controller {
             idx++
             return replacement
         })
-        this.headingTarget.innerText = newValue
+        this.fieldsetLabelTarget.innerText = newValue
     }
 }

--- a/app/javascript/src/controllers/expressions-controller.js
+++ b/app/javascript/src/controllers/expressions-controller.js
@@ -16,12 +16,12 @@ export default class extends Controller {
         })
     }
 
-    expressionTargetDisconnected(element) {
+    expressionTargetDisconnected() {
         this.ensureFirstExpressionCannotBeDeleted()
         this.updateExpressionIndices()
     }
 
-    expressionTargetConnected(element) {
+    expressionTargetConnected() {
         if (!this.connected) return
 
         this.allowFirstExpressionToBeDeleted();

--- a/app/javascript/src/controllers/expressions-controller.js
+++ b/app/javascript/src/controllers/expressions-controller.js
@@ -1,52 +1,48 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets =  [ 'expression' ]
+    static targets = ['expression']
 
-  initialize() {
-    this.connected = false;
-  }
-
-  connect() {
-    Promise.resolve().then(() => {
-      this.connected = true
-      this.ensureFirstExpressionCannotBeDeleted()
-      this.allowFirstExpressionToBeDeleted()
-      this.setExpressionLabels()
-    })
-  }
-
-  expressionTargetDisconnected(element) {
-    this.ensureFirstExpressionCannotBeDeleted()
-    this.setExpressionLabels()
-  }
-  
-  expressionTargetConnected(element) {
-    if (!this.connected) return
-
-    this.allowFirstExpressionToBeDeleted();
-    this.setExpressionLabels()
-  }
-
-  ensureFirstExpressionCannotBeDeleted() {
-    if(this.expressionTargets.length == 1) {
-      this.expressionTargets[0].expressionController.hideDeleteButton()
+    initialize() {
+        this.connected = false;
     }
-  }
 
-  allowFirstExpressionToBeDeleted() {
-    if(this.expressionTargets.length > 1) {
-      this.expressionTargets[0].expressionController.showDeleteButton() 
+    connect() {
+        Promise.resolve().then(() => {
+            this.connected = true
+            this.ensureFirstExpressionCannotBeDeleted()
+            this.allowFirstExpressionToBeDeleted()
+            this.updateExpressionIndices()
+        })
     }
-  }
 
-  setExpressionLabels(element) {
-    this.expressionTargets.forEach( (element, index) => {
-      if( index == 0) {
-       element.expressionController.setLabelText(element.expressionController.firstLabelValue)  
-      } else {
-        element.expressionController.setLabelText(element.expressionController.otherLabelValue)  
-      }
-    });
-  }
+    expressionTargetDisconnected(element) {
+        this.ensureFirstExpressionCannotBeDeleted()
+        this.updateExpressionIndices()
+    }
+
+    expressionTargetConnected(element) {
+        if (!this.connected) return
+
+        this.allowFirstExpressionToBeDeleted();
+        this.updateExpressionIndices()
+    }
+
+    ensureFirstExpressionCannotBeDeleted() {
+        if (this.expressionTargets.length == 1) {
+            this.expressionTargets[0].expressionController.hideDeleteButton()
+        }
+    }
+
+    allowFirstExpressionToBeDeleted() {
+        if (this.expressionTargets.length > 1) {
+            this.expressionTargets[0].expressionController.showDeleteButton()
+        }
+    }
+
+    updateExpressionIndices() {
+        this.expressionTargets.forEach((element, index) => {
+            element.expressionController.indexValue = index + 1
+        })
+    }
 }

--- a/app/javascript/src/controllers/expressions-controller.js
+++ b/app/javascript/src/controllers/expressions-controller.js
@@ -10,31 +10,34 @@ export default class extends Controller {
     connect() {
         Promise.resolve().then(() => {
             this.connected = true
-            this.ensureFirstExpressionCannotBeDeleted()
-            this.allowFirstExpressionToBeDeleted()
+            this.preventFirstExpressionDeletion()
+            this.allowFirstExpressionDeletion()
             this.updateExpressionIndices()
         })
     }
 
     expressionTargetDisconnected() {
-        this.ensureFirstExpressionCannotBeDeleted()
+        this.preventFirstExpressionDeletion()
         this.updateExpressionIndices()
     }
 
-    expressionTargetConnected() {
-        if (!this.connected) return
+    update(event) {
+        if (event.detail.additionType != 'expression') return
 
-        this.allowFirstExpressionToBeDeleted();
-        this.updateExpressionIndices()
+        Promise.resolve().then(() => {
+            this.allowFirstExpressionDeletion();
+            this.updateExpressionIndices();
+        })
     }
 
-    ensureFirstExpressionCannotBeDeleted() {
+
+    preventFirstExpressionDeletion() {
         if (this.expressionTargets.length == 1) {
             this.expressionTargets[0].expressionController.hideDeleteButton()
         }
     }
 
-    allowFirstExpressionToBeDeleted() {
+    allowFirstExpressionDeletion() {
         if (this.expressionTargets.length > 1) {
             this.expressionTargets[0].expressionController.showDeleteButton()
         }

--- a/app/javascript/styles/_mixins.scss
+++ b/app/javascript/styles/_mixins.scss
@@ -89,7 +89,7 @@
 @mixin container_panel {
   background-color: govuk-colour("light-grey");
   border-radius: 15px;
-  padding: govuk-spacing(3) govuk-spacing(4) 1px govuk-spacing(4);
+  padding: govuk-spacing(3) govuk-spacing(4);
 }
 
 @mixin icon_button {

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -24,6 +24,7 @@
 @import "./component_status_message";
 @import "components/settings-screen";
 @import "components/back-link";
+@import "components/panel";
 @import "components/conditional";
 @import "components/expression";
 @import "components/icon-button";

--- a/app/javascript/styles/components/conditional.scss
+++ b/app/javascript/styles/components/conditional.scss
@@ -1,5 +1,4 @@
 .conditional {
-  @include container_panel;
   border: none;
 
   @include govuk-media-query($until: tablet) {
@@ -20,6 +19,14 @@
     top: 14px
   }
 
+}
+
+.conditional--otherwise {
+  padding-top: govuk-spacing(3);
+
+  > h2 span {
+    display: inline;
+  }
 }
 
 .conditional__expressions {

--- a/app/javascript/styles/components/conditional.scss
+++ b/app/javascript/styles/components/conditional.scss
@@ -1,17 +1,23 @@
 .conditional {
   @include container_panel;
+  border: none;
 
   @include govuk-media-query($until: tablet) {
     padding-right: govuk-spacing(5);
   }
 
-  padding-top: govuk-spacing(3);
+  padding-top: govuk-spacing(9);
   padding-bottom: govuk-spacing(4);
   padding-right: 100px;
   position: relative;
 
   &:last-child {
     margin-bottom: govuk-spacing(6);
+  }
+
+  > legend {
+    position:absolute;
+    top: 14px
   }
 
 }

--- a/app/javascript/styles/components/conditional.scss
+++ b/app/javascript/styles/components/conditional.scss
@@ -25,7 +25,7 @@
   position: relative;
 
 
-  label {
+  .label {
     @include govuk-font($size: 24);
 
     display: inline-block;

--- a/app/javascript/styles/components/conditional.scss
+++ b/app/javascript/styles/components/conditional.scss
@@ -19,6 +19,12 @@
     top: 14px
   }
 
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    outline-offset: 0;
+    box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+  }
+
 }
 
 .conditional--otherwise {

--- a/app/javascript/styles/components/expression.scss
+++ b/app/javascript/styles/components/expression.scss
@@ -2,6 +2,7 @@
   margin-top: govuk-spacing(6);
   // padding-left: govuk-spacing(3);
   position: relative;
+  border: none;
 
   &:after {
     background-color: $govuk-border-colour;
@@ -9,7 +10,7 @@
     display: block;
     position: absolute;
     top: 0;
-    left: 10%;
+    left: 13%;
     width: 5px;
     height: 100%;
   }

--- a/app/javascript/styles/components/expression.scss
+++ b/app/javascript/styles/components/expression.scss
@@ -3,6 +3,7 @@
   // padding-left: govuk-spacing(3);
   position: relative;
   border: none;
+  padding: 0;
 
   &:after {
     background-color: $govuk-border-colour;
@@ -10,7 +11,7 @@
     display: block;
     position: absolute;
     top: 0;
-    left: 13%;
+    left: 12%;
     width: 5px;
     height: 100%;
   }
@@ -20,7 +21,7 @@
       background-color: $govuk-error-colour;
     }
 
-    p{
+    p {
       color: $govuk-error-colour;
       font-weight: bold;
       margin-top: govuk-spacing(3);

--- a/app/javascript/styles/components/panel.scss
+++ b/app/javascript/styles/components/panel.scss
@@ -1,0 +1,3 @@
+.panel {
+  @include container_panel;
+}

--- a/app/views/api/conditional_contents/_conditional_fields.html.erb
+++ b/app/views/api/conditional_contents/_conditional_fields.html.erb
@@ -1,6 +1,12 @@
-<div data-controller="conditional" data-conditionals-target="conditional" data-conditional-title-value="Rule">
-  <section class="conditional">
-    <h3 class="govuk-heading-l" data-conditional-target="title">Rule <%= conditional.options[:child_index].to_i+1 %></h3>
+<div  data-controller="conditional" 
+      data-conditionals-target="conditional" 
+      data-conditional-title-value="Rule"
+      data-conditional-delete-label-value="Remove" 
+      data-action="dynamic-fields:fieldsAdded->conditional#focusNewExpression">
+  <fieldset class="panel conditional">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h2 class="govuk-fieldset__heading" data-conditional-target="title">Rule <%= conditional.options[:child_index].to_i+1 %></h3>
+    </legend>
     <%= button_tag 'Delete rule', type: "button", data: { action: "conditional#delete", conditional_target: "deleteButton" }, class: 'prevent-modal-close icon-button icon-button--remove conditional__remover' %>
 
     <div class="conditional__expressions" data-controller="dynamic-fields expressions">
@@ -14,7 +20,9 @@
         <% end %>
       </template>
 
-      <%= button_tag I18n.t('conditional_content.add_condition'), type: 'button', data: { action: 'dynamic-fields#add'}, class: 'govuk-link fb-link-button prevent-modal-close' %>
+      <%= button_tag type: 'button', data: { action: 'dynamic-fields#add', dynamic_fields_type_param: 'expression'}, class: 'govuk-link fb-link-button prevent-modal-close' do %>
+        <%= I18n.t('conditional_content.add_condition') %><span class="govuk-visually-hidden"><%= I18n.t('conditional_content.condition_target', type: 'rule', index: conditional.options[:child_index].to_i+1)%></span>
+      <% end %>
     </div>
   </section>
   <div class="conditional-separator">or</div>

--- a/app/views/api/conditional_contents/_conditional_fields.html.erb
+++ b/app/views/api/conditional_contents/_conditional_fields.html.erb
@@ -1,15 +1,16 @@
 <div  data-controller="conditional" 
       data-conditionals-target="conditional" 
+      data-conditional-conditionals-status-outlet="#conditionals-status"
       data-conditional-title-value="Rule"
       data-conditional-delete-label-value="Remove" 
       data-action="dynamic-fields:fieldsAdded->conditional#focusNewExpression">
-  <fieldset class="panel conditional">
+  <fieldset class="govuk-fieldset panel conditional" data-conditional-target="fieldset" data-conditional-index-value="<%= conditional.options[:child_index]%>" tabindex="-1">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h2 class="govuk-fieldset__heading" data-conditional-target="title">Rule <%= conditional.options[:child_index].to_i+1 %></h3>
     </legend>
     <%= button_tag 'Delete rule', type: "button", data: { action: "conditional#delete", conditional_target: "deleteButton" }, class: 'prevent-modal-close icon-button icon-button--remove conditional__remover' %>
 
-    <div class="conditional__expressions" data-controller="dynamic-fields expressions">
+    <div class="conditional__expressions" data-controller="dynamic-fields expressions" data-action="dynamic-fields:fieldsAdded->expressions#update">
       <%= conditional.fields_for :expressions do |expression| %>
         <%= render 'expression_fields', conditional: conditional, expression: expression, component_uuid: component_uuid  %>
       <% end %>
@@ -24,7 +25,7 @@
         <%= I18n.t('conditional_content.add_condition') %><span class="govuk-visually-hidden"><%= I18n.t('conditional_content.condition_target', type: 'rule', index: conditional.options[:child_index].to_i+1)%></span>
       <% end %>
     </div>
-  </section>
+  </fieldset>
   <div class="conditional-separator">or</div>
 </div>
 

--- a/app/views/api/conditional_contents/_expression_condition.html.erb
+++ b/app/views/api/conditional_contents/_expression_condition.html.erb
@@ -23,6 +23,7 @@
               attribute: 'operator',
             ),
             'aria-label': 'Operator',
+            'aria-describedby': 'operator_hint'
           }
         %>
 
@@ -47,7 +48,8 @@
             expression_index: expression_index,
             attribute: 'field',
           ),
-          'aria-label': 'Answer'
+          'aria-label': 'Answer',
+          'aria-describedby': 'value_hint'
         }
 
       %>

--- a/app/views/api/conditional_contents/_expression_condition.html.erb
+++ b/app/views/api/conditional_contents/_expression_condition.html.erb
@@ -21,8 +21,8 @@
               conditional_index: conditional_index,
               expression_index: expression_index,
               attribute: 'operator',
-
-            )
+            ),
+            'aria-label': 'Operator',
           }
         %>
 
@@ -46,8 +46,8 @@
             conditional_index: conditional_index,
             expression_index: expression_index,
             attribute: 'field',
-
-          )
+          ),
+          'aria-label': 'Answer'
         }
 
       %>

--- a/app/views/api/conditional_contents/_expression_fields.html.erb
+++ b/app/views/api/conditional_contents/_expression_fields.html.erb
@@ -3,6 +3,7 @@
       data-conditional-target="expression"
       data-controller="expression"
       data-expression-error-class="error"
+      data-expression-conditionals-status-outlet="#conditionals-status"
       data-expression-index-value="0"
       data-expression-title-value="condition"
       data-expression-first-label-value="<%= t('branches.expression.if') %>"

--- a/app/views/api/conditional_contents/_expression_fields.html.erb
+++ b/app/views/api/conditional_contents/_expression_fields.html.erb
@@ -19,7 +19,7 @@
       { include_blank: t('branches.select_question') },
       { class: "govuk-select expression__component #{ expression.object.errors[:component].any? ? 'govuk-select--error' : '' }",
         'aria-label': 'Source question',
-        'aria-describedby': ( "condition_#{conditional.options[:child_index]}_expression_#{expression.options[:child_index]}_component_error" if expression.object.errors[:component].any? ),
+        'aria-describedby': ( expression.object.errors[:component].any? ? "condition_#{conditional.options[:child_index]}_expression_#{expression.options[:child_index]}_component_error" : "") + "source_question_hint",
         data: {
           action: 'change->expression#getCondition',
           expression_target: 'question',

--- a/app/views/api/conditional_contents/_expression_fields.html.erb
+++ b/app/views/api/conditional_contents/_expression_fields.html.erb
@@ -1,26 +1,25 @@
 <div  class="expression govuk-form-group <%= expression.object.errors.any? ? 'error' : '' %>"
       data-expressions-target="expression"
+      data-conditional-target="expression"
       data-controller="expression"
       data-expression-error-class="error"
+      data-expression-index-value="0"
+      data-expression-title-value="condition"
       data-expression-first-label-value="<%= t('branches.expression.if') %>"
       data-expression-other-label-value="<%= t('branches.expression.and') %>">
 
-  <%= button_tag 'Delete condition', type: "button", data: { action: "expression#delete", expression_target: "deleteButton"}, class: 'prevent-modal-close icon-button icon-button--remove expression__remover' %>
 
   <div class="conditional__question">
-    <%= expression.label  :component,
-      t('branches.expression.if'),
-      {
-        class: "govuk-label",
-        data: {
-          expression_target: 'label'
-        }
-      }
-    %>
+    <div class="label" data-expression-target="label">
+      <%= t('branches.expression.if') %>
+    </div>
+
     <%= expression.select :component,
       @conditional_content.previous_questions,
       { include_blank: t('branches.select_question') },
       { class: "govuk-select expression__component #{ expression.object.errors[:component].any? ? 'govuk-select--error' : '' }",
+        'aria-label': 'Source question',
+        'aria-describedby': ( "condition_#{conditional.options[:child_index]}_expression_#{expression.options[:child_index]}_component_error" if expression.object.errors[:component].any? ),
         data: {
           action: 'change->expression#getCondition',
           expression_target: 'question',
@@ -39,5 +38,14 @@
         conditional_index: conditional.options[:child_index],
         expression_index: expression.options[:child_index]
       }
+    %>
+
+    <%= button_tag 'Delete condition', 
+      type: "button", 
+      data: { 
+        action: "expression#delete", 
+        expression_target: "deleteButton"
+      }, 
+      class: 'prevent-modal-close icon-button icon-button--remove expression__remover' 
     %>
 </div>

--- a/app/views/api/conditional_contents/_form.html.erb
+++ b/app/views/api/conditional_contents/_form.html.erb
@@ -3,6 +3,7 @@
   <%= f.hidden_field :previous_flow_uuid, value: @conditional_content.previous_flow_uuid %>
   <%= f.hidden_field :component_uuid, value: @conditional_content.component_uuid %>
   
+  <div id="conditionals-status" class="govuk-visually-hidden" data-controller="conditionals-status" role="alert"></div>
   <p id="source_question_hint" hidden><%= t('conditional_content.hints.question') %></p>
   <p id="operator_hint" hidden><%= t('conditional_content.hints.operator') %></p>
   <p id="value_hint" hidden><%= t('conditional_content.hints.value') %></p>
@@ -37,7 +38,7 @@
       </div>
     </fieldset>
 
-    <fieldset class="govuk-fieldset conditionals govuk-!-margin-bottom-6" data-controller="dynamic-fields conditionals" data-selection-reveal-target="reveal" data-action="dynamic-fields:fieldsAdded->conditionals#update">
+    <fieldset class="govuk-fieldset conditionals govuk-!-margin-bottom-6" data-controller="dynamic-fields conditionals" data-selection-reveal-target="reveal" data-action="dynamic-fields:fieldsAdded->conditionals#newConditionalAdded">
       <%= f.fields_for :conditionals, child_index: conditional_index do |conditional| %>
         <%= render 'conditional_fields', conditional: conditional, f: f, component_uuid: f.object.component_uuid %>
       <% end %>

--- a/app/views/api/conditional_contents/_form.html.erb
+++ b/app/views/api/conditional_contents/_form.html.erb
@@ -2,6 +2,10 @@
 <%= form_for @conditional_content, url: api_service_update_conditional_content_path(service.service_id, params[:component_uuid]), method: :put do |f| %>
   <%= f.hidden_field :previous_flow_uuid, value: @conditional_content.previous_flow_uuid %>
   <%= f.hidden_field :component_uuid, value: @conditional_content.component_uuid %>
+  
+  <p id="source_question_hint" hidden><%= t('conditional_content.hints.question') %></p>
+  <p id="operator_hint" hidden><%= t('conditional_content.hints.operator') %></p>
+  <p id="value_hint" hidden><%= t('conditional_content.hints.value') %></p>
 
   <% if f.object.any_errors? %>
     <div class="govuk-error-summary" data-module="govuk-error-summary">

--- a/app/views/api/conditional_contents/_form.html.erb
+++ b/app/views/api/conditional_contents/_form.html.erb
@@ -33,7 +33,7 @@
       </div>
     </fieldset>
 
-    <fieldset class="govuk-fieldset conditionals" data-controller="dynamic-fields conditionals" data-selection-reveal-target="reveal">
+    <fieldset class="govuk-fieldset conditionals govuk-!-margin-bottom-6" data-controller="dynamic-fields conditionals" data-selection-reveal-target="reveal" data-action="dynamic-fields:fieldsAdded->conditionals#update">
       <%= f.fields_for :conditionals, child_index: conditional_index do |conditional| %>
         <%= render 'conditional_fields', conditional: conditional, f: f, component_uuid: f.object.component_uuid %>
       <% end %>
@@ -44,8 +44,15 @@
         <% end %>
       </template>
 
-      <div class="conditional">
-        <%= button_tag I18n.t('conditional_content.add_another_rule'), type: 'button', data: { action: 'dynamic-fields#add'}, class: 'govuk-link fb-link-button prevent-modal-close' %>
+      <div class="panel">
+        <%= button_tag I18n.t('conditional_content.add_another_rule'), 
+          type: 'button', 
+          data: { 
+            action: 'dynamic-fields#add', 
+            dynamic_fields_type_param: 'conditional'
+          }, 
+          class: 'govuk-link fb-link-button prevent-modal-close'
+        %>
       </div>
     </fieldset>
   </div>

--- a/app/views/branches/_conditional_fields.html.erb
+++ b/app/views/branches/_conditional_fields.html.erb
@@ -1,5 +1,10 @@
-<div data-controller="conditional" data-conditionals-target="conditional" data-conditional-title-value="Branch" data-conditional-delete-label-value="Remove">
-  <fieldset class="govuk-fieldset branch conditional" data-conditional-index-value="<%= conditional.options[:child_index]%>">
+<div  data-controller="conditional" 
+      data-conditionals-target="conditional" 
+      data-conditional-title-value="Branch" 
+      data-conditional-delete-label-value="Remove" 
+      data-conditional-destination-label-value="Destination page for "
+      data-action="dynamic-fields:fieldsAdded->conditional#focusNewExpression">
+  <fieldset class="govuk-fieldset panel conditional" data-conditional-index-value="<%= conditional.options[:child_index]%>">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h2 class="govuk-fieldset__heading" data-conditional-target="title">Branch <%= conditional.options[:child_index].to_i+1 %></h2>
     </legend>
@@ -19,13 +24,13 @@
       <%= button_tag I18n.t('conditional_content.add_condition'), type: 'button', data: { action: 'dynamic-fields#add'}, class: 'govuk-link fb-link-button prevent-modal-close' %>
 
       <div class="conditional__question govuk-!-margin-top-5 govuk-form-group <%= conditional.object.errors[:next].any? ? 'govuk-form-group--error' : '' %>">
-
         <% if conditional.object.errors[:next].any? %>
           <p id="branch_conditionals_attributes_<%= conditional.options[:child_index] %>_next_error" class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span>
+          <span class="govuk-visually-hidden"><%= t('activemodel.errors.assistive_prefix') %></span>
             <%= conditional.object.errors[:next].first + (conditional.options[:child_index]+1).to_s %>
           </p>
         <% end %>
+
         <div class="label">
           <%= t('branches.goto') %>
         </div>
@@ -33,8 +38,9 @@
         <select class="govuk-select conditional__destination"
                 name="branch[conditionals_attributes][<%= conditional.options[:child_index] %>][next]"
                 id="branch_conditionals_attributes_<%= conditional.options[:child_index] %>_next"
-                aria-label="Destination page"
-                aria-describedby="<%= conditional.object.errors[:next].any? ? 'branch_conditionals_attributes_'+conditional.options[:child_index].to_s+'_next_error' : '' %>">
+                aria-label="Destination page for "
+                aria-describedby="<%= conditional.object.errors[:next].any? ? 'branch_conditionals_attributes_'+conditional.options[:child_index].to_s+'_next_error' : '' %>"
+                data-conditional-target="destination">
           <option value=""><%= t('branches.select_destination') %></option>
           <%= render partial: "destinations_list",
             locals: {

--- a/app/views/branches/_conditional_fields.html.erb
+++ b/app/views/branches/_conditional_fields.html.erb
@@ -10,7 +10,8 @@
     </legend>
     <%= button_tag 'Delete rule', type: "button", data: { action: "conditional#deleteWithConfirmation", conditional_target: "deleteButton" }, class: 'prevent-modal-close icon-button icon-button--remove conditional__remover' %>
 
-    <div class="conditional__expressions" data-controller="dynamic-fields expressions">
+    <div class="conditional__expressions" data-controller="dynamic-fields expressions" data-action="dynamic-fields:fieldsAdded->expressions#update">
+
       <%= conditional.fields_for :expressions do |expression| %>
         <%= render 'expression_fields', conditional: conditional, expression: expression, branch_uuid: branch_uuid  %>
       <% end %>

--- a/app/views/branches/_conditional_fields.html.erb
+++ b/app/views/branches/_conditional_fields.html.erb
@@ -21,7 +21,7 @@
         <% end %>
       </template>
 
-      <%= button_tag type: 'button', data: { action: 'dynamic-fields#add'}, class: 'govuk-link fb-link-button prevent-modal-close' do %>
+      <%= button_tag type: 'button', data: { action: 'dynamic-fields#add', dynamic_fields_type_param: 'expression'}, class: 'govuk-link fb-link-button prevent-modal-close' do %>
         <%= I18n.t('conditional_content.add_condition') %><span class="govuk-visually-hidden"><%= I18n.t('conditional_content.condition_target', type: 'branch', index: conditional.options[:child_index].to_i+1)%></span>
       <% end %>
 

--- a/app/views/branches/_conditional_fields.html.erb
+++ b/app/views/branches/_conditional_fields.html.erb
@@ -1,5 +1,5 @@
-<div data-controller="conditional" data-conditionals-target="conditional" data-conditional-title-value="Branch" >
-  <section class="branch conditional" data-conditional-index="<%= conditional.options[:child_index]%>">
+<div data-controller="conditional" data-conditionals-target="conditional" data-conditional-title-value="Branch" data-conditional-delete-label-value="Remove">
+  <section class="branch conditional" data-conditional-index-value="<%= conditional.options[:child_index]%>">
     <h3 class="govuk-heading-l" data-conditional-target="title">Branch <%= conditional.options[:child_index].to_i+1 %></h3>
     <%= button_tag 'Delete rule', type: "button", data: { action: "conditional#deleteWithConfirmation", conditional_target: "deleteButton" }, class: 'prevent-modal-close icon-button icon-button--remove conditional__remover' %>
 

--- a/app/views/branches/_conditional_fields.html.erb
+++ b/app/views/branches/_conditional_fields.html.erb
@@ -39,12 +39,11 @@
           <%= t('branches.goto') %>
         </div>
 
-        <p class="govuk-visually-hidden" id="conditional_<%=conditional.options[:child_index]%>_next_hint">The page that will be displayed if all of the conditions for this branch are met</p>
         <select class="govuk-select conditional__destination"
                 name="branch[conditionals_attributes][<%= conditional.options[:child_index] %>][next]"
                 id="branch_conditionals_attributes_<%= conditional.options[:child_index] %>_next"
                 aria-label="Destination page for "
-                aria-describedby="<%= conditional.object.errors[:next].any? ? 'branch_conditionals_attributes_'+conditional.options[:child_index].to_s+'_next_error' : '' %> conditional_<%=conditional.options[:child_index]%>_next_hint"
+                aria-describedby="<%= conditional.object.errors[:next].any? ? 'branch_conditionals_attributes_'+conditional.options[:child_index].to_s+'_next_error' : '' %> destination_hint"
                 data-conditional-target="destination">
           <option value=""><%= t('branches.select_destination') %></option>
           <%= render partial: "destinations_list",

--- a/app/views/branches/_conditional_fields.html.erb
+++ b/app/views/branches/_conditional_fields.html.erb
@@ -1,10 +1,11 @@
 <div  data-controller="conditional" 
       data-conditionals-target="conditional" 
+      data-conditional-branch-status-outlet="#branch-status"
       data-conditional-title-value="Branch" 
       data-conditional-delete-label-value="Remove" 
       data-conditional-destination-label-value="Destination page for "
       data-action="dynamic-fields:fieldsAdded->conditional#focusNewExpression">
-  <fieldset class="govuk-fieldset panel conditional" data-conditional-index-value="<%= conditional.options[:child_index]%>">
+  <fieldset class="govuk-fieldset panel conditional" data-conditional-target="fieldset" data-conditional-index-value="<%= conditional.options[:child_index]%>" tabindex="-1">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       <h2 class="govuk-fieldset__heading" data-conditional-target="title">Branch <%= conditional.options[:child_index].to_i+1 %></h2>
     </legend>

--- a/app/views/branches/_conditional_fields.html.erb
+++ b/app/views/branches/_conditional_fields.html.erb
@@ -1,6 +1,6 @@
 <div  data-controller="conditional" 
       data-conditionals-target="conditional" 
-      data-conditional-branch-status-outlet="#branch-status"
+      data-conditional-conditionals-status-outlet="#conditionals-status"
       data-conditional-title-value="Branch" 
       data-conditional-delete-label-value="Remove" 
       data-conditional-destination-label-value="Destination page for "

--- a/app/views/branches/_conditional_fields.html.erb
+++ b/app/views/branches/_conditional_fields.html.erb
@@ -1,6 +1,8 @@
 <div data-controller="conditional" data-conditionals-target="conditional" data-conditional-title-value="Branch" data-conditional-delete-label-value="Remove">
-  <section class="branch conditional" data-conditional-index-value="<%= conditional.options[:child_index]%>">
-    <h3 class="govuk-heading-l" data-conditional-target="title">Branch <%= conditional.options[:child_index].to_i+1 %></h3>
+  <fieldset class="govuk-fieldset branch conditional" data-conditional-index-value="<%= conditional.options[:child_index]%>">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h2 class="govuk-fieldset__heading" data-conditional-target="title">Branch <%= conditional.options[:child_index].to_i+1 %></h2>
+    </legend>
     <%= button_tag 'Delete rule', type: "button", data: { action: "conditional#deleteWithConfirmation", conditional_target: "deleteButton" }, class: 'prevent-modal-close icon-button icon-button--remove conditional__remover' %>
 
     <div class="conditional__expressions" data-controller="dynamic-fields expressions">
@@ -24,11 +26,14 @@
             <%= conditional.object.errors[:next].first + (conditional.options[:child_index]+1).to_s %>
           </p>
         <% end %>
-        <%= conditional.label :next, t('branches.goto') %>
+        <div class="label">
+          <%= t('branches.goto') %>
+        </div>
 
         <select class="govuk-select conditional__destination"
                 name="branch[conditionals_attributes][<%= conditional.options[:child_index] %>][next]"
                 id="branch_conditionals_attributes_<%= conditional.options[:child_index] %>_next"
+                aria-label="Destination page"
                 aria-describedby="<%= conditional.object.errors[:next].any? ? 'branch_conditionals_attributes_'+conditional.options[:child_index].to_s+'_next_error' : '' %>">
           <option value=""><%= t('branches.select_destination') %></option>
           <%= render partial: "destinations_list",
@@ -51,7 +56,7 @@
       </div>
 
     </div>
-  </section>
+  </fieldset>
   <div class="conditional-separator">or</div>
 </div>
 

--- a/app/views/branches/_conditional_fields.html.erb
+++ b/app/views/branches/_conditional_fields.html.erb
@@ -21,7 +21,9 @@
         <% end %>
       </template>
 
-      <%= button_tag I18n.t('conditional_content.add_condition'), type: 'button', data: { action: 'dynamic-fields#add'}, class: 'govuk-link fb-link-button prevent-modal-close' %>
+      <%= button_tag type: 'button', data: { action: 'dynamic-fields#add'}, class: 'govuk-link fb-link-button prevent-modal-close' do %>
+        <%= I18n.t('conditional_content.add_condition') %><span class="govuk-visually-hidden"><%= I18n.t('conditional_content.condition_target', type: 'branch', index: conditional.options[:child_index].to_i+1)%></span>
+      <% end %>
 
       <div class="conditional__question govuk-!-margin-top-5 govuk-form-group <%= conditional.object.errors[:next].any? ? 'govuk-form-group--error' : '' %>">
         <% if conditional.object.errors[:next].any? %>
@@ -35,11 +37,12 @@
           <%= t('branches.goto') %>
         </div>
 
+        <p class="govuk-visually-hidden" id="conditional_<%=conditional.options[:child_index]%>_next_hint">The page that will be displayed if all of the conditions for this branch are met</p>
         <select class="govuk-select conditional__destination"
                 name="branch[conditionals_attributes][<%= conditional.options[:child_index] %>][next]"
                 id="branch_conditionals_attributes_<%= conditional.options[:child_index] %>_next"
                 aria-label="Destination page for "
-                aria-describedby="<%= conditional.object.errors[:next].any? ? 'branch_conditionals_attributes_'+conditional.options[:child_index].to_s+'_next_error' : '' %>"
+                aria-describedby="<%= conditional.object.errors[:next].any? ? 'branch_conditionals_attributes_'+conditional.options[:child_index].to_s+'_next_error' : '' %> conditional_<%=conditional.options[:child_index]%>_next_hint"
                 data-conditional-target="destination">
           <option value=""><%= t('branches.select_destination') %></option>
           <%= render partial: "destinations_list",

--- a/app/views/branches/_expression_condition.html.erb
+++ b/app/views/branches/_expression_condition.html.erb
@@ -25,6 +25,7 @@
 
             ),
             'aria-label': 'Operator',
+            'aria-describedby': 'operator_hint'
           }
         %>
 
@@ -51,6 +52,7 @@
             attribute: 'field',
           ),
           'aria-label': 'Answer',
+          'aria-describedby': 'value_hint'
         }
       %>
     </div>

--- a/app/views/branches/_expression_condition.html.erb
+++ b/app/views/branches/_expression_condition.html.erb
@@ -9,6 +9,7 @@
           {
             class: "govuk-select expression__operator #{ expression.errors[:operator].any? ? 'govuk-select--error' : '' }",
             data: {
+              expression_target: "operator",
               selection_reveal_target: 'input',
               action: "selection-reveal#toggle"
             },
@@ -22,7 +23,8 @@
               expression_index: expression_index,
               attribute: 'operator',
 
-            )
+            ),
+            'aria-label': 'Operator',
           }
         %>
 
@@ -34,6 +36,7 @@
         {
           class: "govuk-select expression__answer #{ expression.errors[:answer].any? ? 'govuk-select--error' : '' }",
           data: {
+            expression_target: "answer",
             selection_reveal_target: 'reveal',
           },
           name: expression.name_attr(
@@ -46,12 +49,10 @@
             conditional_index: conditional_index,
             expression_index: expression_index,
             attribute: 'field',
-
-          )
+          ),
+          'aria-label': 'Answer',
         }
-
       %>
-
     </div>
   <% end %>
 </turbo-frame>

--- a/app/views/branches/_expression_fields.html.erb
+++ b/app/views/branches/_expression_fields.html.erb
@@ -1,5 +1,4 @@
-<fieldset class="expression govuk-form-group <%= expression.object.errors.any? ? 'error' : '' %>"
-          aria-labelledby="conditional_<%= conditional.options[:child_index] %>_expression_<%=expression.options[:child_index]%>_legend"
+<div class="expression govuk-form-group <%= expression.object.errors.any? ? 'error' : '' %>"
           data-expressions-target="expression"
           data-conditional-target="expression"
           data-controller="expression"
@@ -9,11 +8,6 @@
           data-expression-first-label-value="<%= t('branches.expression.if') %>"
           data-expression-other-label-value="<%= t('branches.expression.and') %>">
   
-    <p id="conditional_<%= conditional.options[:child_index] %>_expression_<%=expression.options[:child_index]%>_legend"
-        class="govuk-visually-hidden"
-        data-expression-target="fieldsetLabel"
-        > Condition <%= expression.options[:child_index].to_i+1 %>, branch <%= conditional.options[:child_index].to_i+1%></p>
-
     <div class="conditional__question">
       <% if expression.object.errors[:component].any? %>
         <p id="condition_<%= conditional.options[:child_index] %>_expression_<%= expression.options[:child_index] %>_component_error" class="govuk-error-message">
@@ -57,4 +51,4 @@
         expression_target: "deleteButton"
       }, 
       class: 'prevent-modal-close icon-button icon-button--remove expression__remover' %>
-</fieldset>
+</div>

--- a/app/views/branches/_expression_fields.html.erb
+++ b/app/views/branches/_expression_fields.html.erb
@@ -1,5 +1,5 @@
 <fieldset class="expression govuk-form-group <%= expression.object.errors.any? ? 'error' : '' %>"
-          aria-labelledby="conditional_<%= conditional.options[:child_index] %>_exression_<%=expression.options[:child_index]%>_legend"
+          aria-labelledby="conditional_<%= conditional.options[:child_index] %>_expression_<%=expression.options[:child_index]%>_legend"
           data-expressions-target="expression"
           data-conditional-target="expression"
           data-controller="expression"
@@ -9,12 +9,10 @@
           data-expression-first-label-value="<%= t('branches.expression.if') %>"
           data-expression-other-label-value="<%= t('branches.expression.and') %>">
   
-    <p id="conditional_<%= conditional.options[:child_index] %>_exression_<%=expression.options[:child_index]%>_legend"
+    <p id="conditional_<%= conditional.options[:child_index] %>_expression_<%=expression.options[:child_index]%>_legend"
         class="govuk-visually-hidden"
-        data-expression-target="heading"
+        data-expression-target="fieldsetLabel"
         > Condition <%= expression.options[:child_index].to_i+1 %>, branch <%= conditional.options[:child_index].to_i+1%></p>
-
-    
 
     <div class="conditional__question">
       <% if expression.object.errors[:component].any? %>

--- a/app/views/branches/_expression_fields.html.erb
+++ b/app/views/branches/_expression_fields.html.erb
@@ -3,7 +3,7 @@
           data-conditional-target="expression"
           data-controller="expression"
           data-expression-error-class="error"
-          data-expression-branch-status-outlet="#branch-status"
+          data-expression-conditionals-status-outlet="#conditionals-status"
           data-expression-index-value="0"
           data-expression-title-value="condition"
           data-expression-first-label-value="<%= t('branches.expression.if') %>"

--- a/app/views/branches/_expression_fields.html.erb
+++ b/app/views/branches/_expression_fields.html.erb
@@ -1,8 +1,9 @@
-
 <div  class="expression govuk-form-group <%= expression.object.errors.any? ? 'error' : '' %>"
       data-expressions-target="expression"
+      data-conditional-target="expression"
       data-controller="expression"
       data-expression-error-class="error"
+      data-expression-index-value=""
       data-expression-first-label-value="<%= t('branches.expression.if') %>"
       data-expression-other-label-value="<%= t('branches.expression.and') %>">
 
@@ -16,19 +17,13 @@
           <%= expression.object.errors[:component].first %>
         </p>
       <% end %>
-      <%= expression.label  :component,
-        t('branches.expression.if'),
-        {
-          class: "govuk-label",
-          data: {
-            expression_target: 'label'
-          }
-        }
-      %>
+
+      <div class="label" data-expression-target="label"><%= t('branches.expression.if') %></div>
       <%= expression.select :component,
         @branch.previous_questions,
         { include_blank: t('branches.select_question') },
         { class: "govuk-select expression__component #{ expression.object.errors[:component].any? ? 'govuk-select--error' : '' }",
+          'aria-label': 'Source question',
           'aria-describedby': ( "condition_#{conditional.options[:child_index]}_expression_#{expression.options[:child_index]}_component_error" if expression.object.errors[:component].any? ),
           data: {
             action: 'change->expression#getCondition',

--- a/app/views/branches/_expression_fields.html.erb
+++ b/app/views/branches/_expression_fields.html.erb
@@ -1,14 +1,20 @@
-<div  class="expression govuk-form-group <%= expression.object.errors.any? ? 'error' : '' %>"
-      data-expressions-target="expression"
-      data-conditional-target="expression"
-      data-controller="expression"
-      data-expression-error-class="error"
-      data-expression-index-value=""
-      data-expression-first-label-value="<%= t('branches.expression.if') %>"
-      data-expression-other-label-value="<%= t('branches.expression.and') %>">
+<fieldset class="expression govuk-form-group <%= expression.object.errors.any? ? 'error' : '' %>"
+          aria-labelledby="conditional_<%= conditional.options[:child_index] %>_exression_<%=expression.options[:child_index]%>_legend"
+          data-expressions-target="expression"
+          data-conditional-target="expression"
+          data-controller="expression"
+          data-expression-error-class="error"
+          data-expression-index-value="0"
+          data-expression-title-value="condition"
+          data-expression-first-label-value="<%= t('branches.expression.if') %>"
+          data-expression-other-label-value="<%= t('branches.expression.and') %>">
+  
+    <p id="conditional_<%= conditional.options[:child_index] %>_exression_<%=expression.options[:child_index]%>_legend"
+        class="govuk-visually-hidden"
+        data-expression-target="heading"
+        > Condition <%= expression.options[:child_index].to_i+1 %>, branch <%= conditional.options[:child_index].to_i+1%></p>
 
-  <%= button_tag 'Delete condition', type: "button", data: { action: "expression#deleteWithConfirmation", expression_target: "deleteButton"}, class: 'prevent-modal-close icon-button icon-button--remove expression__remover' %>
-
+    
 
     <div class="conditional__question">
       <% if expression.object.errors[:component].any? %>
@@ -18,7 +24,10 @@
         </p>
       <% end %>
 
-      <div class="label" data-expression-target="label"><%= t('branches.expression.if') %></div>
+      <div class="label" data-expression-target="label">
+        <%= t('branches.expression.if') %>
+      </div>
+
       <%= expression.select :component,
         @branch.previous_questions,
         { include_blank: t('branches.select_question') },
@@ -42,5 +51,12 @@
         conditional_index: conditional.options[:child_index],
         expression_index: expression.options[:child_index]
       }
-    %>
-</div>
+      %>
+    <%= button_tag 'Delete condition',  
+      type: "button", 
+      data: { 
+        action: "expression#deleteWithConfirmation", 
+        expression_target: "deleteButton"
+      }, 
+      class: 'prevent-modal-close icon-button icon-button--remove expression__remover' %>
+</fieldset>

--- a/app/views/branches/_expression_fields.html.erb
+++ b/app/views/branches/_expression_fields.html.erb
@@ -3,6 +3,7 @@
           data-conditional-target="expression"
           data-controller="expression"
           data-expression-error-class="error"
+          data-expression-branch-status-outlet="#branch-status"
           data-expression-index-value="0"
           data-expression-title-value="condition"
           data-expression-first-label-value="<%= t('branches.expression.if') %>"

--- a/app/views/branches/_expression_fields.html.erb
+++ b/app/views/branches/_expression_fields.html.erb
@@ -26,7 +26,7 @@
         { include_blank: t('branches.select_question') },
         { class: "govuk-select expression__component #{ expression.object.errors[:component].any? ? 'govuk-select--error' : '' }",
           'aria-label': 'Source question',
-          'aria-describedby': ( "condition_#{conditional.options[:child_index]}_expression_#{expression.options[:child_index]}_component_error" if expression.object.errors[:component].any? ),
+          'aria-describedby': ( expression.object.errors[:component].any? ? "condition_#{conditional.options[:child_index]}_expression_#{expression.options[:child_index]}_component_error " : ""  ) + "source_question_hint",
           data: {
             action: 'change->expression#getCondition',
             expression_target: 'question',

--- a/app/views/branches/_expression_fields.html.erb
+++ b/app/views/branches/_expression_fields.html.erb
@@ -50,5 +50,5 @@
         action: "expression#deleteWithConfirmation", 
         expression_target: "deleteButton"
       }, 
-      class: 'prevent-modal-close icon-button icon-button--remove expression__remover' %>
+      class: 'icon-button icon-button--remove expression__remover' %>
 </div>

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -1,7 +1,6 @@
 <%= f.hidden_field :previous_flow_uuid, value: @branch.previous_flow_uuid %>
 <%= f.hidden_field :branch_uuid, value: @branch.branch_uuid %>
 
-
 <div class="conditionals" data-controller="dynamic-fields conditionals" data-selection-reveal-target="reveal">
   <%= f.fields_for :conditionals, child_index: conditional_index do |conditional| %>
     <%= render 'conditional_fields', conditional: conditional, f: f, branch_uuid: @branch.branch_uuid %>
@@ -13,44 +12,49 @@
     <% end %>
   </template>
 
-  <div class="conditional">
+  <div class="panel">
     <%= button_tag I18n.t('branches.branch_add'), type: 'button', data: { action: 'dynamic-fields#add'}, class: 'govuk-link fb-link-button prevent-modal-close' %>
   </div>
 </div>
 
 <p class="branch-or">or</p>
 
-<div class="branch" id="branch-otherwise">
-  <h3 class="name govuk-heading-l">
+<div class="panel conditional conditional--otherwise">
+  <h2 class="govuk-heading-l">
     <%= t('branches.title_otherwise') %>
-    <span class="name govuk-heading-m"><%= t('branches.hint_otherwise') %></span>
-  </h3>
-  <div class="govuk-form-group <%= @branch.errors[:default_next].empty? ? '' : 'govuk-form-group--error' %>">
-    <% @branch.errors[:default_next].each do |message| %>
-      <p class="govuk-error-message"><%= message %></p>
+    <span class="govuk-heading-m"><%= t('branches.hint_otherwise') %></span>
+  </h2>
+
+  <div class="conditional__question govuk-form-group <%= @branch.errors[:default_next].empty? ? '' : 'govuk-form-group--error' %>">
+    <% if @branch.errors[:default_next].any? %>
+      <p id="branch_default_next_error" class="govuk-error-message">
+        <span class="govuk-visually-hidden"><%= t('activemodel.errors.assistive_prefix') %></span>
+        <%= @branch.errors[:default_next].first.message %>
+      </p>
     <% end %>
 
-    <div class="conditional__question">
-      <label class="govuk-label" for="branch_default_next"><%= t('branches.goto') %></label>
-      <select class="govuk-select" name="branch[default_next]" id="branch_default_next" class="conditional__destination">
-        <%= render partial: "destinations_list",
-                  locals: {
-                    destinations: branch_destinations,
-                    selected: @branch.previous_flow_default_next
-                  }
-        %>
-        <% if branch_detached_destinations.present? %>
-          <optgroup class="branch-optgroup" label="<%= t('branches.detached_list') %>">
-            <%= render partial: "destinations_list",
-                      locals: {
-                        destinations: branch_detached_destinations,
-                        selected: @branch.previous_flow_default_next
-                      }
-            %>
-          </optgroup>
-        <% end %>
-      </select>
+    <div class="label">
+      <%= t('branches.goto') %>
     </div>
+
+    <select class="govuk-select" name="branch[default_next]" id="branch_default_next" class="conditional__destination" aria-label="Destination page" aria-describedby="branch_default_next_error">
+      <%= render partial: "destinations_list",
+        locals: {
+          destinations: branch_destinations,
+          selected: @branch.previous_flow_default_next
+        }
+      %>
+      <% if branch_detached_destinations.present? %>
+        <optgroup class="branch-optgroup" label="<%= t('branches.detached_list') %>">
+          <%= render partial: "destinations_list",
+            locals: {
+              destinations: branch_detached_destinations,
+              selected: @branch.previous_flow_default_next
+            }
+          %>
+        </optgroup>
+      <% end %>
+    </select>
   </div>
 </div>
 

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -1,7 +1,7 @@
 <%= f.hidden_field :previous_flow_uuid, value: @branch.previous_flow_uuid %>
 <%= f.hidden_field :branch_uuid, value: @branch.branch_uuid %>
 
-<div id="branch-status" class="govuk-visually-hidden" data-controller="branch-status" role="alert"></div>
+<div id="conditionals-status" class="govuk-visually-hidden" data-controller="conditionals-status" role="alert"></div>
 <p id="source_question_hint" hidden><%= t('branches.hints.question') %></p>
 <p id="operator_hint" hidden><%= t('branches.hints.operator') %></p>
 <p id="value_hint" hidden><%= t('branches.hints.value') %></p>

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -36,8 +36,8 @@
     <div class="label">
       <%= t('branches.goto') %>
     </div>
-
-    <select class="govuk-select" name="branch[default_next]" id="branch_default_next" class="conditional__destination" aria-label="Destination page" aria-describedby="branch_default_next_error">
+    <p class="govuk-visually-hidden" id="branch_default_next_hint">The page that will be displayed if none of the branches have their conditions matched</p>
+    <select class="govuk-select" name="branch[default_next]" id="branch_default_next" class="conditional__destination" aria-label="Destination page" aria-describedby="branch_default_next_error branch_default_next_hint">
       <%= render partial: "destinations_list",
         locals: {
           destinations: branch_destinations,

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -1,7 +1,10 @@
 <%= f.hidden_field :previous_flow_uuid, value: @branch.previous_flow_uuid %>
 <%= f.hidden_field :branch_uuid, value: @branch.branch_uuid %>
 
-<div class="conditionals" data-controller="dynamic-fields conditionals" data-selection-reveal-target="reveal" data-action="dynamic-fields:fieldsAdded->conditionals#update">
+<div id="branch-status" class="govuk-visually-hidden" data-controller="branch-status" role="alert"></div>
+
+<div class="conditionals" data-controller="dynamic-fields conditionals" data-selection-reveal-target="reveal" data-action="dynamic-fields:fieldsAdded->conditionals#newConditionalAdded" tabindex="-1">
+
   <%= f.fields_for :conditionals, child_index: conditional_index do |conditional| %>
     <%= render 'conditional_fields', conditional: conditional, f: f, branch_uuid: @branch.branch_uuid %>
   <% end %>

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -13,7 +13,14 @@
   </template>
 
   <div class="panel">
-    <%= button_tag I18n.t('branches.branch_add'), type: 'button', data: { action: 'dynamic-fields#add', dynamic_fields_type_param: 'conditional'}, class: 'govuk-link fb-link-button prevent-modal-close' %>
+    <%= button_tag I18n.t('branches.branch_add'), 
+      type: 'button', 
+      data: {
+        action: 'dynamic-fields#add',
+        dynamic_fields_type_param: 'conditional'
+      },
+      class: 'govuk-link fb-link-button prevent-modal-close'
+    %>
   </div>
 </div>
 

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -2,6 +2,11 @@
 <%= f.hidden_field :branch_uuid, value: @branch.branch_uuid %>
 
 <div id="branch-status" class="govuk-visually-hidden" data-controller="branch-status" role="alert"></div>
+<p id="source_question_hint" hidden><%= t('branches.hints.question') %></p>
+<p id="operator_hint" hidden><%= t('branches.hints.operator') %></p>
+<p id="value_hint" hidden><%= t('branches.hints.value') %></p>
+<p id="destination_hint" hidden><%= t('branches.hints.destination') %></p>
+<p id="destination_otherwise_hint" hidden><%= t('branches.hints.destination_otherwise') %></p>
 
 <div class="conditionals" data-controller="dynamic-fields conditionals" data-selection-reveal-target="reveal" data-action="dynamic-fields:fieldsAdded->conditionals#newConditionalAdded" tabindex="-1">
 
@@ -47,7 +52,7 @@
       <%= t('branches.goto') %>
     </div>
     <p class="govuk-visually-hidden" id="branch_default_next_hint">The page that will be displayed if none of the branches have their conditions matched</p>
-    <select class="govuk-select" name="branch[default_next]" id="branch_default_next" class="conditional__destination" aria-label="Destination page" aria-describedby="branch_default_next_error branch_default_next_hint">
+    <select class="govuk-select" name="branch[default_next]" id="branch_default_next" class="conditional__destination" aria-label="Destination page" aria-describedby="branch_default_next_error branch_default_next_hint destination_otherwise_hint">
       <%= render partial: "destinations_list",
         locals: {
           destinations: branch_destinations,

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -1,7 +1,7 @@
 <%= f.hidden_field :previous_flow_uuid, value: @branch.previous_flow_uuid %>
 <%= f.hidden_field :branch_uuid, value: @branch.branch_uuid %>
 
-<div class="conditionals" data-controller="dynamic-fields conditionals" data-selection-reveal-target="reveal">
+<div class="conditionals" data-controller="dynamic-fields conditionals" data-selection-reveal-target="reveal" data-action="dynamic-fields:fieldsAdded->conditionals#update">
   <%= f.fields_for :conditionals, child_index: conditional_index do |conditional| %>
     <%= render 'conditional_fields', conditional: conditional, f: f, branch_uuid: @branch.branch_uuid %>
   <% end %>
@@ -13,7 +13,7 @@
   </template>
 
   <div class="panel">
-    <%= button_tag I18n.t('branches.branch_add'), type: 'button', data: { action: 'dynamic-fields#add'}, class: 'govuk-link fb-link-button prevent-modal-close' %>
+    <%= button_tag I18n.t('branches.branch_add'), type: 'button', data: { action: 'dynamic-fields#add', dynamic_fields_type_param: 'conditional'}, class: 'govuk-link fb-link-button prevent-modal-close' %>
   </div>
 </div>
 

--- a/app/views/branches/edit.html.erb
+++ b/app/views/branches/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="branches edit">
   <%= render partial: 'error_summary' %>
 
-  <h1 class="fb-editable govuk-heading-xl"
+  <h1 class="govuk-heading-xl"
       data-fb-content-id="page[heading]"
       data-fb-content-type="element">
     <%= @branch.title %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -632,6 +632,7 @@ en:
         default_next: Otherwise
     errors:
       summary_title: There is a problem
+      assistive_prefix: 'Error: '
       models:
         from_address:
           invalid: Enter an email address in the correct format, like name@example.com

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,6 +251,7 @@ en:
       never: 'Never'
     add_another_rule: 'Add another rule'
     add_condition: 'Add condition'
+    condition_target: ' to %{type} %{index}'
   questions:
     delete_modal:
       can_not_delete_heading: 'You cannot delete this question yet'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,6 +258,10 @@ en:
     add_another_rule: 'Add another rule'
     add_condition: 'Add condition'
     condition_target: ' to %{type} %{index}'
+    hints:
+      question: The question whose answer will be used in this rule
+      operator: The type of comparison that will be made to the answer of the source question
+      value: The value to which the answer to the source question will be compared to
   questions:
     delete_modal:
       can_not_delete_heading: 'You cannot delete this question yet'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -236,6 +236,12 @@ en:
     title_otherwise: 'Otherwise,'
     hint_otherwise: 'if none of the above'
     detached_list: 'Unconnected page'
+    hints:
+      question: The question whose answer will be used in this conditon
+      operator: The type of comparison that will be made to the answer of the source question
+      value: The value to which the answer to the source question will be compared to
+      destination: ", The page that will be displayed if the conditions for branch one are met"
+      destination_otherwise: ", The page that will be displayed none of branches have their condition met"
     delete_modal:
       destinations: 'Go to:'
       lede: 'Choose which branch you want to keep in your form.'


### PR DESCRIPTION
This PR adds in accessible lablleing to the branch edit screen and the conditonal rules editing modal.

These screens worked well for sighted users, but due to the 'sentence construction' design, did not work well for users of screen readers, as most of the fioelds were unlabelled, or unhelpfully labelled.

This PR adds:
* Labels for all fields
* Descriptions for fields
* Better structure/grouping labels
* Ensures these labels are updated correctly when adding/removing conditionals and expressions
* Corrects focus placement after adding an expression
* Improves focus handling on deletion of an expression or condition

N.B. I have added automatic code formatting in my editor now - so more consistency going forward, but possibly slightly noisy diffs for a bit as it shakes out...