### PR TITLE
Add accessible name to modals

### DIFF
--- a/acceptance/features/accessibility_spec.rb
+++ b/acceptance/features/accessibility_spec.rb
@@ -92,7 +92,7 @@ feature 'Accessibility' do
     then_the_page_should_be_accessible
   end
 
-  scenario 'Publishing', pending: true do
+  scenario 'Publishing' do
     # Publishing to Test
     click_link(I18n.t('publish.name'))
     then_the_page_should_be_accessible

--- a/app/javascript/src/component_dialog.js
+++ b/app/javascript/src/component_dialog.js
@@ -242,6 +242,7 @@ class Dialog {
 
     this.$container = dialog.$node.parents(".ui-dialog");
     this.$container.addClass(dialog.#className);
+    this.$container.attr('aria-labelledby', 'dialog-title')
     this.$node.data("instance", dialog);
   }
 

--- a/app/javascript/src/component_dialog_api_request.js
+++ b/app/javascript/src/component_dialog_api_request.js
@@ -69,34 +69,34 @@
 
 **/
 
-const {
-  mergeObjects,
-  safelyActivateFunction,
-} = require('./utilities');
+const { mergeObjects, safelyActivateFunction } = require("./utilities");
 
-const DialogActivator = require('./component_dialog_activator');
+const DialogActivator = require("./component_dialog_activator");
 
 class DialogApiRequest {
-  #className = 'DialogApiRequest';
+  #className = "DialogApiRequest";
   #config;
   #state;
 
   /**
-  * @param {string} url - The url to request the template from
-  * @param {Object} config - config key/value pairs
-  */
+   * @param {string} url - The url to request the template from
+   * @param {Object} config - config key/value pairs
+   */
   constructor(url, config) {
-    this.#config = mergeObjects({
-      activator: false,
-      autoOpen: true,
-      buttons: [],
-      classes: {},
-      closeOnClickSelector: "",
-      onLoad: function(dialog) {},
-      onReady: function(dialog) {},
-      onOpen: function(dialog) {},
-      onClose: function(dialog) {},
-    }, config);
+    this.#config = mergeObjects(
+      {
+        activator: false,
+        autoOpen: true,
+        buttons: [],
+        classes: {},
+        closeOnClickSelector: "",
+        onLoad: function (dialog) {},
+        onReady: function (dialog) {},
+        onOpen: function (dialog) {},
+        onClose: function (dialog) {},
+      },
+      config,
+    );
 
     this.#state = "closed";
     this.$node = $(); // Should be overwritten on successful GET
