### PR TITLE
Allow publishing to live with submission warnings

### DIFF
--- a/app/presenters/publishing_page_presenter.rb
+++ b/app/presenters/publishing_page_presenter.rb
@@ -38,7 +38,7 @@ class PublishingPagePresenter
   def publish_button_disabled?
     return if deployment_environment == 'dev'
 
-    submission_warnings.messages.any? || autocomplete_warning.messages.any?
+    autocomplete_warning.messages.any?
   end
 
   private

--- a/spec/presenters/publishing_page_presenter_spec.rb
+++ b/spec/presenters/publishing_page_presenter_spec.rb
@@ -151,10 +151,16 @@ RSpec.describe PublishingPagePresenter do
         context 'when there are submission warnings' do
           before do
             allow_any_instance_of(SubmissionWarningsPresenter).to receive(:messages).and_return(['Some messages'])
+            allow_any_instance_of(AutocompleteItemsPresenter).to receive(:messages).and_return([])
           end
 
-          it 'returns truthy' do
-            expect(subject.publish_button_disabled?).to be_truthy
+          # we now allow submission warnings in live forms
+          # it 'returns truthy' do
+          #   expect(subject.publish_button_disabled?).to be_truthy
+          # end
+
+          it 'returns falsey' do
+            expect(subject.publish_button_disabled?).to be_falsey
           end
         end
 

--- a/spec/presenters/publishing_page_presenter_spec.rb
+++ b/spec/presenters/publishing_page_presenter_spec.rb
@@ -148,18 +148,13 @@ RSpec.describe PublishingPagePresenter do
           allow_any_instance_of(PublishServiceCreation).to receive(:no_service_output?).and_return(false)
         end
 
-        context 'when there are submission warnings' do
+        context 'when there are submission warnings but not autocomplete warnings' do
           before do
             allow_any_instance_of(SubmissionWarningsPresenter).to receive(:messages).and_return(['Some messages'])
             allow_any_instance_of(AutocompleteItemsPresenter).to receive(:messages).and_return([])
           end
 
-          # we now allow submission warnings in live forms
-          # it 'returns truthy' do
-          #   expect(subject.publish_button_disabled?).to be_truthy
-          # end
-
-          it 'returns falsey' do
+          it 'returns falsey - is allowed to publish' do
             expect(subject.publish_button_disabled?).to be_falsey
           end
         end


### PR DESCRIPTION
We would previously have blocked publishing when missing CYA/Confirmation pages, but we now have both a valid use case to allow a form to publish without and pre-publishing checks in place to prevent cases where this is not valid.