### PR TITLE
Revert pointer-events change for invisible buttons

### DIFF
--- a/app/javascript/styles/_editable_components.scss
+++ b/app/javascript/styles/_editable_components.scss
@@ -18,7 +18,7 @@ editable-content,
   .ActivatedMenuActivator {
     left: -54px;
     opacity: 0;
-    pointer-events: none;
+    //pointer-events: none;
     position: absolute;
     top: 0;
   }
@@ -74,7 +74,7 @@ editable-content,
       right: -55px;
       display: block;
       opacity: 0;
-      pointer-events: none;
+      // pointer-events: none;
 
       &:focus {
         opacity: 1;

--- a/up_arrow_blue.svg
+++ b/up_arrow_blue.svg
@@ -1,3 +1,0 @@
-<svg width="18" height="11" viewBox="0 0 18 11" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1 10L9 2L17 10" stroke="#1D70B8" stroke-width="2"/>
-</svg>


### PR DESCRIPTION
As part of the move work, the css declaration `pointer-events: none` was added to the three dots and move buttons when invisble in order to prevent the cursor becoming a pointer and the user being able to interact with a 'hidden' button.

However, this change made the buttons unclickable in Safari.  

The buttons display when the editable component title is focused, clicking the button unfocuses the title, which hides the button, which safari now treats as unclickable.  

It appears that Safari is executing the `blur` event before the `click` event, meaning the button gets hidden and rendered non-interactive before the click event is fired.  

This PR simply reverts the behaviour to how it was before, in order to allow the editor to function correctly in Safari.  A more complete fix will hopefully follow

P.S. Also removed an extraneous svg that ended up in the root of the project 😊 

