### PR TITLE
Allow components to be moved in any page type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,11 @@ ruby '3.1.3'
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
 
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'movable-components-everywhere'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'movable-components-everywhere'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '3.3.21'
+gem 'metadata_presenter', '3.3.23'
 
 gem 'activerecord-session_store'
 gem 'administrate'

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,11 @@ ruby '3.1.3'
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
 
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'bugfix/conditional-check'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'movable-components-everywhere'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.22'
+# gem 'metadata_presenter', '3.3.21'
 
 gem 'activerecord-session_store'
 gem 'administrate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.3.22)
+    metadata_presenter (3.3.23)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)
@@ -785,7 +785,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.3.22)
+  metadata_presenter (= 3.3.23)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -856,10 +856,10 @@ function editPageContentViewCustomisations() {
 
 function editPageCheckAnswersViewCustomisations() {
   var $button1 = $("[data-component=add-content]");
-  var $target1 = $(".fb-editable").last();
+  var $target1 = $(".govuk-button-group");
   var $button2 = $button1.clone();
   var $target2 = $("#answers-form dl").first();
-  $target1.after($button1);
+  $target1.before($button1);
   $target2.before($button2);
   $button2.attr("data-fb-field-name", "page[add_extra_component]");
 }

--- a/app/javascript/styles/_editable_components.scss
+++ b/app/javascript/styles/_editable_components.scss
@@ -45,7 +45,9 @@ editable-content,
       display: contents;
     }
   }
+}
 
+.components {
   [data-controller*="component"] {
     &.active:before,
     &.active:after,


### PR DESCRIPTION
This PR allows componentsa nd content areas to be moved on page types other then the multiquestion page, namely, content, exit, confirmation and cya pages.  This allows users to move their content blacks around if they want to.
