### PR TITLE
Simple feature flag mechanism per environment

### DIFF
--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -1,0 +1,53 @@
+# Determine whether or not a feature is enabled in this environment.
+#
+# usage (for e.g. feature :foobar):
+#
+#   FeatureFlags.foobar.enabled?
+#
+class FeatureFlags
+  include Singleton
+
+  attr_reader :config, :env_name
+
+  class EnabledFeature
+    def initialize(config, env_name)
+      @env_config = config
+      @env_name = env_name
+    end
+
+    def enabled?
+      @env_config.fetch(@env_name)
+    end
+
+    def disabled?
+      !enabled?
+    end
+  end
+
+  def initialize
+    @env_name = HostEnv.env_name
+    @config = YAML.load_file(
+      Rails.root.join('config', 'features.yml')
+    ).fetch('feature_flags', {}).with_indifferent_access.freeze
+  end
+
+  class << self
+    delegate :method_missing, :respond_to?, to: :instance
+
+    def reset!
+      Singleton.__init__(self)
+    end
+  end
+
+  def method_missing(name, *args)
+    if config.key?(name)
+      EnabledFeature.new(config.fetch(name), env_name)
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(name, _include_private = false)
+    config.key?(name) || super
+  end
+end

--- a/app/lib/host_env.rb
+++ b/app/lib/host_env.rb
@@ -1,0 +1,24 @@
+module HostEnv
+  # Update if more environments are needed
+  NAMED_ENVIRONMENTS = [
+    LOCAL = 'local'.freeze,
+    TEST = 'test'.freeze, # formbuilder-saas-test
+    LIVE = 'live'.freeze  # formbuilder-saas-live
+  ].freeze
+
+  class << self
+    NAMED_ENVIRONMENTS.each { |name| delegate "#{name}?", to: :inquiry }
+
+    def env_name
+      return LOCAL if Rails.env.development? || Rails.env.test?
+
+      ENV.fetch('PLATFORM_ENV')
+    end
+
+    private
+
+    def inquiry
+      env_name.inquiry
+    end
+  end
+end

--- a/config/features.yml
+++ b/config/features.yml
@@ -1,0 +1,5 @@
+feature_flags:
+  developer_tools:
+    local: true
+    test: true   # formbuilder-saas-test
+    live: false  # formbuilder-saas-live

--- a/spec/lib/feature_flags_spec.rb
+++ b/spec/lib/feature_flags_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+describe FeatureFlags do
+  before do
+    # override whatever is in the settings file with these settings
+    # so that tests are predictable
+    allow(
+      described_class.instance
+    ).to receive(:config).and_return(
+      {
+        enabled_foobar_feature: {
+          local: true,
+          test: true,
+          live: true
+        },
+        disabled_foobar_feature: {
+          local: false,
+          test: false,
+          live: false
+        }
+      }.with_indifferent_access
+    )
+  end
+
+  describe '#enabled?' do
+    context 'development environment on local host' do
+      before do
+        allow(
+          described_class.instance
+        ).to receive(:env_name).and_return(HostEnv::LOCAL)
+      end
+
+      it 'has the expected HostEnv' do
+        expect(described_class.instance.env_name).to eq(HostEnv::LOCAL)
+      end
+
+      it 'is enabled' do
+        expect(described_class.enabled_foobar_feature.enabled?).to be true
+      end
+
+      it 'is disabled' do
+        expect(described_class.disabled_foobar_feature.enabled?).to be false
+      end
+    end
+
+    context 'production environment on live server' do
+      before do
+        allow(
+          described_class.instance
+        ).to receive(:env_name).and_return(HostEnv::LIVE)
+      end
+
+      it 'has the expected HostEnv' do
+        expect(described_class.instance.env_name).to eq(HostEnv::LIVE)
+      end
+
+      it 'is enabled' do
+        expect(described_class.enabled_foobar_feature.enabled?).to be true
+      end
+
+      it 'is disabled' do
+        expect(described_class.disabled_foobar_feature.enabled?).to be false
+      end
+    end
+  end
+
+  describe 'handling of method_missing' do
+    context 'a feature defined in the config' do
+      it 'responds true' do
+        expect(described_class.respond_to?(:enabled_foobar_feature)).to be true
+      end
+    end
+
+    context 'a method defined on the superclass' do
+      it 'responds true' do
+        expect(described_class.respond_to?(:object_id)).to be true
+      end
+    end
+
+    context 'unknown method' do
+      it 'responds false' do
+        expect(described_class.respond_to?(:not_a_real_feature)).to be false
+      end
+
+      it 'raises an exception' do
+        expect { described_class.not_a_real_feature }.to raise_exception(NoMethodError)
+      end
+    end
+  end
+end

--- a/spec/lib/host_env_spec.rb
+++ b/spec/lib/host_env_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+describe HostEnv do
+  describe 'local machine environment' do
+    context 'local development rails environment' do
+      before do
+        allow(Rails.env).to receive_messages(development?: true, test?: false)
+      end
+
+      describe '.test?' do
+        it 'returns false' do
+          expect(described_class.test?).to be false
+        end
+      end
+
+      describe '.live?' do
+        it 'returns false' do
+          expect(described_class.live?).to be false
+        end
+      end
+
+      describe '.local?' do
+        it 'returns true' do
+          expect(described_class.local?).to be true
+        end
+      end
+    end
+
+    context 'local test rails environment' do
+      describe '.test?' do
+        it 'returns false' do
+          expect(described_class.test?).to be false
+        end
+      end
+
+      describe '.live?' do
+        it 'returns true' do
+          expect(described_class.live?).to be false
+        end
+      end
+
+      describe '.local?' do
+        it 'returns false' do
+          expect(described_class.local?).to be true
+        end
+      end
+    end
+  end
+
+  describe 'PLATFORM_ENV variable is set in production envs' do
+    before do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+      allow(ENV).to receive(:fetch).with('PLATFORM_ENV').and_return(env_name)
+    end
+
+    context 'test host' do
+      let(:env_name) { HostEnv::TEST }
+
+      it { expect(described_class.local?).to be(false) }
+      it { expect(described_class.test?).to be(true) }
+      it { expect(described_class.live?).to be(false) }
+    end
+
+    context 'live host' do
+      let(:env_name) { HostEnv::LIVE }
+
+      it { expect(described_class.local?).to be(false) }
+      it { expect(described_class.test?).to be(false) }
+      it { expect(described_class.live?).to be(true) }
+    end
+
+    context 'unknown host' do
+      let(:env_name) { 'foobar' }
+
+      it { expect(described_class.local?).to be(false) }
+      it { expect(described_class.test?).to be(false) }
+      it { expect(described_class.live?).to be(false) }
+    end
+  end
+end


### PR DESCRIPTION
This is a simple feature flag mechanism I've used in other services, with little modifications.

This will allow us to check if some code should run or not depending if we are on local environments (including CI and rspec, etc.) or on kubernetes `formbuilder-saas-test` or `formbuilder-saas-live`.

Its main purpose is to handle more easily the address component visibility.