### PR TITLE
Add aria-haspopup attribute

### DIFF
--- a/app/javascript/src/component_dialog.js
+++ b/app/javascript/src/component_dialog.js
@@ -1,99 +1,96 @@
 /**
-* Dialog Component
-* ------------------------------------------------------------------------------
-* Author: Chris Pymm (chris.pymm@digital.justice.gov.uk)
-*
-* Description
-* ===========
-* Wraps a provided jQuery node with jQuery UI Dialog functionality.  The node
-* provided should include any ui buttons to confirm / cancel the action as we do
-* not use the native jQuery UI dialog buttons.
-*
-* These dialogs are intended to be used with a static template (always) present
-* in the page, that does not contain the text content.
-*
-* When the dialog is required the open method is called with the desired
-* content, which is then injected into the template and the dialog opened and
-* shown to the user.
-*
-* Configuration
-* =============
-* Accepts a configuration object with the following properties in the format
-* property (type) [default value]:
-*
-*  - activator ($node | boolean) [false]
-*    Either an existing node that will trigger the dialog, or a boolean value
-*    indicating whether or not to create an activator
-*
-*  - autoOpen (boolean) [false]
-*    Open the dialog on creation.
-*
-*  - classes (object) [{}]
-*    An object of jQuery ui classes that will be applied to the UI dialog
-*    elements
-*
-*  - closeOnClickSelector (string) [button:not([data-node="confirm"])]
-*    jQuery selector string for elements that will close the dialog when
-*    clicked.  Should *not* include the confirmation element.
-*
-*  - confirmOnClickSelector (string) [button[data-node="confirm"]]
-*    jQuery selector string for the 'confirmation' action for the dialog.
-*    bin
-*
-*  - onOpen (function(dialog))
-*    Callable that will be called when the dialog is opened. Recieves the
-*    Dialog class instance as an argument
-*
-*  - onClose (function(dialog))
-*    Callable that will be called when the dialog is closed. Recieves the
-*    Dialog class instance as an argument
-*
-*  - onConfirm (function(dialog))
-*    Callable that will be called when the confirm UI button is clicked. Recieves the
-*    Dialog class instance as an argument
-*
-*  - onReady (function(dialog))
-*    Callable that will be called when the dialog has been instantiated and all
-*    event listeners / JS enhancements have been applied. Recieves the
-*    Dialog class instance as an argument
-*
-* Setters
-* =======
-* As the dialog is initialised on a template node and reused with different
-* injected content for many actions within the app, the following setters are
-* provided to override the global config.
-*
-* content(text)
-* Allows the injection of content for the dialog.  Expects an object with the
-* following properties:
-*  - heading: The dialog heading/title
-*  - content: The main dialog content
-*  - confirm: The label for the confirm button
-*  - cancel: The label for the (optional) cancel button
-*
-*  onClose(callable)
-*  Allows for a custom onClose callback to be provided for a Dialog instance
-*
-*  onConfirm(callable)
-*  Allows for a custom onConfirm callback to be provided for a Dialog instance
-*
-*  onOpen(callable)
-*  Allows for a custom onOpen callback to be provided for a Dialog instance
-*
-* References
-* ==========
-*  - jQueryUI Dialog: https://api.jqueryui.com/dialog
-**/
+ * Dialog Component
+ * ------------------------------------------------------------------------------
+ * Author: Chris Pymm (chris.pymm@digital.justice.gov.uk)
+ *
+ * Description
+ * ===========
+ * Wraps a provided jQuery node with jQuery UI Dialog functionality.  The node
+ * provided should include any ui buttons to confirm / cancel the action as we do
+ * not use the native jQuery UI dialog buttons.
+ *
+ * These dialogs are intended to be used with a static template (always) present
+ * in the page, that does not contain the text content.
+ *
+ * When the dialog is required the open method is called with the desired
+ * content, which is then injected into the template and the dialog opened and
+ * shown to the user.
+ *
+ * Configuration
+ * =============
+ * Accepts a configuration object with the following properties in the format
+ * property (type) [default value]:
+ *
+ *  - activator ($node | boolean) [false]
+ *    Either an existing node that will trigger the dialog, or a boolean value
+ *    indicating whether or not to create an activator
+ *
+ *  - autoOpen (boolean) [false]
+ *    Open the dialog on creation.
+ *
+ *  - classes (object) [{}]
+ *    An object of jQuery ui classes that will be applied to the UI dialog
+ *    elements
+ *
+ *  - closeOnClickSelector (string) [button:not([data-node="confirm"])]
+ *    jQuery selector string for elements that will close the dialog when
+ *    clicked.  Should *not* include the confirmation element.
+ *
+ *  - confirmOnClickSelector (string) [button[data-node="confirm"]]
+ *    jQuery selector string for the 'confirmation' action for the dialog.
+ *    bin
+ *
+ *  - onOpen (function(dialog))
+ *    Callable that will be called when the dialog is opened. Recieves the
+ *    Dialog class instance as an argument
+ *
+ *  - onClose (function(dialog))
+ *    Callable that will be called when the dialog is closed. Recieves the
+ *    Dialog class instance as an argument
+ *
+ *  - onConfirm (function(dialog))
+ *    Callable that will be called when the confirm UI button is clicked. Recieves the
+ *    Dialog class instance as an argument
+ *
+ *  - onReady (function(dialog))
+ *    Callable that will be called when the dialog has been instantiated and all
+ *    event listeners / JS enhancements have been applied. Recieves the
+ *    Dialog class instance as an argument
+ *
+ * Setters
+ * =======
+ * As the dialog is initialised on a template node and reused with different
+ * injected content for many actions within the app, the following setters are
+ * provided to override the global config.
+ *
+ * content(text)
+ * Allows the injection of content for the dialog.  Expects an object with the
+ * following properties:
+ *  - heading: The dialog heading/title
+ *  - content: The main dialog content
+ *  - confirm: The label for the confirm button
+ *  - cancel: The label for the (optional) cancel button
+ *
+ *  onClose(callable)
+ *  Allows for a custom onClose callback to be provided for a Dialog instance
+ *
+ *  onConfirm(callable)
+ *  Allows for a custom onConfirm callback to be provided for a Dialog instance
+ *
+ *  onOpen(callable)
+ *  Allows for a custom onOpen callback to be provided for a Dialog instance
+ *
+ * References
+ * ==========
+ *  - jQueryUI Dialog: https://api.jqueryui.com/dialog
+ **/
 
