### PR TITLE
Add focus styles to govuk-navigation links

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -923,6 +923,14 @@ h1 span.EditableElement {
   li {
     @include list_reset;
   }
+
+  a:focus {
+    @include focus;
+  }
+
+  a:focus:hover {
+    color: $govuk-text-colour;
+  }
 }
 
 /* govuk-app-navigation does not appear to exist

--- a/app/javascript/styles/_mixins.scss
+++ b/app/javascript/styles/_mixins.scss
@@ -58,6 +58,7 @@
   background-color: $govuk-focus-colour;
   color: $govuk-focus-text-colour;
   outline: $govuk-focus-width solid $govuk-focus-colour;
+  outline-offset: 0;
 }
 
 @mixin fb-govuk-button {


### PR DESCRIPTION
Adds the GOV.UK yellow focus styles to the links in the top navigtaion.

**Before**
![image](https://github.com/ministryofjustice/fb-editor/assets/595564/691585bd-c3d6-4bc0-a69b-7b65621081fe)

**After**
![image](https://github.com/ministryofjustice/fb-editor/assets/595564/0366030b-35f1-470a-a5d3-fe460b25d8a8)
