### PR TITLE
Add automated accessibility tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,8 +323,7 @@ jobs:
             echo 'export CI_MODE=true' >> $BASH_ENV
             source $BASH_ENV
 
-            EXCLUDE_FILES="accessibility_spec.rb"
-            circleci tests glob "acceptance/**/*_spec.rb" | rep -ve $EXCLUDE_FILES | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/acceptance/acceptance.xml" --verbose --split-by=timings --timings-type=filename
+            circleci tests glob "acceptance/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/acceptance/acceptance.xml" --verbose --split-by=timings --timings-type=filename
       - store_test_results:
           path: ~/acceptance
       - slack/status: *slack_status
@@ -356,7 +355,8 @@ jobs:
             echo 'export CI_MODE=true' >> $BASH_ENV
             source $BASH_ENV
 
-            circleci tests glob "acceptance/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/acceptance/acceptance.xml" --verbose --split-by=timings --timings-type=filename
+            EXCLUDE_FILES="accessibility_spec.rb"
+            circleci tests glob "acceptance/**/*_spec.rb" | grep -ve $EXCLUDE_FILES | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/acceptance/acceptance.xml" --verbose --split-by=timings --timings-type=filename
       - store_test_results:
           path: ~/acceptance
       - slack/status: *testable_slack_status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,8 @@ jobs:
             echo 'export CI_MODE=true' >> $BASH_ENV
             source $BASH_ENV
 
-            circleci tests glob "acceptance/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/acceptance/acceptance.xml" --verbose --split-by=timings --timings-type=filename
+            EXCLUDE_FILES="accessibility_spec.rb"
+            circleci tests glob "acceptance/**/*_spec.rb" | rep -ve $EXCLUDE_FILES | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/acceptance/acceptance.xml" --verbose --split-by=timings --timings-type=filename
       - store_test_results:
           path: ~/acceptance
       - slack/status: *slack_status

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'tzinfo-data'
 gem 'webpacker', '~> 5.4'
 
 group :development, :test do
+  gem 'axe-core-rspec'
   gem 'brakeman'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,17 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
+    axe-core-api (4.8.2)
+      dumb_delegator
+      virtus
+    axe-core-rspec (4.8.2)
+      axe-core-api
+      dumb_delegator
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     base64 (0.2.0)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
@@ -137,6 +148,8 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cgi (0.4.1)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.2.3)
     crack (1.0.0)
       bigdecimal
@@ -150,12 +163,15 @@ GEM
     delayed_job_active_record (4.1.8)
       activerecord (>= 3.0, < 8.0)
       delayed_job (>= 3.0, < 5)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.5.1)
     docile (1.4.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    dumb_delegator (1.0.0)
     erubi (1.12.0)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
@@ -247,6 +263,7 @@ GEM
     htmlentities (4.3.4)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     jmespath (1.6.2)
     jquery-rails (4.6.0)
       rails-dom-testing (>= 1, < 3)
@@ -716,6 +733,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.1)
+    thread_safe (0.3.6)
     tilt (2.3.0)
     timeout (0.4.1)
     turbo-rails (1.5.0)
@@ -733,6 +751,10 @@ GEM
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -764,6 +786,7 @@ DEPENDENCIES
   administrate
   aws-sdk-s3
   aws-sdk-sesv2
+  axe-core-rspec
   better_errors
   binding_of_caller
   bootsnap (>= 1.4.2)

--- a/acceptance/features/accessibility_spec.rb
+++ b/acceptance/features/accessibility_spec.rb
@@ -19,6 +19,11 @@ feature 'Accessibility' do
     expect(page).to have_content(I18n.t('pages.flow.heading'))
     page.find(:css, '#main-content', visible: true)
     then_the_page_should_be_accessible
+
+    ## With branching
+
+    ## Detatch some pages
+
   end
 
   scenario 'settings' do
@@ -73,13 +78,17 @@ feature 'Accessibility' do
   end
 
   scenario 'Submission Settings > Send a confirmation email' do
+    given_I_add_a_single_question_page_with_email
+    and_I_add_a_page_url('email-page')
+    when_I_add_the_page
+
     click_link(I18n.t('settings.name'))
     click_link(I18n.t('settings.submission.heading'))
     click_link(I18n.t('settings.confirmation_email.heading'))
     then_the_page_should_be_accessible
 
