### PR TITLE
More complete fix for button issue in safari

### DIFF
--- a/app/javascript/src/components/menus/activated_menu.js
+++ b/app/javascript/src/components/menus/activated_menu.js
@@ -47,356 +47,354 @@
  **/
 
 const {
-    property,
-    mergeObjects,
-    createElement,
-    uniqueString
-} = require('../../utilities');
+  property,
+  mergeObjects,
+  createElement,
+  uniqueString,
+} = require("../../utilities");
 
-const tabbable = require('tabbable').tabbable;
-const ActivatedMenuItem = require('./activated_menu_item');
-const ActivatedMenuActivator = require('./activated_menu_activator');
-const ActivatedMenuContainer = require('./activated_menu_container');
+const tabbable = require("tabbable").tabbable;
+const ActivatedMenuItem = require("./activated_menu_item");
+const ActivatedMenuActivator = require("./activated_menu_activator");
+const ActivatedMenuContainer = require("./activated_menu_container");
 
-const ITEMS_SELECTOR = '> li';
+const ITEMS_SELECTOR = "> li";
 
 class ActivatedMenu {
-    #className
-    #config
-    #position
-    #state
-    #currentFocusIndex
+  #className;
+  #config;
+  #position;
+  #state;
+  #currentFocusIndex;
 
-    constructor($menu, config) {
-        let defaults = {
-            container_id: uniqueString("menu"),
-            render: true,
-        }
+  constructor($menu, config) {
+    let defaults = {
+      container_id: uniqueString("menu"),
+      render: true,
+    };
 
-        config = mergeObjects(defaults, config);
+    config = mergeObjects(defaults, config);
 
-        this.$node = $menu;
-        this.$parent = $menu.parent();
-        this.$node.detach();
+    this.$node = $menu;
+    this.$parent = $menu.parent();
+    this.$node.detach();
 
-        this.#config = config;
-        this.#className = "ActivatedMenu";
+    this.#config = config;
+    this.#className = "ActivatedMenu";
 
-        this.#addAttributes();
-        this.activator = new ActivatedMenuActivator(this, config);
-        this.container = new ActivatedMenuContainer(this, config);
-        this.container.$node.hide();
+    this.#addAttributes();
+    this.activator = new ActivatedMenuActivator(this, config);
+    this.container = new ActivatedMenuContainer(this, config);
+    this.container.$node.hide();
 
-        // Default position settings (can be set on instantiation or overide
-        // on-the-fly by passing to component.open() function. Passing in a
-        // position object will set the temporary value this.#state.position.
-        this.#position = mergeObjects({
-            my: "left top",
-            at: "left top",
-            of: this.activator.$node,
-            collision: "flip"
-        }, property(this._config, "menu.position"));
+    // Default position settings (can be set on instantiation or overide
+    // on-the-fly by passing to component.open() function. Passing in a
+    // position object will set the temporary value this.#state.position.
+    this.#position = mergeObjects(
+      {
+        my: "left top",
+        at: "left top",
+        of: this.activator.$node,
+        collision: "flip",
+      },
+      property(this._config, "menu.position"),
+    );
 
-        // Default position is empty - update this dynamically by passing
-        // to component.open() - will be reset on component.close()
-        // See this.#position (above) and jQueryUI documentation
-        // for what value(s) are required.
-        this.#state = {
-            open: false,
-            position: null
-        }
+    // Default position is empty - update this dynamically by passing
+    // to component.open() - will be reset on component.close()
+    // See this.#position (above) and jQueryUI documentation
+    // for what value(s) are required.
+    this.#state = {
+      open: false,
+      position: null,
+    };
 
-        this.#bindMenuEventHandlers();
-        this.#setMenuOpenPosition();
-        this.#initializeMenuItems();
+    this.#bindMenuEventHandlers();
+    this.#setMenuOpenPosition();
+    this.#initializeMenuItems();
 
-        this.$node.data("instance", this); // Add reference for instance from original node.
-        this.$items = this.$node.find(ITEMS_SELECTOR);
-        this.#currentFocusIndex = 0;
+    this.$node.data("instance", this); // Add reference for instance from original node.
+    this.$items = this.$node.find(ITEMS_SELECTOR);
+    this.#currentFocusIndex = 0;
 
