### PR TITLE
Fix heading levels on publishing page

### DIFF
--- a/acceptance/features/accessibility_spec.rb
+++ b/acceptance/features/accessibility_spec.rb
@@ -37,7 +37,7 @@ feature 'Accessibility' do
     then_the_page_should_be_accessible
   end
 
-  scenario 'Settings > Google Analytics', pending: true do
+  scenario 'Settings > Google Analytics' do
     click_link(I18n.t('settings.name'))
     click_link(I18n.t('settings.form_analytics.heading'))
     then_the_page_should_be_accessible
@@ -93,13 +93,20 @@ feature 'Accessibility' do
   end
 
   scenario 'Publishing', pending: true do
+    # Publishing to Test
     click_link(I18n.t('publish.name'))
     then_the_page_should_be_accessible
 
-    click_button('Publish to Test')
+    click_button(I18n.t('actions.publish_to_test'))
     then_the_page_should_be_accessible
 
-    click_link('Publish to Live')
+    click_button('Cancel')
+
+    # Publishing to Live
+    first(:link, I18n.t('actions.publish_to_live')).click
+    then_the_page_should_be_accessible
+
+    click_button(I18n.t('actions.publish_to_live'))
     then_the_page_should_be_accessible
   end
 

--- a/app/views/publish/_publish_for_review.html.erb
+++ b/app/views/publish/_publish_for_review.html.erb
@@ -3,7 +3,7 @@
     <p class="description"><%= t("publish.#{environment}.description") %></p>
 
     <div class="govuk-panel govuk-panel--confirmation">
-      <h3 class="govuk-panel__title"><%= t("publish.publish_for_review.confirmation.heading") %></h3>
+      <h2 class="govuk-panel__title govuk-heading-m"><%= t("publish.publish_for_review.confirmation.heading") %></h2>
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
@@ -39,9 +39,9 @@
               <% end %>
             <% end %>
           </div>
-      
+    
           <div class="review">
-            <h3><%= t('publish.publish_for_review.info.heading') %></h3>
+            <h2 class="govuk-heading-m"><%= t('publish.publish_for_review.info.heading') %></h2>
       
             <p>
               <%= t('publish.publish_for_review.info.content', href: govuk_link_to(t('publish.publish_for_review.info.link_text'), t('publish.publish_for_review.info.link_url'))).html_safe %>


### PR DESCRIPTION
Another small accessibility fix.  For best accessibility, headings should be in order and shouldn't skip levels. So we switch out `<H3>`s for `<H2>`s styled to be the same size.

Also some tweaks to the accessibility test (for the GA settings page)