### PR TITLE
Single question page labelling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -470,12 +470,12 @@ workflows:
       - security:
           requires:
             - build
-      # - rspec_test:
-      #     requires:
-      #       - build
-      # - js_test:
-      #     requires:
-      #       - build
+      - rspec_test:
+          requires:
+            - build
+      - js_test:
+          requires:
+            - build
       - build_web_testable_branch:
           context: *context
           requires:
@@ -483,8 +483,8 @@ workflows:
             - login-to-aws
             - lint
             - security
-            # - rspec_test
-            # - js_test
+            - rspec_test
+            - js_test
           filters:
             branches:
               only:
@@ -496,8 +496,8 @@ workflows:
             - login-to-aws
             - lint
             - security
-            # - rspec_test
-            # - js_test
+            - rspec_test
+            - js_test
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -470,12 +470,12 @@ workflows:
       - security:
           requires:
             - build
-      - rspec_test:
-          requires:
-            - build
-      - js_test:
-          requires:
-            - build
+      # - rspec_test:
+      #     requires:
+      #       - build
+      # - js_test:
+      #     requires:
+      #       - build
       - build_web_testable_branch:
           context: *context
           requires:
@@ -483,8 +483,8 @@ workflows:
             - login-to-aws
             - lint
             - security
-            - rspec_test
-            - js_test
+            # - rspec_test
+            # - js_test
           filters:
             branches:
               only:
@@ -496,8 +496,8 @@ workflows:
             - login-to-aws
             - lint
             - security
-            - rspec_test
-            - js_test
+            # - rspec_test
+            # - js_test
           filters:
             branches:
               only:

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ ruby '3.1.3'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'accessible-labels-for-editing'
-gem 'metadata_presenter', path: '../fb-metadata-presenter'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'semantic-editable-headings'
+# gem 'metadata_presenter', path: '../fb-metadata-presenter'
 # gem 'metadata_presenter', '3.3.7'
 
 gem 'activerecord-session_store'

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ ruby '3.1.3'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'semantic-editable-headings'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'semantic-editable-headings'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '3.3.7'
+gem 'metadata_presenter', '3.3.30'
 
 gem 'activerecord-session_store'
 gem 'administrate'

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ ruby '3.1.3'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'accessible-labels-for-editing'
-# gem 'metadata_presenter', path: '../fb-metadata-presenter'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'accessible-labels-for-editing'
+gem 'metadata_presenter', path: '../fb-metadata-presenter'
 # gem 'metadata_presenter', '3.3.7'
 
 gem 'activerecord-session_store'

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ ruby '3.1.3'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'regex-validator'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'accessible-labels-for-editing'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.28'
+# gem 'metadata_presenter', '3.3.7'
 
 gem 'activerecord-session_store'
 gem 'administrate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.3.28)
+    metadata_presenter (3.3.30)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)
@@ -807,7 +807,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.3.28)
+  metadata_presenter (= 3.3.30)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/acceptance/features/edit_multiple_questions_page_spec.rb
+++ b/acceptance/features/edit_multiple_questions_page_spec.rb
@@ -187,6 +187,7 @@ feature 'Edit multiple questions page' do
   def then_I_add_a_content_component(content:)
     and_I_add_a_component
     and_I_add_a_content_area
+    editor.service_name.click
     expect(editor.first_component.find('[data-element="editable-content-output"]', visible: :all).text).to eq(optional_content)
     when_I_change_editable_content(editor.first_component, content: content)
   end

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -182,8 +182,9 @@ class EditorApp < SitePrism::Page
   elements :radio_options, :xpath, '//input[@type="radio"]', visible: false
   elements :checkboxes_options, :xpath, '//input[@type="checkbox"]', visible: false
 
-  elements :question_heading, 'h1'
-  elements :component_heading, 'h2'
+  element :page_heading, 'h1'
+  elements :question_heading, 'h1 span'
+  elements :component_heading, 'h2 span'
   elements :all_hints, '.govuk-hint'
   elements :editable_options, '.EditableComponentCollectionItem label'
   element :question_hint, '.govuk-hint'

--- a/acceptance/support/branching_steps.rb
+++ b/acceptance/support/branching_steps.rb
@@ -71,7 +71,7 @@ module BranchingSteps
   end
 
   def then_I_should_see_the_branching_page
-    expect(editor.question_heading.first.text).to eq(
+    expect(editor.page_heading.text).to eq(
       I18n.t('default_values.branching_title', branching_number: 1)
     )
   end

--- a/acceptance/support/multiple_questions_page_helper.rb
+++ b/acceptance/support/multiple_questions_page_helper.rb
@@ -12,6 +12,7 @@ module MultipleQuestionsPageHelper
   end
 
   def and_I_add_a_multiple_page_content_component
+    sleep 2
     editor.add_a_component_button.click
     and_I_add_a_content_area
   end

--- a/app/javascript/src/components/menus/question_menu.js
+++ b/app/javascript/src/components/menus/question_menu.js
@@ -35,7 +35,7 @@ class QuestionMenu extends ActivatedMenu {
 
     let $target = this.config.$target;
     if ($target.length) {
-      $target.before(this.activator.$node);
+      this.config.question.$node.prepend(this.activator.$node);
       $target.on("focus.questionmenu", () =>
         this.activator.$node.addClass("active"),
       );

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -574,7 +574,7 @@ function openConditionalContentDialog(component, activator, view) {
 function focusOnEditableComponent() {
   const target = location.hash;
   setTimeout(() => {
-    if (target && target.match(/^[#\w\d_]+$/)) {
+    if (target && target.match(/^[#\w\d_-]+$/)) {
       // Newly added component with fragment identifier so find first
       // first editable item of last component.
       let $newComponent = $(target);

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -686,6 +686,7 @@ function enhanceQuestions(view) {
           optionalFlag: view.text.question_optional_flag,
           aria: {
             question: view.text.aria.question,
+            components: view.text.components
           },
         },
       });
@@ -701,6 +702,7 @@ function enhanceQuestions(view) {
           optionalFlag: view.text.question_optional_flag,
           aria: {
             question: view.text.aria.question,
+            components: view.text.components
           },
         },
       });
@@ -713,6 +715,7 @@ function enhanceQuestions(view) {
         optionalFlag: view.text.question_optional_flag,
         aria: {
           question: view.text.aria.question,
+          components: view.text.components
         },
       },
     });
@@ -727,6 +730,7 @@ function enhanceQuestions(view) {
           optionalFlag: view.text.question_optional_flag,
           aria: {
             question: view.text.aria.question,
+            components: view.text.components
           },
         },
       });
@@ -741,6 +745,7 @@ function enhanceQuestions(view) {
           optionalFlag: view.text.question_optional_flag,
           aria: {
             question: view.text.aria.question,
+            components: view.text.components
           },
         },
       });
@@ -761,6 +766,7 @@ function enhanceQuestions(view) {
           optionalFlag: view.text.question_optional_flag,
           aria: {
             question: view.text.aria.question,
+            components: view.text.components
           },
         },
 
@@ -798,6 +804,7 @@ function enhanceQuestions(view) {
           optionalFlag: view.text.question_optional_flag,
           aria: {
             question: view.text.aria.question,
+            components: view.text.components
           },
         },
 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -725,6 +725,9 @@ function enhanceQuestions(view) {
         form: view.saveButton.$form,
         text: {
           optionalFlag: view.text.question_optional_flag,
+          aria: {
+            question: view.text.aria.question,
+          },
         },
       });
     });

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -898,6 +898,12 @@ function accessibilityQuestionViewEnhancements(view) {
     "optional_content_description",
   );
 
+  $('#new_answers .govuk-button[aria-disabled="true"]')
+    .attr("aria-describedby", "disabled_input_description")
+    .on("click", (e) => {
+      e.preventDefault();
+    });
+
   // $(".Question h1, .Question h2").attr("aria-label", view.text.aria.question);
   // $(".govuk-hint").attr("aria-label", view.text.aria.hint);
 }

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -586,7 +586,7 @@ function focusOnEditableComponent() {
         }
       }
     } else {
-      const pageTitle = $("h1.EditableElement").get(0);
+      const pageTitle = $("h1 .EditableElement").get(0);
       if (pageTitle) {
         pageTitle.focus();
       } else {
@@ -686,7 +686,7 @@ function enhanceQuestions(view) {
           optionalFlag: view.text.question_optional_flag,
           aria: {
             question: view.text.aria.question,
-            components: view.text.components
+            components: view.text.components,
           },
         },
       });
@@ -702,7 +702,7 @@ function enhanceQuestions(view) {
           optionalFlag: view.text.question_optional_flag,
           aria: {
             question: view.text.aria.question,
-            components: view.text.components
+            components: view.text.components,
           },
         },
       });
@@ -715,7 +715,7 @@ function enhanceQuestions(view) {
         optionalFlag: view.text.question_optional_flag,
         aria: {
           question: view.text.aria.question,
-          components: view.text.components
+          components: view.text.components,
         },
       },
     });
@@ -730,7 +730,7 @@ function enhanceQuestions(view) {
           optionalFlag: view.text.question_optional_flag,
           aria: {
             question: view.text.aria.question,
-            components: view.text.components
+            components: view.text.components,
           },
         },
       });
@@ -745,7 +745,7 @@ function enhanceQuestions(view) {
           optionalFlag: view.text.question_optional_flag,
           aria: {
             question: view.text.aria.question,
-            components: view.text.components
+            components: view.text.components,
           },
         },
       });
@@ -766,7 +766,7 @@ function enhanceQuestions(view) {
           optionalFlag: view.text.question_optional_flag,
           aria: {
             question: view.text.aria.question,
-            components: view.text.components
+            components: view.text.components,
           },
         },
 