-        if (config.render) {
+    if (config.render) {
+      this.close();
+      this.render();
+    }
+  }
+
+  get config() {
+    return this.#config;
+  }
+
+  get state() {
+    return this.#state;
+  }
+
+  get position() {
+    return this.#position;
+  }
+
+  get currentFocusItem() {
+    return this.$items.eq(this.#currentFocusIndex);
+  }
+
+  set currentActivator(element) {
+    this.#state.activator = element;
+  }
+
+  render() {
+    this.container.render();
+    this.activator.render();
+  }
+
+  isOpen() {
+    return this.#state.open;
+  }
+
+  // Opens the menu.
+  // @position (Object) Optional (jQuery position) object.
+  open(config = {}) {
+    if (config.position) {
+      this.#setMenuOpenPosition(config.position);
+    } else {
+      this.#calculateMenuOpenPosition(this.activator.$node);
+    }
+    this.container.$node.position(this.state.position);
+    this.container.$node.show();
+    this.activator.$node.attr("aria-expanded", true);
+    this.focus();
+    this.#state.open = true;
+  }
+
+  close() {
+    this.closeAllSubmenus();
+    this.#state.open = false;
+    this.container.$node.hide();
+    this.activator.$node.removeAttr("aria-expanded");
+    this.activator.$node.focus();
+
+    // Reset any externally/temporary setting of
+    // component._state.position back to default.
+    this.#resetMenuOpenPosition();
+  }
+
+  closeAllSubmenus() {
+    var $subMenus = this.$node.find('ul[role="menu"]');
+    $subMenus.each(function () {
+      $(this).hide();
+    });
+  }
+
+  focus(index = 0) {
+    var $items = this.$items;
+
+    if (index > $items.length - 1) {
+      index = 0;
+    }
+    if (index < 0) {
+      index = $items.length - 1;
+    }
+    var $item = $($items[index]).find("> :first-child");
+    if ($item.parent().is("[aria-disabled]")) {
+      // if item is disabled, skip it
+      if (index > this.#currentFocusIndex) {
+        this.focus(index + 1);
+      } else {
+        this.focus(index - 1);
+      }
+    } else {
+      this.#currentFocusIndex = index;
+      $item[0].focus();
+      this.$node.attr("aria-activedescendant", $item.attr("id"));
+    }
+  }
+
+  focusNext() {
+    this.focus(this.#currentFocusIndex + 1);
+  }
+
+  focusPrev() {
+    this.focus(this.#currentFocusIndex - 1);
+  }
+
+  focusItem($node) {
+    const index = this.$items.index($node);
+    this.focus(index);
+  }
+
+  focusLast() {
+    const index = this.$items.length - 1;
+    this.focus(index);
+  }
+
+  #initializeMenuItems() {
+    const menu = this;
+    menu.$node.find("li").each(function () {
+      new ActivatedMenuItem($(this), menu);
+    });
+  }
+
+  #addAttributes() {
+    this.$node.addClass(this.#className);
+    this.$node.attr("role", "menu");
+  }
+
+  #bindMenuEventHandlers() {
+    const component = this;
+
+    this.$node.on("mouseout", (event) => {
+      // event.currentTarget will be the menu (UL) element.
+      // check if relatedTarget is not a child element.
+      this.#state.close = true;
+      if (!$.contains(event.currentTarget, event.relatedTarget)) {
+        setTimeout(function (e) {
+          if (component.state.close) {
+            component.close();
+          }
+        }, 100);
+      }
+    });
+
+    this.$node.on("mouseover", (event) => {
+      this.#state.close = false;
+    });
+
+    this.$node.on("keydown", (event) => {
+      if (this.state.open) {
+        let key = event.originalEvent.key;
+        let shiftKey = event.originalEvent.shiftKey;
+
+        switch (key) {
+          case "Home":
+            event.preventDefault();
+            this.focus(0);
+            break;
+          case "End":
+            event.preventDefault();
+            this.focusLast();
+            break;
+          case "ArrowDown":
+            event.preventDefault();
+            this.focusNext();
+            break;
+          case "ArrowUp":
+            event.preventDefault();
+            this.focusPrev();
+            break;
+          case "Escape":
             this.close();
-            this.render();
-        }
-    }
-
-    get config() {
-        return this.#config;
-    }
-
-    get state() {
-        return this.#state;
-    }
-
-    get position() {
-        return this.#position;
-    }
-
-    get currentFocusItem() {
-        return this.$items.eq(this.#currentFocusIndex);
-    }
-
-    set currentActivator(element) {
-        this.#state.activator = element;
-    }
-
-    render() {
-        this.container.render();
-        this.activator.render();
-    }
-
-    isOpen() {
-        return this.#state.open;
-    }
-
-    // Opens the menu.
-    // @position (Object) Optional (jQuery position) object.
-    open(config = {}) {
-        if (config.position) {
-            this.#setMenuOpenPosition(config.position);
-        }
-        else {
-            this.#calculateMenuOpenPosition(this.activator.$node);
-        }
-        this.container.$node.position(this.state.position);
-        this.container.$node.show();
-        this.activator.$node.attr("aria-expanded", true);
-        this.focus()
-        this.#state.open = true;
-    }
-
-    close() {
-        this.closeAllSubmenus();
-        this.#state.open = false;
-        this.container.$node.hide();
-        this.activator.$node.removeAttr("aria-expanded");
-        this.activator.$node.focus();
-
-        // Reset any externally/temporary setting of
-        // component._state.position back to default.
-        this.#resetMenuOpenPosition();
-    }
-
-    closeAllSubmenus() {
-        var $subMenus = this.$node.find('ul[role="menu"]');
-        $subMenus.each(function() {
-            $(this).hide();
-        });
-    }
-
-    focus(index = 0) {
-        var $items = this.$items;
-
-        if (index > $items.length - 1) {
-            index = 0;
-        }
-        if (index < 0) {
-            index = $items.length - 1;
-        }
-        var $item = $($items[index]).find('> :first-child');
-        if ($item.parent().is('[aria-disabled]')) {
-            // if item is disabled, skip it
-            if (index > this.#currentFocusIndex) {
-                this.focus(index + 1);
+            this.activator.$node.focus();
+            break;
+          case "Tab":
+            event.preventDefault();
+            // close will set focus on the activator by default, so we call first
+            this.close();
+            // now we can set the focus to the correct item
+            let tabbableElements = tabbable(document, { displayCheck: "full" });
+            let index = tabbableElements.indexOf(this.activator.$node[0]);
+            // focus on the next/previous item after the activator node
+            if (shiftKey) {
+              tabbableElements[index - 1].focus();
             } else {
-                this.focus(index - 1);
+              tabbableElements[index + 1].focus();
             }
-        } else {
-            this.#currentFocusIndex = index;
-            $item[0].focus();
-            this.$node.attr('aria-activedescendant', $item.attr('id'));
+            break;
         }
-    }
+      }
+    });
 
-    focusNext() {
-        this.focus(this.#currentFocusIndex + 1);
-    }
+    // Add a trigger for any listening document event
+    // to activate on menu item selection.
+    if (this.config.selection_event) {
+      let component = this;
+      component.$node.on("menuselect", function (event, ui) {
+        var e = event.originalEvent;
+        var original = {};
 
-    focusPrev() {
-        this.focus(this.#currentFocusIndex - 1);
-    }
+        if (e) {
+          if (component.config.preventDefault) {
+            e.preventDefault();
+            original.element = e.target;
+            original.event = e;
+          }
+        }
 
-    focusItem($node) {
-        const index = this.$items.index($node);
-        this.focus(index);
-    }
-
-    focusLast() {
-        const index = this.$items.length - 1;
-        this.focus(index);
-    }
-
-    #initializeMenuItems() {
-        const menu = this;
-        menu.$node.find('li').each(function() {
-            new ActivatedMenuItem($(this), menu);
+        $(document).trigger(component.config.selection_event, {
+          activator: ui.item,
+          menu: event.currentTarget,
+          component: component,
+          original: original,
         });
+      });
     }
+  }
 
-    #addAttributes() {
-        this.$node.addClass(this.#className);
-        this.$node.attr("role", "menu");
+  /*
+   * Sets the menu position to the passed setting or uses the
+   * default setting (which can also be changed in constructor
+   * by passing in configuration at instantiation time.
+   *
+   * Uses the jQueryUI position() utility function for the
+   * values to set.
+   * e.g. @position (Object) {
+   *                           my: "left top",
+   *                           at: "left bottom",
+   *                           of: some_element_here
+   *                         }
+   **/
+  #setMenuOpenPosition(position) {
+    var pos = position || {};
+    this.#state.position = {
+      my: pos.my || this.position.my,
+      at: pos.at || this.position.at,
+      of: pos.of || this.position.of,
+    };
+  }
+
+  /*
+   * Positions the menu in relation to the activator and default
+   * position values, but tries to calculate if needs to reverse
+   * the open position based on if the activator is too far right.
+   **/
+  #calculateMenuOpenPosition($activator) {
+    var activatorLeft = $activator[0].getBoundingClientRect().left;
+    var rightBoundary = window.innerWidth;
+    var menuWidth = this.$node.outerWidth();
+
+    if (rightBoundary - activatorLeft < menuWidth) {
+      this.#setMenuOpenPosition({
+        my: "right top",
+        at: "right top",
+        of: $activator,
+      });
+    } else {
+      this.#setMenuOpenPosition();
     }
+  }
 
-    #bindMenuEventHandlers() {
-        const component = this;
-
-        this.$node.on("mouseout", (event) => {
-            console.log('mouseout')
-            // event.currentTarget will be the menu (UL) element.
-            // check if relatedTarget is not a child element.
-            this.#state.close = true;
-            if (!$.contains(event.currentTarget, event.relatedTarget)) {
-                setTimeout(function(e) {
-                    if (component.state.close) {
-                        component.close();
-                    }
-                }, 100);
-            }
-        });
-
-        this.$node.on("mouseover", (event) => {
-            this.#state.close = false;
-        });
-
-        this.$node.on('keydown', (event) => {
-            if (this.state.open) {
-                let key = event.originalEvent.key;
-                let shiftKey = event.originalEvent.shiftKey;
-
-                switch (key) {
-                    case 'Home':
-                        event.preventDefault();
-                        this.focus(0);
-                        break;
-                    case 'End':
-                        event.preventDefault();
-                        this.focusLast();
-                        break;
-                    case 'ArrowDown':
-                        event.preventDefault();
-                        this.focusNext();
-                        break;
-                    case 'ArrowUp':
-                        event.preventDefault();
-                        this.focusPrev();
-                        break;
-                    case 'Escape':
-                        this.close();
-                        this.activator.$node.focus();
-                        break;
-                    case 'Tab':
-                        event.preventDefault();
-                        // close will set focus on the activator by default, so we call first
-                        this.close();
-                        // now we can set the focus to the correct item
-                        let tabbableElements = tabbable(document, { displayCheck: 'full' })
-                        let index = tabbableElements.indexOf(this.activator.$node[0]);
-                        // focus on the next/previous item after the activator node
-                        if (shiftKey) {
-                            tabbableElements[index - 1].focus();
-                        } else {
-                            tabbableElements[index + 1].focus();
-                        }
-                        break;
-                }
-            }
-        });
-
-
-        // Add a trigger for any listening document event
-        // to activate on menu item selection.
-        if (this.config.selection_event) {
-            let component = this;
-            component.$node.on("menuselect", function(event, ui) {
-                var e = event.originalEvent;
-                var original = {};
-
-                if (e) {
-                    if (component.config.preventDefault) {
-                        e.preventDefault();
-                        original.element = e.target;
-                        original.event = e;
-                    }
-                }
-
-                $(document).trigger(component.config.selection_event, {
-                    activator: ui.item,
-                    menu: event.currentTarget,
-                    component: component,
-                    original: original
-                });
-            });
-        }
-    }
-
-    /*
-     * Sets the menu position to the passed setting or uses the
-     * default setting (which can also be changed in constructor
-     * by passing in configuration at instantiation time.
-     *
-     * Uses the jQueryUI position() utility function for the
-     * values to set.
-     * e.g. @position (Object) {
-     *                           my: "left top",
-     *                           at: "left bottom",
-     *                           of: some_element_here
-     *                         }
-     **/
-    #setMenuOpenPosition(position) {
-        var pos = position || {};
-        this.#state.position = {
-            my: (pos.my || this.position.my),
-            at: (pos.at || this.position.at),
-            of: (pos.of || this.position.of)
-        }
-    }
-
-    /*
-     * Positions the menu in relation to the activator and default
-     * position values, but tries to calculate if needs to reverse
-     * the open position based on if the activator is too far right.
-     **/
-    #calculateMenuOpenPosition($activator) {
-        var activatorLeft = $activator[0].getBoundingClientRect().left;
-        var rightBoundary = window.innerWidth;
-        var menuWidth = this.$node.outerWidth();
-
-        if (rightBoundary - activatorLeft < menuWidth) {
-            this.#setMenuOpenPosition({
-                my: "right top",
-                at: "right top",
-                of: $activator
-            });
-        }
-        else {
-            this.#setMenuOpenPosition();
-        }
-    }
-
-    /*
-     * Removes any position values that have occurred as a result of
-     * calling the setMenuOpenPosition() function.
-     * Note: This assumes that no external JS script is trying to
-     * set values independently of the ActivatedMenu class functionality.
-     * Clearing the values is required to stop jQueryUI position()
-     * functionality adding to existing, each time it's called.
-     * An alternative might be to set position once, and not on each
-     * ActivatedMenu.open call. There is a minor performance gain that
-     * could be claimed, but it would also be less flexible, if the
-     * activators (used for position reference) need to be dynamically
-     * moved for any enhance or future design improvements.
-     **/
-    #resetMenuOpenPosition() {
-        var node = this.container.$node.get(0);
-        node.style.left = "";
-        node.style.right = "";
-        node.style.top = "";
-        node.style.bottom = "";
-        node.style.position = "";
-        this.#state.position = null; // Reset because this one is set on-the-fly
-    }
+  /*
+   * Removes any position values that have occurred as a result of
+   * calling the setMenuOpenPosition() function.
+   * Note: This assumes that no external JS script is trying to
+   * set values independently of the ActivatedMenu class functionality.
+   * Clearing the values is required to stop jQueryUI position()
+   * functionality adding to existing, each time it's called.
+   * An alternative might be to set position once, and not on each
+   * ActivatedMenu.open call. There is a minor performance gain that
+   * could be claimed, but it would also be less flexible, if the
+   * activators (used for position reference) need to be dynamically
+   * moved for any enhance or future design improvements.
+   **/
+  #resetMenuOpenPosition() {
+    var node = this.container.$node.get(0);
+    node.style.left = "";
+    node.style.right = "";
+    node.style.top = "";
+    node.style.bottom = "";
+    node.style.position = "";
+    this.#state.position = null; // Reset because this one is set on-the-fly
+  }
 }
-
 
 module.exports = ActivatedMenu;

--- a/app/javascript/src/components/menus/activated_menu_activator.js
+++ b/app/javascript/src/components/menus/activated_menu_activator.js
@@ -17,106 +17,103 @@
  *
  **/
 