@@ -140,15 +140,17 @@ class DialogApiRequest {
   }
 
   focus() {
-    const el = this.$node.find('.govuk-button:not([type="disabled"]):not([data-method="delete"])').eq(0);
-    if(el){
+    const el = this.$node
+      .find('.govuk-button:not([type="disabled"]):not([data-method="delete"])')
+      .eq(0);
+    if (el) {
       el.focus();
     }
   }
 
   focusActivator() {
     // Attempt to refocus on original activator
-    if(this.activator) {
+    if (this.activator) {
       this.activator.focus();
     }
   }
@@ -156,15 +158,14 @@ class DialogApiRequest {
   #initialize(url) {
     const dialog = this;
 
-    $.get(url)
-    .done( (response) => {
+    $.get(url).done((response) => {
       this.$node = $(response);
       safelyActivateFunction(dialog.#config.onLoad, dialog);
 
       this.#build();
       this.#enhance();
 
-      if(this.#config.autoOpen) {
+      if (this.#config.autoOpen) {
         this.open();
       }
     });
@@ -174,7 +175,7 @@ class DialogApiRequest {
     const dialog = this;
 
     // this.activator is true || $node setup a DialogActivator
-    if(this.activator) {
+    if (this.activator) {
       this.#addActivator();
     }
 
@@ -185,16 +186,19 @@ class DialogApiRequest {
       height: "auto",
       modal: true,
       resizable: false,
-      open: function() { dialog.#state = "open" },
-      close: function() {
+      open: function () {
+        dialog.#state = "open";
+      },
+      close: function () {
         dialog.#state = "closed";
         dialog.focusActivator();
         dialog.#destroy();
-      }
+      },
     });
 
     this.$container = dialog.$node.parents(".ui-dialog");
     this.$container.addClass(dialog.#className);
+    this.$container.attr("aria-labelledby", "dialog-title");
     this.$node.data("instance", dialog);
   }
 
@@ -209,45 +213,48 @@ class DialogApiRequest {
   #setupButtons() {
     const dialog = this;
 
-    if(this.#config.closeOnClickSelector) {
+    if (this.#config.closeOnClickSelector) {
       let $buttons = $(this.#config.closeOnClickSelector, dialog.$node);
-      $buttons.on("click", function() {
+      $buttons.on("click", function () {
         dialog.close();
       });
-    }
-    else {
-      this.$node.dialog("option", "buttons",
-        [
-          {
-            text: dialog.#config.buttons.length > 0 && dialog.#config.buttons[0].text || "ok",
-            click: () => {
-              // Attempt to run any passed button.click action.
-              if(dialog.#config.buttons.length > 0) {
-                safelyActivateFunction(dialog.#config.buttons[0].click, dialog);
-              }
-              // Make sure the dialog closes
-              dialog.close();
+    } else {
+      this.$node.dialog("option", "buttons", [
+        {
+          text:
+            (dialog.#config.buttons.length > 0 &&
+              dialog.#config.buttons[0].text) ||
+            "ok",
+          click: () => {
+            // Attempt to run any passed button.click action.
+            if (dialog.#config.buttons.length > 0) {
+              safelyActivateFunction(dialog.#config.buttons[0].click, dialog);
             }
+            // Make sure the dialog closes
+            dialog.close();
           },
-          {
-            text: dialog.#config.buttons.length > 0 && dialog.#config.buttons[1].text || "cancel",
-            click: () => {
-              // Attempt to run any passed button.click action.
-              if(dialog.#config.buttons.length > 1) {
-                safelyActivateFunction(dialog.#config.buttons[1].click, dialog);
-              }
-              // Make sure the dialog closes
-              dialog.close();
+        },
+        {
+          text:
+            (dialog.#config.buttons.length > 0 &&
+              dialog.#config.buttons[1].text) ||
+            "cancel",
+          click: () => {
+            // Attempt to run any passed button.click action.
+            if (dialog.#config.buttons.length > 1) {
+              safelyActivateFunction(dialog.#config.buttons[1].click, dialog);
             }
-          }
-        ]
-      );
+            // Make sure the dialog closes
+            dialog.close();
+          },
+        },
+      ]);
     }
   }
 
   #destroy() {
-    if(this.$node.dialog('instance')) {
-      this.$node.dialog('destroy');
+    if (this.$node.dialog("instance")) {
+      this.$node.dialog("destroy");
     }
     this.$node.remove();
   }
@@ -259,16 +266,14 @@ class DialogApiRequest {
     var activator = new DialogActivator(this.#config.activator, {
       dialog: this,
       text: this.#config.activatorText,
-      classes: this.#config.classes?.activator || '',
-      $target: $marker
+      classes: this.#config.classes?.activator || "",
+      $target: $marker,
     });
 
     this.activator = activator.$node;
 
     $marker.remove();
   }
-
 }
-
 
 module.exports = DialogApiRequest;

--- a/app/javascript/src/component_dialog_form.js
+++ b/app/javascript/src/component_dialog_form.js
@@ -277,6 +277,7 @@ class DialogForm {
 
     this.$container = dialog.$node.parents(".ui-dialog");
     this.$container.addClass(dialog.#className);
+    this.$container.attr('aria-labelledby', 'dialog-title')
     this.$node.data("instance", dialog);
   }
 

--- a/app/views/api/autocomplete/_show.html.erb
+++ b/app/views/api/autocomplete/_show.html.erb
@@ -1,7 +1,7 @@
 <div class="component-dialog-api-request" id="autocomplete_items">
   <%= form_for @items, url: api_service_autocomplete_path(service_id: service.service_id, component_id: @items.component_id), method: :post, multipart: true do |form| %>
   <div class="govuk-form-group">
-      <%= form.label :file, t('dialogs.autocomplete.legend'), class: "govuk-label govuk-label--m" %>
+      <%= form.label :file, t('dialogs.autocomplete.legend'), id: "dialog-title", class: "govuk-label govuk-label--m" %>
 
       <% if items_present?(@items.component_id) %>
         <div class="govuk-warning-text govuk-!-margin-bottom-2">

--- a/app/views/api/branches/destroy_message.html.erb
+++ b/app/views/api/branches/destroy_message.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.heading_delete', label: @branch.title) %>
   </h3>
 

--- a/app/views/api/component_validations/_new.html.erb
+++ b/app/views/api/component_validations/_new.html.erb
@@ -6,7 +6,7 @@
       html: { novalidate: true } do |f| %>
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <legend id="dialog-title" class="govuk-fieldset__legend govuk-fieldset__legend--m">
             <%= @component_validation.label -%>
           </legend>
           <% if @component_validation.validator == 'max_files' %>

--- a/app/views/api/conditional_contents/_form.html.erb
+++ b/app/views/api/conditional_contents/_form.html.erb
@@ -30,7 +30,7 @@
   <% end %>
   
   <div data-controller="selection-reveal" data-selection-reveal-matches-value="<%= ["always", "never"].to_json %>">
-    <fieldset class="govuk-fieldset govuk-!-margin-bottom-5" aria-labelledby="conditional-content-title">
+    <fieldset class="govuk-fieldset govuk-!-margin-bottom-5" aria-labelledby="dialog-title">
       <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
         <% f.object.options_for_display.each do |option| %>
           <%= f.govuk_radio_button :display, option[:value], label: { text: option[:text] }, data: { selection_reveal_target: "input", action: "selection-reveal#toggle" } %>

--- a/app/views/api/conditional_contents/edit.html.erb
+++ b/app/views/api/conditional_contents/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="component-dialog-api-request" id="conditional_content_dialog">
   <div class="conditional-visibility edit">
-    <h2 id="conditional-content-title" class="govuk-heading-m"><%= t('conditional_content.heading') %></h2>
+    <h2 id="dialog-title" class="govuk-heading-m"><%= t('conditional_content.heading') %></h2>
     <%= form_for @conditional_content, url: api_service_update_conditional_content_path(service.service_id, params[:component_uuid]), method: :put, data: { turbo: true } do |f| %>
       <%= render 'form', f: f %>
     <% end %> 

--- a/app/views/api/destinations/new.html.erb
+++ b/app/views/api/destinations/new.html.erb
@@ -1,7 +1,7 @@
 <div class="component-dialog-api-request">
   <%= form_for @destination, url: api_service_flow_destinations_path(service.service_id, @destination.flow_uuid) do |f| %>
     <div class="govuk-form-group ">
-      <%= f.label :destination_uuid, t('dialogs.destination.label'), class: "govuk-label govuk-label--m"  %>
+      <%= f.label :destination_uuid, t('dialogs.destination.label'), class: "govuk-label govuk-label--m", id: "dialog-title"  %>
       <div class="govuk-hint">
         <%= t('dialogs.destination.lede', title: @destination.title) %>
       </div>

--- a/app/views/api/external_start_page_urls/_external_start_page_url.html.erb
+++ b/app/views/api/external_start_page_urls/_external_start_page_url.html.erb
@@ -1,6 +1,6 @@
 <div class="component-dialog-api-request" id="external_start_page_url">
   <%= form_for @external_url, url: api_service_external_start_page_index_path(service.service_id), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-    <h2 class="govuk-heading-m"><%= editing? ? t('external_start_page_url.editing_title') : t('external_start_page_url.title') %></h2>
+    <h2 id="dialog-title" class="govuk-heading-m"><%= editing? ? t('external_start_page_url.editing_title') : t('external_start_page_url.title') %></h2>
     
     <% if !editing? %>
       <p class="description"><%= t('external_start_page_url.content') %></p>

--- a/app/views/api/external_start_page_urls/preview.html.erb
+++ b/app/views/api/external_start_page_urls/preview.html.erb
@@ -1,5 +1,5 @@
 <div class="component-dialog-api-request" id="external_start_page_preview">
-  <h2 class="govuk-heading-m"><%= t('external_start_page_url.preview.title') %></h2>
+  <h2 id="dialog-title" class="govuk-heading-m"><%= t('external_start_page_url.preview.title') %></h2>
   <p class="description"><%= t('external_start_page_url.preview.content_one') %></p>
   <p class="description"><%= t('external_start_page_url.preview.content_two', href: govuk_link_to(t('external_start_page_url.preview.link_text'), settings_form_name_url_index_path(service.service_id))).html_safe %></p>
 

--- a/app/views/api/move/_branch_destination_no_default_next.html.erb
+++ b/app/views/api/move/_branch_destination_no_default_next.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request"
      data-component="DialogApiRequest" id="branch_destination_no_default_next">
 
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.move.you_cannot_move_this_page') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/move/_new.html.erb
+++ b/app/views/api/move/_new.html.erb
@@ -4,7 +4,7 @@
       <%= f.hidden_field :previous_flow_uuid, value: @move.previous_flow_uuid %>
       <%= f.hidden_field :previous_conditional_uuid, value: @move.previous_conditional_uuid %>
       <%= f.hidden_field :target_conditional_uuid, value: '' %>
-      <%= f.label :target_uuid, t('dialogs.move.label', title: @move.title), class: "govuk-label govuk-label--m" %>
+      <%= f.label :target_uuid, t('dialogs.move.label', title: @move.title), id: "dialog-title", class: "govuk-label govuk-label--m" %>
       <p> <%= t('dialogs.move.lede') %></p>
       <div class="govuk-form-group">
         <select class="govuk-select" name="move[target_uuid]" id="move_target_uuid">

--- a/app/views/api/move/_stacked_branches_not_supported.html.erb
+++ b/app/views/api/move/_stacked_branches_not_supported.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request"
      data-component="DialogApiRequest" id="stacked_branches_not_supported">
 
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.move.you_cannot_move_this_page') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/pages/_delete_branch_destination_page_modal.html.erb
+++ b/app/views/api/pages/_delete_branch_destination_page_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.heading_delete', label: @page.title) %>
   </h3>
   <p data-node="content">

--- a/app/views/api/pages/_delete_branch_destination_page_no_default_next_modal.html.erb
+++ b/app/views/api/pages/_delete_branch_destination_page_no_default_next_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.heading_delete_no_default_next') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/pages/_delete_modal.html.erb
+++ b/app/views/api/pages/_delete_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.heading_delete', label: @page.title) %>
   </h3>
   <p data-node="content">

--- a/app/views/api/pages/_delete_page_used_for_branching_not_supported_modal.html.erb
+++ b/app/views/api/pages/_delete_page_used_for_branching_not_supported_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request"
      data-component="DialogApiRequest">
 
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('pages.delete_modal.you_cannot_delete_this_page') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/pages/_delete_page_used_for_conditional_content_modal.html.erb
+++ b/app/views/api/pages/_delete_page_used_for_conditional_content_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('pages.delete_modal.you_cannot_delete_this_page') %>
   </h3>
 

--- a/app/views/api/pages/_delete_page_used_for_confirmation_email_modal.html.erb
+++ b/app/views/api/pages/_delete_page_used_for_confirmation_email_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('pages.delete_modal.can_not_delete_email_page_heading') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/pages/_stack_branches_not_supported_modal.html.erb
+++ b/app/views/api/pages/_stack_branches_not_supported_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request"
      data-component="DialogApiRequest">
 
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('pages.delete_modal.you_cannot_delete_this_page') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/question_options/_delete_option_modal.html.erb
+++ b/app/views/api/question_options/_delete_option_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.heading_delete_option', label: @label) %>
   </h3>
   <p data-node="content">

--- a/app/views/api/question_options/_delete_option_used_for_branching_modal.html.erb
+++ b/app/views/api/question_options/_delete_option_used_for_branching_modal.html.erb
@@ -1,5 +1,5 @@
 <div class="component component-dialog component-dialog-delete" id="dialog-confirmation-delete">
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('question_items.delete_modal.can_not_delete_heading') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/question_options/_delete_option_used_for_conditional_content_modal.html.erb
+++ b/app/views/api/question_options/_delete_option_used_for_conditional_content_modal.html.erb
@@ -1,5 +1,5 @@
 <div class="component component-dialog component-dialog-delete" id="dialog-confirmation-delete">
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('question_items.delete_modal.can_not_delete_heading') %>
   </h3>
 

--- a/app/views/api/questions/_delete_question_modal.html.erb
+++ b/app/views/api/questions/_delete_question_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.heading_delete', label: @question.humanised_title) %>
   </h3>
   <p data-node="content">

--- a/app/views/api/questions/_delete_question_used_for_branching_modal.html.erb
+++ b/app/views/api/questions/_delete_question_used_for_branching_modal.html.erb
@@ -1,5 +1,5 @@
 <div class="component component-dialog component-dialog-delete" id="dialog-confirmation-delete">
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('questions.delete_modal.can_not_delete_heading') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/questions/_delete_question_used_for_conditional_content_modal.html.erb
+++ b/app/views/api/questions/_delete_question_used_for_conditional_content_modal.html.erb
@@ -1,5 +1,5 @@
 <div class="component component-dialog component-dialog-delete" id="dialog-confirmation-delete">
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('questions.delete_modal.can_not_delete_heading') %>
   </h3>
 

--- a/app/views/api/questions/_delete_question_used_for_confirmation_email_modal.html.erb
+++ b/app/views/api/questions/_delete_question_used_for_confirmation_email_modal.html.erb
@@ -1,5 +1,5 @@
 <div class="component component-dialog component-dialog-delete" id="dialog-confirmation-delete">
-  <h3 data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('questions.delete_modal.can_not_delete_heading') %>
   </h3>
   <p data-node="content">

--- a/app/views/partials/_template_dialog.html.erb
+++ b/app/views/partials/_template_dialog.html.erb
@@ -3,7 +3,7 @@
         data-classes="dialog-message">
 
   <div class="component component-dialog" id="dialog">
-    <h3 data-node="heading" class="govuk-label govuk-label--m">
+    <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
       <%= t('dialogs.heading') %>
     </h3>
 

--- a/app/views/partials/_template_dialog_confirmation.html.erb
+++ b/app/views/partials/_template_dialog_confirmation.html.erb
@@ -5,7 +5,7 @@
         data-text-ok="<%= t('dialogs.button_ok') %>">
 
   <div class="component component-dialog component-dialog-confirmation" id="dialog-confirmation">
-    <h3 data-node="heading" class="govuk-label govuk-label--m">
+    <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
       <%= t('dialogs.heading') %>
     </h3>
     <p data-node="content">

--- a/app/views/partials/_template_dialog_confirmation_delete.html.erb
+++ b/app/views/partials/_template_dialog_confirmation_delete.html.erb
@@ -5,7 +5,7 @@
         data-text-ok="<%= t('dialogs.button_delete') %>">
 
   <div class="component component-dialog component-dialog-delete" id="dialog-confirmation-delete">
-    <h3 data-node="heading" class="govuk-label govuk-label--m"><%= t('dialogs.heading_delete') %></h3>
+    <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m"><%= t('dialogs.heading_delete') %></h3>
     <p data-node="content"><%= t('dialogs.message_delete') %></p>
     <div class="govuk-button-group">
       <button class="govuk-button govuk-button--warning" data-node="confirm" data-method="delete"><%= t('dialogs.button_delete') %></button>

--- a/app/views/publish/_form.html.erb
+++ b/app/views/publish/_form.html.erb
@@ -22,7 +22,7 @@
 <% if deployment_environment == 'dev' %>
   <%= f.hidden_field :require_authentication, value: 1 %>
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-0">
-    <h2 data-node="heading" class="govuk-fieldset__heading govuk-!-margin-top-0">
+    <h2 id="dialog-title" data-node="heading" class="govuk-fieldset__heading govuk-!-margin-top-0">
       <%= t('activemodel.attributes.publish_service_creation.test_title') %>
     </h2>
   </legend>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -28,7 +28,7 @@
         <%= form_for(@service_creation, url: services_path) do |f| %>
           <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
             <%= tag.div class: 'govuk-character-count', data: { module: 'govuk-character-count', maxlength: Editor::Service::MAXIMUM, threshold: 90 } do %>
-              <%= f.label :service_name, class: "govuk-label govuk-label--m" %>
+              <%= f.label :service_name, class: "govuk-label govuk-label--m", id: "dialog-title" %>
               <% f.object.errors.each do |error|  %>
                 <p class="govuk-error-message"><%= error.message %></p>
               <% end %>


### PR DESCRIPTION
We use jQueryUI for our modal dialogs but we hide the default jQueryUI titlebar of the modal.

This means the `aria-labelledby` attribute for the modal set by JQueryUI refences a non-visible and empty element 🤦 

This PR updates our modal dialog JS classes to set the aria-labelledby attribute to 'dialog-title'

Then all of the modal templates have been updated to add `id="dialog-title` to the appropriate `heading`, `label` or `legend` element.