@@ -804,7 +804,7 @@ function enhanceQuestions(view) {
           optionalFlag: view.text.question_optional_flag,
           aria: {
             question: view.text.aria.question,
-            components: view.text.components
+            components: view.text.components,
           },
         },
 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -925,9 +925,6 @@ function accessibilityQuestionViewEnhancements(view) {
     .on("click", (e) => {
       e.preventDefault();
     });
-
-  // $(".Question h1, .Question h2").attr("aria-label", view.text.aria.question);
-  // $(".govuk-hint").attr("aria-label", view.text.aria.hint);
 }
 
 /* Enhances the static content should it require special formatting

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -684,6 +684,9 @@ function enhanceQuestions(view) {
         text: {
           default_content: view.text.defaults.content,
           optionalFlag: view.text.question_optional_flag,
+          aria: {
+            question: view.text.aria.question,
+          },
         },
       });
     });
@@ -696,6 +699,9 @@ function enhanceQuestions(view) {
         text: {
           default_content: view.text.defaults.content,
           optionalFlag: view.text.question_optional_flag,
+          aria: {
+            question: view.text.aria.question,
+          },
         },
       });
     });
@@ -705,6 +711,9 @@ function enhanceQuestions(view) {
       form: view.saveButton.$form,
       text: {
         optionalFlag: view.text.question_optional_flag,
+        aria: {
+          question: view.text.aria.question,
+        },
       },
     });
   });
@@ -727,6 +736,9 @@ function enhanceQuestions(view) {
         form: view.saveButton.$form,
         text: {
           optionalFlag: view.text.question_optional_flag,
+          aria: {
+            question: view.text.aria.question,
+          },
         },
       });
     });
@@ -745,7 +757,7 @@ function enhanceQuestions(view) {
           optionHint: view.text.defaults.option_hint,
           optionalFlag: view.text.question_optional_flag,
           aria: {
-            answers: view.text.aria.answers,
+            question: view.text.aria.question,
           },
         },
 
@@ -782,7 +794,7 @@ function enhanceQuestions(view) {
           optionHint: view.text.defaults.option_hint,
           optionalFlag: view.text.question_optional_flag,
           aria: {
-            answers: view.text.aria.answers,
+            question: view.text.aria.question,
           },
         },
 

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -891,9 +891,15 @@ function editPageSingleQuestionViewCustomisations() {
  * safely assume full JS availability.
  **/
 function accessibilityQuestionViewEnhancements(view) {
-  $(".fb-section_heading").attr("aria-label", view.text.aria.section_header);
-  $(".Question h1, .Question h2").attr("aria-label", view.text.aria.question);
-  $(".govuk-hint").attr("aria-label", view.text.aria.hint);
+  $(".fb-section_heading").attr("aria-label", view.text.aria.section_heading);
+
+  $(".fb-section_heading").attr(
+    "aria-describedby",
+    "optional_content_description",
+  );
+
+  // $(".Question h1, .Question h2").attr("aria-label", view.text.aria.question);
+  // $(".govuk-hint").attr("aria-label", view.text.aria.hint);
 }
 
 /* Enhances the static content should it require special formatting

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -143,12 +143,6 @@ class EditableElement extends EditableBase {
 
   edit() {
     this.removePlaceholder();
-    if (
-      this.$node.text().trim() == this.config.defaultLabelValue ||
-      this.$node.text().trim() == this.config.defaultItemLabelValue
-    ) {
-      this.selectContent();
-    }
     this.$node.addClass(this._config.editClassname);
   }
 

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -103,11 +103,12 @@ class EditableElement extends EditableBase {
       singleLineInputRestrictions(e),
     );
 
+    // Adding textare role makes contenteditable element show in the screenreader form controls rotor
     $node.attr("contentEditable", true);
-    // $node.attr("role", "textbox"); // Accessibility helper.
+    $node.attr("role", "textbox");
     $node.addClass("EditableElement");
-    
-    if(this._content == this._defaultContent){
+
+    if (this._content == this._defaultContent) {
       $node.attr("aria-describedby", "optional_content_description");
     }
   }
@@ -159,10 +160,10 @@ class EditableElement extends EditableBase {
         ? this._originalContent
         : this._defaultContent;
 
-        this.$node.attr("aria-describedby", "optional_content_description");
+      this.$node.attr("aria-describedby", "optional_content_description");
     } else {
       this.content = currentContent;
-      this.$node.removeAttr('aria-describedby')
+      this.$node.removeAttr("aria-describedby");
     }
 
     this.$node.removeClass(this._config.editClassname);
@@ -175,6 +176,7 @@ class EditableElement extends EditableBase {
   }
 
   focus() {
+    console.log("editable element focus");
     this.$node.focus();
   }
 
@@ -506,6 +508,7 @@ class EditableComponentBase extends EditableBase {
 
   // Focus on first editable element.
   focus() {
+    console.log("editable_component focus");
     for (var i in this._elements) {
       if (this._elements.hasOwnProperty(i)) {
         this._elements[i].focus();

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -176,7 +176,6 @@ class EditableElement extends EditableBase {
   }
 
   focus() {
-    console.log("editable element focus");
     this.$node.focus();
   }
 
@@ -508,7 +507,6 @@ class EditableComponentBase extends EditableBase {
 
   // Focus on first editable element.
   focus() {
-    console.log("editable_component focus");
     for (var i in this._elements) {
       if (this._elements.hasOwnProperty(i)) {
         this._elements[i].focus();

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -99,7 +99,7 @@ class EditableElement extends EditableBase {
     );
 
     $node.attr("contentEditable", true);
-    $node.attr("role", "textbox"); // Accessibility helper.
+    // $node.attr("role", "textbox"); // Accessibility helper.
     $node.addClass("EditableElement");
 
     this._content = $node.text().trim();

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -921,7 +921,6 @@ class EditableCollectionFieldComponent extends EditableComponentBase {
  **/
 class EditableComponentCollectionItem extends EditableComponentBase {
   constructor(editableCollectionFieldComponent, $node, config, index) {
-    console.log("editable collection item class constructor");
     super(
       $node,
       mergeObjects(
@@ -934,7 +933,6 @@ class EditableComponentCollectionItem extends EditableComponentBase {
     );
 
     this.menu = createEditableCollectionItemMenu(this, config, index);
-    console.log("adding events to editable collection item");
     $node.on("focus.EditableComponentCollectionItem", "*", function () {
       $node.addClass(config.editClassname);
     });

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -91,6 +91,11 @@ class EditableElement extends EditableBase {
       : undefined;
     var required = defaultContent === undefined;
 
+    this._content = $node.text().trim();
+    this._originalContent = originalContent;
+    this._defaultContent = defaultContent;
+    this._required = required;
+
     $node.on("blur.editablecomponent", this.update.bind(this));
     $node.on("focus.editablecomponent", this.edit.bind(this));
     $node.on("paste.editablecomponent", (e) => pasteAsPlainText(e));
@@ -101,11 +106,10 @@ class EditableElement extends EditableBase {
     $node.attr("contentEditable", true);
     // $node.attr("role", "textbox"); // Accessibility helper.
     $node.addClass("EditableElement");
-
-    this._content = $node.text().trim();
-    this._originalContent = originalContent;
-    this._defaultContent = defaultContent;
-    this._required = required;
+    
+    if(this._content == this._defaultContent){
+      $node.attr("aria-describedby", "optional_content_description");
+    }
   }
 
   get content() {
@@ -154,8 +158,11 @@ class EditableElement extends EditableBase {
       this.content = this._required
         ? this._originalContent
         : this._defaultContent;
+
+        this.$node.attr("aria-describedby", "optional_content_description");
     } else {
       this.content = currentContent;
+      this.$node.removeAttr('aria-describedby')
     }
 
     this.$node.removeClass(this._config.editClassname);

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -20,13 +20,13 @@ const ATTRIBUTE_DEFAULT_TEXT = "fb-default-text";
 const SELECTOR_DISABLED =
   "input:not(:hidden), textarea:not([data-element]), select";
 const SELECTOR_LABEL_HEADING = "label h1, label h2, legend h1, legend h2";
-const SELECTOR_EDITABLE_LABEL = "label h1 span, label h2, legend h1 span, legend h2 span";
+const SELECTOR_EDITABLE_LABEL =
+  "label h1 span, label h2 span, legend h1 span, legend h2 span";
 
 class Question {
   constructor($node, config) {
     var $editableLabel = $(SELECTOR_EDITABLE_LABEL, $node);
     var $heading = $(SELECTOR_LABEL_HEADING, $node);
-    console.log($editableLabel);
     var conf = mergeObjects(
       {
         // Config defaults
@@ -139,8 +139,6 @@ class Question {
       }
     }
 
-    console.log(this.$editableLabel);
-
     // If we've changed the this.$editableLabel content, or the editor has, we
     // need to check whether required flag needs to show, or not.
     this.$editableLabel.data("instance").update();
@@ -162,8 +160,6 @@ class Question {
 
   addAccessibleLabels() {
     // Set an accessible label for the editable heading
-    console.log(this.config.text.aria.components);
-    console.log(this.config.type);
     this.$editableLabel.attr(
       "aria-label",
       this.labels.title.replace(

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -23,7 +23,6 @@ const SELECTOR_LABEL_HEADING = "label h1, label h2, legend h1, legend h2";
 
 class Question {
   constructor($node, config) {
-    console.log("question class constructor");
     var $heading = $(SELECTOR_LABEL_HEADING, $node);
     var conf = mergeObjects(
       {

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -172,11 +172,7 @@ class Question {
       );
 
     // Accessible label and description for the question hint text (where present)
-    this.$node
-      .find(".govuk-hint")
-      .first()
-      .attr("aria-label", this.labels.hint)
-      .attr("aria-describedby", "optional_content_description");
+    this.$node.find(".govuk-hint").first().attr("aria-label", this.labels.hint);
 
     // For the label wrapping the heading we provide an accessible group name
     // Remove the 'for' attribute, otherwise clicking will focus the questions

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -20,10 +20,13 @@ const ATTRIBUTE_DEFAULT_TEXT = "fb-default-text";
 const SELECTOR_DISABLED =
   "input:not(:hidden), textarea:not([data-element]), select";
 const SELECTOR_LABEL_HEADING = "label h1, label h2, legend h1, legend h2";
+const SELECTOR_EDITABLE_LABEL = "label h1 span, label h2, legend h1 span, legend h2 span";
 
 class Question {
   constructor($node, config) {
+    var $editableLabel = $(SELECTOR_EDITABLE_LABEL, $node);
     var $heading = $(SELECTOR_LABEL_HEADING, $node);
+    console.log($editableLabel);
     var conf = mergeObjects(
       {
         // Config defaults
@@ -47,18 +50,21 @@ class Question {
     this.config = conf;
     this.data = $node.data("fb-content-data");
     this.$node = $node;
+    this.$editableLabel = $editableLabel;
     this.$heading = $heading;
     this.editable = editableComponent($node, conf);
     this.menu = createQuestionMenu.call(this);
     this.labels = this.config.text.aria.question;
 
+    this.$heading.attr("aria-label", this.$editableLabel.text());
     // Check view state on element edit or interaction and set initial state.
-    this.$heading.on("focus", () => {
+    this.$editableLabel.on("focus", () => {
       this.$node.addClass("active");
     });
-    $heading.on("blur", () => {
+    $editableLabel.on("blur", () => {
       this.$node.removeClass("active");
       this.setRequiredFlag.bind(this);
+      this.$heading.attr("aria-label", this.$editableLabel.text());
     });
     this.setRequiredFlag();
     this.addAccessibleLabels();
@@ -126,16 +132,18 @@ class Question {
     var regex = new RegExp(escapedTextWithSpace + "$", "i");
 
     if (this.required) {
-      this.$heading.text(this.$heading.text().replace(regex, ""));
+      this.$editableLabel.text(this.$editableLabel.text().replace(regex, ""));
     } else {
-      if (!this.$heading.text().match(regex)) {
-        this.$heading.text(`${this.$heading.text()} ${text}`);
+      if (!this.$editableLabel.text().match(regex)) {
+        this.$editableLabel.text(`${this.$editableLabel.text()} ${text}`);
       }
     }
 
-    // If we've changed the this.$heading content, or the editor has, we
+    console.log(this.$editableLabel);
+
+    // If we've changed the this.$editableLabel content, or the editor has, we
     // need to check whether required flag needs to show, or not.
-    this.$heading.data("instance").update();
+    this.$editableLabel.data("instance").update();
   }
 
   focus() {
@@ -156,7 +164,7 @@ class Question {
     // Set an accessible label for the editable heading
     console.log(this.config.text.aria.components);
     console.log(this.config.type);
-    this.$heading.attr(
+    this.$editableLabel.attr(
       "aria-label",
       this.labels.title.replace(
         "{{type}}",
@@ -228,7 +236,7 @@ function createQuestionMenu() {
 
   return new QuestionMenu($ul, {
     activator_text: template.data("activator-text"),
-    $target: question.$heading,
+    $target: question.$editableLabel,
     question: question,
     menu: {
       position: {

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -50,6 +50,7 @@ class Question {
     this.$heading = $heading;
     this.editable = editableComponent($node, conf);
     this.menu = createQuestionMenu.call(this);
+    this.labels = this.config.view.text.aria.question;
 
     // Check view state on element edit or interaction and set initial state.
     this.$heading.on("focus", () => {
@@ -152,9 +153,11 @@ class Question {
   }
 
   addAccessibleLabels() {
-    console.log("question superclass accessible labels");
     // Set an accessible label for the editable heading
-    this.$heading.attr("aria-label", this.config.type + " question title");
+    this.$heading.attr(
+      "aria-label",
+      this.labels.title.replace("{{type}}", this.config.type),
+    );
 
     // Remove the description from the fieldset element as it is confusing when editing
     this.$node.find("fieldset").removeAttr("aria-describedby");
@@ -163,24 +166,23 @@ class Question {
     // the group label, as it gets confusing
     this.$node
       .find("fieldset > legend")
-      .attr("aria-label", `Edit ${this.config.type} question`);
+      .attr(
+        "aria-label",
+        this.labels.legend.replace("{{type}}", this.config.type),
+      );
 
     // Accessible label and description for the question hint text (where present)
     this.$node
       .find(".govuk-hint")
       .first()
-      .attr("aria-label", "Optional hint text for question")
+      .attr("aria-label", this.labels.hint)
       .attr("aria-describedby", "optional_content_description");
 
     // For the label wrapping the heading we provide an accessible group name
     // Remove the 'for' attribute, otherwise clicking will focus the questions
     // form field
     if (!this.$node.find("fieldset").length > 0) {
-      this.$node
-        .find("label.govuk-label")
-        .first()
-        // .attr("aria-label", "Question")
-        .attr("for", "");
+      this.$node.find("label.govuk-label").first().attr("for", "");
     }
 
     // Accessibly prevent input in editor mode
@@ -195,7 +197,7 @@ class Question {
       .find(SELECTOR_DISABLED)
       .attr("aria-disabled", true)
       .attr("readonly", "")
-      .attr("aria-label", "Answer field")
+      .attr("aria-label", this.labels.answer)
       .attr("aria-describedby", "disabled_input_description")
       .css("pointer-events", "none")
       .on("click", (e) => {

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -60,6 +60,18 @@ class Question {
       this.setRequiredFlag.bind(this);
     });
     this.setRequiredFlag();
+
+    this.$heading.attr("aria-label", conf.type + " question title");
+    this.$node
+      .find(".govuk-hint")
+      .first()
+      .attr("aria-label", "Optional hint text for question");
+    this.$node
+      .find(".govuk-hint")
+      .first()
+      .attr("aria-describedby", "optional_content_description");
+
+    this.$node.find("label.govuk-label").attr("aria-label", "Question");
   }
 
   get required() {

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -154,9 +154,14 @@ class Question {
 
   addAccessibleLabels() {
     // Set an accessible label for the editable heading
+    console.log(this.config.text.aria.components);
+    console.log(this.config.type);
     this.$heading.attr(
       "aria-label",
-      this.labels.title.replace("{{type}}", this.config.type),
+      this.labels.title.replace(
+        "{{type}}",
+        this.config.text.aria.components.types[this.config.type],
+      ),
     );
 
     // Remove the description from the fieldset element as it is confusing when editing

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -50,7 +50,7 @@ class Question {
     this.$heading = $heading;
     this.editable = editableComponent($node, conf);
     this.menu = createQuestionMenu.call(this);
-    this.labels = this.config.view.text.aria.question;
+    this.labels = this.config.text.aria.question;
 
     // Check view state on element edit or interaction and set initial state.
     this.$heading.on("focus", () => {

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -44,7 +44,7 @@ class Question {
     );
 
     $node.addClass("Question");
-    this._config = conf;
+    this.config = conf;
     this.data = $node.data("fb-content-data");
     this.$node = $node;
     this.$heading = $heading;
@@ -60,62 +60,7 @@ class Question {
       this.setRequiredFlag.bind(this);
     });
     this.setRequiredFlag();
-
-    // Set an accessible label for the editable heading
-    this.$heading.attr("aria-label", conf.type + " question title");
-
-    // Remove the description from the fieldset element as it is confusing when editing
-    this.$node.find("fieldset").removeAttr("aria-describedby");
-
-    // We add this so that in the editor the text in the legend is not used as
-    // the group label, as it gets confusing
-    this.$node
-      .find("fieldset > legend")
-      .attr("aria-label", `Edit ${conf.type} question`);
-
-    // Accessible label and description for the question hint text (where present)
-    this.$node
-      .find(".govuk-hint")
-      .first()
-      .attr("aria-label", "Optional hint text for question")
-      .attr("aria-describedby", "optional_content_description");
-
-    // For the label wrapping the heading we provide an accessible group name
-    // Remove the 'for' attribute, otherwise clicking will focus the questions
-    // form field
-    if (!this.$node.find("fieldset").length > 0) {
-      this.$node
-        .find("label.govuk-label")
-        .first()
-        // .attr("aria-label", "Question")
-        .attr("for", "");
-    }
-
-    // Accessibly prevent input in editor mode
-    // 1. aria-disabled : communicate disabled state to AT
-    // 2. readonly : prevent text input
-    // 3. aria-label : provide an screen-reader label for the field
-    // 4. aria-describedby : explain why field is disabled
-    // 5. pointer-events : mouse interaction (required for <select>)
-    // 6. prevent click events
-    // 7. prevent space or enter triggering field (required for <select>)
-    $node
-      .find(SELECTOR_DISABLED)
-      .attr("aria-disabled", true)
-      .attr("readonly", "")
-      .attr("aria-label", "Answer field")
-      .attr("aria-describedby", "disabled_input_description")
-      .css("pointer-events", "none")
-      .on("click", (e) => {
-        e.preventDefault();
-        return false;
-      })
-      .on("keydown", (e) => {
-        if (e.key == " " || e.key == "Enter") {
-          e.preventDefault();
-          return false;
-        }
-      });
+    this.addAccessibleLabels();
   }
 
   get required() {
@@ -172,7 +117,7 @@ class Question {
    * This function is to handle the adding the extra element.
    **/
   setRequiredFlag() {
-    var text = this._config.text.optionalFlag;
+    var text = this.config.text.optionalFlag;
     // Escape the parentheses
     var escapedTextWithSpace = " " + text.replace(/(\(|\))/gim, "\\$1");
     // $ - must be at the end of the string
@@ -204,6 +149,65 @@ class Question {
   save() {
     // TODO: Replace with proper mechanism to remove this workaround
     this.editable.save();
+  }
+
+  addAccessibleLabels() {
+    console.log("question superclass accessible labels");
+    // Set an accessible label for the editable heading
+    this.$heading.attr("aria-label", this.config.type + " question title");
+
+    // Remove the description from the fieldset element as it is confusing when editing
+    this.$node.find("fieldset").removeAttr("aria-describedby");
+
+    // We add this so that in the editor the text in the legend is not used as
+    // the group label, as it gets confusing
+    this.$node
+      .find("fieldset > legend")
+      .attr("aria-label", `Edit ${this.config.type} question`);
+
+    // Accessible label and description for the question hint text (where present)
+    this.$node
+      .find(".govuk-hint")
+      .first()
+      .attr("aria-label", "Optional hint text for question")
+      .attr("aria-describedby", "optional_content_description");
+
+    // For the label wrapping the heading we provide an accessible group name
+    // Remove the 'for' attribute, otherwise clicking will focus the questions
+    // form field
+    if (!this.$node.find("fieldset").length > 0) {
+      this.$node
+        .find("label.govuk-label")
+        .first()
+        // .attr("aria-label", "Question")
+        .attr("for", "");
+    }
+
+    // Accessibly prevent input in editor mode
+    // 1. aria-disabled : communicate disabled state to AT
+    // 2. readonly : prevent text input
+    // 3. aria-label : provide an screen-reader label for the field
+    // 4. aria-describedby : explain why field is disabled
+    // 5. pointer-events : mouse interaction (required for <select>)
+    // 6. prevent click events
+    // 7. prevent space or enter triggering field (required for <select>)
+    this.$node
+      .find(SELECTOR_DISABLED)
+      .attr("aria-disabled", true)
+      .attr("readonly", "")
+      .attr("aria-label", "Answer field")
+      .attr("aria-describedby", "disabled_input_description")
+      .css("pointer-events", "none")
+      .on("click", (e) => {
+        e.preventDefault();
+        return false;
+      })
+      .on("keydown", (e) => {
+        if (e.key == " " || e.key == "Enter") {
+          e.preventDefault();
+          return false;
+        }
+      });
   }
 }
 

--- a/app/javascript/src/question_address.js
+++ b/app/javascript/src/question_address.js
@@ -12,25 +12,39 @@
  *
  **/
 
-
-const utilities = require('./utilities');
+const utilities = require("./utilities");
 const mergeObjects = utilities.mergeObjects;
-const Question = require('./question');
+const Question = require("./question");
 
 const SELECTOR_HINT = ".govuk-hint";
-const SELECTOR_LABEL = "legend > :first-child";
+const SELECTOR_LABEL = "legend > h1 span, legend > h2 span";
+const SELECTOR_DISABLED = "input:not(:hidden)";
 
 class AddressQuestion extends Question {
   constructor($node, config) {
-    super($node, mergeObjects({
-      // Add stuff here if you want to set defaults
-      selectorLabel: SELECTOR_LABEL,
-      selectorHint: SELECTOR_HINT
-    }, config));
+    super(
+      $node,
+      mergeObjects(
+        {
+          // Add stuff here if you want to set defaults
+          selectorLabel: SELECTOR_LABEL,
+          selectorHint: SELECTOR_HINT,
+        },
+        config,
+      ),
+    );
 
     $node.addClass("AddressQuestion");
   }
-}
 
+  addAccessibleLabels() {
+    super.addAccessibleLabels();
+    // Provide more informative accessible labels
+    this.$node.find(SELECTOR_DISABLED).each(function () {
+      const label = $(this).prev("label").text();
+      $(this).attr("aria-label", `${label} answer field`);
+    });
+  }
+}
 
 module.exports = AddressQuestion;

--- a/app/javascript/src/question_autocomplete.js
+++ b/app/javascript/src/question_autocomplete.js
@@ -13,26 +13,30 @@
  *
  **/
 
-
-const utilities = require('./utilities');
+const utilities = require("./utilities");
 const mergeObjects = utilities.mergeObjects;
-const Question = require('./question');
+const Question = require("./question");
 
 const SELECTOR_HINT = ".govuk-hint";
-const SELECTOR_LABEL = "label h1, label h2, legend h1, legend h2";
+const SELECTOR_LABEL = "label h1 span, label h2 span";
 
 class AutocompleteQuestion extends Question {
   constructor($node, config) {
-    super($node, mergeObjects({
-      // Add stuff here if you want to set defaults
-      default_content: "empty",
-      selectorLabel: SELECTOR_LABEL,
-      selectorHint: SELECTOR_HINT
-    }, config));
+    super(
+      $node,
+      mergeObjects(
+        {
+          // Add stuff here if you want to set defaults
+          default_content: "empty",
+          selectorLabel: SELECTOR_LABEL,
+          selectorHint: SELECTOR_HINT,
+        },
+        config,
+      ),
+    );
 
     $node.addClass("AutocompleteQuestion");
   }
 }
-
 
 module.exports = AutocompleteQuestion;

--- a/app/javascript/src/question_checkboxes.js
+++ b/app/javascript/src/question_checkboxes.js
@@ -127,7 +127,9 @@ class CheckboxesQuestion extends Question {
       .attr("aria-describedby", "optional_content_description");
 
     // Add index to item three-dot button
-    $node.find("button").attr('aria-label', `${this.labels.items.menu_button} ${index}`);
+    $node
+      .find("button")
+      .attr("aria-label", `${this.labels.items.menu_button} ${index}`);
   }
 }
 

--- a/app/javascript/src/question_checkboxes.js
+++ b/app/javascript/src/question_checkboxes.js
@@ -24,79 +24,84 @@ const SELECTOR_ITEM_LABEL = "label";
 
 class CheckboxesQuestion extends Question {
   constructor($node, config) {
-    super(
-      $node,
-      mergeObjects(
-        {
-          // Add stuff here if you want to set defaults
-          selectorLabel: SELECTOR_LABEL,
-          selectorHint: SELECTOR_HINT,
-          selectorCollectionItem: SELECTOR_ITEM,
-          selectorComponentCollectionItemLabel: SELECTOR_ITEM_LABEL,
-          selectorComponentCollectionItemHint: SELECTOR_ITEM_HINT,
+    let conf = mergeObjects(
+      {
+        // Add stuff here if you want to set defaults
+        selectorLabel: SELECTOR_LABEL,
+        selectorHint: SELECTOR_HINT,
+        selectorCollectionItem: SELECTOR_ITEM,
+        selectorComponentCollectionItemLabel: SELECTOR_ITEM_LABEL,
+        selectorComponentCollectionItemHint: SELECTOR_ITEM_HINT,
 
-          filters: {
-            _id: function (index) {
-              return this.replace(/^(.*)?[\d]+$/, "$1" + index);
-            },
-            value: function (index) {
-              return this.replace(/^(.*)?[\d]+$/, "$1" + index);
-            },
+        filters: {
+          _id: function (index) {
+            return this.replace(/^(.*)?[\d]+$/, "$1" + index);
           },
-
-          onCollectionItemClone: function ($node) {
-            // @node is the collection item (e.g. <div> wrapping <input type=radio> and <label> elements)
-            // Runs after the collection item has been cloned, so further custom manipulation can be
-            // carried out on the element.
-            $node.find("label").text(config.text.option);
-            $node.find("span").text(config.text.optionHint);
-          },
-          onItemRemove: function (item) {
-            // @item (EditableComponentItem) Item to be deleted.
-            // Runs before removing an editable Collection item.
-            // Provides an opportunity for clean up.
-            var activatedMenu = item.$node.data("ActivatedMenu");
-            if (activatedMenu) {
-              activatedMenu.activator.$node.remove();
-              activatedMenu.$node.remove();
-              activatedMenu.container.$node.remove();
-            }
-          },
-          onItemRemoveConfirmation: function (item) {
-            // @item (EditableComponentItem) Item to be deleted.
-            // Runs before onItemRemove when removing an editable Collection item.
+          value: function (index) {
+            return this.replace(/^(.*)?[\d]+$/, "$1" + index);
           },
         },
-        config,
-      ),
+
+        onCollectionItemClone: function ($node) {
+          // @node is the collection item (e.g. <div> wrapping <input type=radio> and <label> elements)
+          // Runs after the collection item has been cloned, so further custom manipulation can be
+          // carried out on the element.
+          $node.find("label").text(config.text.option);
+          $node.find("span").text(config.text.optionHint);
+        },
+        onItemRemove: function (item) {
+          // @item (EditableComponentItem) Item to be deleted.
+          // Runs before removing an editable Collection item.
+          // Provides an opportunity for clean up.
+          var activatedMenu = item.$node.data("ActivatedMenu");
+          if (activatedMenu) {
+            activatedMenu.activator.$node.remove();
+            activatedMenu.$node.remove();
+            activatedMenu.container.$node.remove();
+          }
+        },
+        onItemRemoveConfirmation: function (item) {
+          // @item (EditableComponentItem) Item to be deleted.
+          // Runs before onItemRemove when removing an editable Collection item.
+        },
+      },
+      config,
     );
+    super($node, conf);
 
+    this.config = conf;
+    this._preservedItemCount = 1;
     $node.addClass("CheckboxesQuestion");
+    this.addAccessibleLabels();
+  }
 
-    $node.find("fieldset > legend").attr("aria-label", "Question");
+  addAccessibleLabels() {
+    // We add this so that in the editor the text in the legend is not used as
+    // the group label, as it gets confusing
+    this.$node.find("fieldset > legend").attr("aria-label", "Question");
 
-    $node
+    // Similarly we add a group label for the answers section
+    this.$node
       .find(".EditableComponentCollectionItem")
       .first()
       .parent()
-      .attr("aria-label", config.text.aria.answers);
+      .attr("aria-label", this.config.text.aria.answers);
 
-    this._preservedItemCount = 1;
-
-    $node.find(".govuk-checkboxes__label").each(function (index) {
+    // Add labels for each of the contentEditable checkbox <label> elements
+    this.$node.find(".govuk-checkboxes__label").each(function (index) {
       $(this).attr("aria-label", `Label for checkbox option ${index + 1}`);
     });
 
-    $node.find(".govuk-checkboxes__hint").each(function (index) {
+    // Add labels for the hint text elements for each option
+    // Add the describedyby for optional content too
+    this.$node.find(".govuk-checkboxes__hint").each(function (index) {
       $(this).attr(
         "aria-label",
         `Optional hint text for checkbox option ${index + 1}`,
       );
-    });
 
-    $node
-      .find(".govuk-checkboxes__hint")
-      .attr("aria-describedby", "optional_content_description");
+      $(this).attr("aria-describedby", "optional_content_description");
+    });
   }
 }
 

--- a/app/javascript/src/question_checkboxes.js
+++ b/app/javascript/src/question_checkboxes.js
@@ -12,10 +12,9 @@
  *
  **/
 
-
-const utilities = require('./utilities');
+const utilities = require("./utilities");
 const mergeObjects = utilities.mergeObjects;
-const Question = require('./question');
+const Question = require("./question");
 
 const SELECTOR_HINT = "fieldset > .govuk-hint";
 const SELECTOR_LABEL = "legend > :first-child";
@@ -23,57 +22,81 @@ const SELECTOR_ITEM = ".govuk-checkboxes__item";
 const SELECTOR_ITEM_HINT = ".govuk-hint";
 const SELECTOR_ITEM_LABEL = "label";
 
-
 class CheckboxesQuestion extends Question {
   constructor($node, config) {
-    super($node, mergeObjects({
-      // Add stuff here if you want to set defaults
-      selectorLabel: SELECTOR_LABEL,
-      selectorHint: SELECTOR_HINT,
-      selectorCollectionItem: SELECTOR_ITEM,
-      selectorComponentCollectionItemLabel: SELECTOR_ITEM_LABEL,
-      selectorComponentCollectionItemHint: SELECTOR_ITEM_HINT,
+    super(
+      $node,
+      mergeObjects(
+        {
+          // Add stuff here if you want to set defaults
+          selectorLabel: SELECTOR_LABEL,
+          selectorHint: SELECTOR_HINT,
+          selectorCollectionItem: SELECTOR_ITEM,
+          selectorComponentCollectionItemLabel: SELECTOR_ITEM_LABEL,
+          selectorComponentCollectionItemHint: SELECTOR_ITEM_HINT,
 
-      filters: {
-        _id: function(index) {
-          return this.replace(/^(.*)?[\d]+$/, "$1" + index);
+          filters: {
+            _id: function (index) {
+              return this.replace(/^(.*)?[\d]+$/, "$1" + index);
+            },
+            value: function (index) {
+              return this.replace(/^(.*)?[\d]+$/, "$1" + index);
+            },
+          },
+
+          onCollectionItemClone: function ($node) {
+            // @node is the collection item (e.g. <div> wrapping <input type=radio> and <label> elements)
+            // Runs after the collection item has been cloned, so further custom manipulation can be
+            // carried out on the element.
+            $node.find("label").text(config.text.option);
+            $node.find("span").text(config.text.optionHint);
+          },
+          onItemRemove: function (item) {
+            // @item (EditableComponentItem) Item to be deleted.
+            // Runs before removing an editable Collection item.
+            // Provides an opportunity for clean up.
+            var activatedMenu = item.$node.data("ActivatedMenu");
+            if (activatedMenu) {
+              activatedMenu.activator.$node.remove();
+              activatedMenu.$node.remove();
+              activatedMenu.container.$node.remove();
+            }
+          },
+          onItemRemoveConfirmation: function (item) {
+            // @item (EditableComponentItem) Item to be deleted.
+            // Runs before onItemRemove when removing an editable Collection item.
+          },
         },
-        value: function(index) {
-          return this.replace(/^(.*)?[\d]+$/, "$1" + index);
-        }
-      },
-
-      onCollectionItemClone: function($node) {
-         // @node is the collection item (e.g. <div> wrapping <input type=radio> and <label> elements)
-         // Runs after the collection item has been cloned, so further custom manipulation can be
-         // carried out on the element.
-         $node.find("label").text(config.text.option);
-         $node.find("span").text(config.text.optionHint);
-      },
-      onItemRemove: function(item) {
-        // @item (EditableComponentItem) Item to be deleted.
-        // Runs before removing an editable Collection item.
-        // Provides an opportunity for clean up.
-        var activatedMenu = item.$node.data("ActivatedMenu");
-        if(activatedMenu) {
-          activatedMenu.activator.$node.remove();
-          activatedMenu.$node.remove();
-          activatedMenu.container.$node.remove();
-        }
-      },
-      onItemRemoveConfirmation: function(item) {
-        // @item (EditableComponentItem) Item to be deleted.
-        // Runs before onItemRemove when removing an editable Collection item.
-      }
-    }, config));
+        config,
+      ),
+    );
 
     $node.addClass("CheckboxesQuestion");
 
-    // If any Collection items are present with ability to be removed, we need
-    // to find them and scoop up the Remove buttons to put in menu component.
-    $node.find(".EditableComponentCollectionItem").first().parent().attr("aria-label", config.text.aria.answers);
+    $node.find("fieldset > legend").attr("aria-label", "Question");
+
+    $node
+      .find(".EditableComponentCollectionItem")
+      .first()
+      .parent()
+      .attr("aria-label", config.text.aria.answers);
 
     this._preservedItemCount = 1;
+
+    $node.find(".govuk-checkboxes__label").each(function (index) {
+      $(this).attr("aria-label", `Label for checkbox option ${index + 1}`);
+    });
+
+    $node.find(".govuk-checkboxes__hint").each(function (index) {
+      $(this).attr(
+        "aria-label",
+        `Optional hint text for checkbox option ${index + 1}`,
+      );
+    });
+
+    $node
+      .find(".govuk-checkboxes__hint")
+      .attr("aria-describedby", "optional_content_description");
   }
 }
 

--- a/app/javascript/src/question_checkboxes.js
+++ b/app/javascript/src/question_checkboxes.js
@@ -127,7 +127,7 @@ class CheckboxesQuestion extends Question {
       .attr("aria-describedby", "optional_content_description");
 
     // Add index to item three-dot button
-    $node.find("button").text(`${this.labels.items.menu_button} ${index}`);
+    $node.find("button").attr('aria-label', `${this.labels.items.menu_button} ${index}`);
   }
 }
 

--- a/app/javascript/src/question_checkboxes.js
+++ b/app/javascript/src/question_checkboxes.js
@@ -17,7 +17,7 @@ const mergeObjects = utilities.mergeObjects;
 const Question = require("./question");
 
 const SELECTOR_HINT = "fieldset > .govuk-hint";
-const SELECTOR_LABEL = "legend > :first-child";
+const SELECTOR_LABEL = "legend > h1 span, legend > h2 span";
 const SELECTOR_ITEM = ".govuk-checkboxes__item";
 const SELECTOR_ITEM_HINT = ".govuk-checkboxes__hint";
 const SELECTOR_ITEM_LABEL = ".govuk-checkboxes__label";

--- a/app/javascript/src/question_checkboxes.js
+++ b/app/javascript/src/question_checkboxes.js
@@ -111,10 +111,11 @@ class CheckboxesQuestion extends Question {
     this.config = conf;
     this._preservedItemCount = 1;
     $node.addClass("CheckboxesQuestion");
-    this.addAccessibleLabels();
   }
 
   addAccessibleLabels() {
+    super.addAccessibleLabels();
+    console.log("checkboxes accessible labels");
     // Similarly we add a group label for the answers section
     this.$node
       .find(".EditableComponentCollectionItem")

--- a/app/javascript/src/question_checkboxes.js
+++ b/app/javascript/src/question_checkboxes.js
@@ -63,7 +63,6 @@ class CheckboxesQuestion extends Question {
         },
         afterItemRemove: function (items) {
           items.forEach(function (item, index) {
-            console.log(item.$node.find("button"));
             item.$node
               .find(".govuk-checkboxes__label")
               .attr("aria-label", `Label for option ${index + 1}`);
@@ -83,7 +82,6 @@ class CheckboxesQuestion extends Question {
           });
         },
         onItemAdd: function ($node) {
-          console.log($node.data("instance").component.items.length);
           const index = $node.data("instance").component.items.length;
           $node
             .find(".govuk-checkboxes__label")

--- a/app/javascript/src/question_date.js
+++ b/app/javascript/src/question_date.js
@@ -17,7 +17,7 @@ const mergeObjects = utilities.mergeObjects;
 const Question = require("./question");
 
 const SELECTOR_HINT = ".govuk-hint";
-const SELECTOR_LABEL = "legend > :first-child";
+const SELECTOR_LABEL = "legend > h1 span, legend > h2 span";
 const SELECTOR_DISABLED = "input:not(:hidden)";
 
 class DateQuestion extends Question {

--- a/app/javascript/src/question_date.js
+++ b/app/javascript/src/question_date.js
@@ -12,25 +12,39 @@
  *
  **/
 
-
-const utilities = require('./utilities');
+const utilities = require("./utilities");
 const mergeObjects = utilities.mergeObjects;
-const Question = require('./question');
+const Question = require("./question");
 
 const SELECTOR_HINT = ".govuk-hint";
 const SELECTOR_LABEL = "legend > :first-child";
+const SELECTOR_DISABLED = "input:not(:hidden)";
 
 class DateQuestion extends Question {
   constructor($node, config) {
-    super($node, mergeObjects({
-      // Add stuff here if you want to set defaults
-      selectorLabel: SELECTOR_LABEL,
-      selectorHint: SELECTOR_HINT
-    }, config));
+    super(
+      $node,
+      mergeObjects(
+        {
+          // Add stuff here if you want to set defaults
+          selectorLabel: SELECTOR_LABEL,
+          selectorHint: SELECTOR_HINT,
+        },
+        config,
+      ),
+    );
 
     $node.addClass("DateQuestion");
+    this.addAccessibleLabels();
+  }
+
+  addAccessibleLabels() {
+    // Provide more informative accessible labels
+    this.$node.find(SELECTOR_DISABLED).each(function () {
+      const label = $(this).prev("label").text();
+      $(this).attr("aria-label", `${label} answer field`);
+    });
   }
 }
-
 
 module.exports = DateQuestion;

--- a/app/javascript/src/question_date.js
+++ b/app/javascript/src/question_date.js
@@ -39,6 +39,7 @@ class DateQuestion extends Question {
   }
 
   addAccessibleLabels() {
+    super.addAccessibleLabels();
     // Provide more informative accessible labels
     this.$node.find(SELECTOR_DISABLED).each(function () {
       const label = $(this).prev("label").text();

--- a/app/javascript/src/question_radios.js
+++ b/app/javascript/src/question_radios.js
@@ -24,13 +24,11 @@ const SELECTOR_DISABLED = "input:not(:hidden)";
 
 class RadiosQuestion extends Question {
   constructor($node, config) {
-    console.log("radio question class constructor");
     // // When the labels are <label> elements they won't have an aria-label
     // // announced by Voiceover
     // $node.find(".govuk-radios__label").each(function () {
     //   changeTag(this, "div");
     // });
-    console.log("labels turned into spans");
     let conf = mergeObjects(
       {
         // Add stuff here if you want to set defaults
@@ -69,7 +67,6 @@ class RadiosQuestion extends Question {
         },
         afterItemRemove: function (items) {
           items.forEach(function (item, index) {
-            console.log(item.$node.find("button"));
             item.$node
               .find(".govuk-radios__label")
               .attr("aria-label", `Label for option ${index + 1}`);
@@ -89,7 +86,6 @@ class RadiosQuestion extends Question {
           });
         },
         onItemAdd: function ($node) {
-          console.log($node.data("instance").component.items.length);
           const index = $node.data("instance").component.items.length;
           $node
             .find(".govuk-radios__label")

--- a/app/javascript/src/question_radios.js
+++ b/app/javascript/src/question_radios.js
@@ -16,7 +16,7 @@ const { mergeObjects, changeTag } = require("./utilities");
 const Question = require("./question");
 
 const SELECTOR_HINT = "fieldset > .govuk-hint";
-const SELECTOR_LABEL = "legend > :first-child";
+const SELECTOR_LABEL = "legend > h1 span, legend > h2 span";
 const SELECTOR_ITEM = ".govuk-radios__item";
 const SELECTOR_ITEM_HINT = ".govuk-radios__hint";
 const SELECTOR_ITEM_LABEL = ".govuk-radios__label";
@@ -128,7 +128,9 @@ class RadiosQuestion extends Question {
       .attr("aria-describedby", "optional_content_description");
 
     // Add index to item three-dot button
-    $node.find("button").attr('aria-label', `${this.labels.items.menu_button} ${index}`);
+    $node
+      .find("button")
+      .attr("aria-label", `${this.labels.items.menu_button} ${index}`);
   }
 }
 

--- a/app/javascript/src/question_radios.js
+++ b/app/javascript/src/question_radios.js
@@ -120,6 +120,7 @@ class RadiosQuestion extends Question {
   }
 
   addAccessibleLabels() {
+    super.addAccessibleLabels();
     // Similarly we add a group label for the answers section
     this.$node
       .find(".EditableComponentCollectionItem")

--- a/app/javascript/src/question_radios.js
+++ b/app/javascript/src/question_radios.js
@@ -128,7 +128,7 @@ class RadiosQuestion extends Question {
       .attr("aria-describedby", "optional_content_description");
 
     // Add index to item three-dot button
-    $node.find("button").text(`${this.labels.items.menu_button} ${index}`);
+    $node.find("button").attr('aria-label', `${this.labels.items.menu_button} ${index}`);
   }
 }
 

--- a/app/javascript/src/question_radios.js
+++ b/app/javascript/src/question_radios.js
@@ -12,10 +12,9 @@
  *
  **/
 
-
-const utilities = require('./utilities');
+const utilities = require("./utilities");
 const mergeObjects = utilities.mergeObjects;
-const Question = require('./question');
+const Question = require("./question");
 
 const SELECTOR_HINT = "fieldset > .govuk-hint";
 const SELECTOR_LABEL = "legend > :first-child";
@@ -23,58 +22,86 @@ const SELECTOR_ITEM = ".govuk-radios__item";
 const SELECTOR_ITEM_HINT = ".govuk-hint";
 const SELECTOR_ITEM_LABEL = "label";
 
-
 class RadiosQuestion extends Question {
   constructor($node, config) {
-    super($node, mergeObjects({
-      // Add stuff here if you want to set defaults
-      selectorLabel: SELECTOR_LABEL,
-      selectorHint: SELECTOR_HINT,
-      selectorCollectionItem: SELECTOR_ITEM,
-      selectorComponentCollectionItemLabel: SELECTOR_ITEM_LABEL,
-      selectorComponentCollectionItemHint: SELECTOR_ITEM_HINT,
+    let conf = mergeObjects(
+      {
+        // Add stuff here if you want to set defaults
+        selectorLabel: SELECTOR_LABEL,
+        selectorHint: SELECTOR_HINT,
+        selectorCollectionItem: SELECTOR_ITEM,
+        selectorComponentCollectionItemLabel: SELECTOR_ITEM_LABEL,
+        selectorComponentCollectionItemHint: SELECTOR_ITEM_HINT,
 
-      filters: {
-        _id: function(index) {
-          return this.replace(/^(.*)?[\d]+$/, "$1" + index);
+        filters: {
+          _id: function (index) {
+            return this.replace(/^(.*)?[\d]+$/, "$1" + index);
+          },
+          value: function (index) {
+            return this.replace(/^(.*)?[\d]+$/, "$1" + index);
+          },
         },
-        value: function(index) {
-          return this.replace(/^(.*)?[\d]+$/, "$1" + index);
-        }
+
+        onCollectionItemClone: function ($node) {
+          // @node is the collection item (e.g. <div> wrapping <input type=radio> and <label> elements)
+          // Runs after the collection item has been cloned, so further custom manipulation can be
+          // carried out on the element.
+          $node.find("label").text(config.text.option);
+          $node.find("span").text(config.text.optionHint);
+        },
+        onItemRemove: function (item) {
+          // @item (EditableComponentItem) Item to be deleted.
+          // Runs before removing an editable Collection item.
+          // Provides an opportunity for clean up.
+          var activatedMenu = item.$node.data("ActivatedMenu");
+          if (activatedMenu) {
+            activatedMenu.activator.$node.remove();
+            activatedMenu.$node.remove();
+            activatedMenu.container.$node.remove();
+          }
+        },
+        onItemRemoveConfirmation: function (item) {
+          // @item (EditableComponentItem) Item to be deleted.
+          // Runs before onItemRemove when removing an editable Collection item.
+        },
       },
+      config,
+    );
+    super($node, conf);
 
-      onCollectionItemClone: function($node) {
-         // @node is the collection item (e.g. <div> wrapping <input type=radio> and <label> elements)
-         // Runs after the collection item has been cloned, so further custom manipulation can be
-         // carried out on the element.
-         $node.find("label").text(config.text.option);
-         $node.find("span").text(config.text.optionHint);
-      },
-      onItemRemove: function(item) {
-        // @item (EditableComponentItem) Item to be deleted.
-        // Runs before removing an editable Collection item.
-        // Provides an opportunity for clean up.
-        var activatedMenu = item.$node.data("ActivatedMenu");
-        if(activatedMenu) {
-          activatedMenu.activator.$node.remove();
-          activatedMenu.$node.remove();
-          activatedMenu.container.$node.remove();
-        }
-      },
-      onItemRemoveConfirmation: function(item) {
-        // @item (EditableComponentItem) Item to be deleted.
-        // Runs before onItemRemove when removing an editable Collection item.
-      }
-    }, config));
-
-    $node.addClass("RadiosQuestion");
-
-    // If any Collection items are present with ability to be removed, we need
-    // to find them and scoop up the Remove buttons to put in menu component.
-    $node.find(".EditableComponentCollectionItem").first().parent().attr("aria-label", config.text.aria.answers);
-
-
+    this.config = conf;
     this._preservedItemCount = 2;
+    $node.addClass("RadiosQuestion");
+    this.addAccessibleLabels();
+  }
+
+  addAccessibleLabels() {
+    // We add this so that in the editor the text in the legend is not used as
+    // the group label, as it gets confusing
+    this.$node.find("fieldset > legend").attr("aria-label", "Question");
+
+    // Similarly we add a group label for the answers section
+    this.$node
+      .find(".EditableComponentCollectionItem")
+      .first()
+      .parent()
+      .attr("aria-label", this.config.text.aria.answers);
+
+    // Add labels for each of the contentEditable checkbox <label> elements
+    this.$node.find(".govuk-radios__label").each(function (index) {
+      $(this).attr("aria-label", `Label for radio option ${index + 1}`);
+    });
+
+    // Add labels for the hint text elements for each option
+    // Add the describedyby for optional content too
+    this.$node.find(".govuk-radios__hint").each(function (index) {
+      $(this).attr(
+        "aria-label",
+        `Optional hint text for radio option ${index + 1}`,
+      );
+
+      $(this).attr("aria-describedby", "optional_content_description");
+    });
   }
 }
 

--- a/app/javascript/src/question_radios.js
+++ b/app/javascript/src/question_radios.js
@@ -18,17 +18,12 @@ const Question = require("./question");
 const SELECTOR_HINT = "fieldset > .govuk-hint";
 const SELECTOR_LABEL = "legend > :first-child";
 const SELECTOR_ITEM = ".govuk-radios__item";
-const SELECTOR_ITEM_HINT = ".govuk-hint";
+const SELECTOR_ITEM_HINT = ".govuk-radios__hint";
 const SELECTOR_ITEM_LABEL = ".govuk-radios__label";
 const SELECTOR_DISABLED = "input:not(:hidden)";
 
 class RadiosQuestion extends Question {
   constructor($node, config) {
-    // // When the labels are <label> elements they won't have an aria-label
-    // // announced by Voiceover
-    // $node.find(".govuk-radios__label").each(function () {
-    //   changeTag(this, "div");
-    // });
     let conf = mergeObjects(
       {
         // Add stuff here if you want to set defaults
@@ -65,43 +60,14 @@ class RadiosQuestion extends Question {
             activatedMenu.container.$node.remove();
           }
         },
-        afterItemRemove: function (items) {
-          items.forEach(function (item, index) {
-            item.$node
-              .find(".govuk-radios__label")
-              .attr("aria-label", `Label for option ${index + 1}`);
-            item.$node
-              .find(SELECTOR_DISABLED)
-              .attr("aria-disabled", true)
-              .attr("aria-label", `Answer option ${index + 1}`)
-              .attr("aria-describedby", "disabled_input_description")
-              .on("click", (e) => {
-                e.preventDefault();
-              });
-            item.$node
-              .find(".govuk-radios__hint")
-              .attr("aria-label", `Optional hint text for option ${index + 1}`)
-              .attr("aria-describedby", "optional_content_description");
-            item.$node.find("button").text(`Edit option ${index + 1}`);
+        afterItemRemove: (items) => {
+          items.forEach((item, index) => {
+            this.updateItemAccessibleLabels(item.$node, index + 1);
           });
         },
-        onItemAdd: function ($node) {
+        onItemAdd: ($node) => {
           const index = $node.data("instance").component.items.length;
-          $node
-            .find(".govuk-radios__label")
-            .attr("aria-label", `Label for option ${index}`);
-          $node
-            .find(SELECTOR_DISABLED)
-            .attr("aria-disabled", true)
-            .attr("aria-label", `Answer option ${index}`)
-            .attr("aria-describedby", "disabled_input_description")
-            .on("click", (e) => {
-              e.preventDefault();
-            });
-          $node
-            .find(".govuk-radios__hint")
-            .attr("aria-label", `Optional hint text for option ${index}`)
-            .attr("aria-describedby", "optional_content_description");
+          this.updateItemAccessibleLabels($node, index);
         },
         onItemRemoveConfirmation: function (item) {
           // @item (EditableComponentItem) Item to be deleted.
@@ -116,39 +82,53 @@ class RadiosQuestion extends Question {
     this.config = conf;
     this._preservedItemCount = 2;
     $node.addClass("RadiosQuestion");
-    this.addAccessibleLabels();
+    // this.addAccessibleLabels();
   }
 
   addAccessibleLabels() {
     super.addAccessibleLabels();
-    // Similarly we add a group label for the answers section
-    this.$node
-      .find(".EditableComponentCollectionItem")
-      .first()
-      .parent()
-      .attr("aria-role", "group")
-      .attr("aria-label", this.config.text.aria.answers);
+    // Add a group label for the answers section
+    this.$node.find(".EditableComponentCollectionItem").first().parent().attr({
+      "aria-role": "group",
+      "aria-label": this.labels.answers,
+    });
 
+    // Update the labels for all of the items
+    this.$node
+      .find(SELECTOR_ITEM)
+      .toArray()
+      .forEach((item, index) => {
+        this.updateItemAccessibleLabels($(item), index + 1);
+      });
+  }
+
+  updateItemAccessibleLabels($node, index) {
     // Add labels for each of the contentEditable checkbox <label> elements
     // remove 'for' attribute to prevent AT reading this for the field itself
-    this.$node.find(".govuk-radios__label").each(function (index) {
-      $(this)
-        .attr("aria-label", `Label for option ${index + 1}`)
-        .removeAttr("for");
-    });
+    $node
+      .find(SELECTOR_ITEM_LABEL)
+      .attr("aria-label", `${this.labels.items.label} ${index}`)
+      .removeAttr("for");
 
     // Provide labels with indexes for input options
-    this.$node.find(SELECTOR_DISABLED).each(function (index) {
-      $(this).attr("aria-label", `Answer option ${index + 1}`);
-    });
+    $node
+      .find(SELECTOR_DISABLED)
+      .attr("aria-disabled", true)
+      .attr("aria-label", `${this.labels.items.answer} ${index}`)
+      .attr("aria-describedby", "disabled_input_description")
+      .on("click", (e) => {
+        e.preventDefault();
+      });
 
     // Add labels for the hint text elements for each option
     // Add the describedyby for optional content too
-    this.$node.find(".govuk-radios__hint").each(function (index) {
-      $(this)
-        .attr("aria-label", `Optional hint text for option ${index + 1}`)
-        .attr("aria-describedby", "optional_content_description");
-    });
+    $node
+      .find(SELECTOR_ITEM_HINT)
+      .attr("aria-label", `${this.labels.items.hint} ${index}`)
+      .attr("aria-describedby", "optional_content_description");
+
+    // Add index to item three-dot button
+    $node.find("button").text(`${this.labels.items.menu_button} ${index}`);
   }
 }
 

--- a/app/javascript/src/question_radios.js
+++ b/app/javascript/src/question_radios.js
@@ -12,18 +12,25 @@
  *
  **/
 
-const utilities = require("./utilities");
-const mergeObjects = utilities.mergeObjects;
+const { mergeObjects, changeTag } = require("./utilities");
 const Question = require("./question");
 
 const SELECTOR_HINT = "fieldset > .govuk-hint";
 const SELECTOR_LABEL = "legend > :first-child";
 const SELECTOR_ITEM = ".govuk-radios__item";
 const SELECTOR_ITEM_HINT = ".govuk-hint";
-const SELECTOR_ITEM_LABEL = "label";
+const SELECTOR_ITEM_LABEL = ".govuk-radios__label";
+const SELECTOR_DISABLED = "input:not(:hidden)";
 
 class RadiosQuestion extends Question {
   constructor($node, config) {
+    console.log("radio question class constructor");
+    // // When the labels are <label> elements they won't have an aria-label
+    // // announced by Voiceover
+    // $node.find(".govuk-radios__label").each(function () {
+    //   changeTag(this, "div");
+    // });
+    console.log("labels turned into spans");
     let conf = mergeObjects(
       {
         // Add stuff here if you want to set defaults
@@ -49,7 +56,7 @@ class RadiosQuestion extends Question {
           $node.find("label").text(config.text.option);
           $node.find("span").text(config.text.optionHint);
         },
-        onItemRemove: function (item) {
+        beforeItemRemove: function (item) {
           // @item (EditableComponentItem) Item to be deleted.
           // Runs before removing an editable Collection item.
           // Provides an opportunity for clean up.
@@ -60,6 +67,46 @@ class RadiosQuestion extends Question {
             activatedMenu.container.$node.remove();
           }
         },
+        afterItemRemove: function (items) {
+          items.forEach(function (item, index) {
+            console.log(item.$node.find("button"));
+            item.$node
+              .find(".govuk-radios__label")
+              .attr("aria-label", `Label for option ${index + 1}`);
+            item.$node
+              .find(SELECTOR_DISABLED)
+              .attr("aria-disabled", true)
+              .attr("aria-label", `Answer option ${index + 1}`)
+              .attr("aria-describedby", "disabled_input_description")
+              .on("click", (e) => {
+                e.preventDefault();
+              });
+            item.$node
+              .find(".govuk-radios__hint")
+              .attr("aria-label", `Optional hint text for option ${index + 1}`)
+              .attr("aria-describedby", "optional_content_description");
+            item.$node.find("button").text(`Edit option ${index + 1}`);
+          });
+        },
+        onItemAdd: function ($node) {
+          console.log($node.data("instance").component.items.length);
+          const index = $node.data("instance").component.items.length;
+          $node
+            .find(".govuk-radios__label")
+            .attr("aria-label", `Label for option ${index}`);
+          $node
+            .find(SELECTOR_DISABLED)
+            .attr("aria-disabled", true)
+            .attr("aria-label", `Answer option ${index}`)
+            .attr("aria-describedby", "disabled_input_description")
+            .on("click", (e) => {
+              e.preventDefault();
+            });
+          $node
+            .find(".govuk-radios__hint")
+            .attr("aria-label", `Optional hint text for option ${index}`)
+            .attr("aria-describedby", "optional_content_description");
+        },
         onItemRemoveConfirmation: function (item) {
           // @item (EditableComponentItem) Item to be deleted.
           // Runs before onItemRemove when removing an editable Collection item.
@@ -67,6 +114,7 @@ class RadiosQuestion extends Question {
       },
       config,
     );
+
     super($node, conf);
 
     this.config = conf;
@@ -76,31 +124,33 @@ class RadiosQuestion extends Question {
   }
 
   addAccessibleLabels() {
-    // We add this so that in the editor the text in the legend is not used as
-    // the group label, as it gets confusing
-    this.$node.find("fieldset > legend").attr("aria-label", "Question");
-
     // Similarly we add a group label for the answers section
     this.$node
       .find(".EditableComponentCollectionItem")
       .first()
       .parent()
+      .attr("aria-role", "group")
       .attr("aria-label", this.config.text.aria.answers);
 
     // Add labels for each of the contentEditable checkbox <label> elements
+    // remove 'for' attribute to prevent AT reading this for the field itself
     this.$node.find(".govuk-radios__label").each(function (index) {
-      $(this).attr("aria-label", `Label for radio option ${index + 1}`);
+      $(this)
+        .attr("aria-label", `Label for option ${index + 1}`)
+        .removeAttr("for");
+    });
+
+    // Provide labels with indexes for input options
+    this.$node.find(SELECTOR_DISABLED).each(function (index) {
+      $(this).attr("aria-label", `Answer option ${index + 1}`);
     });
 
     // Add labels for the hint text elements for each option
     // Add the describedyby for optional content too
     this.$node.find(".govuk-radios__hint").each(function (index) {
-      $(this).attr(
-        "aria-label",
-        `Optional hint text for radio option ${index + 1}`,
-      );
-
-      $(this).attr("aria-describedby", "optional_content_description");
+      $(this)
+        .attr("aria-label", `Optional hint text for option ${index + 1}`)
+        .attr("aria-describedby", "optional_content_description");
     });
   }
 }

--- a/app/javascript/src/question_text.js
+++ b/app/javascript/src/question_text.js
@@ -12,26 +12,30 @@
  *
  **/
 
-
-const utilities = require('./utilities');
+const utilities = require("./utilities");
 const mergeObjects = utilities.mergeObjects;
-const Question = require('./question');
+const Question = require("./question");
 
 const SELECTOR_HINT = ".govuk-hint";
-const SELECTOR_LABEL = "label h1, label h2, legend h1, legend h2";
+const SELECTOR_LABEL = "label h1 span, label h2 span";
 
 class TextQuestion extends Question {
   constructor($node, config) {
-    super($node, mergeObjects({
-      // Add stuff here if you want to set defaults
-      default_content: "empty",
-      selectorLabel: SELECTOR_LABEL,
-      selectorHint: SELECTOR_HINT
-    }, config));
+    super(
+      $node,
+      mergeObjects(
+        {
+          // Add stuff here if you want to set defaults
+          default_content: "empty",
+          selectorLabel: SELECTOR_LABEL,
+          selectorHint: SELECTOR_HINT,
+        },
+        config,
+      ),
+    );
 
     $node.addClass("TextQuestion");
   }
 }
-
 
 module.exports = TextQuestion;

--- a/app/javascript/src/question_textarea.js
+++ b/app/javascript/src/question_textarea.js
@@ -1,5 +1,5 @@
 /**
- * Date Question
+ * Textarea Question
  * ----------------------------------------------------
  * Description:
  * Textarea component extension of Question
@@ -12,25 +12,29 @@
  *
  **/
 
-
-const utilities = require('./utilities');
+const utilities = require("./utilities");
 const mergeObjects = utilities.mergeObjects;
-const Question = require('./question');
+const Question = require("./question");
 
 const SELECTOR_HINT = "[data-fb-node=hint]";
-const SELECTOR_LABEL = "label h1, label h2, legend h1, legend h2";
+const SELECTOR_LABEL = "label h1 span , label h2 span";
 
 class TextareaQuestion extends Question {
   constructor($node, config) {
-    super($node, mergeObjects({
-      // Add stuff here if you want to set defaults
-      selectorLabel: SELECTOR_LABEL,
-      selectorHint: SELECTOR_HINT
-    }, config));
+    super(
+      $node,
+      mergeObjects(
+        {
+          // Add stuff here if you want to set defaults
+          selectorLabel: SELECTOR_LABEL,
+          selectorHint: SELECTOR_HINT,
+        },
+        config,
+      ),
+    );
 
     $node.addClass("TextareaQuestion");
   }
 }
-
 
 module.exports = TextareaQuestion;

--- a/app/javascript/styles/_component_activated_menu.scss
+++ b/app/javascript/styles/_component_activated_menu.scss
@@ -47,7 +47,7 @@
     padding-right: 30px;
     position: relative;
 
-    &[aria-haspopup] {
+    &[aria-haspopup="menu"] {
       &:after {
         content: ">";
         font-family: monospace;

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -127,8 +127,8 @@ a[disabled] {
 }
 
 .govuk-button[aria-disabled="true"] {
-    opacity: 0.5;
-    pointer-events: none;
+  opacity: 0.5;
+  pointer-events: none;
 }
 
 .fb-govuk-button {
@@ -355,6 +355,11 @@ a[disabled] {
 
 /* Editable components
  * ------------------- */
+
+h1 span.EditableElement {
+  display: inline-block;
+}
+
 [data-component="add-component"] ul {
   display: none;
 }

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -126,6 +126,11 @@ a[disabled] {
   }
 }
 
+.govuk-button[aria-disabled="true"] {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
 .fb-govuk-button {
   // govuk-button style is green but we want blue buttons on fb-editor.
   @include fb-govuk-button;

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -357,7 +357,7 @@ a[disabled] {
  * ------------------- */
 
 h1 span.EditableElement {
-  display: inline-block;
+  display: block;
 }
 
 [data-component="add-component"] ul {

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -403,6 +403,7 @@ a[disabled] {
       background-color: Canvas; /*[2]*/
     }
   }
+
   .flow-titlebar {
     z-index: 1;
     margin-bottom: govuk-spacing(8);
@@ -624,6 +625,7 @@ a[disabled] {
     // make the link fill the whole area and clip it
     & > h2 a {
       clip-path: polygon(0% 50%, 50% 0%, 100% 50%, 50% 100%);
+
       top: 0;
       left: 0;
       right: 0;

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -31,6 +31,7 @@
 <%= render partial: 'partials/template_dialog_configuration' %>
 <%= render partial: 'partials/template_content_property_fields' %>
 <%= render partial: 'partials/template_question_property_fields' %>
+<%= render partial: 'partials/accessible_descriptions' %>
 
 <% # app.page is initialised in partials/properties. %>
 <% # JS object should exist at this point so we're not checking for existence. %>

--- a/app/views/partials/_accessible_descriptions.html.erb
+++ b/app/views/partials/_accessible_descriptions.html.erb
@@ -1,1 +1,2 @@
 <p id="optional_content_description" hidden><%= t('aria.optional_content_description') %></p>
+<p id="disabled_input_description" hidden><%= t('aria.disabled_input_description') %></p>

--- a/app/views/partials/_accessible_descriptions.html.erb
+++ b/app/views/partials/_accessible_descriptions.html.erb
@@ -1,0 +1,1 @@
+<p id="optional_content_description" hidden><%= t('aria.optional_content_description') %></p>

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -27,11 +27,22 @@
     },
     text: {
       aria: {
-        answers: "<%= t('aria.answers') %>",
         hint: "<%= t('aria.hint') %>",
-        question: "<%= t('aria.question') %>",
         section_heading: "<%= t('aria.section_heading') %>",
         disabled_save_description: "<%= t('aria.disabled_save_description') %>",
+        question: {
+          title: "<%=t('aria.question.title')%>",
+          legend: "<%=t('aria.question.legend')%>",
+          hint: "<%=t('aria.question.hint')%>",
+          answers: "<%= t('aria.question.answers') %>",
+          answer: "<%=t('aria.question.answer')%>",
+          items: {
+            label: "<%=t('aria.question.items.label')%>", 
+            hint:"<%=t('aria.question.items.hint')%>",
+            answer:"<%=t('aria.question.items.answer')%>", 
+            menu_button:"<%=t('aria.question.items.menu_button')%>", 
+          },
+        },
       },
       branches: {
         branch_edit: "<%= t('branches.branch_edit') %>",

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -54,7 +54,20 @@
       },
       components: {
         move_up: "<%= t('components.actions.move_up') %>",
-        move_down: "<%= t('components.actions.move_down') %>"
+        move_down: "<%= t('components.actions.move_down') %>",
+        types: {
+          text: "<%= t('components.list.text')%>",
+          textarea: "<%= t('components.list.textarea')%>",
+          email: "<%= t('components.list.email')%>",
+          number: "<%= t('components.list.number')%>",
+          date: "<%= t('components.list.date')%>",
+          radios: "<%= t('components.list.radios')%>",
+          checkboxes: "<%= t('components.list.checkboxes')%>",
+          upload: "<%= t('components.list.upload')%>",
+          multiupload: "<%= t('components.list.upload')%>",
+          autocomplete: "<%= t('components.list.autocomplete')%>",
+          address: "<%= t('components.list.address')%>",
+        }
       },
       content_visibility: {
         label_question_and: "<%= t('branches.expression.and') %>",

--- a/app/views/partials/_template_component_question_menu.html.erb
+++ b/app/views/partials/_template_component_question_menu.html.erb
@@ -4,12 +4,18 @@
           data-component-uuid="<%= component.uuid %>"
           data-activator-text="<%= t('question.menu.activator') %>">
     <ul class="govuk-navigation component-activated-menu">
-      <li data-action="required" data-validation="required"><span role="menuitemcheckbox" aria-checked="<%= component.validation ? component.validation['required'] : 'false' -%>"><%= t('question.menu.required')%></span></li>
+      <li data-action="required" data-validation="required">
+        <span role="menuitemcheckbox" 
+              aria-checked="<%= component.validation ? component.validation['required'] : 'false' -%>"
+              aria-haspopup="dialog">
+          <%= t('question.menu.required')%>
+        </span>
+      </li>
 
       <% if component.type  == 'autocomplete' %>
         <li data-action="upload"
             data-api-path="<%= URI.decode_www_form_component(api_service_autocomplete_path(service.service_id, component.uuid))%>">
-            <span><%= t('question.menu.upload_options') %></span>
+          <span aria-haspopup="dialog"><%= t('question.menu.upload_options') %></span>
         </li>
       <% end %>
 
@@ -18,13 +24,17 @@
           <li data-action="validation"
             data-validation="<%= validation %>"
             data-api-path="<%= URI.decode_www_form_component(api_service_page_component_validations_path(service.service_id, @page.uuid, component.uuid, validation)) -%>">
-            <span><%= t("question.menu.#{validation}") %></span>
+            <span aria-haspopup="dialog"><%= t("question.menu.#{validation}") %></span>
           </li>
         <% else %>
           <li data-action="validation"
               data-validation="<%= validation %>"
               data-api-path="<%= URI.decode_www_form_component(api_service_page_component_validations_path(service.service_id, @page.uuid, component.uuid, validation)) -%>">
-              <span role="menuitemcheckbox" aria-checked="<%= component.validation[validation] ? 'true' : 'false' -%>"><%= t("question.menu.#{validation}") %></span>
+            <span role="menuitemcheckbox" 
+                  aria-checked="<%= component.validation[validation] ? 'true' : 'false' -%>" 
+                  aria-haspopup="dialog">
+              <%= t("question.menu.#{validation}") %>
+            </span>
           </li>
         <% end %>
       <% end %>
@@ -32,7 +42,9 @@
       <% unless @page.type == 'page.singlequestion' %>
          <li data-action="remove"
             data-api-path="<%= URI.decode_www_form_component(api_service_page_question_destroy_message_path(service.service_id, @page.uuid, component.uuid, method: :delete)) -%>">
-          <span class="destructive"><%= t('question.menu.remove')%></span>
+          <span class="destructive" aria-haspopup="dialog">
+            <%= t('question.menu.remove')%>
+          </span>
         </li>
       <% end %>
     </ul>

--- a/app/views/partials/_template_content_menu.html.erb
+++ b/app/views/partials/_template_content_menu.html.erb
@@ -5,10 +5,10 @@
     <ul class="govuk-navigation component-activated-menu">
         <% unless @page.type == 'page.start' %>
           <li data-action="conditional-content">
-            <span><%= t('content.menu.show_if') %></span>
+            <span aria-haspopup="dialog"><%= t('content.menu.show_if') %></span>
           </li>
         <% end %>
-      <li data-action="remove"><span class="destructive"><%= t('content.menu.remove')%></span></li>
+      <li data-action="remove"><span class="destructive" aria-haspopup="dialog"><%= t('content.menu.remove')%></span></li>
     </ul>
   </script>
 <% end %>

--- a/app/views/partials/_template_editable_collection_item_menu.html.erb
+++ b/app/views/partials/_template_editable_collection_item_menu.html.erb
@@ -5,7 +5,7 @@
     <%#= we unescape the route helper in order to keep the url placeholders intact for JS to replace them -%>
     <li data-action="remove"
         data-api-path="<%= URI.decode_www_form_component(api_service_page_question_question_option_destroy_message_path(service.service_id,@page.uuid,'#{question_uuid}', '#{option_uuid}', method: :delete) ) -%>">
-      <span class="destructive"><%= t('question.menu.remove')%></span>
+      <span class="destructive" aria-haspopup="dialog"><%= t('question.menu.remove')%></span>
     </li>
   </ul>
 </script>

--- a/app/views/partials/_template_question_menu.html.erb
+++ b/app/views/partials/_template_question_menu.html.erb
@@ -3,10 +3,10 @@
         data-component-template="QuestionMenu"
         data-activator-text="<%= t('question.menu.activator') %>">
   <ul class="govuk-navigation component-activated-menu">
-    <li data-action="required"><span role="menuitemcheckbox"><%= t('question.menu.required')%></span></li>
+    <li data-action="required"><span role="menuitemcheckbox" aria-haspopup="dialog"><%= t('question.menu.required')%></span></li>
     <li data-action="remove"
         data-api-path="<%= api_service_page_question_destroy_message_path(service.service_id,@page.uuid,'question_uuid', method: :delete) -%>">
-      <span class="destructive"><%= t('question.menu.remove')%></span>
+      <span class="destructive" aria-haspopup="dialog"><%= t('question.menu.remove')%></span>
     </li>
   </ul>
 </script>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
     flow_thumbnail: 'Form page'
     disabled_save_description: 'No changes to save'
     optional_content_description: 'This will not be displayed if left unchanged'
+    disabled_input_description: 'Only active when published or previewed'
     page:
       start: Start page
       singlequestion: Single question page

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,8 @@ en:
     section_heading: Optional section heading
     flow_thumbnail: 'Form page'
     disabled_save_description: 'No changes to save'
+    optional_content_description: 'This will not be displayed if left unchanged'
+    disabled_input_description: 'Only active when published or previewed'
     page:
       start: Start page
       singlequestion: Single question page
@@ -24,8 +26,6 @@ en:
         hint: "Optional hint text for option"
         answer: "Answer field for option"
         menu_button: "Edit option"
-      optional_content_description: 'This will not be displayed if left unchanged'
-      disabled_input_description: 'Only active when published or previewed'
   assistive_text:
     warning: warning
     incomplete: incomplete

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,9 +3,10 @@ en:
     answers: Answers
     hint: Question Hint
     question: Question
-    section_heading: Section Heading
+    section_heading: Optional section heading
     flow_thumbnail: 'Form page'
     disabled_save_description: 'No changes to save'
+    optional_content_description: 'This will not be displayed if left unchanged'
     page:
       start: Start page
       singlequestion: Single question page
@@ -384,7 +385,7 @@ en:
   question:
     optional_flag: '(optional)'
     menu:
-      activator: 'Properties'
+      activator: 'Question properties'
       remove: 'Delete...'
       required: 'Required...'
       date_after: 'Earliest date...'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,13 +1,10 @@
 en:
   aria:
-    answers: Answers
     hint: Question Hint
     question: Question
     section_heading: Optional section heading
     flow_thumbnail: 'Form page'
     disabled_save_description: 'No changes to save'
-    optional_content_description: 'This will not be displayed if left unchanged'
-    disabled_input_description: 'Only active when published or previewed'
     page:
       start: Start page
       singlequestion: Single question page
@@ -16,6 +13,19 @@ en:
       confirmation: Confirmation page
       content: Content page
       exit: Exit page
+    question:
+      title: "{{type}} question title"
+      legend: "Edit {{type}} question"
+      hint: "Optional hint text for question"
+      answers: Answers
+      answer: "Answer field"
+      items:
+        label: "Label for option"
+        hint: "Optional hint text for option"
+        answer: "Answer field for option"
+        menu_button: "Edit option"
+      optional_content_description: 'This will not be displayed if left unchanged'
+      disabled_input_description: 'Only active when published or previewed'
   assistive_text:
     warning: warning
     incomplete: incomplete

--- a/spec/requests/welsh_localisation_spec.rb
+++ b/spec/requests/welsh_localisation_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'Welsh localisation', type: :request do
     context 'question buttons' do
       it 'has a disabled continue button translated to Welsh' do
         assert_select 'div.govuk-button-group' do
-          assert_select 'button.govuk-button--disabled', 'Parhau'
+          assert_select 'button.govuk-button', 'Parhau'
         end
       end
     end

--- a/test/editable_components/editable_collection_field_component/callbacks_test.js
+++ b/test/editable_components/editable_collection_field_component/callbacks_test.js
@@ -1,48 +1,56 @@
+require("../../setup");
 
-require('../../setup');
-
-describe('EditableCollectionFieldComponment', function() {
-  const helpers = require('./helpers');
+describe("EditableCollectionFieldComponment", function () {
+  const helpers = require("./helpers");
   const c = helpers.constants;
-  const COMPONENT_ID = 'editable-collection-field-component-callbacks-test';
+  const COMPONENT_ID = "editable-collection-field-component-callbacks-test";
 
-  describe('Callbacks', function() {
+  describe("Callbacks", function () {
     var sandbox;
 
-    beforeEach(function() {
+    beforeEach(function () {
       sandbox = sinon.createSandbox();
     });
 
-    afterEach(function() {
+    afterEach(function () {
       sandbox.restore();
       helpers.teardownView(COMPONENT_ID);
     });
 
-    it('calls the onCollectionItemClone() callback', function() {
+    it("calls the onCollectionItemClone() callback", function () {
       var spy = sinon.spy();
-      var created = helpers.createEditableCollectionFieldComponent(COMPONENT_ID, {
-        onCollectionItemClone: spy,
-      });
+      var created = helpers.createEditableCollectionFieldComponent(
+        COMPONENT_ID,
+        {
+          onCollectionItemClone: spy,
+        },
+      );
 
-      expect(spy).to.have.been.calledOnce
+      expect(spy).to.have.been.calledOnce;
     });
 
-    it('calls the onItemAdd() callback', function() {
+    it("calls the onItemAdd() callback", function () {
       var spy = sinon.spy();
-      var created = helpers.createEditableCollectionFieldComponent(COMPONENT_ID, {
-        onItemAdd: spy,
-      });
+      var created = helpers.createEditableCollectionFieldComponent(
+        COMPONENT_ID,
+        {
+          onItemAdd: spy,
+        },
+      );
 
       created.instance.addItem();
 
       expect(spy).to.have.been.calledOnce;
     });
 
-    it('calls the onItemRemove() callback', function(){
+    it("calls the beforeItemRemove() callback", function () {
       var spy = sinon.spy();
-      var created = helpers.createEditableCollectionFieldComponent(COMPONENT_ID, {
-        onItemRemove: spy,
-      });
+      var created = helpers.createEditableCollectionFieldComponent(
+        COMPONENT_ID,
+        {
+          beforeItemRemove: spy,
+        },
+      );
 
       created.instance.removeItem(created.instance.items[1]);
 

--- a/test/editable_components/editable_component_base_test.js
+++ b/test/editable_components/editable_component_base_test.js
@@ -1,17 +1,21 @@
-require('../setup');
+require("../setup");
 
-describe('EditableComponentbase', function() {
-  const {EditableComponentBase} = require('../../app/javascript/src/editable_components');
-  const { EditableElement } = require('../../app/javascript/src/editable_components');
-  const EDITABLE_INPUT_ID = 'editable-input-id';
-  const EDITABLE_LABEL_TEXT = 'editable label';
-  const EDITABLE_HINT_TEXT = 'editable hint';
-  const EDITABLE_CLASSNAME = 'editable-classname';
-  const EDITABLE_UUID = '1234567890'
+describe("EditableComponentbase", function () {
+  const {
+    EditableComponentBase,
+  } = require("../../app/javascript/src/editable_components");
+  const {
+    EditableElement,
+  } = require("../../app/javascript/src/editable_components");
+  const EDITABLE_INPUT_ID = "editable-input-id";
+  const EDITABLE_LABEL_TEXT = "editable label";
+  const EDITABLE_HINT_TEXT = "editable hint";
+  const EDITABLE_CLASSNAME = "editable-classname";
+  const EDITABLE_UUID = "1234567890";
 
   var $node, $form, component;
 
-  beforeEach(function() {
+  beforeEach(function () {
     var html = `<form id="editableForm">
       </form>
       <div id="editableComponent">
@@ -22,122 +26,111 @@ describe('EditableComponentbase', function() {
 
     $(document.body).append(html);
 
-    $node = $(document).find('#editableComponent');
-    $form = $(document).find('#editableForm');
+    $node = $(document).find("#editableComponent");
+    $form = $(document).find("#editableForm");
 
     component = new EditableComponentBase($node, {
-        editClassname: EDITABLE_CLASSNAME,
-        form: $form,
-        id: EDITABLE_INPUT_ID,
-        type: 'editable-type',
-        data: {
-          _uuid: EDITABLE_UUID
-        },
-        selectorDisabled: 'input',
-        selectorElementLabel: '.editable-label',
-        selectorElementHint: '.editable-hint',
-      }
-    );
+      editClassname: EDITABLE_CLASSNAME,
+      form: $form,
+      id: EDITABLE_INPUT_ID,
+      type: "editable-type",
+      data: {
+        _uuid: EDITABLE_UUID,
+      },
+      selectorDisabled: "input",
+      selectorElementLabel: ".editable-label",
+      selectorElementHint: ".editable-hint",
+    });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     $node.remove();
     $form.remove();
     $node = $form = component = undefined;
-  })
+  });
 
-  describe('Properties', function() {
-    it("should make the instance available as data on the $node", function() {
+  describe("Properties", function () {
+    it("should make the instance available as data on the $node", function () {
       var instance = component.$node.data("instance");
       expect(instance).to.exist;
       expect(component).to.equal(instance);
     });
 
-    it("should make the $node public", function() {
+    it("should make the $node public", function () {
       expect(component.$node).to.exist;
       expect(component.$node.length).to.equal(1);
       expect(component.$node.get(0)).to.equal(component.$node.get(0));
     });
 
-    it('should have a public data property', function() {
-      expect(component.data).to.exist
+    it("should have a public data property", function () {
+      expect(component.data).to.exist;
       expect(component.data).to.eql({
         _uuid: EDITABLE_UUID,
-      })
+      });
     });
 
-    it('should have a public (marked private) elements property', function() {
-      var $label = $node.find('.editable-label');
-      var $hint = $node.find('.editable-hint');
+    it("should have a public (marked private) elements property", function () {
+      var $label = $node.find(".editable-label");
+      var $hint = $node.find(".editable-hint");
 
       expect(component._elements).to.exist;
-      expect(component._elements).to.have.property('label');
-      expect(component._elements).to.have.property('hint');
+      expect(component._elements).to.have.property("label");
+      expect(component._elements).to.have.property("hint");
 
-      expect(component._elements.label ).to.be.an.instanceof(EditableElement);
+      expect(component._elements.label).to.be.an.instanceof(EditableElement);
       expect(component._elements.label.$node).to.eql($label);
 
       expect(component._elements.hint).to.be.an.instanceof(EditableElement);
       expect(component._elements.hint.$node).to.eql($hint);
     });
 
-    it('content property should return the elements data', function() {
+    it("content property should return the elements data", function () {
       var json = JSON.stringify({
         _uuid: EDITABLE_UUID,
       });
 
       expect(component.content).to.eql(json);
     });
-
   });
 
-  describe('Component', function() {
-    it('should disable elements based on selectorDisabled', function() {
-      var input =  $node.find('input');
-
-      expect(input.attr('disabled')).to.equal('disabled');
-    });
-  });
-
-  describe('Methods', function() {
-    describe('save', function() {
-
-      it('should save the contents of elements into component data', function() {
+  describe("Methods", function () {
+    describe("save", function () {
+      it("should save the contents of elements into component data", function () {
         component.save();
 
         expect(component.data).to.eql({
           _uuid: EDITABLE_UUID,
           label: EDITABLE_LABEL_TEXT,
-          hint: EDITABLE_HINT_TEXT
+          hint: EDITABLE_HINT_TEXT,
         });
       });
 
-      it('should update the data on save', function() {
-        var $label = $node.find('.editable-label');
-        var $hint = $node.find('.editable-hint');
+      it("should update the data on save", function () {
+        var $label = $node.find(".editable-label");
+        var $hint = $node.find(".editable-hint");
 
-        component._elements.label.$node.text( 'Updated Label' );
+        component._elements.label.$node.text("Updated Label");
         component._elements.label.update();
-        component._elements.hint.$node.text( 'Updated Hint' );
+        component._elements.hint.$node.text("Updated Hint");
         component._elements.hint.update();
 
         component.save();
 
         expect(component.data).to.eql({
           _uuid: EDITABLE_UUID,
-          label: 'Updated Label',
-          hint: 'Updated Hint'
+          label: "Updated Label",
+          hint: "Updated Hint",
         });
       });
     });
 
-    describe('focus', function() {
-      it('should focus the first editable element', function() {
-        var label = document.querySelector('.editable-label');
+    describe("focus", function () {
+      it("should focus the first editable element", function () {
+        var label = document.querySelector(".editable-label");
         component.focus();
 
         expect(document.activeElement).to.eql(label);
-      })
-    })
+      });
+    });
   });
 });


### PR DESCRIPTION
This is a rather large PR, that updatest he single question pages to have good accesible labelling for all elements.

The code for this gets a little gnarly as we have to remove the default semantics and labelling asscoiations for the form elements as used in the runner and replace them with new labelling for the editor context.

There are three main things happening:
1. Editable `h1` elements now have a child `<span>` which is used for all the editble semantics in order for the `h1` to retain heading semantics.
2. The question form inputs and buttons are now no longer `disabled` as that makes them invisible to AT, they are now `aria-disabled` so take part in the accessibility tree and can be focused, but not interacted with.
3. All elements now have labelsa nd/or descriptions for screenreaders.

This now means that running AXE checker on the single question pages reports no issues.