-const {
-    createElement,
-    uniqueString
-} = require('../../utilities');
+const { createElement, uniqueString } = require("../../utilities");
 
 class ActivatedMenuActivator {
-    #config;
-    #className;
+  #config;
+  #className;
 
-    /**
-     * @param {ActivatedMenu} the menu instance to be activated
-     * @param {object} ActivatedMenu configuration object
-     */
-    constructor(menu, config) {
-        let $node = config.activator;
-        this.#config = config;
-        this.#className = "ActivatedMenuActivator";
-        this.menu = menu;
+  /**
+   * @param {ActivatedMenu} the menu instance to be activated
+   * @param {object} ActivatedMenu configuration object
+   */
+  constructor(menu, config) {
+    let $node = config.activator;
+    this.#config = config;
+    this.#className = "ActivatedMenuActivator";
+    this.menu = menu;
 
-        if (!$node || $node.length < 1) {
-            this.$node = this.#createNode();
-        } else {
-            this.$node = $node;
-        }
-        this.$node.data("instance", this);
-
-        this.#addAttributes();
-        this.#bindEventHandlers();
-
+    if (!$node || $node.length < 1) {
+      this.$node = this.#createNode();
+    } else {
+      this.$node = $node;
     }
+    this.$node.data("instance", this);
 
-    render() {
-        if (this.menu.$parent.find('.flow-conditions').length) {
-            this.$node.insertBefore(this.menu.$parent.find('.flow-conditions'))
-        } else {
-            this.menu.$parent.append(this.$node);
-        }
+    this.#addAttributes();
+    this.#bindEventHandlers();
+  }
+
+  render() {
+    if (this.menu.$parent.find(".flow-conditions").length) {
+      this.$node.insertBefore(this.menu.$parent.find(".flow-conditions"));
+    } else {
+      this.menu.$parent.append(this.$node);
     }
+  }
 
-    /**
-     * Creates a button element using config
-     * @return {jQuery}
-     */
-    #createNode() {
-        const $node = $(
-            createElement("button",
-                this.#config.activator_text,
-                this.#config.activator_classname
-            )
-        );
-        return $node;
-    }
+  /**
+   * Creates a button element using config
+   * @return {jQuery}
+   */
+  #createNode() {
+    const $node = $(
+      createElement(
+        "button",
+        this.#config.activator_text,
+        this.#config.activator_classname,
+      ),
+    );
+    return $node;
+  }
 
-    #addAttributes() {
-        this.$node.addClass(this.#className);
-        this.$node.attr("type", "button");
-        this.$node.attr("id", uniqueString("menuActivator"));
-        this.$node.attr("aria-haspopup", "menu");
-        this.$node.attr("aria-controls", this.#config.container_id);
-        this.menu.$node.attr("aria-labelledby", this.$node.attr("id"));
-    }
+  #addAttributes() {
+    this.$node.addClass(this.#className);
+    this.$node.attr("type", "button");
+    this.$node.attr("id", uniqueString("menuActivator"));
+    this.$node.attr("aria-haspopup", "menu");
+    this.$node.attr("aria-controls", this.#config.container_id);
+    this.menu.$node.attr("aria-labelledby", this.$node.attr("id"));
+  }
 
-    #bindEventHandlers() {
-        this.$node.on("click.ActivatedMenuActivator", (event) => {
-            this.menu.currentActivator = event.currentTarget;
-            this.menu.open();
-        });
+  #bindEventHandlers() {
+    this.$node.on("mousedown.ActivatedMenuActivator", (event) => {
+      this.menu.currentActivator = event.currentTarget;
+      this.menu.open();
+    });
 
-        this.$node.on("focus", (event) => {
-            this.$node.addClass("active");
-        });
+    this.$node.on("focus", (event) => {
+      this.$node.addClass("active");
+    });
 
-        this.$node.on("blur", (event) => {
-            if (!this.menu.state.open) {
-                this.$node.removeClass("active");
-            }
-        });
+    this.$node.on("blur", (event) => {
+      if (!this.menu.state.open) {
+        this.$node.removeClass("active");
+      }
+    });
 
-        this.$node.on("keydown", (event) => {
-            let key = event.originalEvent.code;
+    this.$node.on("keydown", (event) => {
+      let key = event.originalEvent.code;
 
-            switch (key) {
-                case 'Enter':
-                case 'Space':
-                case 'ArrowDown':
-                    event.preventDefault();
+      switch (key) {
+        case "Enter":
+        case "Space":
+        case "ArrowDown":
+          event.preventDefault();
 
-                    this.menu.currentActivator = event.currentTarget;
-                    this.menu.open();
-                    this.menu.focus();
-                    break;
-                case 'ArrowUp':
-                    event.preventDefault();
+          this.menu.currentActivator = event.currentTarget;
+          this.menu.open();
+          this.menu.focus();
+          break;
+        case "ArrowUp":
+          event.preventDefault();
 
-                    this.menu.currentActivator = event.currentTarget;
-                    this.menu.open();
-                    this.menu.focusLast();
-                    break;
-            }
-        });
-    }
+          this.menu.currentActivator = event.currentTarget;
+          this.menu.open();
+          this.menu.focusLast();
+          break;
+      }
+    });
+  }
 }
 module.exports = ActivatedMenuActivator;

--- a/app/javascript/src/components/menus/question_menu.js
+++ b/app/javascript/src/components/menus/question_menu.js
@@ -10,29 +10,38 @@
  *       https://api.jqueryui.com/menu
  *
  **/
