### PR TITLE
Add focus state to add-option button

### DIFF
--- a/app/javascript/styles/_editable_components.scss
+++ b/app/javascript/styles/_editable_components.scss
@@ -134,6 +134,12 @@ editable-content,
   @include button_type_link;
   @include addition_icon;
   margin: 0 0 0 55px;
+
+  &:focus {
+    @include focus;
+    border-color: $govuk-text-colour;
+    outline: none;
+  }
 }
 
 .EditableCollectionItemRemover {


### PR DESCRIPTION
The add option button for radio andf checkbox components was missing a visual focus state.

This PR adds in the correct focus styles.

<img width="488" alt="image" src="https://github.com/ministryofjustice/fb-editor/assets/595564/1ed97d2f-b172-4115-8d6a-6e68c4a1680b">
