### PR TITLE
Regex validator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ ruby '3.1.3'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'regex-validator'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'regex-validator'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '3.3.16'
+gem 'metadata_presenter', '3.3.26'
 
 gem 'activerecord-session_store'
 gem 'administrate'

--- a/Gemfile
+++ b/Gemfile
@@ -5,13 +5,13 @@ ruby '3.1.3'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'movable-components-everywhere'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'regex-validator'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.24'
+# gem 'metadata_presenter', '3.3.16'
 
+gem 'dotenv', '2.8.1'
 gem 'activerecord-session_store'
 gem 'administrate'
 gem 'aws-sdk-s3'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'metadata_presenter',
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 # gem 'metadata_presenter', '3.3.16'
 
-gem 'dotenv', '2.8.1'
 gem 'activerecord-session_store'
 gem 'administrate'
 gem 'aws-sdk-s3'
@@ -19,6 +18,7 @@ gem 'aws-sdk-sesv2'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'daemons'
 gem 'delayed_job_active_record'
+gem 'dotenv', '2.8.1'
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.10.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,17 @@
 GIT
+  remote: https://github.com/citizensadvice/capybara_accessible_selectors
+  revision: 679abc42cce81b43ed81d31bbe7ad6a96dbe7fef
+  tag: v0.11.0
+  specs:
+    capybara_accessible_selectors (0.11.0)
+      capybara (~> 3.36)
+
+GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: f011bb013e83daa9ef348a029254960e550edbf9
+  revision: c98cfa891be3191391d0f8c36a7b104849215954
   branch: regex-validator
   specs:
-    metadata_presenter (3.3.24)
+    metadata_presenter (3.3.18)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)
@@ -202,7 +210,7 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (3.25.3)
+    google-protobuf (3.25.3-x86_64-darwin)
     googleapis-common-protos-types (1.13.0)
       google-protobuf (~> 3.18)
     govspeak (7.1.1)
@@ -296,20 +304,8 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-<<<<<<< HEAD
-    metadata_presenter (3.3.24)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (~> 4.1.1)
-      json-schema (~> 4.1.1)
-      kramdown (~> 2.4.0)
-      rails (~> 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-      uk_postcode
     method_source (1.0.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.5)
     minitest (5.22.2)
     msgpack (1.7.2)
     multi_json (1.15.0)
@@ -325,8 +321,7 @@ GEM
     net-smtp (0.4.0.1)
       net-protocol
     nio4r (2.7.0)
-    nokogiri (1.16.2)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.16.2-x86_64-darwin)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -768,7 +763,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-21
 
 DEPENDENCIES
   activerecord-session_store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,22 +6,6 @@ GIT
     capybara_accessible_selectors (0.11.0)
       capybara (~> 3.36)
 
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 3c277ccf3a8f9e9a8abbb310ea609d660ce5f67d
-  branch: regex-validator
-  specs:
-    metadata_presenter (3.3.25)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (~> 4.1.1)
-      json-schema (~> 4.1.1)
-      kramdown (~> 2.4.0)
-      rails (~> 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-      uk_postcode
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -304,6 +288,16 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    metadata_presenter (3.3.26)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (~> 4.1.1)
+      json-schema (~> 4.1.1)
+      kramdown (~> 2.4.0)
+      rails (~> 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+      uk_postcode
     method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.22.2)
@@ -790,7 +784,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter!
+  metadata_presenter (= 3.3.26)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 45c47297fabc70e3932329a9af8080320d10276b
+  revision: 374cd69f60746ceb7a2f3ebe79003e584cc20a76
   branch: regex-validator
   specs:
     metadata_presenter (3.3.24)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 374cd69f60746ceb7a2f3ebe79003e584cc20a76
+  revision: b6fef8060c73ba6e1abd9bde86c743c190eb960c
   branch: regex-validator
   specs:
     metadata_presenter (3.3.24)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: b6fef8060c73ba6e1abd9bde86c743c190eb960c
+  revision: 3c277ccf3a8f9e9a8abbb310ea609d660ce5f67d
   branch: regex-validator
   specs:
-    metadata_presenter (3.3.24)
+    metadata_presenter (3.3.25)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: c98cfa891be3191391d0f8c36a7b104849215954
+  revision: f011bb013e83daa9ef348a029254960e550edbf9
   branch: regex-validator
   specs:
-    metadata_presenter (3.3.18)
+    metadata_presenter (3.3.24)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)
@@ -210,7 +210,7 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (3.25.3-x86_64-darwin)
+    google-protobuf (3.25.3)
     googleapis-common-protos-types (1.13.0)
       google-protobuf (~> 3.18)
     govspeak (7.1.1)
@@ -321,7 +321,9 @@ GEM
     net-smtp (0.4.0.1)
       net-protocol
     nio4r (2.7.0)
-    nokogiri (1.16.2-x86_64-darwin)
+    nokogiri (1.16.2)
+      racc (~> 1.4)
+    nokogiri (1.16.2)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -763,7 +765,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
-  x86_64-darwin-21
+  ruby
 
 DEPENDENCIES
   activerecord-session_store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: c98cfa891be3191391d0f8c36a7b104849215954
+  revision: f011bb013e83daa9ef348a029254960e550edbf9
   branch: regex-validator
   specs:
-    metadata_presenter (3.3.18)
+    metadata_presenter (3.3.24)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: f011bb013e83daa9ef348a029254960e550edbf9
+  revision: 45c47297fabc70e3932329a9af8080320d10276b
   branch: regex-validator
   specs:
     metadata_presenter (3.3.24)
