### PR TITLE
Bump metadata presenter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ ruby '3.1.3'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'movable-components-everywhere'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.23'
+gem 'metadata_presenter', '3.3.24'
 
 gem 'activerecord-session_store'
 gem 'administrate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.3.23)
+    metadata_presenter (3.3.24)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)
@@ -785,7 +785,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.3.23)
+  metadata_presenter (= 3.3.24)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
https://trello.com/c/bfXgPTNU
https://trello.com/c/sYULK6k1

This fixes 2 bugs, one with the positioning of the error summary component, and other related to uploaded jpeg files.

https://github.com/ministryofjustice/fb-metadata-presenter/pull/390