-const {
-  mergeObjects,
-  safelyActivateFunction,
-} = require('./utilities');
+const { mergeObjects, safelyActivateFunction } = require("./utilities");
 
-const DialogActivator = require('./component_dialog_activator');
+const DialogActivator = require("./component_dialog_activator");
 
 class Dialog {
-  #className = 'Dialog';
+  #className = "Dialog";
   #config;
   #defaultText = {};
   #elements = {};
@@ -104,19 +101,22 @@ class Dialog {
    * @param {Object} config - config key/value pairs
    */
   constructor($node, config) {
-    this.#config = mergeObjects({
-      activator: false,
-      autoOpen: false,
-      classes: {},
-      closeOnClickSelector: 'button:not([data-node="confirm"])',
-      confirmOnClickSelector: 'button[data-node="confirm"]',
-      onOpen: function(dialog) {},
-      onClose: function(dialog) {},
-      onConfirm: function(dialog) {},
-      onReady: function(dialog) {},
-    }, config);
+    this.#config = mergeObjects(
+      {
+        activator: false,
+        autoOpen: false,
+        classes: {},
+        closeOnClickSelector: 'button:not([data-node="confirm"])',
+        confirmOnClickSelector: 'button[data-node="confirm"]',
+        onOpen: function (dialog) {},
+        onClose: function (dialog) {},
+        onConfirm: function (dialog) {},
+        onReady: function (dialog) {},
+      },
+      config,
+    );
 
-    this.#state = 'closed';
+    this.#state = "closed";
     this.$node = $(); // Should be overwritten once intialised
     this.$container = $(); // Should be overwritten once intialised
 
@@ -127,7 +127,7 @@ class Dialog {
     return this.#config.activator;
   }
 
