### PR TITLE
Use presenter version 3.3.21

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ ruby '3.1.3'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'move-components'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.19'
+gem 'metadata_presenter', '3.3.21'
 
 gem 'activerecord-session_store'
 gem 'administrate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.3.19)
+    metadata_presenter (3.3.21)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)
@@ -785,7 +785,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.3.19)
+  metadata_presenter (= 3.3.21)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
Resolves a bug where content wouldn't show on pages displaying validation errors

Editable
<img width="751" alt="image" src="https://github.com/ministryofjustice/fb-editor/assets/7647632/9f025092-29fd-4df7-826f-b9dd2df539e3">

Preview
<img width="1106" alt="image" src="https://github.com/ministryofjustice/fb-editor/assets/7647632/df06c94a-ec31-487b-92f8-f2e65398e9fe">