@@ -321,8 +321,6 @@ GEM
     net-smtp (0.4.0.1)
       net-protocol
     nio4r (2.7.0)
-    nokogiri (1.16.2)
-      racc (~> 1.4)
     nokogiri (1.16.2)
       racc (~> 1.4)
     oauth2 (2.0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,18 @@
 GIT
-  remote: https://github.com/citizensadvice/capybara_accessible_selectors
-  revision: 679abc42cce81b43ed81d31bbe7ad6a96dbe7fef
-  tag: v0.11.0
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: c98cfa891be3191391d0f8c36a7b104849215954
+  branch: regex-validator
   specs:
-    capybara_accessible_selectors (0.11.0)
-      capybara (~> 3.36)
+    metadata_presenter (3.3.18)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (~> 4.1.1)
+      json-schema (~> 4.1.1)
+      kramdown (~> 2.4.0)
+      rails (~> 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+      uk_postcode
 
 GEM
   remote: https://rubygems.org/
@@ -152,10 +160,10 @@ GEM
       delayed_job (>= 3.0, < 5)
     diff-lcs (1.5.1)
     docile (1.4.0)
-    dotenv (3.1.0)
-    dotenv-rails (3.1.0)
-      dotenv (= 3.1.0)
-      railties (>= 6.1)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
@@ -288,6 +296,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+<<<<<<< HEAD
     metadata_presenter (3.3.24)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
@@ -775,6 +784,7 @@ DEPENDENCIES
   capybara_accessible_selectors!
   daemons
   delayed_job_active_record
+  dotenv (= 2.8.1)
   dotenv-rails
   factory_bot_rails
   faraday
@@ -785,7 +795,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.3.24)
+  metadata_presenter!
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/acceptance/features/component_validations_spec.rb
+++ b/acceptance/features/component_validations_spec.rb
@@ -181,7 +181,7 @@ feature 'Component validations' do
         preview: preview,
         field: preview_field,
         first_answer: preview_first_answer,
-        second_answer: prview_second_answer,
+        second_answer: preview_second_answer,
         error_message: preview_error_message
       )
     end
@@ -332,6 +332,50 @@ feature 'Component validations' do
     end
   end
 
+  shared_examples 'a regex validation' do
+    scenario 'configuring string regex validation' do
+      and_I_visit_a_page(page_url)
+      when_I_want_to_select_question_properties
+      then_I_should_see_the_string_regex_validations
+
+      and_I_select_a_validation(menu_text)
+      then_I_should_see_the_validation_modal(label, status_label)
+
+      and_I_enable_the_validation
+      and_I_set_the_input_value(first_answer)
+      click_button(I18n.t('dialogs.component_validations.button'))
+      then_I_should_not_see_the_validation_modal(label, status_label)
+
+      when_I_want_to_select_question_properties
+      and_I_select_a_validation(menu_text)
+      then_I_should_see_the_previously_set_configuration(first_answer)
+      and_I_set_the_input_value(second_answer)
+      click_button(I18n.t('dialogs.component_validations.button'))
+
+      and_I_click_save
+      when_I_want_to_select_question_properties
+      and_I_select_a_validation(menu_text)
+      and_I_set_the_input_value('')
+      click_button(I18n.t('dialogs.component_validations.button'))
+      then_I_should_see_an_error_message(
+        I18n.t(
+          'activemodel.errors.models.string_regex_pattern.blank',
+          label: label
+        ))
+      click_button(I18n.t('dialogs.button_cancel'))
+
+      and_I_return_to_flow_page
+      preview = when_I_preview_the_page(page_url)
+      then_I_should_preview_the_page(
+        preview: preview,
+        field: preview_field,
+        first_answer: preview_first_answer,
+        second_answer: preview_second_answer,
+        error_message: preview_error_message
+      )
+    end
+  end
+
   context 'minimum validation' do
     let(:page_url) { 'Number' }
     let(:menu_text) { I18n.t('question.menu.minimum') }
@@ -422,7 +466,7 @@ feature 'Component validations' do
     let(:second_answer) { '3' }
     let(:preview_field) { 'answers[text_text_1]' }
     let(:preview_first_answer) { 'Po' }
-    let(:prview_second_answer) { 'Akira' }
+    let(:preview_second_answer) { 'Akira' }
     let(:preview_error_message) { 'Your answer for "Text" must be 3 characters or more' }
 
     it_behaves_like 'a string length characters validation'
@@ -439,7 +483,7 @@ feature 'Component validations' do
     let(:second_answer) { '10' }
     let(:preview_field) { 'answers[text_text_1]' }
     let(:preview_first_answer) { 'Wolfeschlegelshteinhausenbergerdorff' }
-    let(:prview_second_answer) { 'Bob' }
+    let(:preview_second_answer) { 'Bob' }
     let(:preview_error_message) { 'Your answer for "Text" must be 10 characters or fewer' }
 
     it_behaves_like 'a string length characters validation'
@@ -490,6 +534,22 @@ feature 'Component validations' do
     let(:first_answer) { '3' }
 
     it_behaves_like 'a max files validation'
+  end
+
+  context 'regex pattern' do
+    let(:page_url) { 'Text' }
+    let(:menu_text) { I18n.t('question.menu.pattern') }
+    let(:label) { I18n.t('dialogs.component_validations.string.pattern.label') }
+    let(:status_label) { I18n.t('dialogs.component_validations.string.pattern.status_label') }
+    let(:first_answer) { '[A-Z]' }
+    let(:second_answer) { '[a-z]' }
+    let(:preview_field) { 'answers[text_text_1]' }
+    let(:preview_first_answer) { 'ABC' }
+    let(:preview_second_answer) { 'abc' }
+    let(:preview_error_message) { 'Your answer for "Text" must match the required format' }
+
+    it_behaves_like 'a regex validation'
+    it_behaves_like 'a disabled component validation'
   end
 
   def and_I_visit_a_page(flow_title)