-const { mergeObjects }  = require('../../utilities');
-const ActivatedMenu = require('./activated_menu');
-
+const { mergeObjects } = require("../../utilities");
+const ActivatedMenu = require("./activated_menu");
 
 class QuestionMenu extends ActivatedMenu {
   constructor($node, config) {
-    super($node, mergeObjects({
-      activator_text: "",
-      $target: $(), // Used in placing the activator
-      question: {}, // TODO: Not sure if we should do this way
-      view: {},
-      onSetRequired: function(){} // Called at end of set required function
-    }, config));
+    super(
+      $node,
+      mergeObjects(
+        {
+          activator_text: "",
+          $target: $(), // Used in placing the activator
+          question: {}, // TODO: Not sure if we should do this way
+          view: {},
+          onSetRequired: function () {}, // Called at end of set required function
+        },
+        config,
+      ),
+    );
 
     $node.on("menuselect", (event, ui) => {
       this.selection(event, ui.item);
     });
 
     let $target = this.config.$target;
-    if($target.length) {
+    if ($target.length) {
       $target.before(this.activator.$node);
-      $target.on("focus.questionmenu", () => this.activator.$node.addClass("active"));
-      $target.on("blur.questionmenu", () => this.activator.$node.removeClass("active"));
+      $target.on("focus.questionmenu", () =>
+        this.activator.$node.addClass("active"),
+      );
+      $target.on("blur.questionmenu", () => {
+        this.activator.$node.removeClass("active");
+      });
     }
 
     this.container.$node.addClass("QuestionMenu");
@@ -45,13 +54,13 @@ class QuestionMenu extends ActivatedMenu {
     this.selectedItem = item;
 
     event.preventDefault();
-    switch(action) {
+    switch (action) {
       case "remove":
-           this.remove();
-           break;
+        this.remove();
+        break;
       case "required":
-          this.required();
-          break;
+        this.required();
+        break;
       case "validation":
         this.validation(item);
         break;
@@ -77,7 +86,10 @@ class QuestionMenu extends ActivatedMenu {
 
   validation(menuItem) {
     var validation = menuItem.data("validation");
-    $(document).trigger("QuestionMenuSelectionValidation", { question: this.question, validation: validation });
+    $(document).trigger("QuestionMenuSelectionValidation", {
+      question: this.question,
+      validation: validation,
+    });
   }
 
   upload() {
@@ -94,29 +106,34 @@ class QuestionMenu extends ActivatedMenu {
   }
 
   setEnabledValidations() {
-    var validationData = Object.assign( {}, this.question.data.validation ); // don't mutate the question data
+    var validationData = Object.assign({}, this.question.data.validation); // don't mutate the question data
 
-    if(validationData.hasOwnProperty('min_length') || validationData.hasOwnProperty('min_word') ){
+    if (
+      validationData.hasOwnProperty("min_length") ||
+      validationData.hasOwnProperty("min_word")
+    ) {
       validationData.min_string_length = true;
     }
 
-    if(validationData.hasOwnProperty('max_length') || validationData.hasOwnProperty('max_word') ){
+    if (
+      validationData.hasOwnProperty("max_length") ||
+      validationData.hasOwnProperty("max_word")
+    ) {
       validationData.max_string_length = true;
     }
 
-    this.$node.find("[data-validation]").each(function() {
-      var validationType = $(this).data('validation');
-      if( validationType == 'max_files' ) {
-        return
+    this.$node.find("[data-validation]").each(function () {
+      var validationType = $(this).data("validation");
+      if (validationType == "max_files") {
+        return;
       }
-      
-      if( validationData[validationType] ) {
-        $(this).find('> :first-child').attr('aria-checked', 'true');
+
+      if (validationData[validationType]) {
+        $(this).find("> :first-child").attr("aria-checked", "true");
       } else {
-        $(this).find('> :first-child').attr('aria-checked', 'false');
+        $(this).find("> :first-child").attr("aria-checked", "false");
       }
     });
   }
-
 }
 module.exports = QuestionMenu;

--- a/app/javascript/src/controllers/orderable-item-controller.js
+++ b/app/javascript/src/controllers/orderable-item-controller.js
@@ -45,13 +45,27 @@ export default class extends Controller {
     if (!this.hasUpButtonTarget) {
       this.element.insertAdjacentHTML(
         "beforeend",
-        `<button type="button" class="icon-button icon-button--move icon-button--up" data-orderable-item-target="upButton" data-action="orderable-item#moveUp:prevent">${this.upButtonLabel}</button>`,
+        `<button type="button" 
+                 class="icon-button icon-button--move icon-button--up" 
+                 data-orderable-item-target="upButton" 
+                 data-action="mousedown->orderable-item#moveUp:prevent 
+                              keydown.enter->orderable-item#moveUp:prevent 
+                              keyup.space->orderable-item#moveUp:prevent">
+            ${this.upButtonLabel}
+        </button>`,
       );
     }
     if (!this.hasDownButtonTarget) {
       this.element.insertAdjacentHTML(
         "beforeend",
-        `<button type="button" class="icon-button icon-button--move icon-button--down" data-orderable-item-target="downButton" data-action="orderable-item#moveDown:prevent">${this.downButtonLabel}</button>`,
+        `<button type="button"
+                 class="icon-button icon-button--move icon-button--down"
+                 data-orderable-item-target="downButton"
+                 data-action="mousedown->orderable-item#moveDown:prevent 
+                              keydown.enter->orderable-item#moveDown:prevent 
+                              keyup.space->orderable-item#moveDown:prevent">
+            ${this.downButtonLabel}
+        </button>`,
       );
     }
   }

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -9,7 +9,6 @@
  *
  **/
 
-
 const {
   mergeObjects,
   createElement,
@@ -17,12 +16,12 @@ const {
   safelyActivateFunction,
   addHiddenInpuElementToForm,
   updateHiddenInputOnForm,
-} = require('./utilities');
+} = require("./utilities");
 
-const showdown  = require('showdown');
-const sanitizeHtml = require('sanitize-html');
+const showdown = require("showdown");
+const sanitizeHtml = require("sanitize-html");
 
-const EditableCollectionItemMenu = require('./components/menus/editable_collection_item_menu');
+const EditableCollectionItemMenu = require("./components/menus/editable_collection_item_menu");
 
 /* Editable Base:
  * Shared code across the editable component types.
@@ -55,16 +54,20 @@ class EditableBase {
   remove() {
     // 1. Remove any form element with target name.
     // 2. Add uuid of target component to delete_components array.
-    var $input = $(this._config.form).find("[name='" + this._config.id + "']")
-    if($input.length) {
+    var $input = $(this._config.form).find("[name='" + this._config.id + "']");
+    if ($input.length) {
       $input.remove();
     }
-    addHiddenInpuElementToForm(this._config.form, "delete_components[]", this._config.data._uuid);
+    addHiddenInpuElementToForm(
+      this._config.form,
+      "delete_components[]",
+      this._config.data._uuid,
+    );
   }
 
   save() {
-    console.log('Editable base save')
-    console.log(this.content)
+    console.log("Editable base save");
+    console.log(this.content);
     updateHiddenInputOnForm(this._config.form, this._config.id, this.content);
   }
 
@@ -72,7 +75,6 @@ class EditableBase {
     $(document).trigger("SaveRequired");
   }
 }
-
 
 /* Editable Element:
  * Used for creating simple content control objects on HTML
@@ -86,13 +88,17 @@ class EditableElement extends EditableBase {
   constructor($node, config) {
     super($node, config);
     var originalContent = $node.text().trim(); // Trim removes whitespace from template.
-    var defaultContent = config.attributeDefaultText ? $node.data(config.attributeDefaultText) : undefined ;
+    var defaultContent = config.attributeDefaultText
+      ? $node.data(config.attributeDefaultText)
+      : undefined;
     var required = defaultContent === undefined;
 
     $node.on("blur.editablecomponent", this.update.bind(this));
-    $node.on("focus.editablecomponent", this.edit.bind(this) );
-    $node.on("paste.editablecomponent", e => pasteAsPlainText(e) );
-    $node.on("keydown.editablecomponent", e => singleLineInputRestrictions(e) );
+    $node.on("focus.editablecomponent", this.edit.bind(this));
+    $node.on("paste.editablecomponent", (e) => pasteAsPlainText(e));
+    $node.on("keydown.editablecomponent", (e) =>
+      singleLineInputRestrictions(e),
+    );
 
     $node.attr("contentEditable", true);
     $node.attr("role", "textbox"); // Accessibility helper.
@@ -106,11 +112,10 @@ class EditableElement extends EditableBase {
 
   get content() {
     var content;
-    if(this._required) {
-      content = (this._content == "" ? this._originalContent : this._content);
-    }
-    else {
-      content = (this._content == this._defaultContent ? "" : this._content);
+    if (this._required) {
+      content = this._content == "" ? this._originalContent : this._content;
+    } else {
+      content = this._content == this._defaultContent ? "" : this._content;
     }
     return content;
   }
@@ -118,11 +123,14 @@ class EditableElement extends EditableBase {
   set content(content) {
     var trimmedContent = content.trim();
 
-    if(this._content != trimmedContent) {
+    if (this._content != trimmedContent) {
       this._content = trimmedContent;
 
       // If something changed...
-      if(this._content != this._defaultContent || this._content != this._originalContent) {
+      if (
+        this._content != this._defaultContent ||
+        this._content != this._originalContent
+      ) {
         this.emitSaveRequired();
       }
     }
@@ -132,7 +140,10 @@ class EditableElement extends EditableBase {
 
   edit() {
     this.removePlaceholder();
-    if(this.$node.text().trim() == this.config.defaultLabelValue || this.$node.text().trim() == this.config.defaultItemLabelValue) {
+    if (
+      this.$node.text().trim() == this.config.defaultLabelValue ||
+      this.$node.text().trim() == this.config.defaultItemLabelValue
+    ) {
       this.selectContent();
     }
     this.$node.addClass(this._config.editClassname);
@@ -141,10 +152,12 @@ class EditableElement extends EditableBase {
   update() {
     const currentContent = this.$node.text();
 
-    if(currentContent == '' ){
-      this.content = (this._required ? this._originalContent : this._defaultContent);
+    if (currentContent == "") {
+      this.content = this._required
+        ? this._originalContent
+        : this._defaultContent;
     } else {
-      this.content = currentContent
+      this.content = currentContent;
     }
 
     this.$node.removeClass(this._config.editClassname);
@@ -161,8 +174,8 @@ class EditableElement extends EditableBase {
   }
 
   removePlaceholder() {
-    if(this.$node.text().trim() == this._defaultContent) {
-      this.$node.text('')
+    if (this.$node.text().trim() == this._defaultContent) {
+      this.$node.text("");
     }
   }
 
@@ -175,16 +188,15 @@ class EditableElement extends EditableBase {
   }
 
   moveCaretToEndOfContent() {
-    const range = document.createRange();//Create a range (a range is a like the selection but invisible)
-    const selection = window.getSelection();//get the selection object (allows you to change selection)
+    const range = document.createRange(); //Create a range (a range is a like the selection but invisible)
+    const selection = window.getSelection(); //get the selection object (allows you to change selection)
 
-    range.selectNodeContents(this.$node.get(0));//Select the entire contents of the element with the range
-    range.collapse(false);//collapse the range to the end point. false means collapse to end rather than the start
-    selection.removeAllRanges();//remove any selections already made
-    selection.addRange(range);//make the range you have just created the visible selection
+    range.selectNodeContents(this.$node.get(0)); //Select the entire contents of the element with the range
+    range.collapse(false); //collapse the range to the end point. false means collapse to end rather than the start
+    selection.removeAllRanges(); //remove any selections already made
+    selection.addRange(range); //make the range you have just created the visible selection
   }
 }
-
 
 /* Editable Content:
  * Used for creating complex content control objects on HTML areas such as a <DIV>,
@@ -208,8 +220,8 @@ class EditableContent extends EditableElement {
 
   constructor($node, config) {
     super($node, config);
-    var $input = $("<textarea class=\"input\"></textarea>");
-    var $output = $("<div class=\"output\"></div>");
+    var $input = $('<textarea class="input"></textarea>');
+    var $output = $('<div class="output"></div>');
     var $span = $("<span>measure</span>");
     var html = $node.html().trim(); // Stored Markdown is originally converted at template level
     var lineHeight;
@@ -217,7 +229,7 @@ class EditableContent extends EditableElement {
     // Use temporary hidden <span> for obtaining lineHeight measurement
     $span.css({
       font: "inherit",
-      visibility: "hidden"
+      visibility: "hidden",
     });
 
     $node.append($span);
@@ -236,8 +248,11 @@ class EditableContent extends EditableElement {
     $node.attr("contentEditable", false);
 
     // Add event to required element
-    $output.on("click.editablecontent, focus.editablecontent", this.edit.bind(this) );
-    $input.on("blur.editablecontent", this.update.bind(this) );
+    $output.on(
+      "click.editablecontent, focus.editablecontent",
+      this.edit.bind(this),
+    );
+    $input.on("blur.editablecontent", this.update.bind(this));
     // TODO: Experimental and not quite working properly auto-resizing effort.
     //       Disabled for MVP unless there is time to get it right.
     //$input.on("keydown.editablecontent, paste.editablecontent", EditableContent.inputResizer.bind(this) );
@@ -247,14 +262,14 @@ class EditableContent extends EditableElement {
     $node.addClass("EditableContent");
 
     this.#converter = new showdown.Converter({
-                    noHeaderId: true,
-                    strikethrough: true,
-                    omitExtraWLInCodeBlocks: true,
-                    simplifiedAutoLink: false,
-                    tables: true,
-                    disableForced4SpacesIndentedSublists: true
-                  });
-    this.#converter.setFlavor('github');
+      noHeaderId: true,
+      strikethrough: true,
+      omitExtraWLInCodeBlocks: true,
+      simplifiedAutoLink: false,
+      tables: true,
+      disableForced4SpacesIndentedSublists: true,
+    });
+    this.#converter.setFlavor("github");
 
     this._editing = false;
     this._lineHeight = lineHeight;
@@ -262,7 +277,7 @@ class EditableContent extends EditableElement {
     this.$output = $output;
     this.content = this.#convertToMarkdown(html);
 
-    if(config.text.default_content) {
+    if (config.text.default_content) {
       this._defaultContent = config.text.default_content;
     }
 
@@ -273,15 +288,16 @@ class EditableContent extends EditableElement {
   // Get content must always return Markdown because that's what we save.
   get content() {
     var content = this.#markdown;
-    var contentWithoutWhitespace = content.replace(/\s/mig, "");
-    var defaultWithoutWhitespace = this._defaultContent.replace(/\s/mig, "");
+    var contentWithoutWhitespace = content.replace(/\s/gim, "");
+    var defaultWithoutWhitespace = this._defaultContent.replace(/\s/gim, "");
 
     // Remove whitespace for better comparison
-    content = (contentWithoutWhitespace == defaultWithoutWhitespace ? "" : content);
+    content =
+      contentWithoutWhitespace == defaultWithoutWhitespace ? "" : content;
 
     // Bit hacky but we handle one type of content value as a string (see above),
     // and the other (component) content as a JSON string for all the component data.
-    if(this._config.data) {
+    if (this._config.data) {
       this._config.data.content = content;
       content = JSON.stringify(this._config.data);
     }
@@ -291,8 +307,11 @@ class EditableContent extends EditableElement {
 
   set content(markdown) {
     // Check if configuration requires external adjustment to markdown
-    if(this._config.markdownAdjustment) {
-      markdown = safelyActivateFunction(this._config.markdownAdjustment, markdown);
+    if (this._config.markdownAdjustment) {
+      markdown = safelyActivateFunction(
+        this._config.markdownAdjustment,
+        markdown,
+      );
     }
     this.#markdown = markdown;
     this.emitSaveRequired();
@@ -317,7 +336,7 @@ class EditableContent extends EditableElement {
     // Figure out what content to show in output area.
     const currentInput = this.$input.val().trim();
     const defaultContent = this._defaultContent || this._originalContent;
-    const markdown = (currentInput == "" ? defaultContent : currentInput);
+    const markdown = currentInput == "" ? defaultContent : currentInput;
     const html = this.#convertToHtml(markdown);
 
     // Assign the cleaned markup to be saved
@@ -332,14 +351,14 @@ class EditableContent extends EditableElement {
   // Adds the passed content to output area.
   #output(content) {
     // Check if configuration requires external adjustment to html
-    if(this._config.htmlAdjustment) {
+    if (this._config.htmlAdjustment) {
       content = safelyActivateFunction(this._config.htmlAdjustment, content);
     }
 
     this.$output.html(content);
   }
 
-    /* Convert HTML to Markdown by tapping into third-party code.
+  /* Convert HTML to Markdown by tapping into third-party code.
    * Includes clean up of HTML by stripping attributes and unwanted trailing spaces.
    **/
   #convertToMarkdown(html) {
@@ -351,12 +370,11 @@ class EditableContent extends EditableElement {
     // Use a simple regex to fix the problem. N.B. Trailing space is included in
     // regex because showdown inserts a space between each node before conversion,
     // meaning the text nodes after a <br> have a leading space
-    markdown = markdown.replace(/<br\s?\/?>\n\n /mig, "  \n");
+    markdown = markdown.replace(/<br\s?\/?>\n\n /gim, "  \n");
 
     markdown = this.#cleanInput(markdown);
     return markdown;
   }
-
 
   /* Convert Markdown to HTML by tapping into third-party code.
    * Includes clean up of both Markdown and resulting HTML to fix noticed issues.
@@ -405,32 +423,33 @@ class EditableContent extends EditableElement {
    **/
   #cleanInput(input) {
     // 1.
-    input = input.replace(/\n<!--.*?-->/mig, "");
+    input = input.replace(/\n<!--.*?-->/gim, "");
     // 2.
-    input = input.replace(/\]\(\<(.*?)\>\)/mig, "]($1)");
+    input = input.replace(/\]\(\<(.*?)\>\)/gim, "]($1)");
     // 3.
-    input = input.replace(/\<([\w\-\.]+@{1}[\w\-\.]+)>/mig, "$mailto$1$mailto");
+    input = input.replace(/\<([\w\-\.]+@{1}[\w\-\.]+)>/gim, "$mailto$1$mailto");
     // 4.
     input = sanitizeHtml(input);
     // 5.
-    input = input.replace(/\$mailto([\w\-\.]+@{1}[\w\-\.]+)\$mailto/mig, "<$1>");
+    input = input.replace(
+      /\$mailto([\w\-\.]+@{1}[\w\-\.]+)\$mailto/gim,
+      "<$1>",
+    );
     // 6.
-    input = input.replace(/\n&gt;(\s{1}.*?\n)/mig, "\n>$1");
+    input = input.replace(/\n&gt;(\s{1}.*?\n)/gim, "\n>$1");
 
     return input;
   }
-
 }
 
 /* Experimental effort to auto-resize input area.
  * Currently not used as not working 100%.
  **/
-EditableContent.inputResizer = function(e) {
-  if(e.which == 13) {
+EditableContent.inputResizer = function (e) {
+  if (e.which == 13) {
     this.$input.height(this.$input.height() + this._lineHeight);
   }
-}
-
+};
 
 /* Editable Component Base:
  * Share code across the editable component types.
@@ -452,9 +471,12 @@ class EditableComponentBase extends EditableBase {
     //        something: new EditableElement($node.find("something"), config)
     //        and any others...
     //      }
-    this._elements = arguments.length > 2 && elements || {
-      label: new EditableElement($node.find(config.selectorElementLabel), config),
-      hint: new EditableElement($node.find(config.selectorElementHint), config)
+    this._elements = (arguments.length > 2 && elements) || {
+      label: new EditableElement(
+        $node.find(config.selectorElementLabel),
+        config,
+      ),
+      hint: new EditableElement($node.find(config.selectorElementHint), config),
     };
 
     $node.find(config.selectorDisabled).attr("disabled", true); // Prevent input in editor mode.
@@ -481,15 +503,14 @@ class EditableComponentBase extends EditableBase {
 
   // Focus on first editable element.
   focus() {
-    for(var i in this._elements) {
-      if(this._elements.hasOwnProperty(i)) {
+    for (var i in this._elements) {
+      if (this._elements.hasOwnProperty(i)) {
         this._elements[i].focus();
         break;
       }
     }
   }
 }
-
 
 /* Editable Text Field Component:
  * Structured editable component comprising of one or more elements.
@@ -524,14 +545,19 @@ class EditableTextFieldComponent extends EditableComponentBase {
     //       Maybe make this EditableAttribute instance when class is
     //       ready so we can edit attribute values, such as placeholder.
     //  {input: new EditableAttribute($node.find("input"), config)}
-    super($node, mergeObjects({
-      selectorElementLabel: config.selectorLabel,
-      selectorElementHint: config.selectorHint
-    }, config));
+    super(
+      $node,
+      mergeObjects(
+        {
+          selectorElementLabel: config.selectorLabel,
+          selectorElementHint: config.selectorHint,
+        },
+        config,
+      ),
+    );
     $node.addClass("EditableTextFieldComponent");
   }
 }
-
 
 /* Editable Textarea Field Component:
  * Structured editable component comprising of one or more elements.
@@ -562,14 +588,19 @@ class EditableTextFieldComponent extends EditableComponentBase {
  **/
 class EditableTextareaFieldComponent extends EditableComponentBase {
   constructor($node, config) {
-    super($node, mergeObjects({
-      selectorElementLabel: config.selectorLabel,
-      selectorElementHint: config.selectorHint
-    }, config));
+    super(
+      $node,
+      mergeObjects(
+        {
+          selectorElementLabel: config.selectorLabel,
+          selectorElementHint: config.selectorHint,
+        },
+        config,
+      ),
+    );
     $node.addClass("EditableTextareaFieldComponent");
   }
 }
-
 
 /* Editable Group Field Component:
  * Structured editable component comprising of one or more fields wrapped in fieldset.
@@ -609,10 +640,16 @@ class EditableTextareaFieldComponent extends EditableComponentBase {
  **/
 class EditableGroupFieldComponent extends EditableComponentBase {
   constructor($node, config) {
-    super($node, mergeObjects({
-      selectorElementLabel: config.selectorLabel,
-      selectorElementHint: config.selectorHint
-    }, config));
+    super(
+      $node,
+      mergeObjects(
+        {
+          selectorElementLabel: config.selectorLabel,
+          selectorElementHint: config.selectorHint,
+        },
+        config,
+      ),
+    );
     $node.addClass("EditableGroupFieldComponent");
   }
 
@@ -626,7 +663,6 @@ class EditableGroupFieldComponent extends EditableComponentBase {
     this.data.hint = elements.hint.content;
   }
 }
-
 
 /* Editable Collection (Radios/Checkboxes) Field Component:
  * Structured editable component comprising of one or more elements.
@@ -682,15 +718,21 @@ class EditableGroupFieldComponent extends EditableComponentBase {
  **/
 class EditableCollectionFieldComponent extends EditableComponentBase {
   constructor($node, config) {
-    super($node, mergeObjects({
-      selectorElementLabel: config.selectorLabel,
-      selectorElementHint: config.selectorHint
-    }, config));
+    super(
+      $node,
+      mergeObjects(
+        {
+          selectorElementLabel: config.selectorLabel,
+          selectorElementHint: config.selectorHint,
+        },
+        config,
+      ),
+    );
 
     this.items = [];
     // TODO: this should be refactored - preservedItemCount should just be a
     // config key not dependent on type
-    this._preservedItemCount = (this.type == "radios" ? 2 : 1); // Either minimum 2 radios or 1 checkbox.
+    this._preservedItemCount = this.type == "radios" ? 2 : 1; // Either minimum 2 radios or 1 checkbox.
 
     this.#createCollectionItemTemplate(config);
     this.#createEditableCollectionItems(config);
@@ -712,20 +754,20 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
 
     // Set data from items.
     this.data.items = [];
-    for(var i=0; i< this.items.length; ++i) {
+    for (var i = 0; i < this.items.length; ++i) {
       this.data.items.push(this.items[i].data);
     }
   }
 
- /*
- * Create an item template which can be cloned in component.addItem()
- * config (Object) key/value pairs for extra information.
- *
- * Note: Initial index elements of Array/Collection is called directly
- * without any checking for existence. This is because they should always
- * exist and, if they do not, we want the script to throw an error
- * because it would alert us to something very wrong.
- **/
+  /*
+   * Create an item template which can be cloned in component.addItem()
+   * config (Object) key/value pairs for extra information.
+   *
+   * Note: Initial index elements of Array/Collection is called directly
+   * without any checking for existence. This is because they should always
+   * exist and, if they do not, we want the script to throw an error
+   * because it would alert us to something very wrong.
+   **/
   #createCollectionItemTemplate(config) {
     var $clone = this.$node.find(config.selectorCollectionItem).eq(0).clone();
     var data = mergeObjects({}, config.data, ["items", "_uuid"]); // pt.1 Copy without items and component uuid.
@@ -746,25 +788,33 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
     this.$itemTemplate = $clone;
   }
 
-   /*
+  /*
    * Find radio or checkbox items and enhance with editable functionality.
    * Creates the initialising values for this.items
    * config (Object) key/value pairs for extra information.
    **/
-    #createEditableCollectionItems(config) {
+  #createEditableCollectionItems(config) {
     var component = this;
-    component.$node.find(config.selectorCollectionItem).each(function(i) {
+    component.$node.find(config.selectorCollectionItem).each(function (i) {
       // WARNING! DO NOT MOVE data or itemConfig OUTSIDE OF THIS LOOP
       // Due to JS reference handling of objects we need to make sure data and itemConfig are
       // inside the loop to instantiate two completely different variables. JS will not pass
       // by value so the alternative is creating EditableCollectionItems that share these objects.
       var data = mergeObjects({}, config.data, ["items", "_uuid"]); // pt.1 Copy without items and component uuid.
-      var itemConfig = mergeObjects({ preserveItem: (i < component._preservedItemCount) }, config, ["data"]); // pt.2 Without data
+      var itemConfig = mergeObjects(
+        { preserveItem: i < component._preservedItemCount },
+        config,
+        ["data"],
+      ); // pt.2 Without data
       itemConfig.data = mergeObjects(data, config.data.items[i]); // Bug fix response to JS reference handling.
 
       // Only wrap in EditableComponentCollectionItem functionality if doesn't look like it has it.
-      if(this.className.indexOf("EditableComponentCollectionItem") < 0) {
-        var item = new EditableComponentCollectionItem(component, $(this), itemConfig);
+      if (this.className.indexOf("EditableComponentCollectionItem") < 0) {
+        var item = new EditableComponentCollectionItem(
+          component,
+          $(this),
+          itemConfig,
+        );
         component.items.push(item);
       }
     });
@@ -777,11 +827,14 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
    **/
   #updateItems() {
     var filters = this._config.filters;
-    for(var i=0; i < this.items.length; ++i) {
-      this.items[i].data = this.#applyFilters(filters, i+1, this.items[i].data);
+    for (var i = 0; i < this.items.length; ++i) {
+      this.items[i].data = this.#applyFilters(
+        filters,
+        i + 1,
+        this.items[i].data,
+      );
     }
   }
-
 
   /*
    * Applies config.filters to the data passed in, with an index number, since this should
@@ -792,11 +845,10 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
    **/
   #applyFilters(filters, unique, data) {
     var filtered_data = {};
-    for(var prop in data) {
-      if(filters && filters.hasOwnProperty(prop)) {
+    for (var prop in data) {
+      if (filters && filters.hasOwnProperty(prop)) {
         filtered_data[prop] = filters[prop].call(data[prop], unique);
-      }
-      else {
+      } else {
         filtered_data[prop] = data[prop];
       }
     }
@@ -813,7 +865,11 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
     var $lastItem = this.items[this.items.length - 1].$node;
     var $clone = this.$itemTemplate.clone();
     $lastItem.after($clone);
-    var item = new EditableComponentCollectionItem(this, $clone, this.$itemTemplate.data("config"));
+    var item = new EditableComponentCollectionItem(
+      this,
+      $clone,
+      this.$itemTemplate.data("config"),
+    );
     this.items.push(item);
     this.#updateItems();
 
@@ -823,7 +879,7 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
 
   // Dynamically removes an item to the components collection
   removeItem(item) {
-    if(this.canHaveItemsRemoved()) {
+    if (this.canHaveItemsRemoved()) {
       var index = this.items.indexOf(item);
       safelyActivateFunction(this._config.onItemRemove, item);
       this.items.splice(index, 1);
@@ -835,18 +891,12 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
 
   save() {
     // Trigger the save action on items before calling it's own.
-    for(var i=0; i<this.items.length; ++i) {
+    for (var i = 0; i < this.items.length; ++i) {
       this.items[i].save();
     }
     super.save();
   }
 }
-
-
-
-
-
-
 
 /* Editable Component Collection Item:
  * Used for things like Radio Options/Checkboxes that have a label and hint element
@@ -864,18 +914,24 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
  **/
 class EditableComponentCollectionItem extends EditableComponentBase {
   constructor(editableCollectionFieldComponent, $node, config) {
-    super($node, mergeObjects({
-      selectorElementLabel: config.selectorComponentCollectionItemLabel,
-      selectorElementHint: config.selectorComponentCollectionItemHint
-    }, config));
+    super(
+      $node,
+      mergeObjects(
+        {
+          selectorElementLabel: config.selectorComponentCollectionItemLabel,
+          selectorElementHint: config.selectorComponentCollectionItemHint,
+        },
+        config,
+      ),
+    );
 
     this.menu = createEditableCollectionItemMenu(this, config);
 
-    $node.on("focus.EditableComponentCollectionItem", "*", function() {
+    $node.on("focus.EditableComponentCollectionItem", "*", function () {
       $node.addClass(config.editClassname);
     });
 
-    $node.on("blur.EditableComponentCollectionItem", "*", function() {
+    $node.on("blur.EditableComponentCollectionItem", "*", function () {
       $node.removeClass(config.editClassname);
     });
 
@@ -884,11 +940,10 @@ class EditableComponentCollectionItem extends EditableComponentBase {
   }
 
   remove() {
-    if(this._config.onItemRemoveConfirmation) {
+    if (this._config.onItemRemoveConfirmation) {
       // If we have confirgured a way to confirm first...
       safelyActivateFunction(this._config.onItemRemoveConfirmation, this);
-    }
-    else {
+    } else {
       // or just run the remove function.
       this.component.removeItem(this);
     }
@@ -898,20 +953,20 @@ class EditableComponentCollectionItem extends EditableComponentBase {
     // Doesn't need super because we're not writing to hidden input.
     this.content = this._elements;
   }
-
 }
-
 
 class EditableCollectionItemInjector {
   constructor(editableCollectionFieldComponent, config) {
     var conf = mergeObjects({}, config);
-    var text = mergeObjects({ itemAdd: 'add' }, config.text);
+    var text = mergeObjects({ itemAdd: "add" }, config.text);
     var $node = $(createElement("button", text.itemAdd, conf.classes));
-    editableCollectionFieldComponent.$node.find('.govuk-form-group').after($node);
+    editableCollectionFieldComponent.$node
+      .find(".govuk-form-group")
+      .after($node);
     $node.addClass("EditableCollectionItemInjector");
     $node.attr("type", "button");
     $node.data("instance", this);
-    $node.on("click", function(e) {
+    $node.on("click", function (e) {
       e.preventDefault();
       editableCollectionFieldComponent.addItem();
     });
@@ -927,23 +982,19 @@ function createEditableCollectionItemMenu(item, config) {
 
   item.$node.append($ul);
 
-
   return new EditableCollectionItemMenu($ul, {
-      activator_text: config.text.edit,
-      container_id: uniqueString("activatedMenu-"),
-      collectionItem: item,
-      view: config.view,
-      menu: {
-        position: {
-          my: "left top",
-          at: "left top" }
-      }
-    });
+    activator_text: config.text.edit,
+    container_id: uniqueString("activatedMenu-"),
+    collectionItem: item,
+    view: config.view,
+    menu: {
+      position: {
+        my: "left top",
+        at: "left top",
+      },
+    },
+  });
 }
-
-
-
-
 
 /* Single Line Input Restrictions
  * Browser contentEditable mode means some pain in trying to prevent
@@ -952,9 +1003,8 @@ function createEditableCollectionItemMenu(item, config) {
  * prevent unwanted entry with this function.
  **/
 function singleLineInputRestrictions(event) {
-
   // Prevent ENTER adding <div><br></div> nonsense.
-  if(event.which == 13) {
+  if (event.which == 13) {
     event.preventDefault();
   }
 }
@@ -969,22 +1019,21 @@ function pasteAsPlainText(event) {
   event.preventDefault();
   var content = "";
   if (event.clipboardData || event.originalEvent.clipboardData) {
-    content = (event.originalEvent || event).clipboardData.getData('text/plain');
-  }
-  else {
+    content = (event.originalEvent || event).clipboardData.getData(
+      "text/plain",
+    );
+  } else {
     if (window.clipboardData) {
-      content = window.clipboardData.getData('Text');
+      content = window.clipboardData.getData("Text");
     }
   }
 
   if (document.queryCommandSupported("insertText")) {
     document.execCommand("insertText", false, content);
-  }
-  else {
+  } else {
     document.execCommand("paste", false, content);
   }
 }
-
 
 /* Determin what type of node is passed and create editable content type
  * to match.
@@ -994,7 +1043,7 @@ function pasteAsPlainText(event) {
  **/
 function editableComponent($node, config) {
   var klass;
-  switch(config.type) {
+  switch (config.type) {
     case "element":
       klass = EditableElement;
       break;
@@ -1025,9 +1074,8 @@ function editableComponent($node, config) {
   return new klass($node, config);
 }
 
-
 // Make available for importing.
-module.exports =  {
+module.exports = {
   editableComponent: editableComponent,
   EditableComponentBase: EditableComponentBase,
   EditableBase: EditableBase,
@@ -1038,4 +1086,4 @@ module.exports =  {
   EditableGroupFieldComponent: EditableGroupFieldComponent,
   EditableCollectionFieldComponent: EditableCollectionFieldComponent,
   EditableComponentCollectionItem: EditableComponentCollectionItem,
-}
+};

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -17,7 +17,8 @@ const editableComponent = require("./editable_components").editableComponent;
 const QuestionMenu = require("./components/menus/question_menu");
 
 const ATTRIBUTE_DEFAULT_TEXT = "fb-default-text";
-const SELECTOR_DISABLED = "input:not(:hidden), textarea:not([data-element]), select";
+const SELECTOR_DISABLED =
+  "input:not(:hidden), textarea:not([data-element]), select";
 const SELECTOR_LABEL_HEADING = "label h1, label h2, legend h1, legend h2";
 
 class Question {

--- a/app/javascript/styles/_editable_components.scss
+++ b/app/javascript/styles/_editable_components.scss
@@ -18,7 +18,7 @@ editable-content,
   .ActivatedMenuActivator {
     left: -54px;
     opacity: 0;
-    //pointer-events: none;
+    pointer-events: none;
     position: absolute;
     top: 0;
   }
@@ -74,7 +74,7 @@ editable-content,
       right: -55px;
       display: block;
       opacity: 0;
-      // pointer-events: none;
+      pointer-events: none;
 
       &:focus {
         opacity: 1;

--- a/test/component_activated_content_menu_test.js
+++ b/test/component_activated_content_menu_test.js
@@ -1,324 +1,338 @@
 require("./setup");
 
-describe("ContentMenu", function() {
+describe("ContentMenu", function () {
+  const ContentMenu = require("../app/javascript/src/components/menus/content_menu");
+  const COMPONENT_CLASSNAME = "ContentMenu";
+  const CONTAINER_ID = "activated-content-menu-test-container-id";
+  const CONTAINER_CLASSNAME =
+    "activated-content-menu-test-classname and-another-activated-menu-classname";
+  const ACTIVATOR_CLASSNAME = "activated-content-menu-activator-test-classname";
+  const ACTIVATOR_TEXT = "activated content menu activator";
+  const MENU_ID = "activated-content-menu-test-menu-id";
+  const TEST_SELECTION_EVENT_NAME = "ContentMenuTestSelectionEventName";
+  var content;
 
-    const ContentMenu = require("../app/javascript/src/components/menus/content_menu");
-    const COMPONENT_CLASSNAME = "ContentMenu";
-    const CONTAINER_ID = "activated-content-menu-test-container-id";
-    const CONTAINER_CLASSNAME = "activated-content-menu-test-classname and-another-activated-menu-classname";
-    const ACTIVATOR_CLASSNAME = "activated-content-menu-activator-test-classname";
-    const ACTIVATOR_TEXT = "activated content menu activator";
-    const MENU_ID = "activated-content-menu-test-menu-id";
-    const TEST_SELECTION_EVENT_NAME = "ContentMenuTestSelectionEventName";
-    var content;
+  /* Function to fake a generic content good enough
+   * only for testing purpose.
+   **/
+  function FakeContentClass() {
+    var $node = $("<div></div>");
+    $node.addClass("Content FakeContent");
+    $(document.body).append($node);
 
-    /* Function to fake a generic content good enough
-     * only for testing purpose.
-     **/
-    function FakeContentClass() {
-        var $node = $("<div></div>")
-        $node.addClass("Content FakeContent");
-        $(document.body).append($node);
+    this.$node = $node;
+    this.editable = { fake: "editable", content: "object" };
+    this.data = {
+      validation: {
+        something: true,
+      },
+    };
+  }
 
-        this.$node = $node;
-        this.editable = { fake: "editable", content: "object" }
-        this.data = {
-            validation: {
-                something: true
-            }
-        }
-    }
+  before(function () {
+    // jQuery is present in document because the
+    // components use it so we can use it here.
 
-    before(function() {
-        // jQuery is present in document because the
-        // components use it so we can use it here.
-
-        var $ul = $(`<ul>
+    var $ul = $(`<ul>
                    <li data-action="remove"><span>Remove</span></li>
                    <li data-action="detonate"><span>Detonate</span></li>
                  </ul>`);
 
-        content = new FakeContentClass();
+    content = new FakeContentClass();
 
-        $(document.body).append($ul);
-        $ul.attr("id", MENU_ID);
-        content.menu = new ContentMenu(content, $ul, {
-            activator_classname: ACTIVATOR_CLASSNAME,
-            activator_text: ACTIVATOR_TEXT,
+    $(document.body).append($ul);
+    $ul.attr("id", MENU_ID);
+    content.menu = new ContentMenu(content, $ul, {
+      activator_classname: ACTIVATOR_CLASSNAME,
+      activator_text: ACTIVATOR_TEXT,
 
-            container_id: CONTAINER_ID,
-            container_classname: CONTAINER_CLASSNAME,
-            selection_event: TEST_SELECTION_EVENT_NAME
-        });
+      container_id: CONTAINER_ID,
+      container_classname: CONTAINER_CLASSNAME,
+      selection_event: TEST_SELECTION_EVENT_NAME,
+    });
+  });
+
+  // ensure menu is closed before each test.
+  beforeEach(function () {
+    content.menu.close();
+  });
+
+  after(function () {
+    content.menu.activator.$node.remove();
+    content.menu.container.$node.remove();
+    content.menu.$node.remove();
+    content.menu = null;
+
+    content.$node.remove();
+    content = null;
+  });
+
+  describe("ContentMenu", function () {
+    it("should have the basic HTML in place", function () {
+      expect($("#" + MENU_ID).length).to.equal(1);
     });
 
-    // ensure menu is closed before each test.
-    beforeEach(function() {
-        content.menu.close();
+    it("should have the component class name present", function () {
+      expect(
+        $("#" + MENU_ID)
+          .parent()
+          .hasClass(COMPONENT_CLASSNAME),
+      ).to.be.true;
     });
 
-
-    after(function() {
-        content.menu.activator.$node.remove();
-        content.menu.container.$node.remove();
-        content.menu.$node.remove();
-        content.menu = null;
-
-        content.$node.remove();
-        content = null;
+    it("should make the $node public", function () {
+      expect(content.menu.$node).to.exist;
+      expect(content.menu.$node.length).to.equal(1);
     });
 
-    describe("ContentMenu", function() {
-        it("should have the basic HTML in place", function() {
-            expect($("#" + MENU_ID).length).to.equal(1);
-        });
-
-        it("should have the component class name present", function() {
-            expect($("#" + MENU_ID).parent().hasClass(COMPONENT_CLASSNAME)).to.be.true;
-        });
-
-        it("should make the $node public", function() {
-            expect(content.menu.$node).to.exist;
-            expect(content.menu.$node.length).to.equal(1);
-        });
-
-        it("should make the content public", function() {
-            expect(content.menu.component).to.exist;
-            expect(content.menu.component.$node.length).to.equal(1);
-        });
-
-        it("should make the activator public", function() {
-            expect(content.menu.activator).to.exist;
-        });
-
-        it("should make the container public", function() {
-            expect(content.menu.container).to.exist;
-        });
-
-        it("should make the instance available as data on the $node", function() {
-            expect(content.menu.$node.data("instance")).to.exist;
-            expect(content.menu.$node.data("instance")).to.equal(content.menu);
-        });
-
-        it("should be able to get menu config", function() {
-            expect(content.menu.config).to.exist;
-            expect(content.menu.config.activator_text).to.exist;
-            expect(content.menu.config.activator_text).to.equal(ACTIVATOR_TEXT);
-        });
-
-        it("should not be able set menu config", function() {
-            content.menu.config = {
-                activator_text: "nope",
-            };
-            expect(content.menu.config.activator_text).to.equal(ACTIVATOR_TEXT);
-        });
-
-        it("should be able to get menu position", function() {
-            expect(content.menu.position).to.exist;
-            expect(content.menu.position.my).to.exist;
-            expect(content.menu.position.my).to.equal("left top");
-            expect(content.menu.position.at).to.exist;
-            expect(content.menu.position.at).to.equal("left top");
-            expect(content.menu.position.of).to.exist;
-        });
-
-        it("should not be able set menu position", function() {
-            content.menu.position = {
-                my: "bottom right",
-            };
-            expect(content.menu.position.my).to.equal("left top");
-        });
-
-        it("should be able to get menu state", function() {
-            expect(content.menu.state).to.exist;
-            expect(content.menu.state.open).to.exist;
-        });
-
-        it("should not be able set menu state", function() {
-            content.menu.state = {
-                open: true,
-            };
-            expect(content.menu.state.open).to.be.false;
-        });
-
-        it("should open the menu by the open() method", function() {
-            expect(content.menu.container.$node.get(0).style.display).to.equal("none");
-            content.menu.open();
-            expect(content.menu.container.$node.get(0).style.display).to.equal("");
-        });
-
-        it("should set the state.open to true when open() is activated", function() {
-            expect(content.menu.state.open).to.be.false;
-            content.menu.open();
-            expect(content.menu.state.open).to.be.true;
-        });
-
-        /* TODO: Test is on hold because we cannot use jsDom
-         * for testing position of elements
-         **/
-        it("should set the position values passed in open()");
-
-        it("should close the menu by the close() method", function() {
-            content.menu.open();
-            expect(content.menu.container.$node.get(0).style.display).to.equal("");
-
-            content.menu.close();
-            expect(content.menu.container.$node.get(0).style.display).to.equal("none");
-        });
-
-        it("should set the state.open to false when close() is activated", function() {
-            content.menu.open();
-            expect(content.menu.state.open).to.be.true;
-
-            content.menu.close();
-            expect(content.menu.state.open).to.be.false;
-        });
-
-        /* TODO: Test is on hold because we cannot use jsDom
-         * for testing position of elements
-         */
-        it("should reset the position values on close()");
-
-        /* TODO: Test is on hold because we cannot use jsDom
-         * for testing mouse events
-         **/
-        it("should close the menu on mouseout (not sure if can test)");
+    it("should make the content public", function () {
+      expect(content.menu.component).to.exist;
+      expect(content.menu.component.$node.length).to.equal(1);
     });
 
-    describe("Actions", function() {
-        it("should activate the detected action method on item selection", function() {
-            var $target = content.menu.$node.find("li[data-action=remove]");
-            var originalMethod = content.menu.remove;
-            var value = 1;
-
-            content.menu.remove = function() {
-                value += 1;
-            }
-            // Check initial value
-            expect(value).to.equal(1);
-
-            // Select and check again
-            $target.click();
-            expect(value).to.equal(2);
-
-            // Reset to original method
-            content.menu.remove = originalMethod;
-        });
-
-        it("should trigger ContentMenuSelectionRemove event on remove()", function() {
-            var value = 1;
-            var $target;
-
-            $(document).on("ContentMenuSelectionRemove", function() {
-                value += 1;
-            });
-
-            expect(value).to.equal(1);
-
-            $target = content.menu.$node.find("li[data-action=remove]");
-            expect($target.length).to.equal(1);
-
-            $target.click();
-            expect(value).to.equal(2);
-        });
-
-        it("should trigger a selection event label on item selection", function() {
-            var value = 1;
-            var $target;
-
-            $(document).on(TEST_SELECTION_EVENT_NAME, function() {
-                value += 1;
-            });
-
-            expect(value).to.equal(1);
-
-            $target = content.menu.$node.find("li:first");
-            expect($target.length).to.equal(1);
-
-            $target.click();
-            expect(value).to.equal(2);
-        });
+    it("should make the activator public", function () {
+      expect(content.menu.activator).to.exist;
     });
 
-    describe("ActivatedMenuContainer", function() {
-        it("should apply the config.container_id to $node", function() {
-            expect(content.menu.container.$node.attr("id")).to.equal(CONTAINER_ID);
-        });
-
-        it("should apply the config.container_classname to $node", function() {
-            var classes = CONTAINER_CLASSNAME.split(" ");
-            for (var i = 0; i < classes.length; ++i) {
-                expect(content.menu.container.$node.hasClass(classes[i])).to.be.true;
-            }
-        });
-
-        it("should add the Container to the DOM", function() {
-            var $node = $("#" + CONTAINER_ID);
-            expect($node).to.exist;
-            expect($node.length).to.equal(1);
-        });
-
-        it("should wrap the passed menu element", function() {
-            expect(content.menu.$node.parent().attr("id")).to.equal(CONTAINER_ID);
-        });
-
-        it("should make the menu public", function() {
-            expect(content.menu.container.menu).to.exist;
-            expect(content.menu.container.menu).to.equal(content.menu);
-        });
-
-        it("should make the $node public", function() {
-            expect(content.menu.container.$node).to.exist;
-            expect(content.menu.container.$node.length).to.equal(1);
-        });
-
-        it("should make the instance available as data on the $node", function() {
-            expect(content.menu.container.$node.data("instance")).to.exist;
-            expect(content.menu.container.$node.data("instance")).to.equal(content.menu.container);
-        });
+    it("should make the container public", function () {
+      expect(content.menu.container).to.exist;
     });
 
-    describe("ActivatedMenuActivator (passed)", function() {
-        it("should create an activator", function() {
-            expect(content.menu.activator).to.exist;
-            expect(content.menu.activator.$node).to.exist;
-            expect(content.menu.activator.$node.length).to.equal(1);
-        });
-
-        it("should make the $node public", function() {
-            expect(content.menu.activator.$node).to.exist;
-            expect(content.menu.activator.$node.length).to.equal(1);
-        });
-
-        it("should make the menu public", function() {
-            expect(content.menu.activator.menu).to.exist;
-            expect(content.menu.activator.menu).to.equal(content.menu);
-        });
-
-        it("should make the instance available as data on the $node", function() {
-            expect(content.menu.activator.$node.data("instance")).to.exist;
-            expect(content.menu.activator.$node.data("instance")).to.equal(content.menu.activator);
-        });
-
-        it("should use config.activator_text for any created activator", function() {
-            expect(content.menu.config).to.exist;
-            expect(content.menu.config.activator_text).to.exist;
-            expect(content.menu.config.activator_text).to.equal(ACTIVATOR_TEXT);
-            expect(content.menu.activator.$node.text()).to.equal(ACTIVATOR_TEXT);
-        });
-
-        it("should apply config.activator_classname to any created activator", function() {
-            expect(content.menu.activator).to.exist;
-            expect(content.menu.activator.$node).to.exist;
-            expect(content.menu.activator.$node.length).to.equal(1);
-            expect(content.menu.activator.$node.hasClass(ACTIVATOR_CLASSNAME)).to.be.true;
-        });
-
-        it("should open the menu when activator is clicked", function() {
-            expect(content.menu.container.$node.get(0).style.display).to.equal("none");
-
-            content.menu.activator.$node.click();
-            expect(content.menu.container.$node.get(0).style.display).to.equal("");
-        });
+    it("should make the instance available as data on the $node", function () {
+      expect(content.menu.$node.data("instance")).to.exist;
+      expect(content.menu.$node.data("instance")).to.equal(content.menu);
     });
+
+    it("should be able to get menu config", function () {
+      expect(content.menu.config).to.exist;
+      expect(content.menu.config.activator_text).to.exist;
+      expect(content.menu.config.activator_text).to.equal(ACTIVATOR_TEXT);
+    });
+
+    it("should not be able set menu config", function () {
+      content.menu.config = {
+        activator_text: "nope",
+      };
+      expect(content.menu.config.activator_text).to.equal(ACTIVATOR_TEXT);
+    });
+
+    it("should be able to get menu position", function () {
+      expect(content.menu.position).to.exist;
+      expect(content.menu.position.my).to.exist;
+      expect(content.menu.position.my).to.equal("left top");
+      expect(content.menu.position.at).to.exist;
+      expect(content.menu.position.at).to.equal("left top");
+      expect(content.menu.position.of).to.exist;
+    });
+
+    it("should not be able set menu position", function () {
+      content.menu.position = {
+        my: "bottom right",
+      };
+      expect(content.menu.position.my).to.equal("left top");
+    });
+
+    it("should be able to get menu state", function () {
+      expect(content.menu.state).to.exist;
+      expect(content.menu.state.open).to.exist;
+    });
+
+    it("should not be able set menu state", function () {
+      content.menu.state = {
+        open: true,
+      };
+      expect(content.menu.state.open).to.be.false;
+    });
+
+    it("should open the menu by the open() method", function () {
+      expect(content.menu.container.$node.get(0).style.display).to.equal(
+        "none",
+      );
+      content.menu.open();
+      expect(content.menu.container.$node.get(0).style.display).to.equal("");
+    });
+
+    it("should set the state.open to true when open() is activated", function () {
+      expect(content.menu.state.open).to.be.false;
+      content.menu.open();
+      expect(content.menu.state.open).to.be.true;
+    });
+
+    /* TODO: Test is on hold because we cannot use jsDom
+     * for testing position of elements
+     **/
+    it("should set the position values passed in open()");
+
+    it("should close the menu by the close() method", function () {
+      content.menu.open();
+      expect(content.menu.container.$node.get(0).style.display).to.equal("");
+
+      content.menu.close();
+      expect(content.menu.container.$node.get(0).style.display).to.equal(
+        "none",
+      );
+    });
+
+    it("should set the state.open to false when close() is activated", function () {
+      content.menu.open();
+      expect(content.menu.state.open).to.be.true;
+
+      content.menu.close();
+      expect(content.menu.state.open).to.be.false;
+    });
+
+    /* TODO: Test is on hold because we cannot use jsDom
+     * for testing position of elements
+     */
+    it("should reset the position values on close()");
+
+    /* TODO: Test is on hold because we cannot use jsDom
+     * for testing mouse events
+     **/
+    it("should close the menu on mouseout (not sure if can test)");
+  });
+
+  describe("Actions", function () {
+    it("should activate the detected action method on item selection", function () {
+      var $target = content.menu.$node.find("li[data-action=remove]");
+      var originalMethod = content.menu.remove;
+      var value = 1;
+
+      content.menu.remove = function () {
+        value += 1;
+      };
+      // Check initial value
+      expect(value).to.equal(1);
+
+      // Select and check again
+      $target.click();
+      expect(value).to.equal(2);
+
+      // Reset to original method
+      content.menu.remove = originalMethod;
+    });
+
+    it("should trigger ContentMenuSelectionRemove event on remove()", function () {
+      var value = 1;
+      var $target;
+
+      $(document).on("ContentMenuSelectionRemove", function () {
+        value += 1;
+      });
+
+      expect(value).to.equal(1);
+
+      $target = content.menu.$node.find("li[data-action=remove]");
+      expect($target.length).to.equal(1);
+
+      $target.click();
+      expect(value).to.equal(2);
+    });
+
+    it("should trigger a selection event label on item selection", function () {
+      var value = 1;
+      var $target;
+
+      $(document).on(TEST_SELECTION_EVENT_NAME, function () {
+        value += 1;
+      });
+
+      expect(value).to.equal(1);
+
+      $target = content.menu.$node.find("li:first");
+      expect($target.length).to.equal(1);
+
+      $target.click();
+      expect(value).to.equal(2);
+    });
+  });
+
+  describe("ActivatedMenuContainer", function () {
+    it("should apply the config.container_id to $node", function () {
+      expect(content.menu.container.$node.attr("id")).to.equal(CONTAINER_ID);
+    });
+
+    it("should apply the config.container_classname to $node", function () {
+      var classes = CONTAINER_CLASSNAME.split(" ");
+      for (var i = 0; i < classes.length; ++i) {
+        expect(content.menu.container.$node.hasClass(classes[i])).to.be.true;
+      }
+    });
+
+    it("should add the Container to the DOM", function () {
+      var $node = $("#" + CONTAINER_ID);
+      expect($node).to.exist;
+      expect($node.length).to.equal(1);
+    });
+
+    it("should wrap the passed menu element", function () {
+      expect(content.menu.$node.parent().attr("id")).to.equal(CONTAINER_ID);
+    });
+
+    it("should make the menu public", function () {
+      expect(content.menu.container.menu).to.exist;
+      expect(content.menu.container.menu).to.equal(content.menu);
+    });
+
+    it("should make the $node public", function () {
+      expect(content.menu.container.$node).to.exist;
+      expect(content.menu.container.$node.length).to.equal(1);
+    });
+
+    it("should make the instance available as data on the $node", function () {
+      expect(content.menu.container.$node.data("instance")).to.exist;
+      expect(content.menu.container.$node.data("instance")).to.equal(
+        content.menu.container,
+      );
+    });
+  });
+
+  describe("ActivatedMenuActivator (passed)", function () {
+    it("should create an activator", function () {
+      expect(content.menu.activator).to.exist;
+      expect(content.menu.activator.$node).to.exist;
+      expect(content.menu.activator.$node.length).to.equal(1);
+    });
+
+    it("should make the $node public", function () {
+      expect(content.menu.activator.$node).to.exist;
+      expect(content.menu.activator.$node.length).to.equal(1);
+    });
+
+    it("should make the menu public", function () {
+      expect(content.menu.activator.menu).to.exist;
+      expect(content.menu.activator.menu).to.equal(content.menu);
+    });
+
+    it("should make the instance available as data on the $node", function () {
+      expect(content.menu.activator.$node.data("instance")).to.exist;
+      expect(content.menu.activator.$node.data("instance")).to.equal(
+        content.menu.activator,
+      );
+    });
+
+    it("should use config.activator_text for any created activator", function () {
+      expect(content.menu.config).to.exist;
+      expect(content.menu.config.activator_text).to.exist;
+      expect(content.menu.config.activator_text).to.equal(ACTIVATOR_TEXT);
+      expect(content.menu.activator.$node.text()).to.equal(ACTIVATOR_TEXT);
+    });
+
+    it("should apply config.activator_classname to any created activator", function () {
+      expect(content.menu.activator).to.exist;
+      expect(content.menu.activator.$node).to.exist;
+      expect(content.menu.activator.$node.length).to.equal(1);
+      expect(content.menu.activator.$node.hasClass(ACTIVATOR_CLASSNAME)).to.be
+        .true;
+    });
+
+    it("should open the menu when activator is clicked", function () {
+      expect(content.menu.container.$node.get(0).style.display).to.equal(
+        "none",
+      );
+
+      content.menu.activator.$node.trigger("mousedown");
+      expect(content.menu.container.$node.get(0).style.display).to.equal("");
+    });
+  });
 });

--- a/test/menus/activated_menu_activator/events_test.js
+++ b/test/menus/activated_menu_activator/events_test.js
@@ -59,7 +59,7 @@ describe("ActivatedMenuActivator", function() {
       expect(created.item.menu.state.open).to.be.false;
       expect(created.item.menu.currentActivator).to.equal(undefined);
 
-      created.$node.click()
+      created.$node.trigger('mousedown')
       expect(created.item.menu.state.open).to.be.true;
       expect(created.item.menu.currentActivator).to.equal(created.$node.get(0));
     });


### PR DESCRIPTION
This PR implements a fix to the click event issue on component buttons in safari.  

As mentioned in #2568 this was caused by the `blur` event triggering before the `click` event.  It seems that this is per-spec behaviour and Safari was behaving as it should, and Chrome and Firefox shouldn't have worked.

The solution here was to switch from `click` event to `mousedown` event, as the mousedown event will fire before the click event, meaning the button is still visible and interactivew hen the `click` event fires.

Apologies for the diff: I made changes in files that haven't been edited for a while, so they've been reformatted by prettier.  