-    page.find('#email-settings-send-by-email-dev-1-field', visible: false).check
-    page.find('#email-settings-send-by-email-production-1-field', visible: false).check
+    page.find('#confirmation-email-settings-send-by-confirmation-email-dev-1-field', visible: false).check
+    page.find('#confirmation-email-settings-send-by-confirmation-email-production-1-field', visible: false).check
     then_the_page_should_be_accessible
   end
 
@@ -95,82 +104,87 @@ feature 'Accessibility' do
   end
 
   context 'Standalone Pages' do
-    scenario 'Privacy Page', pending: true  do
-      # editor.footer_pages_link.click
+    scenario 'Privacy Page', pending: true do
       editor.privacy_link.click
-    then_the_page_should_be_accessible
+      then_the_page_should_be_accessible
     end
 
-    scenario 'Cookies Page', pending: true do
-      # editor.footer_pages_link.click
+    scenario 'Cookies Page' do
       editor.cookies_link.click
-    then_the_page_should_be_accessible
+      then_the_page_should_be_accessible
     end
 
     scenario 'Accessibility Page', pending: true do
-      # editor.footer_pages_link.click
       editor.accessibility_link.click
-    then_the_page_should_be_accessible
+      then_the_page_should_be_accessible
     end
   end
 
   context 'Editing Pages' do
     scenario 'Confirmation Page', pending: true do
       given_I_edit_a_confirmation_page
-    then_the_page_should_be_accessible
+      then_the_page_should_be_accessible
     end
 
     scenario 'Check Answers Page', pending: true  do
       given_I_edit_a_check_your_answers_page
-    then_the_page_should_be_accessible
+      then_the_page_should_be_accessible
     end
 
     scenario 'Start Page', pending: true do
       click_link('Service name goes here')
-    then_the_page_should_be_accessible
+      then_the_page_should_be_accessible
     end
 
-    scenario 'Content Page', pending: true do
+    scenario 'Content Page' do
       and_I_add_a_content_page('Some Content')
-    then_the_page_should_be_accessible
+      then_the_page_should_be_accessible
+    end
+
+    scenario 'Exit Page', pending: true do
+      given_I_add_an_exit_page('Some Content')
+      then_the_page_should_be_accessible
     end
 
     scenario 'Multiple Question Page', pending: true do
+      given_I_have_a_multiple_questions_page
+      then_the_page_should_be_accessible
     end
 
     context 'Single Question Pages' do
       scenario 'Text Question', pending: true do
         given_I_have_a_single_question_page_with_text
+        then_the_page_should_be_accessible
       end
 
       scenario 'Textarea Question', pending: true do
         given_I_have_a_single_question_page_with_text_area
-    then_the_page_should_be_accessible
+        then_the_page_should_be_accessible
       end
 
       scenario 'Email Question', pending: true do
         given_I_have_a_single_question_page_with_email
-    then_the_page_should_be_accessible
+        then_the_page_should_be_accessible
       end
 
       scenario 'Number Question', pending: true do
         given_I_have_a_single_question_page_with_number
-    then_the_page_should_be_accessible
+        then_the_page_should_be_accessible
       end
 
       scenario 'Date Question', pending: true do
         given_I_have_a_single_question_page_with_date
-    then_the_page_should_be_accessible
+        then_the_page_should_be_accessible
       end
 
       scenario 'Radios Question', pending: true do
         given_I_have_a_single_question_page_with_radio
-    then_the_page_should_be_accessible
+        then_the_page_should_be_accessible
       end
 
       scenario 'Checkboxes Question', pending: true do
         given_I_have_a_single_question_page_with_checkboxes
-    then_the_page_should_be_accessible
+        then_the_page_should_be_accessible
         editor.question_heading.first.set('Checkboxes Question')
         when_I_save_my_changes
         and_I_return_to_the_flow_page
@@ -180,23 +194,30 @@ feature 'Accessibility' do
         given_I_add_a_single_question_page_with_autocomplete
         and_I_add_a_page_url
         when_I_add_the_page
-    then_the_page_should_be_accessible
+        then_the_page_should_be_accessible
+      end
+
+      scenario 'Address Question', pending: true do
+        given_I_have_a_single_question_page_with_upload
+        then_the_page_should_be_accessible
       end
 
       scenario 'File Upload Question', pending: true do
         given_I_have_a_single_question_page_with_upload