@@ -620,5 +680,9 @@ feature 'Component validations' do
   def and_I_click_save
     sleep(1)
     click_button(I18n.t('actions.save'))
+  end
+
+  def then_I_should_see_the_string_regex_validations
+    expect(page).to have_content(I18n.t('question.menu.pattern'))
   end
 end

--- a/app/models/component_validations/base_component_validation.rb
+++ b/app/models/component_validations/base_component_validation.rb
@@ -14,7 +14,7 @@ class BaseComponentValidation
     end
   }
   with_options presence: {
-    if: proc { |obj| obj.enabled? && obj.validator != 'pattern'},
+    if: proc { |obj| obj.enabled? && obj.validator != 'pattern' },
     message: lambda do |object, _|
                I18n.t(
                  'activemodel.errors.models.base_component_validation.blank',

--- a/app/models/component_validations/base_component_validation.rb
+++ b/app/models/component_validations/base_component_validation.rb
@@ -14,7 +14,7 @@ class BaseComponentValidation
     end
   }
   with_options presence: {
-    if: proc { |obj| obj.enabled? },
+    if: proc { |obj| obj.enabled? && obj.validator != 'pattern'},
     message: lambda do |object, _|
                I18n.t(
                  'activemodel.errors.models.base_component_validation.blank',
@@ -22,7 +22,7 @@ class BaseComponentValidation
                )
              end
   } do
-    validates :value, unless: proc { |obj| obj.component_type == 'date' }
+    validates :value, unless: proc { |obj| obj.component_type == 'date' || obj.validator == 'pattern' }
   end
 
   STRING_LENGTH_VALIDATIONS = %w[max_string_length min_string_length].freeze

--- a/app/models/component_validations/pattern_validation.rb
+++ b/app/models/component_validations/pattern_validation.rb
@@ -1,6 +1,5 @@
 class PatternValidation < BaseComponentValidation
   attr_accessor :pattern
-
   DEFAULT_METADATA_KEY = 'pattern'.freeze
 
   with_options presence: {
@@ -9,6 +8,8 @@ class PatternValidation < BaseComponentValidation
   } do
     validates :value
   end
+  validates_with RegexValidator, if: :run_validation?
+
 
   def status_label
     I18n.t('dialogs.component_validations.string.pattern.status_label')

--- a/app/models/component_validations/pattern_validation.rb
+++ b/app/models/component_validations/pattern_validation.rb
@@ -1,5 +1,7 @@
 class PatternValidation < BaseComponentValidation
-  attr_accessor :string_length
+  attr_accessor :pattern
+
+  DEFAULT_METADATA_KEY = 'pattern'.freeze
 
   def status_label
     'Set a specific answer format'

--- a/app/models/component_validations/pattern_validation.rb
+++ b/app/models/component_validations/pattern_validation.rb
@@ -1,5 +1,6 @@
 class PatternValidation < BaseComponentValidation
   attr_accessor :pattern
+
   DEFAULT_METADATA_KEY = 'pattern'.freeze
 
   with_options presence: {
@@ -9,7 +10,6 @@ class PatternValidation < BaseComponentValidation
     validates :value
   end
   validates_with RegexValidator, if: :run_validation?
-
 
   def status_label
     I18n.t('dialogs.component_validations.string.pattern.status_label')

--- a/app/models/component_validations/pattern_validation.rb
+++ b/app/models/component_validations/pattern_validation.rb
@@ -5,17 +5,17 @@ class PatternValidation < BaseComponentValidation
 
   with_options presence: {
     if: proc { |obj| obj.enabled? },
-    message: 'Enter a regular expression'
+    message: I18n.t('activemodel.errors.models.string_regex_pattern.blank')
   } do
     validates :value
   end
 
   def status_label
-    'Set a specific answer format'
+    I18n.t('dialogs.component_validations.string.pattern.status_label')
   end
 
   def label
-    'Specific answer format'
+    I18n.t('dialogs.component_validations.string.pattern.label')
   end
 
   def component_partial

--- a/app/models/component_validations/pattern_validation.rb
+++ b/app/models/component_validations/pattern_validation.rb
@@ -1,7 +1,13 @@
 class PatternValidation < BaseComponentValidation
   attr_accessor :pattern
-
   DEFAULT_METADATA_KEY = 'pattern'.freeze
+
+  with_options presence: {
+    if: proc { |obj| obj.enabled? },
+    message: "Enter a regular expression"
+  } do
+    validates :value
+  end
 
   def status_label
     'Set a specific answer format'

--- a/app/models/component_validations/pattern_validation.rb
+++ b/app/models/component_validations/pattern_validation.rb
@@ -1,0 +1,15 @@
+class PatternValidation < BaseComponentValidation
+  attr_accessor :string_length
+
+  def status_label
+    'Set a specific answer format'
+  end
+
+  def label
+    'Specific answer format'
+  end
+
+  def component_partial
+    'string_regex_validation'
+  end
+end

--- a/app/models/component_validations/pattern_validation.rb
+++ b/app/models/component_validations/pattern_validation.rb
@@ -1,10 +1,11 @@
 class PatternValidation < BaseComponentValidation
   attr_accessor :pattern
+
   DEFAULT_METADATA_KEY = 'pattern'.freeze
 
   with_options presence: {
     if: proc { |obj| obj.enabled? },
-    message: "Enter a regular expression"
+    message: 'Enter a regular expression'
   } do
     validates :value
   end

--- a/app/validators/regex_validator.rb
+++ b/app/validators/regex_validator.rb
@@ -9,8 +9,7 @@ class RegexValidator < ActiveModel::Validator
         I18n.t('activemodel.errors.models.string_regex_pattern.remove_delimiter')
       )
     end
-
-    if OPTIONS.include?(record.value.split('/').last)
+    if record.value.split('/').last.chars.to_set.subset?(OPTIONS.to_set)
       record.errors.add(
         :pattern,
         I18n.t('activemodel.errors.models.string_regex_pattern.remove_options')

--- a/app/validators/regex_validator.rb
+++ b/app/validators/regex_validator.rb
@@ -1,5 +1,22 @@
 class RegexValidator < ActiveModel::Validator
+  DELIMITER = '/'.freeze
+  OPTIONS = %w[i x m o].freeze
+
   def validate(record)
+    if record.value.first == DELIMITER || record.value.last == DELIMITER
+      record.errors.add(
+        :pattern,
+        I18n.t('activemodel.errors.models.string_regex_pattern.remove_delimiter')
+      )
+    end
+
+    if OPTIONS.include?(record.value.split('/').last)
+      record.errors.add(
+        :pattern,
+        I18n.t('activemodel.errors.models.string_regex_pattern.remove_options')
+      )
+    end
+
     Regexp.new(record.value)
   rescue RegexpError
     record.errors.add(

--- a/app/validators/regex_validator.rb
+++ b/app/validators/regex_validator.rb
@@ -1,0 +1,10 @@
+class RegexValidator < ActiveModel::Validator
+  def validate(record)
+    Regexp.new(record.value)
+  rescue RegexpError
+    record.errors.add(
+      :pattern,
+      I18n.t('activemodel.errors.models.string_regex_pattern.invalid')
+    )
+  end
+end

--- a/app/validators/regex_validator.rb
+++ b/app/validators/regex_validator.rb
@@ -1,6 +1,6 @@
 class RegexValidator < ActiveModel::Validator
   DELIMITER = '/'.freeze
-  OPTIONS = %w[i x m o].freeze
+  OPTIONS = %w[i x m].freeze
 
   def validate(record)
     if record.value.first == DELIMITER || record.value.last == DELIMITER

--- a/app/views/api/component_validations/_new.html.erb
+++ b/app/views/api/component_validations/_new.html.erb
@@ -31,7 +31,7 @@
           <% else %>
             <% if @component_validation.validator == 'pattern' %>
               <p>
-                <%= t('dialogs.component_validations.instruction_regex_pattern') %>
+                <%= t('dialogs.component_validations.regex.instruction_regex_pattern', regex_href:t('dialogs.component_validations.regex.regex_link' )).html_safe %>
               </p>
             <% end %>
           <div class="govuk-checkboxes" data-module="govuk-checkboxes">

--- a/app/views/api/component_validations/_new.html.erb
+++ b/app/views/api/component_validations/_new.html.erb
@@ -31,7 +31,7 @@
           <% else %>
             <% if @component_validation.validator == 'pattern' %>
               <p>
-                <%= "Use a regular expression (regex) to validate answers against a specific format, such as a reference number or case ID." %>
+                <%= t('dialogs.component_validations.instruction_regex_pattern') %>
               </p>
             <% end %>
           <div class="govuk-checkboxes" data-module="govuk-checkboxes">

--- a/app/views/api/component_validations/_new.html.erb
+++ b/app/views/api/component_validations/_new.html.erb
@@ -29,6 +29,11 @@
             </div>
           </div>
           <% else %>
+            <% if @component_validation.validator == 'pattern' %>
+              <p>
+                <%= "Use a regular expression (regex) to validate answers against a specific format, such as a reference number or case ID." %>
+              </p>
+            <% end %>
           <div class="govuk-checkboxes" data-module="govuk-checkboxes">
             <div class="govuk-checkboxes__item">
               <input class="govuk-checkboxes__input" id="component_validation_status" name="component_validation[status]" type="checkbox" value="enabled" <%= @component_validation.enabled? ? 'checked' : '' %>>

--- a/app/views/api/component_validations/_string_regex_validation.html.erb
+++ b/app/views/api/component_validations/_string_regex_validation.html.erb
@@ -1,9 +1,9 @@
-<p><b>Regular expression</b></p>
+<p><b><%= t('dialogs.component_validations.regex.title') %></b></p>
 <div class="flex align-items-center">
   <label class="govuk-label govuk-label--m govuk-visually-hidden" for="component_validation_value">
     <%= @component_validation.label %>
   </label>
-  <input class="govuk-input govuk-input--width-5 <%= @component_validation.errors.present? ? 'govuk-input--error' : '' %>"
+  <input class="govuk-input govuk-input--width-20 <%= @component_validation.errors.present? ? 'govuk-input--error' : '' %>"
          id="component_validation_value"
          name="component_validation[value]"
          pattern="*"
@@ -15,4 +15,3 @@
          value="<%= @component_validation.main_value %>">
 </div>
 <p><%= t('dialogs.component_validations.regex.hint_regex_pattern') %></p>
-

--- a/app/views/api/component_validations/_string_regex_validation.html.erb
+++ b/app/views/api/component_validations/_string_regex_validation.html.erb
@@ -14,5 +14,5 @@
          <%=   @component_validation.errors.present? ? 'aria-invalid=true' : '' %>
          value="<%= @component_validation.main_value %>">
 </div>
-<p><%= "You should also explain the required format in the question's hint text to help users with their answer." %></p>
+<p><%= t('dialogs.component_validations.hint_regex_pattern') %></p>
 

--- a/app/views/api/component_validations/_string_regex_validation.html.erb
+++ b/app/views/api/component_validations/_string_regex_validation.html.erb
@@ -1,4 +1,8 @@
 <p><b><%= t('dialogs.component_validations.regex.title') %></b></p>
+<div class="govuk-hint" >
+<%= t('dialogs.component_validations.regex.hint_regex_pattern') %>
+</div>
+
 <div class="flex align-items-center">
   <label class="govuk-label govuk-label--m govuk-visually-hidden" for="component_validation_value">
     <%= @component_validation.label %>
@@ -14,4 +18,4 @@
          <%=   @component_validation.errors.present? ? 'aria-invalid=true' : '' %>
          value="<%= @component_validation.main_value %>">
 </div>
-<p><%= t('dialogs.component_validations.regex.hint_regex_pattern') %></p>
+<p><%= t('dialogs.component_validations.regex.advice_regex_pattern') %></p>

--- a/app/views/api/component_validations/_string_regex_validation.html.erb
+++ b/app/views/api/component_validations/_string_regex_validation.html.erb
@@ -14,5 +14,5 @@
          <%=   @component_validation.errors.present? ? 'aria-invalid=true' : '' %>
          value="<%= @component_validation.main_value %>">
 </div>
-<p><%= t('dialogs.component_validations.hint_regex_pattern') %></p>
+<p><%= t('dialogs.component_validations.regex.hint_regex_pattern') %></p>
 

--- a/app/views/api/component_validations/_string_regex_validation.html.erb
+++ b/app/views/api/component_validations/_string_regex_validation.html.erb
@@ -1,0 +1,18 @@
+<p><b>Regular expression</b></p>
+<div class="flex align-items-center">
+  <label class="govuk-label govuk-label--m govuk-visually-hidden" for="component_validation_value">
+    <%= @component_validation.label %>
+  </label>
+  <input class="govuk-input govuk-input--width-5 <%= @component_validation.errors.present? ? 'govuk-input--error' : '' %>"
+         id="component_validation_value"
+         name="component_validation[value]"
+         pattern="*"
+         inputmode="email"
+         spellcheck="false"
+         autocomplete=""
+         aria-describedby="<%= @component_validation.errors.present? ? 'component_validation_value_error' : '' %> hint-text-prompt"
+         <%=   @component_validation.errors.present? ? 'aria-invalid=true' : '' %>
+         value="<%= @component_validation.main_value %>">
+</div>
+<p><%= "You should also explain the required format in the question's hint text to help users with their answer." %></p>
+

--- a/app/views/api/component_validations/_string_regex_validation.html.erb
+++ b/app/views/api/component_validations/_string_regex_validation.html.erb
@@ -1,12 +1,10 @@
-<label class="govuk-label govuk-label--m" for="component_validation_value">
+<label class="govuk-label govuk-label--s" for="component_validation_value">
 <%= t('dialogs.component_validations.regex.title') %>
 </label>
 <div class="govuk-hint" id="regex_pattern_hint" >
 <%= t('dialogs.component_validations.regex.hint_regex_pattern') %>
 </div>
-
-<div class="flex align-items-center">
-  <input class="govuk-input govuk-input--width-20 <%= @component_validation.errors.present? ? 'govuk-input--error' : '' %>"
+<input class="govuk-input govuk-input--width-20 <%= @component_validation.errors.present? ? 'govuk-input--error' : '' %>"
          id="component_validation_value"
          name="component_validation[value]"
          pattern="*"
@@ -16,5 +14,5 @@
          aria-describedby="<%= @component_validation.errors.present? ? 'component_validation_value_error' : '' %> regex_pattern_hint"
          <%=   @component_validation.errors.present? ? 'aria-invalid=true' : '' %>
          value="<%= @component_validation.main_value %>">
-</div>
+
 <p><%= t('dialogs.component_validations.regex.advice_regex_pattern') %></p>

--- a/app/views/api/component_validations/_string_regex_validation.html.erb
+++ b/app/views/api/component_validations/_string_regex_validation.html.erb
@@ -1,12 +1,11 @@
-<p><b><%= t('dialogs.component_validations.regex.title') %></b></p>
-<div class="govuk-hint" >
+<label class="govuk-label govuk-label--m" for="component_validation_value">
+<%= t('dialogs.component_validations.regex.title') %>
+</label>
+<div class="govuk-hint" id="regex_pattern_hint" >
 <%= t('dialogs.component_validations.regex.hint_regex_pattern') %>
 </div>
 
 <div class="flex align-items-center">
-  <label class="govuk-label govuk-label--m govuk-visually-hidden" for="component_validation_value">
-    <%= @component_validation.label %>
-  </label>
   <input class="govuk-input govuk-input--width-20 <%= @component_validation.errors.present? ? 'govuk-input--error' : '' %>"
          id="component_validation_value"
          name="component_validation[value]"
@@ -14,7 +13,7 @@
          inputmode="email"
          spellcheck="false"
          autocomplete=""
-         aria-describedby="<%= @component_validation.errors.present? ? 'component_validation_value_error' : '' %> hint-text-prompt"
+         aria-describedby="<%= @component_validation.errors.present? ? 'component_validation_value_error' : '' %> regex_pattern_hint"
          <%=   @component_validation.errors.present? ? 'aria-invalid=true' : '' %>
          value="<%= @component_validation.main_value %>">
 </div>

--- a/config/initializers/enabled_validations.rb
+++ b/config/initializers/enabled_validations.rb
@@ -18,4 +18,5 @@ Rails.application.config.enabled_validations = %w[
   max_files
   address
   postcode
+  pattern
 ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,8 +98,10 @@ en:
         content: We were unable to redo your last action.
     component_validations:
       hint_text_prompt: You may want to mention this requirement in the question's hint text to help users with their answer
-      hint_regex_pattern: You should also explain the required format in the question's hint text to help users with their answer.
-      instruction_regex_pattern: "Use a regular expression (regex) to validate answers against a specific format, such as a reference number or case ID."
+      regex:
+        hint_regex_pattern: You should also explain the required format in the question's hint text to help users with their answer.
+        instruction_regex_pattern: Use a regular expression ( %{regex_href} ) to validate answers against a specific format, such as a reference number or case ID.
+        regex_link: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/building-and-editing/#regex" target="_blank" rel="noopener noreferrer">regex</a>
       date:
         day: Day
         month: Month

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,8 +99,9 @@ en:
     component_validations:
       hint_text_prompt: You may want to mention this requirement in the question's hint text to help users with their answer
       regex:
+        title: Regular expression
         hint_regex_pattern: You should also explain the required format in the question's hint text to help users with their answer.
-        instruction_regex_pattern: Use a regular expression ( %{regex_href} ) to validate answers against a specific format, such as a reference number or case ID.
+        instruction_regex_pattern: Use a regular expression (%{regex_href}) to validate answers against a specific format, such as a reference number or case ID.
         regex_link: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/building-and-editing/#regex" target="_blank" rel="noopener noreferrer">regex</a>
       date:
         day: Day

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,7 +100,7 @@ en:
       hint_text_prompt: You may want to mention this requirement in the question's hint text to help users with their answer
       regex:
         title: Regular expression
-        hint_regex_pattern: Do not include a ‘/’ at the beginning or end. Do not include any options such as ‘i’, ‘x’, ‘m’ or ‘o’.
+        hint_regex_pattern: Do not include a ‘/’ at the beginning or end. Do not include any options such as ‘i’, ‘x’ or ‘m’.
         advice_regex_pattern: You should also explain the required format in the question's hint text to help users with their answer.
         instruction_regex_pattern: Use a %{regex_href} (regex) to validate answers against a specific format, such as a reference number or case ID.
         regex_link: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/building-and-editing/#regex" target="_blank" rel="noopener noreferrer">regular expression</a>
@@ -705,7 +705,7 @@ en:
           blank: Enter a regular expression
           invalid: Enter a valid regular expression
           remove_delimiter: Your regular expression cannot include a ‘/’ at the beginning or end
-          remove_options: Your regular expression cannot include options such as ‘i’, ‘x’, ‘m’ or ‘o’
+          remove_options: Your regular expression cannot include options such as ‘i’, ‘x’, ‘m’
         date_validation:
           invalid: "%{label} is not a valid date"
           missing_attribute: "%{label} should include a %{attribute}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,8 @@ en:
         content: We were unable to redo your last action.
     component_validations:
       hint_text_prompt: You may want to mention this requirement in the question's hint text to help users with their answer
+      hint_regex_pattern: You should also explain the required format in the question's hint text to help users with their answer.
+      instruction_regex_pattern: "Use a regular expression (regex) to validate answers against a specific format, such as a reference number or case ID."
       date:
         day: Day
         month: Month
@@ -123,6 +125,9 @@ en:
         max:
           label: Maximum answer length
           status_label: Set a maximum answer length
+        pattern:
+          label: Specific answer format
+          status_label: Set a specific answer format
       max_files:
         label: 'Maximum number of files that can be uploaded'
         hint: 'Set a limit for this page of between 1 and 10 files'
@@ -692,6 +697,8 @@ en:
           validator: "%{validator} is not valid for %{component} component"
           blank: "Enter an answer for %{label}"
           format: "%{message}"
+        string_regex_pattern:
+          blank: Enter a regular expression
         date_validation:
           invalid: "%{label} is not a valid date"
           missing_attribute: "%{label} should include a %{attribute}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,7 +100,8 @@ en:
       hint_text_prompt: You may want to mention this requirement in the question's hint text to help users with their answer
       regex:
         title: Regular expression
-        hint_regex_pattern: You should also explain the required format in the question's hint text to help users with their answer.
+        hint_regex_pattern: Do not include a ‘/’ at the beginning or end. Do not include any options such as ‘i’, ‘x’, ‘m’ or ‘o’
+        advice_regex_pattern: You should also explain the required format in the question's hint text to help users with their answer.
         instruction_regex_pattern: Use a %{regex_href} (regex) to validate answers against a specific format, such as a reference number or case ID.
         regex_link: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/building-and-editing/#regex" target="_blank" rel="noopener noreferrer">regular expression</a>
       date:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,8 +101,8 @@ en:
       regex:
         title: Regular expression
         hint_regex_pattern: You should also explain the required format in the question's hint text to help users with their answer.
-        instruction_regex_pattern: Use a regular expression (%{regex_href}) to validate answers against a specific format, such as a reference number or case ID.
-        regex_link: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/building-and-editing/#regex" target="_blank" rel="noopener noreferrer">regex</a>
+        instruction_regex_pattern: Use a %{regex_href} (regex) to validate answers against a specific format, such as a reference number or case ID.
+        regex_link: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/building-and-editing/#regex" target="_blank" rel="noopener noreferrer">regular expression</a>
       date:
         day: Day
         month: Month

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -386,6 +386,7 @@ en:
       min_string_length: 'Minimum answer length...'
       upload_options: 'Autocomplete options...'
       max_files: 'Number of files...'
+      pattern: 'Specific answer format (regex)...'
     dialog:
       heading_remove: Delete the component '#{label}'?
       heading_required: 'Is answering this question required?'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -703,7 +703,9 @@ en:
           format: "%{message}"
         string_regex_pattern:
           blank: Enter a regular expression
-          invalid: Enter a valid regular expression. It cannot include a ‘/’ at the beginning or end or include options such as ‘i’, ‘x’, ‘m’ or ‘o‘
+          invalid: Enter a valid regular expression
+          remove_delimiter: Your regular expression cannot include a ‘/’ at the beginning or end
+          remove_options: Your regular expression cannot include options such as ‘i’, ‘x’, ‘m’ or ‘o’
         date_validation:
           invalid: "%{label} is not a valid date"
           missing_attribute: "%{label} should include a %{attribute}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -702,6 +702,7 @@ en:
           format: "%{message}"
         string_regex_pattern:
           blank: Enter a regular expression
+          invalid: Enter a valid regular expression
         date_validation:
           invalid: "%{label} is not a valid date"
           missing_attribute: "%{label} should include a %{attribute}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,7 +100,7 @@ en:
       hint_text_prompt: You may want to mention this requirement in the question's hint text to help users with their answer
       regex:
         title: Regular expression
-        hint_regex_pattern: Do not include a ‘/’ at the beginning or end. Do not include any options such as ‘i’, ‘x’, ‘m’ or ‘o’
+        hint_regex_pattern: Do not include a ‘/’ at the beginning or end. Do not include any options such as ‘i’, ‘x’, ‘m’ or ‘o’.
         advice_regex_pattern: You should also explain the required format in the question's hint text to help users with their answer.
         instruction_regex_pattern: Use a %{regex_href} (regex) to validate answers against a specific format, such as a reference number or case ID.
         regex_link: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/building-and-editing/#regex" target="_blank" rel="noopener noreferrer">regular expression</a>
@@ -703,7 +703,7 @@ en:
           format: "%{message}"
         string_regex_pattern:
           blank: Enter a regular expression
-          invalid: Enter a valid regular expression
+          invalid: Enter a valid regular expression. It cannot include a ‘/’ at the beginning or end or include options such as ‘i’, ‘x’, ‘m’ or ‘o‘
         date_validation:
           invalid: "%{label} is not a valid date"
           missing_attribute: "%{label} should include a %{attribute}"

--- a/spec/models/component_validations/pattern_validation_spec.rb
+++ b/spec/models/component_validations/pattern_validation_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe 'PatternValidation' do
   let(:validator) { 'pattern' }
   let(:status) { 'enabled' }
   let(:expected_blank_error) { 'Enter a regular expression' }
-  let(:value) { '\w+'}
+  let(:value) { '\w+' }
 
   it_behaves_like 'a base component validation'
 
   describe '#main_value' do
     context 'when value is present' do
-      let(:value) { '\d+'}
+      let(:value) { '\d+' }
 
       it 'returns the value initialised in the model' do
         expect(subject.main_value).to eq(value)
@@ -33,14 +33,13 @@ RSpec.describe 'PatternValidation' do
   end
 
   describe '#to_metadata' do
-    let(:value) { '\d+'}
+    let(:value) { '\d+' }
     let(:expected_metadata) { { 'pattern' => value } }
 
     it 'returns default metadata' do
       expect(subject.to_metadata).to eq(expected_metadata)
     end
   end
-
 
   context '#valid when there are no value provided for regex' do
     let(:value) { '' }

--- a/spec/models/component_validations/pattern_validation_spec.rb
+++ b/spec/models/component_validations/pattern_validation_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'PatternValidation' do
   let(:component_uuid) { 'fda1e5a1-ed5f-49c9-a943-dc930a520984' }
   let(:validator) { 'pattern' }
   let(:status) { 'enabled' }
-  let(:expected_blank_error) { 'Enter a regular expression' }
+  let(:expected_blank_error) { I18n.t('activemodel.errors.models.string_regex_pattern.blank') }
   let(:value) { '\w+' }
 
   it_behaves_like 'a base component validation'

--- a/spec/models/component_validations/pattern_validation_spec.rb
+++ b/spec/models/component_validations/pattern_validation_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe 'PatternValidation' do
+  let(:subject) { PatternValidation.new(validation_params) }
+  let(:latest_metadata) { metadata_fixture(:version) }
+  let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+  let(:validation_params) do
+    {
+      service:,
+      page_uuid:,
+      component_uuid:,
+      validator:,
+      status:,
+      value:
+    }
+  end
+
+  let(:page_uuid) { 'e8708909-922e-4eaf-87a5-096f7a713fcb' } # how well do you know star wars?
+  let(:component_uuid) { 'fda1e5a1-ed5f-49c9-a943-dc930a520984' }
+  let(:validator) { 'pattern' }
+  let(:status) { 'enabled' }
+  let(:expected_blank_error) { 'Enter a regular expression' }
+  let(:value) { '\w+'}
+
+  it_behaves_like 'a base component validation'
+
+  describe '#main_value' do
+    context 'when value is present' do
+      let(:value) { '\d+'}
+
+      it 'returns the value initialised in the model' do
+        expect(subject.main_value).to eq(value)
+      end
+    end
+  end
+
+  describe '#to_metadata' do
+    let(:value) { '\d+'}
+    let(:expected_metadata) { { 'pattern' => value } }
+
+    it 'returns default metadata' do
+      expect(subject.to_metadata).to eq(expected_metadata)
+    end
+  end
+
+
+  context '#valid when there are no value provided for regex' do
+    let(:value) { '' }
+
+    it 'it returns invalid' do
+      expect(subject).to be_invalid
+    end
+
+    it 'surfaces the error' do
+      subject.valid?
+      expect(subject.errors.full_messages.first).to eq(expected_blank_error)
+    end
+  end
+end

--- a/spec/validators/regex_validator_spec.rb
+++ b/spec/validators/regex_validator_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe RegexValidator do
+  let(:subject) { PatternValidation.new(validation_params) }
+  let(:latest_metadata) { metadata_fixture(:regex) }
+  let(:service) { MetadataPresenter::Service.new(latest_metadata) }
+  let(:validation_params) do
+    {
+      service:,
+      page_uuid:,
+      component_uuid:,
+      validator:,
+      status:,
+      value:
+    }
+  end
+  let(:page_uuid) { '121183c6-7ee8-4b5d-b74a-dacee8aa4cd5' } # single question regex
+  let(:component_uuid) { '375b6aa9-6548-4d71-ab69-6ff6c68a9d2f' } # expect a good regex
+  let(:validator) { 'pattern' }
+  let(:status) { 'enabled' }
+  let(:value) { '\\D+' }
+
+  describe '#validate' do
+    before { subject.validate }
+
+    context 'when a valid regex' do
+      it 'returns valid' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'when not a valid regex' do
+      let(:value) { '/[01]?[0-9]|2[0-3]):[0-5][0-9]/' }
+
+      it 'returns invalid' do
+        expect(subject).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/validators/regex_validator_spec.rb
+++ b/spec/validators/regex_validator_spec.rb
@@ -100,6 +100,19 @@ RSpec.describe RegexValidator do
         end
       end
 
+      context 'for several options' do
+        let(:value) { '\d{5}/ix' }
+
+        it 'returns invalid' do
+          expect(subject).to_not be_valid
+        end
+
+        it 'returns an error message' do
+          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.string_regex_pattern.remove_options'))
+        end
+      end
+    end
+
     context 'when it contains several issues' do
       let(:value) { '/[01]?[0-9]|2[0-3]):[0-5][0-9]/i' }
 

--- a/spec/validators/regex_validator_spec.rb
+++ b/spec/validators/regex_validator_spec.rb
@@ -28,10 +28,89 @@ RSpec.describe RegexValidator do
     end
 
     context 'when not a valid regex' do
-      let(:value) { '/[01]?[0-9]|2[0-3]):[0-5][0-9]/' }
+      let(:value) { '[01]?[0-9]|2[0-3]):[0-5][0-9]' }
 
       it 'returns invalid' do
         expect(subject).to_not be_valid
+      end
+
+      it 'returns an error message' do
+        expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.string_regex_pattern.invalid'))
+      end
+    end
+
+    context 'when it contains delimiter at the beginning' do
+      let(:value) { '/[a-z]' }
+
+      it 'returns invalid' do
+        expect(subject).to_not be_valid
+      end
+
+      it 'returns an error message' do
+        expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.string_regex_pattern.remove_delimiter'))
+      end
+    end
+
+    context 'when it contains delimiter at the end' do
+      let(:value) { '[a-z]/' }
+
+      it 'returns invalid' do
+        expect(subject).to_not be_valid
+      end
+
+      it 'returns an error message' do
+        expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.string_regex_pattern.remove_delimiter'))
+      end
+    end
+
+    context 'when it contains options' do
+      context 'for insensitive case' do
+        let(:value) { '[a-z]/i' }
+
+        it 'returns invalid' do
+          expect(subject).to_not be_valid
+        end
+
+        it 'returns an error message' do
+          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.string_regex_pattern.remove_options'))
+        end
+      end
+
+      context 'for multiline regex' do
+        let(:value) { '[a-z].[0-9]{3}/m' }
+
+        it 'returns invalid' do
+          expect(subject).to_not be_valid
+        end
+
+        it 'returns an error message' do
+          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.string_regex_pattern.remove_options'))
+        end
+      end
+
+      context 'for extended regex' do
+        let(:value) { '\D{5}/x' }
+
+        it 'returns invalid' do
+          expect(subject).to_not be_valid
+        end
+
+        it 'returns an error message' do
+          expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.string_regex_pattern.remove_options'))
+        end
+      end
+
+    context 'when it contains several issues' do
+      let(:value) { '/[01]?[0-9]|2[0-3]):[0-5][0-9]/i' }
+
+      it 'returns invalid' do
+        expect(subject).to_not be_valid
+      end
+
+      it 'shows all error messages' do
+        expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.string_regex_pattern.invalid'))
+        expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.string_regex_pattern.remove_options'))
+        expect(subject.errors.full_messages).to include(I18n.t('activemodel.errors.models.string_regex_pattern.remove_delimiter'))
       end
     end
   end


### PR DESCRIPTION
### Context
This is part of the regex validation work. See ticket:
[Trello](https://trello.com/c/wrPiUcjl/3950-add-regex-modal-in-editor)

### Implementation
We are adding pattern in the enabled validation, that corresponds to the type of validator used in the presenter schemas. 
We are also adding component validation in the Editor to make sure the regex is not empty.
We are updating the partial used for this validation.
The regex is being saved in the form metadata in validation, pattern JSON field.

### Tests 
Unit tests for Editor regex minimal validation. 
Manual and mob testing