### PR TITLE
Fix blue notification appearing on form error

### DIFF
--- a/app/controllers/settings/reference_payment_controller.rb
+++ b/app/controllers/settings/reference_payment_controller.rb
@@ -1,5 +1,5 @@
 class Settings::ReferencePaymentController < FormController
-  before_action :assign_form_objects, only: :index
+  before_action :assign_form_objects, only: %i[index create]
 
   def index; end
 


### PR DESCRIPTION
https://trello.com/c/kjGWZoFD

The blue important message box was showing when there is an error message even though it's not supposed to.

This is because on form submission some variables were not being properly assigned and if the form gave error, the view would incorrectly show the blue notification due to this.

Fixed by assigning these variables also in the `#create` action so they are present in the view if the form triggers an error.

![errors](https://github.com/ministryofjustice/fb-editor/assets/687910/403d4203-1ba7-4528-a0a4-4601b7eac3b5)
