### PR TITLE
Update GOV.UK Frontend to 4.8.0 and bump presenter to 3.3.21

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ ruby '3.1.3'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'move-components'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.19'
+gem 'metadata_presenter', '3.3.21'
 
 gem 'activerecord-session_store'
 gem 'administrate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.3.19)
+    metadata_presenter (3.3.21)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)
@@ -785,7 +785,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.3.19)
+  metadata_presenter (= 3.3.21)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "accessible-autocomplete": "^2.0.4",
     "chai-dom": "^1.11.0",
     "dompurify": "^3.0.3",
-    "govuk-frontend": "4.4.1",
+    "govuk-frontend": "4.8.0",
     "govuk-markdown": "^0.3.0",
     "jquery": "^3.6.4",
     "jquery-ui-dist": "^1.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2915,9 +2915,10 @@ globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
 
-govuk-frontend@4.4.1:
-  version "4.4.1"
-  resolved "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz"
+govuk-frontend@4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.8.0.tgz#df4e56c762e93aae74fed214bb6be08e13783772"
+  integrity sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==
 
 govuk-markdown@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
This PR updates GOV.UK frontend to 4.8.0 and bumps the presenter version to include the template with the new Tudor crown.

Presenter 3.3.21 also includes a bugfix for content areas disappearing when validation errors occur.