-  get state(){
+  get state() {
     return this.#state;
   }
 
@@ -155,23 +155,23 @@ class Dialog {
   }
 
   set content(text) {
-    let content = mergeObjects(this.#defaultText, text)
+    let content = mergeObjects(this.#defaultText, text);
 
-    this.#elements.heading.text( content.heading );
-    this.#elements.content.html( content.content );
-    this.#elements.confirm.text( content.confirm );
-    this.#elements.cancel.text( content.cancel );
+    this.#elements.heading.text(content.heading);
+    this.#elements.content.html(content.content);
+    this.#elements.confirm.text(content.confirm);
+    this.#elements.cancel.text(content.cancel);
   }
 
   isOpen() {
-    return this.#state == 'open';
+    return this.#state == "open";
   }
 
   open(text) {
     const dialog = this;
 
     this.content = text || {};
-    this.$node.dialog('open');
+    this.$node.dialog("open");
     this.#state = "open";
 
     safelyActivateFunction(this.#config.onOpen, dialog);
@@ -186,31 +186,32 @@ class Dialog {
 
     this.focusActivator();
 
-    this.$node.dialog('close');
-    this.#state = 'closed';
+    this.$node.dialog("close");
+    this.#state = "closed";
 
-    safelyActivateFunction(callback || function(){}, dialog);
+    safelyActivateFunction(callback || function () {}, dialog);
     safelyActivateFunction(this.#config.onClose, dialog);
 
-    this.#config.onClose = this.originalOnClose || function() {};
-    this.#config.onConfirm = this.originalOnConfirm || function() {};
-    this.#config.onOpen = this.originalOnOpen || function() {};
+    this.#config.onClose = this.originalOnClose || function () {};
+    this.#config.onConfirm = this.originalOnConfirm || function () {};
+    this.#config.onOpen = this.originalOnOpen || function () {};
   }
 
   focus() {
-    const el = this.$node.find('.govuk-button:not([type="disabled"]):not([data-method="delete"])').eq(0);
-    if(el){
+    const el = this.$node
+      .find('.govuk-button:not([type="disabled"]):not([data-method="delete"])')
+      .eq(0);
+    if (el) {
       el.focus();
     }
   }
 
   focusActivator() {
     // Attempt to refocus on original activator
-    if(this.activator) {
+    if (this.activator) {
       this.activator.focus();
     }
   }
-
 
   #initialize($node) {
     this.$node = $node;
@@ -218,7 +219,7 @@ class Dialog {
     this.#build();
     this.#enhance();
 
-    if( this.#config.autoOpen ) {
+    if (this.#config.autoOpen) {
       this.open();
     }
   }
@@ -227,7 +228,7 @@ class Dialog {
     var dialog = this;
 
     // this.activator is true || $node setup a DialogActivator
-    if(this.activator) {
+    if (this.activator) {
       this.#addActivator();
     }
 
@@ -248,23 +249,23 @@ class Dialog {
 
   #enhance() {
     const dialog = this;
-    const $content = $('[data-node="content"]', $content);
+    const $content = $('[data-node="content"]', this.$node);
 
     this.#setElements();
     this.#setDefaultText();
 
-    this.$node.find('h3').attr('id', 'dialog-title')
-    this.$container.attr('aria-labelledby', 'dialog-title')
+    this.$node.find("h3").attr("id", "dialog-title");
+    this.$container.attr("aria-labelledby", "dialog-title");
     if ($content.length) {
       $content.attr("id", "dialog-content");
       this.$container.attr("aria-describedby", "dialog-content");
     }
 
-    if(this.#config.closeOnClickSelector) {
+    if (this.#config.closeOnClickSelector) {
       this.#setupCloseButtons();
     }
 
-    if(this.#config.confirmOnClickSelector) {
+    if (this.#config.confirmOnClickSelector) {
       this.#setupConfirmButton();
     }
 
@@ -277,7 +278,7 @@ class Dialog {
       content: this.$node.find("[data-node='content']"),
       confirm: this.$node.find("[data-node='confirm']"),
       cancel: this.$node.find("[data-node='cancel']"),
-    }
+    };
   }
 
   #setDefaultText() {
@@ -286,16 +287,16 @@ class Dialog {
       content: this.#elements.content.text(),
       confirm: this.#elements.confirm.text(),
       cancel: this.#elements.cancel.text(),
-    }
+    };
   }
 
   /* Add event listeners to configured close buttons */
   #setupCloseButtons() {
     const dialog = this;
 
-    if(this.#config.closeOnClickSelector) {
+    if (this.#config.closeOnClickSelector) {
       let $buttons = $(this.#config.closeOnClickSelector, this.$container);
-      $buttons.on("click", function() {
+      $buttons.on("click", function () {
         dialog.close();
       });
     }
@@ -303,8 +304,11 @@ class Dialog {
 
   #setupConfirmButton() {
     const dialog = this;
-    const $button = $(this.#config.confirmOnClickSelector, this.$container).first();
-    $button.on("click", function(e) {
+    const $button = $(
+      this.#config.confirmOnClickSelector,
+      this.$container,
+    ).first();
+    $button.on("click", function (e) {
       e.preventDefault();
       dialog.close(dialog.#config.onConfirm);
     });
@@ -317,15 +321,14 @@ class Dialog {
     var activator = new DialogActivator(this.#config.activator, {
       dialog: this,
       text: this.#config.activatorText,
-      classes: this.#config.classes?.activator || '',
-      $target: $marker
+      classes: this.#config.classes?.activator || "",
+      $target: $marker,
     });
 
     this.activator = activator.$node;
 
     $marker.remove();
   }
-
 }
 
 module.exports = Dialog;

--- a/app/javascript/src/component_dialog.js
+++ b/app/javascript/src/component_dialog.js
@@ -241,16 +241,24 @@ class Dialog {
     });
 
     this.$container = dialog.$node.parents(".ui-dialog");
+    this.$container.attr("aria-modal", true);
     this.$container.addClass(dialog.#className);
-    this.$container.attr('aria-labelledby', 'dialog-title')
     this.$node.data("instance", dialog);
   }
 
   #enhance() {
     const dialog = this;
+    const $content = $('[data-node="content"]', $content);
 
     this.#setElements();
     this.#setDefaultText();
+
+    this.$node.find('h3').attr('id', 'dialog-title')
+    this.$container.attr('aria-labelledby', 'dialog-title')
+    if ($content.length) {
+      $content.attr("id", "dialog-content");
+      this.$container.attr("aria-describedby", "dialog-content");
+    }
 
     if(this.#config.closeOnClickSelector) {
       this.#setupCloseButtons();

--- a/app/javascript/src/component_dialog_activator.js
+++ b/app/javascript/src/component_dialog_activator.js
@@ -59,6 +59,7 @@ class DialogActivator {
   #createActivator($target, text) {
     var $activator = $("<button></button>");
     $activator.text((text || "open dialog"));
+    $activator.attr('aria-haspopup', 'dialog')
     $target.before($activator);
     return $activator;
   }

--- a/app/javascript/src/component_dialog_api_request.js
+++ b/app/javascript/src/component_dialog_api_request.js
@@ -205,7 +205,7 @@ class DialogApiRequest {
 
   #enhance() {
     const dialog = this;
-    const $content = $('[data-node="content"]', $content);
+    const $content = $('[data-node="content"]', this.$node);
 
     this.#setupButtons();
 

--- a/app/javascript/src/component_dialog_api_request.js
+++ b/app/javascript/src/component_dialog_api_request.js
@@ -197,15 +197,25 @@ class DialogApiRequest {
     });
 
     this.$container = dialog.$node.parents(".ui-dialog");
+    this.$container.attr("aria-modal", true);
     this.$container.addClass(dialog.#className);
-    this.$container.attr("aria-labelledby", "dialog-title");
+
     this.$node.data("instance", dialog);
   }
 
   #enhance() {
     const dialog = this;
+    const $content = $('[data-node="content"]', $content);
 
     this.#setupButtons();
+
+    this.$container.attr("aria-labelledby", "dialog-title");
+    this.$container.removeAttr("aria-describedby");
+
+    if ($content.length) {
+      $content.attr("id", "dialog-content");
+      this.$container.attr("aria-describedby", "dialog-content");
+    }
 
     safelyActivateFunction(dialog.#config.onReady, dialog);
   }

--- a/app/javascript/src/component_dialog_form.js
+++ b/app/javascript/src/component_dialog_form.js
@@ -1,121 +1,120 @@
 /**
-* Dialog Form Component
-* ------------------------------------------------------------------------------
-* Author: Chris Pymm (chris.pymm@digital.justice.gov.uk)
-*
-* Description
-* ===========
-* Provides a jQuery UI dialog around either a provided HTML template node wihtin
-* the page, or an HTML teplate recieved via an API request.
-*
-* This class is effectively a combination of the Dialog and DialogApiRequest
-* classes with added functionality to handle forms.
-*
-* The form within the dialog can either be submitted synchronoously or
-* asynchronously.
-*
-* Configuration
-* =============
-* Accepts a configuration object with the following properties in the format
-* property (type) [default value]:
-*
-*  - activator ($node | boolean) [false]
-*    Either an existing node that will trigger the dialog, or a boolean value
-*    indicating whether or not to create an activator
-*
-*  - autoOpen (boolean) [false]
-*    Open the dialog on creation.
-*
-*  - classes (object) [{}]
-*    An object of jQuery ui classes that will be applied to the UI dialog
-*    elements
-*
-*  - closeOnClickSelector (string) ['button[type="button]']
-*    jQuery selector string for elements that will close the dialog when
-*    clicked.
-*
-*  - submitOnClickSelector (string) ['button[type="submit"]']
-*    jQuery selector string for the button that will submit the form wihtin the
-*    dialog when clicked.
-*
-*  - remote (boolean) [false]
-*    Whether the form will submit async or not
-*
-*  - disableOnSubmit (false|string) [false]
-*    Only used when remote is true.  If a string is provided, the submit button
-*    will be disabled on submit, and its label set to the value of this option.
-*
-*  - onOpen (function(dialog))
-*    Callable that will be called when the dialog is opened. Recieves the
-*    Dialog class instance as an argument
-*
-*  - onClose (function(dialog))
-*    Callable that will be called when the dialog is closed. Recieves the
-*    Dialog class instance as an argument
-*
-*  - onLoad (function(dialog))
-*    Callable that will be called when the response from the server is
-*    successfully recieved, but before the jQuery dialog is initialized or any
-*    enhancements ahve been applied to the repsonse. Recieves the Dialog class
-*    instance as an argument
-*
-*  - onReady (function(dialog))
-*    Callable that will be called when the dialog has been instantiated and all
-*    event listeners / JS enhancements have been applied. Recieves the
-*    Dialog class instance as an argument
-*
-*  - onError (function(dialog))
-*    Callable that will be called if there is an error in submitting the form
-*    asynchronously. Recieves the Dialog class instance as an argument
-*
-*  - onSuccess (function(dialog))
-*    Callable that will be called on successful async submission of the form.
-*    Recieves the Dialog class instance as an argument
-*
-*  - beforeSubmit (function(dialog))
-*    Callable that will be called on click of the submit button but before
-*    dialog.submit() is called.  Allows manipulation of form values / data if
-*    required. Recieves the Dialog class instance as an argument
-*
-**/
+ * Dialog Form Component
+ * ------------------------------------------------------------------------------
+ * Author: Chris Pymm (chris.pymm@digital.justice.gov.uk)
+ *
+ * Description
+ * ===========
+ * Provides a jQuery UI dialog around either a provided HTML template node wihtin
+ * the page, or an HTML teplate recieved via an API request.
+ *
+ * This class is effectively a combination of the Dialog and DialogApiRequest
+ * classes with added functionality to handle forms.
+ *
+ * The form within the dialog can either be submitted synchronoously or
+ * asynchronously.
+ *
+ * Configuration
+ * =============
+ * Accepts a configuration object with the following properties in the format
+ * property (type) [default value]:
+ *
+ *  - activator ($node | boolean) [false]
+ *    Either an existing node that will trigger the dialog, or a boolean value
+ *    indicating whether or not to create an activator
+ *
+ *  - autoOpen (boolean) [false]
+ *    Open the dialog on creation.
+ *
+ *  - classes (object) [{}]
+ *    An object of jQuery ui classes that will be applied to the UI dialog
+ *    elements
+ *
+ *  - closeOnClickSelector (string) ['button[type="button]']
+ *    jQuery selector string for elements that will close the dialog when
+ *    clicked.
+ *
+ *  - submitOnClickSelector (string) ['button[type="submit"]']
+ *    jQuery selector string for the button that will submit the form wihtin the
+ *    dialog when clicked.
+ *
+ *  - remote (boolean) [false]
+ *    Whether the form will submit async or not
+ *
+ *  - disableOnSubmit (false|string) [false]
+ *    Only used when remote is true.  If a string is provided, the submit button
+ *    will be disabled on submit, and its label set to the value of this option.
+ *
+ *  - onOpen (function(dialog))
+ *    Callable that will be called when the dialog is opened. Recieves the
+ *    Dialog class instance as an argument
+ *
+ *  - onClose (function(dialog))
+ *    Callable that will be called when the dialog is closed. Recieves the
+ *    Dialog class instance as an argument
+ *
+ *  - onLoad (function(dialog))
+ *    Callable that will be called when the response from the server is
+ *    successfully recieved, but before the jQuery dialog is initialized or any
+ *    enhancements ahve been applied to the repsonse. Recieves the Dialog class
+ *    instance as an argument
+ *
+ *  - onReady (function(dialog))
+ *    Callable that will be called when the dialog has been instantiated and all
+ *    event listeners / JS enhancements have been applied. Recieves the
+ *    Dialog class instance as an argument
+ *
+ *  - onError (function(dialog))
+ *    Callable that will be called if there is an error in submitting the form
+ *    asynchronously. Recieves the Dialog class instance as an argument
+ *
+ *  - onSuccess (function(dialog))
+ *    Callable that will be called on successful async submission of the form.
+ *    Recieves the Dialog class instance as an argument
+ *
+ *  - beforeSubmit (function(dialog))
+ *    Callable that will be called on click of the submit button but before
+ *    dialog.submit() is called.  Allows manipulation of form values / data if
+ *    required. Recieves the Dialog class instance as an argument
+ *
+ **/
 
-const {
-mergeObjects,
-safelyActivateFunction,
-meta
-} = require('./utilities');
+const { mergeObjects, safelyActivateFunction, meta } = require("./utilities");
 
-const DialogActivator = require('./component_dialog_activator');
+const DialogActivator = require("./component_dialog_activator");
 
 class DialogForm {
-  #className = 'DialogForm';
+  #className = "DialogForm";
   #config;
   #remoteSource;
   #state;
 
   /**
-  * @param {string|jQuery} source - Either a url to request html from or jQuery node
-  * @param {Object} config - config key/value pairs
-  */
+   * @param {string|jQuery} source - Either a url to request html from or jQuery node
+   * @param {Object} config - config key/value pairs
+   */
   constructor(source, config) {
-    this.#config = mergeObjects({
-      activator: false,
-      autoOpen: false,
-      classes: {},
-      closeOnClickSelector: 'button[type="button"]',
-      submitOnClickSelector: 'button[type="submit"]',
-      remote: false,
-      requestMethod: 'GET',
-      requestData: {},
-      disableOnSubmit: '',
-      onLoad: function(dialog) {},
-      onReady: function(dialog) {},
-      beforeSubmit: function(dialog) {},
-      onSuccess: function(data, dialog) {},
-      onError: function(data, dialog) {},
-      onOpen: function(dialog) {},
-      onClose: function(dialog) {},
-    }, config);
+    this.#config = mergeObjects(
+      {
+        activator: false,
+        autoOpen: false,
+        classes: {},
+        closeOnClickSelector: 'button[type="button"]',
+        submitOnClickSelector: 'button[type="submit"]',
+        remote: false,
+        requestMethod: "GET",
+        requestData: {},
+        disableOnSubmit: "",
+        onLoad: function (dialog) {},
+        onReady: function (dialog) {},
+        beforeSubmit: function (dialog) {},
+        onSuccess: function (data, dialog) {},
+        onError: function (data, dialog) {},
+        onOpen: function (dialog) {},
+        onClose: function (dialog) {},
+      },
+      config,
+    );
 
     this.#remoteSource = false;
     this.#state = "closed";
@@ -145,7 +144,7 @@ class DialogForm {
   open() {
     var dialog = this;
 
-    if(this.$node.dialog('instance')) {
+    if (this.$node.dialog("instance")) {
       this.$node.dialog("open");
       this.#state = "open";
       safelyActivateFunction(this.#config.onOpen, dialog);
@@ -161,19 +160,19 @@ class DialogForm {
     // Attempt to refocus on original activator
     this.focusActivator();
 
-    if(this.$node.dialog('instance')) {
+    if (this.$node.dialog("instance")) {
       this.$node.dialog("close");
       safelyActivateFunction(dialog.#config.onClose, dialog);
       this.#state = "closed";
     }
 
-    if(this.#remoteSource){
+    if (this.#remoteSource) {
       this.#destroy();
     }
   }
 
   submit() {
-    if( this.#config.remote ) {
+    if (this.#config.remote) {
       this.#submitRemote();
     } else {
       this.$form.submit();
@@ -184,17 +183,24 @@ class DialogForm {
     // If there is an error summary initialize it and it sill be given focus
     // else if there is an invalid input, place focus there
     // else focus on the first input/button that is not hidden or disabled
-    const errorSummary = this.$form.get(0)?.querySelector('[data-module="govuk-error-summary"]')
+    const errorSummary = this.$form
+      .get(0)
+      ?.querySelector('[data-module="govuk-error-summary"]');
     if (errorSummary) {
-      new window.GOVUKFrontend.ErrorSummary(errorSummary).init()
-    } 
-    else {
-      let el = this.$node.parent().find('input[aria-invalid]').get(0);
+      new window.GOVUKFrontend.ErrorSummary(errorSummary).init();
+    } else {
+      let el = this.$node.parent().find("input[aria-invalid]").get(0);
       if (!el) {
-        el = this.$node.parent().find('input:not([type="hidden"], [type="disabled"]), .govuk-button:not([type="disabled"])').not(".ui-dialog-titlebar-close").eq(0);
+        el = this.$node
+          .parent()
+          .find(
+            'input:not([type="hidden"], [type="disabled"]), .govuk-button:not([type="disabled"])',
+          )
+          .not(".ui-dialog-titlebar-close")
+          .eq(0);
       }
 
-      if (el){
+      if (el) {
         el.focus();
       }
     }
@@ -202,16 +208,16 @@ class DialogForm {
 
   focusActivator() {
     // Attempt to refocus on original activator
-    if(this.activator) {
+    if (this.activator) {
       this.activator.focus();
     }
   }
 
   /*
-  * simply a function alias for better readability / nicer api
-  * expected to be called if the dialog html is changed dynamically
-  * will re-enhance the html to add the required functionality
-  * */
+   * simply a function alias for better readability / nicer api
+   * expected to be called if the dialog html is changed dynamically
+   * will re-enhance the html to add the required functionality
+   * */
   refresh() {
     this.#enhance();
   }
@@ -219,51 +225,49 @@ class DialogForm {
   #initialize(source) {
     var dialog = this;
 
-    if(typeof source == 'string') {
+    if (typeof source == "string") {
       this.#remoteSource = true;
-      $.ajax(source, this.#requestConfig())
-      .done((response) => {
+      $.ajax(source, this.#requestConfig()).done((response) => {
         this.$node = $(response);
         this.#build();
         // Allow a function to be specified in dialog config
         safelyActivateFunction(dialog.#config.onLoad, dialog);
         this.#enhance();
-        if(this.#config.autoOpen) {
+        if (this.#config.autoOpen) {
           this.open();
         }
-      })
+      });
     } else {
       this.$node = source;
 
       this.#build();
       this.#enhance();
 
-      if(this.#config.autoOpen) {
+      if (this.#config.autoOpen) {
         this.open();
       }
     }
-
   }
 
   #requestConfig() {
     let config = {
       method: this.#config.requestMethod,
-    }
-    if(this.#config.requestMethod == 'POST') {
+    };
+    if (this.#config.requestMethod == "POST") {
       config.headers = {
-        'X-CSRF-Token': meta('csrf-token') 
-      }
-      config.data = this.#config.requestData
+        "X-CSRF-Token": meta("csrf-token"),
+      };
+      config.data = this.#config.requestData;
     }
 
-    return config
+    return config;
   }
 
   #build() {
     var dialog = this;
 
     // this.activator is true || $node setup a DialogActivator
-    if(this.activator) {
+    if (this.activator) {
       this.#addActivator();
     }
     this.$node.dialog({
@@ -276,28 +280,28 @@ class DialogForm {
     });
 
     this.$container = dialog.$node.parents(".ui-dialog");
-    this.$container.attr('aria-modal', true)
+    this.$container.attr("aria-modal", true);
     this.$container.addClass(dialog.#className);
     this.$node.data("instance", dialog);
   }
 
   #enhance() {
     var dialog = this;
-    const $content = $('[data-node="content"]', $content);
+    const $content = $('[data-node="content"]', this.$node);
 
-    this.$form = this.$node.is('form') ? this.$node : this.$node.find('form');
-    this.$container.attr('aria-labelledby', 'dialog-title')
+    this.$form = this.$node.is("form") ? this.$node : this.$node.find("form");
+    this.$container.attr("aria-labelledby", "dialog-title");
 
     if ($content.length) {
       $content.attr("id", "dialog-content");
       this.$container.attr("aria-describedby", "dialog-content");
     }
 
-    if(this.#config.closeOnClickSelector) {
+    if (this.#config.closeOnClickSelector) {
       this.#setupCloseButtons();
     }
 
-    if(this.#config.submitOnClickSelector) {
+    if (this.#config.submitOnClickSelector) {
       this.#setupSubmitButton();
     }
 
@@ -307,9 +311,9 @@ class DialogForm {
   /* add event listeners to configured close buttons */
   #setupCloseButtons() {
     var dialog = this;
-    if(this.#config.closeOnClickSelector) {
+    if (this.#config.closeOnClickSelector) {
       let $buttons = $(this.#config.closeOnClickSelector, this.$container);
-      $buttons.on("click", function() {
+      $buttons.on("click", function () {
         dialog.close();
       });
     }
@@ -318,14 +322,17 @@ class DialogForm {
   /* add event listeners to configured submit button */
   #setupSubmitButton() {
     var dialog = this;
-    let $button = $(this.#config.submitOnClickSelector, this.$container).first();
-    $button.on("click", function(e) {
+    let $button = $(
+      this.#config.submitOnClickSelector,
+      this.$container,
+    ).first();
+    $button.on("click", function (e) {
       e.preventDefault();
-      if(dialog.#config.remote && dialog.#config.disableOnSubmit) {
+      if (dialog.#config.remote && dialog.#config.disableOnSubmit) {
         $button.text(dialog.#config.disableOnSubmit);
-        $button.attr('disabled', 'disabled');
+        $button.attr("disabled", "disabled");
       }
-      safelyActivateFunction(dialog.#config.beforeSubmit, dialog );
+      safelyActivateFunction(dialog.#config.beforeSubmit, dialog);
       dialog.submit();
     });
   }
@@ -334,50 +341,48 @@ class DialogForm {
     var dialog = this;
 
     $.ajax({
-      type: 'POST',
-      url: dialog.$form.attr('action'),
+      type: "POST",
+      url: dialog.$form.attr("action"),
       data: new FormData(dialog.$form.get(0)),
       processData: false,
       contentType: false,
-      success: function(data) {
+      success: function (data) {
         safelyActivateFunction(dialog.#config.onSuccess, data, dialog);
         dialog.close();
-        if (data['max_files']) {
+        if (data["max_files"]) {
           $(document).trigger("MaxFilesSave");
         }
       },
-      error: function(data) {
+      error: function (data) {
         safelyActivateFunction(dialog.#config.onError, data, dialog);
         dialog.focus();
-      }
+      },
     });
   }
 
   #destroy() {
-    if(this.$node.dialog('instance')) {
-      this.$node.dialog('destroy');
+    if (this.$node.dialog("instance")) {
+      this.$node.dialog("destroy");
     }
     this.$node.remove();
   }
 
   #addActivator() {
     var $marker = $("<span></span>");
-    if(this.$node) {
-    this.$node.before($marker);
-    var activator = new DialogActivator(this.#config.activator, {
-      dialog: this,
-      text: this.#config.activatorText,
-      classes: this.#config.classes?.activator || '',
-      $target: $marker
-    });
+    if (this.$node) {
+      this.$node.before($marker);
+      var activator = new DialogActivator(this.#config.activator, {
+        dialog: this,
+        text: this.#config.activatorText,
+        classes: this.#config.classes?.activator || "",
+        $target: $marker,
+      });
 
-    this.activator = activator.$node;
+      this.activator = activator.$node;
 
-    $marker.remove();
+      $marker.remove();
     }
   }
-
 }
-
 
 module.exports = DialogForm;

--- a/app/javascript/src/component_dialog_form.js
+++ b/app/javascript/src/component_dialog_form.js
@@ -276,15 +276,22 @@ class DialogForm {
     });
 
     this.$container = dialog.$node.parents(".ui-dialog");
+    this.$container.attr('aria-modal', true)
     this.$container.addClass(dialog.#className);
-    this.$container.attr('aria-labelledby', 'dialog-title')
     this.$node.data("instance", dialog);
   }
 
   #enhance() {
     var dialog = this;
+    const $content = $('[data-node="content"]', $content);
 
     this.$form = this.$node.is('form') ? this.$node : this.$node.find('form');
+    this.$container.attr('aria-labelledby', 'dialog-title')
+
+    if ($content.length) {
+      $content.attr("id", "dialog-content");
+      this.$container.attr("aria-describedby", "dialog-content");
+    }
 
     if(this.#config.closeOnClickSelector) {
       this.#setupCloseButtons();

--- a/app/views/partials/_template_dialog.html.erb
+++ b/app/views/partials/_template_dialog.html.erb
@@ -3,14 +3,8 @@
         data-classes="dialog-message">
 
   <div class="component component-dialog" id="dialog">
-    <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
-      <%= t('dialogs.heading') %>
-    </h3>
-
-    <p data-node="content">
-      <%= t('dialogs.message') %>
-    </p>
-
+    <h3 data-node="heading" class="govuk-label govuk-label--m"></h3>
+    <p data-node="content"></p>
     <div class="govuk-button-group">
       <button class="govuk-button fb-govuk-button" data-node="confirm"><%= t('dialogs.button_ok') %></button>
     </div>

--- a/app/views/partials/_template_dialog_confirmation.html.erb
+++ b/app/views/partials/_template_dialog_confirmation.html.erb
@@ -5,17 +5,11 @@
         data-text-ok="<%= t('dialogs.button_ok') %>">
 
   <div class="component component-dialog component-dialog-confirmation" id="dialog-confirmation">
-    <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
-      <%= t('dialogs.heading') %>
-    </h3>
-    <p data-node="content">
-      <%= t('dialogs.message') %>
-    </p>
-
+    <h3 data-node="heading" class="govuk-label govuk-label--m"></h3>
+    <p data-node="content"></p>
     <div>
       <button class="govuk-button" data-node="confirm"><%= t('dialogs.button_ok') %></button>
       <button class="govuk-button govuk-button--secondary" data-node="cancel"><%= t('dialogs.button_cancel') %></button>
     </div>
-
   </div>
 </script>

--- a/app/views/partials/_template_dialog_confirmation_delete.html.erb
+++ b/app/views/partials/_template_dialog_confirmation_delete.html.erb
@@ -5,8 +5,8 @@
         data-text-ok="<%= t('dialogs.button_delete') %>">
 
   <div class="component component-dialog component-dialog-delete" id="dialog-confirmation-delete">
-    <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m"><%= t('dialogs.heading_delete') %></h3>
-    <p data-node="content"><%= t('dialogs.message_delete') %></p>
+    <h3 data-node="heading" class="govuk-label govuk-label--m"></h3>
+    <p data-node="content"></p>
     <div class="govuk-button-group">
       <button class="govuk-button govuk-button--warning" data-node="confirm" data-method="delete"><%= t('dialogs.button_delete') %></button>
       <button class="govuk-button govuk-button--secondary" data-node="cancel"><%= t('dialogs.button_cancel') %></button>

--- a/app/views/publish/_publish_environment.html.erb
+++ b/app/views/publish/_publish_environment.html.erb
@@ -34,6 +34,7 @@
       data-module="govuk-button"
       type="button"
       data-fb-action="publish"
+      aria-haspopup="dialog"
       aria-disabled="<%= presenter.publish_button_disabled? %>"
       hidden >
       <%= t("publish.#{environment}.button") %>

--- a/app/views/services/_connection_menu.html.erb
+++ b/app/views/services/_connection_menu.html.erb
@@ -12,39 +12,39 @@
         <span><%= t('actions.add_single_question') -%></span>
         <ul class="govuk-navigation" role="menu">
           <li data-page-type="singlequestion"
-              data-component-type="text"><span><%= t('components.list.text') -%></span></li>
+              data-component-type="text"><span aria-haspopup="dialog"><%= t('components.list.text') -%></span></li>
           <li data-page-type="singlequestion"
               data-component-type="textarea"><span><%= t('components.list.textarea') -%></span></li>
           <li data-page-type="singlequestion"
-              data-component-type="email"><span><%= t('components.list.email') -%></span></li>
+              data-component-type="email"><span aria-haspopup="dialog"><%= t('components.list.email') -%></span></li>
           <li data-page-type="singlequestion"
-              data-component-type="number"><span><%= t('components.list.number') -%></span></li>
+              data-component-type="number"><span aria-haspopup="dialog"><%= t('components.list.number') -%></span></li>
           <li data-page-type="singlequestion"
-              data-component-type="date"><span><%= t('components.list.date') -%></span></li>
+              data-component-type="date"><span aria-haspopup="dialog"><%= t('components.list.date') -%></span></li>
           <li data-page-type="singlequestion"
-              data-component-type="address"><span><%= t('components.list.address') -%></span></li>
+              data-component-type="address"><span aria-haspopup="dialog"><%= t('components.list.address') -%></span></li>
           <li data-page-type="singlequestion"
-              data-component-type="radios"><span><%= t('components.list.radios') -%></span></li>
+              data-component-type="radios"><span aria-haspopup="dialog"><%= t('components.list.radios') -%></span></li>
           <li data-page-type="singlequestion"
-              data-component-type="checkboxes"><span><%= t('components.list.checkboxes') -%></span></li>
+              data-component-type="checkboxes"><span aria-haspopup="dialog"><%= t('components.list.checkboxes') -%></span></li>
           <li data-page-type="singlequestion"
-              data-component-type="autocomplete"><span><%= t('components.list.autocomplete') -%></span></li>
+              data-component-type="autocomplete"><span aria-haspopup="dialog"><%= t('components.list.autocomplete') -%></span></li>
           <li data-page-type="singlequestion"
-              data-component-type="multiupload"><span><%= t('components.list.upload') -%></span></li>
+              data-component-type="multiupload"><span aria-haspopup="dialog"><%= t('components.list.upload') -%></span></li>
         </ul>
       </li>
 
-      <li data-page-type="multiplequestions"><span><%= t('actions.add_multi_question') -%></span></li>
+      <li data-page-type="multiplequestions"><span aria-haspopup="dialog"><%= t('actions.add_multi_question') -%></span></li>
 
-      <li data-page-type="content"><span><%= t('actions.add_content') -%></span></li>
+      <li data-page-type="content"><span aria-haspopup="dialog"><%= t('actions.add_content') -%></span></li>
 
       <% unless item[:type] == 'page.start' %>
-        <li data-page-type="exit"><span><%= t('actions.add_exit') -%></span></li>
+        <li data-page-type="exit"><span aria-haspopup="dialog"><%= t('actions.add_exit') -%></span></li>
       <% end %>
     <% end %>
 
     <% if !service.checkanswers_page.present? && item[:type] != 'flow.branch' && (item[:next].blank? || item[:next] == service.confirmation_page&.uuid) %>
-      <li data-page-type="checkanswers"><span><%= t('actions.add_check_answers') -%></span></li>
+      <li data-page-type="checkanswers"><span aria-haspopup="dialog"><%= t('actions.add_check_answers') -%></span></li>
     <% end %>
 
     <% if item[:type] == 'page.checkanswers' %>
@@ -57,7 +57,7 @@
           </li>
         <% end %>
       <% else %>
-        <li data-page-type="confirmation"><span><%= t('actions.add_confirmation') -%></span></li>
+        <li data-page-type="confirmation"><span aria-haspopup="dialog"><%= t('actions.add_confirmation') -%></span></li>
       <% end %>
     <% end %>
 
@@ -65,13 +65,13 @@
       <% unless item[:type] == 'page.start' %>
         <li data-action="link">
           <%= link_to t('services.branch'),
-            new_branches_path(service.service_id, item[:uuid]) %>
+            new_branches_path(service.service_id, item[:uuid]), 'aria-haspopup': 'dialog' %>
         </li>
       <% end %>
 
       <li data-action="destination">
         <%= link_to t('actions.change_destination'),
-          new_api_service_flow_destination_path(service.service_id, item[:uuid]) %>
+          new_api_service_flow_destination_path(service.service_id, item[:uuid]), 'aria-haspopup': 'dialog' %>
       </li>
     <% end %>
 </ul>

--- a/app/views/services/_flow_branch_menu.html.erb
+++ b/app/views/services/_flow_branch_menu.html.erb
@@ -12,6 +12,8 @@
     <%= link_to t('actions.delete_branch'),
         api_service_branch_destroy_message_path(service.service_id, item[:uuid]),
         method: :delete,
-        class: 'destructive delete' %>
+        class: 'destructive delete',
+        'aria-haspopup': 'dialog'
+      %>
   </li>
 </ul>

--- a/app/views/services/_flow_page_menu.html.erb
+++ b/app/views/services/_flow_page_menu.html.erb
@@ -7,7 +7,7 @@
   <% if item[:type] == 'page.start' && using_external_start_page? %>
     <li data-action="toggle-external-start-page"
       data-url="<%= new_api_service_external_start_page_path(service.service_id, item[:uuid]) -%>">
-      <a href="<%= new_api_service_external_start_page_path(service.service_id, item[:uuid]) -%>"><%= t('actions.edit_external_start_page') %></a>
+      <a href="<%= new_api_service_external_start_page_path(service.service_id, item[:uuid]) -%>" aria-haspopup="dialog"><%= t('actions.edit_external_start_page') %></a>
     </li>
     <li data-action="preview-external-start-page"
       data-url="<%= api_service_preview_external_start_page_path(service.service_id, item[:uuid]) -%>">
@@ -42,7 +42,8 @@
             item[:uuid],
             item[:previous_uuid].to_s,
             item[:previous_conditional_uuid].to_s
-          ) %>
+          ),
+          'aria-haspopup': 'dialog' %>
       </li>
     <% end %>
 
@@ -51,14 +52,16 @@
         <%= link_to t('actions.delete_page'),
           api_service_page_destroy_message_path(service.service_id, item[:uuid]),
           method: :delete,
-          class: 'destructive delete' %>
+          class: 'destructive delete',
+          'aria-haspopup': 'dialog'
+        %>
       </li>
     <% end %>
 
     <% if item[:type] == 'page.start' && !using_external_start_page? %>
       <li data-action="toggle-external-start-page"
         data-url="<%= new_api_service_external_start_page_path(service.service_id, item[:uuid]) -%>">
-        <a href="<%= new_api_service_external_start_page_path(service.service_id) -%>"><%= t('actions.enable_external_start_page') %></a>
+        <a href="<%= new_api_service_external_start_page_path(service.service_id) -%>" aria-haspopup="dialog"><%= t('actions.enable_external_start_page') %></a>
       </li>
     <% end %>
   <% end %>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -35,7 +35,7 @@
     <%= f.hidden_field :conditional_uuid, value: '' %>
 
     <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
-      <%= f.label :page_url, class: "govuk-label govuk-label--m" %>
+      <%= f.label :page_url, class: "govuk-label govuk-label--m", id: "dialog-title" %>
       <div class="govuk-hint" id="add-page-hint"><%= t('activemodel.attributes.page_creation.page_url_hint') %></div>
       <% f.object.errors.each do |error|  %>
         <p class="govuk-error-message"><%= error.message %></p>


### PR DESCRIPTION
For best accessibility any control that launches a dialog should have an `aria-haspopup` attribute set to `dialog`.

This PR adds that attribute to all dialog controls.

It also makes a couple of adjustments for linking dialog titles and descriptions too.

These changes all follow WAI authoring best practices, but MacOS Voiceover doesn't seem to support most of them 😞 
* Dialog titles are not announced
* The haspopup attribute is ignored.

Further testing is required, but I windows/NVDA shoudl make use of these improvements.

