### PR TITLE
Bump MDP version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby '3.1.3'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'semantic-editable-headings'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.30'
+gem 'metadata_presenter', '3.3.31'
 
 gem 'activerecord-session_store'
 gem 'administrate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.3.30)
+    metadata_presenter (3.3.31)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)
@@ -807,7 +807,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.3.30)
+  metadata_presenter (= 3.3.31)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
Fixes issue with generating back link when page object is nil (when going direct to a 404) by adding a guard