-    then_the_page_should_be_accessible
+        then_the_page_should_be_accessible
       end
     end
 
     scenario 'Adding a Branching Point', pending: true do
         editor.connection_menu('Checkboxes Question').click
         and_I_add_branching_to_the_page
-    then_the_page_should_be_accessible
+        then_the_page_should_be_accessible
+        
+      ### Interact with the page and check
     end
 
-    scenario 'Editing a Branching Point', pending: true do
-      then_the_page_should_be_accessible
+    scenario 'Editing a Branching Point' do
+      # then_the_page_should_be_accessible
     end
 
   end

--- a/acceptance/features/accessibility_spec.rb
+++ b/acceptance/features/accessibility_spec.rb
@@ -1,0 +1,207 @@
+require_relative '../spec_helper'
+require 'axe-rspec'
+
+feature 'Accessibility' do
+  let(:editor) { EditorApp.new }
+  let(:service_name) { generate_service_name }
+
+  background do
+    given_I_am_logged_in
+    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
+  end
+
+  scenario 'services list' do
+    click_link(I18n.t('partials.header.forms'))
+    then_the_page_should_be_accessible
+  end
+
+  scenario 'flow_view' do
+    expect(page).to have_content(I18n.t('pages.flow.heading'))
+    page.find(:css, '#main-content', visible: true)
+    then_the_page_should_be_accessible
+  end
+
+  scenario 'settings' do
+    click_link(I18n.t('settings.name'))
+    then_the_page_should_be_accessible
+  end
+
+  scenario 'Settings > Form details' do
+    click_link(I18n.t('settings.name'))
+    click_link(I18n.t('settings.form_name.heading'))
+    then_the_page_should_be_accessible
+  end
+
+  scenario 'Settings > Google Analytics', pending: true do
+    click_link(I18n.t('settings.name'))
+    click_link(I18n.t('settings.form_analytics.heading'))
+    then_the_page_should_be_accessible
+
+    page.find('#form_analytics_settings_enabled_test', visible: false).check
+    page.find('#form_analytics_settings_enabled_live', visible: false).check
+    then_the_page_should_be_accessible
+  end
+
+  scenario 'Settings > Reference & Payment' do
+    click_link(I18n.t('settings.name'))
+    click_link(I18n.t('settings.reference_payment.link'))
+    then_the_page_should_be_accessible
+  end
+
+  scenario 'Settings > Save and Return' do
+    click_link(I18n.t('settings.name'))
+    click_link(I18n.t('settings.save_and_return.heading'))
+    then_the_page_should_be_accessible
+  end
+
+
+  scenario 'Settings > Submission Settings Index' do
+    click_link(I18n.t('settings.name'))
+    click_link(I18n.t('settings.submission.heading'))
+    then_the_page_should_be_accessible
+  end
+
+  scenario 'Submission Settings > Collect information' do
+    click_link(I18n.t('settings.name'))
+    click_link(I18n.t('settings.submission.heading'))
+    click_link(I18n.t('settings.collection_email.heading'))
+    then_the_page_should_be_accessible
+
+    page.find('#email-settings-send-by-email-dev-1-field', visible: false).check
+    page.find('#email-settings-send-by-email-production-1-field', visible: false).check
+    then_the_page_should_be_accessible
+  end
+
+  scenario 'Submission Settings > Send a confirmation email' do
+    click_link(I18n.t('settings.name'))
+    click_link(I18n.t('settings.submission.heading'))
+    click_link(I18n.t('settings.confirmation_email.heading'))
+    then_the_page_should_be_accessible
+
+    page.find('#email-settings-send-by-email-dev-1-field', visible: false).check
+    page.find('#email-settings-send-by-email-production-1-field', visible: false).check
+    then_the_page_should_be_accessible
+  end
+
+  scenario 'Publishing', pending: true do
+    click_link(I18n.t('publish.name'))
+    then_the_page_should_be_accessible
+
+    click_button('Publish to Test')
+    then_the_page_should_be_accessible
+
+    click_link('Publish to Live')
+    then_the_page_should_be_accessible
+  end
+
+  context 'Standalone Pages' do
+    scenario 'Privacy Page', pending: true  do
+      # editor.footer_pages_link.click
+      editor.privacy_link.click
+    then_the_page_should_be_accessible
+    end
+
+    scenario 'Cookies Page', pending: true do
+      # editor.footer_pages_link.click
+      editor.cookies_link.click
+    then_the_page_should_be_accessible
+    end
+
+    scenario 'Accessibility Page', pending: true do
+      # editor.footer_pages_link.click
+      editor.accessibility_link.click
+    then_the_page_should_be_accessible
+    end
+  end
+
+  context 'Editing Pages' do
+    scenario 'Confirmation Page', pending: true do
+      given_I_edit_a_confirmation_page
+    then_the_page_should_be_accessible
+    end
+
+    scenario 'Check Answers Page', pending: true  do
+      given_I_edit_a_check_your_answers_page
+    then_the_page_should_be_accessible
+    end
+
+    scenario 'Start Page', pending: true do
+      click_link('Service name goes here')
+    then_the_page_should_be_accessible
+    end
+
+    scenario 'Content Page', pending: true do
+      and_I_add_a_content_page('Some Content')
+    then_the_page_should_be_accessible
+    end
+
+    scenario 'Multiple Question Page', pending: true do
+    end
+
+    context 'Single Question Pages' do
+      scenario 'Text Question', pending: true do
+        given_I_have_a_single_question_page_with_text
+      end
+
+      scenario 'Textarea Question', pending: true do
+        given_I_have_a_single_question_page_with_text_area
+    then_the_page_should_be_accessible
+      end
+
+      scenario 'Email Question', pending: true do
+        given_I_have_a_single_question_page_with_email
+    then_the_page_should_be_accessible
+      end
+
+      scenario 'Number Question', pending: true do
+        given_I_have_a_single_question_page_with_number
+    then_the_page_should_be_accessible
+      end
+
+      scenario 'Date Question', pending: true do
+        given_I_have_a_single_question_page_with_date
+    then_the_page_should_be_accessible
+      end
+
+      scenario 'Radios Question', pending: true do
+        given_I_have_a_single_question_page_with_radio
+    then_the_page_should_be_accessible
+      end
+
+      scenario 'Checkboxes Question', pending: true do
+        given_I_have_a_single_question_page_with_checkboxes
+    then_the_page_should_be_accessible
+        editor.question_heading.first.set('Checkboxes Question')
+        when_I_save_my_changes
+        and_I_return_to_the_flow_page
+      end
+
+      scenario 'Autocomplete Question', pending: true do
+        given_I_add_a_single_question_page_with_autocomplete
+        and_I_add_a_page_url
+        when_I_add_the_page
+    then_the_page_should_be_accessible
+      end
+
+      scenario 'File Upload Question', pending: true do
+        given_I_have_a_single_question_page_with_upload
+    then_the_page_should_be_accessible
+      end
+    end
+
+    scenario 'Adding a Branching Point', pending: true do
+        editor.connection_menu('Checkboxes Question').click
+        and_I_add_branching_to_the_page
+    then_the_page_should_be_accessible
+    end
+
+    scenario 'Editing a Branching Point', pending: true do
+      then_the_page_should_be_accessible
+    end
+
+  end
+
+  def then_the_page_should_be_accessible
+    expect(page).to be_axe_clean.according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa, :wcag22aa, :'best-practice')
+  end
+end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -40,6 +40,7 @@ class EditorApp < SitePrism::Page
   element :footer_pages_link, 'button', text: I18n.t('pages.footer')
   element :cookies_link, :link, 'Cookies', class: 'govuk-link'
   element :privacy_link, :link, 'Privacy', class: 'govuk-link'
+  element :accessibility_link, :link, 'Accessibility', class: 'govuk-link'
 
   element :pages_link, :link, I18n.t('pages.name')
   element :publishing_link, :link, I18n.t('publish.name')


### PR DESCRIPTION
This PR adds a set of automated accessibility tests for every page in the editor.

A bunch of these are marked as either `pending` or `skip` as they currently fail.  The aim is that I can work through these to ensure every page is passing a basic accessibility audit.

The CircleCI config has been modified to exclude the accessibility test - this is to ensure that it doesn't fail the deploy at this point.  Even when these tests are complete and passing, we may not want an accessibility fail to block deploy, so we may need to aadjust the pipeline config to handle this test spec differently.
