### PR TITLE
Ensure orderableItemControllers property is optional

### DIFF
--- a/app/javascript/src/controllers/orderable-items-controller.js
+++ b/app/javascript/src/controllers/orderable-items-controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
     useControllerName(this);
     useAncestry(this);
     queueMicrotask(() => {
-      this.orderableItemControllers.forEach((controller) => {
+      this.orderableItemControllers?.forEach((controller) => {
         controller.appendButtons();
       });
     });


### PR DESCRIPTION
One last tiny bugfix I spotted after the quickfix earlier today.

There are times when the `orderableItemControllers` can be `nil` or `unidentfied` which triggers an error.  This happens when the components area is empty, so it has no user impact, but we should prevent the error anyway.