### PR TITLE
Update dialog labelledby to prevent dupliate ids

### DIFF
--- a/acceptance/features/accessibility_spec.rb
+++ b/acceptance/features/accessibility_spec.rb
@@ -7,11 +7,14 @@ feature 'Accessibility' do
 
   background do
     given_I_am_logged_in
-    given_I_have_a_service_fixture(fixture: 'default_new_service_fixture')
+    given_I_have_a_service_fixture(fixture: 'all_component_types_fixture')
   end
 
   scenario 'services list' do
     click_link(I18n.t('partials.header.forms'))
+    then_the_page_should_be_accessible
+
+    click_button(I18n.t('services.create'))
     then_the_page_should_be_accessible
   end
 
@@ -19,6 +22,27 @@ feature 'Accessibility' do
     expect(page).to have_content(I18n.t('pages.flow.heading'))
     page.find(:css, '#main-content', visible: true)
     then_the_page_should_be_accessible
+
+    # Start page modal
+    and_I_click_on_the_page_menu('Service name goes here')
+    and_I_click_on_use_external_start_page
+    then_the_page_should_be_accessible
+
+    click_button('Cancel')
+    editor.service_name.click
+
+    # move page modal
+    # and_I_click_on_the_page_menu('Text')
+    # editor.move_page_link.click
+    # then_the_page_should_be_accessible
+
+    # click_button('Cancel')
+    # editor.service_name.click
+
+    # delete page modal
+    # and_I_click_on_the_page_menu('Text')
+    # editor.delete_page_link.click
+    # then_the_page_should_be_accessible
 
     ## With branching
 
@@ -92,7 +116,7 @@ feature 'Accessibility' do
     then_the_page_should_be_accessible
   end
 
-  scenario 'Publishing', pending: true do
+  scenario 'Publishing' do
     # Publishing to Test
     click_link(I18n.t('publish.name'))
     then_the_page_should_be_accessible
@@ -231,5 +255,10 @@ feature 'Accessibility' do
 
   def then_the_page_should_be_accessible
     expect(page).to be_axe_clean.according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa, :wcag22aa, :'best-practice')
+  end
+
+
+  def and_I_click_on_use_external_start_page
+    page.click_on I18n.t('actions.enable_external_start_page')
   end
 end

--- a/app/javascript/src/component_dialog.js
+++ b/app/javascript/src/component_dialog.js
@@ -250,15 +250,18 @@ class Dialog {
   #enhance() {
     const dialog = this;
     const $content = $('[data-node="content"]', this.$node);
+    const $heading = $('[data-node="heading"]', this.$node);
+    const labelledBy = $heading.length
+      ? $heading.attr("id")
+      : this.#config.titleId;
 
     this.#setElements();
     this.#setDefaultText();
 
-    this.$node.find("h3").attr("id", "dialog-title");
-    this.$container.attr("aria-labelledby", "dialog-title");
-    if ($content.length) {
-      $content.attr("id", "dialog-content");
-      this.$container.attr("aria-describedby", "dialog-content");
+    this.$container.attr("aria-labelledby", labelledBy);
+    this.$container.removeAttr("aria-describedby");
+    if ($content.length && $content.attr("id")) {
+      this.$container.attr("aria-describedby", $content.attr("id"));
     }
 
     if (this.#config.closeOnClickSelector) {

--- a/app/javascript/src/component_dialog_api_request.js
+++ b/app/javascript/src/component_dialog_api_request.js
@@ -194,6 +194,9 @@ class DialogApiRequest {
         dialog.focusActivator();
         dialog.#destroy();
       },
+      focus: function () {
+        console.log("dialog focus event");
+      },
     });
 
     this.$container = dialog.$node.parents(".ui-dialog");
@@ -206,15 +209,17 @@ class DialogApiRequest {
   #enhance() {
     const dialog = this;
     const $content = $('[data-node="content"]', this.$node);
+    const $heading = $('[data-node="heading"]', this.$node);
+    const labelledBy = $heading.length
+      ? $heading.attr("id")
+      : this.#config.titleId;
 
     this.#setupButtons();
 
-    this.$container.attr("aria-labelledby", "dialog-title");
+    this.$container.attr("aria-labelledby", labelledBy);
     this.$container.removeAttr("aria-describedby");
-
-    if ($content.length) {
-      $content.attr("id", "dialog-content");
-      this.$container.attr("aria-describedby", "dialog-content");
+    if ($content.length && $content.attr("id")) {
+      this.$container.attr("aria-describedby", $content.attr("id"));
     }
 
     safelyActivateFunction(dialog.#config.onReady, dialog);

--- a/app/javascript/src/component_dialog_form.js
+++ b/app/javascript/src/component_dialog_form.js
@@ -105,6 +105,7 @@ class DialogForm {
         requestMethod: "GET",
         requestData: {},
         disableOnSubmit: "",
+        titleId: "dialog-title",
         onLoad: function (dialog) {},
         onReady: function (dialog) {},
         beforeSubmit: function (dialog) {},
@@ -288,13 +289,17 @@ class DialogForm {
   #enhance() {
     var dialog = this;
     const $content = $('[data-node="content"]', this.$node);
+    const $heading = $('[data-node="heading"]', this.$node);
+    const labelledBy = $heading.length
+      ? $heading.attr("id")
+      : this.#config.titleId;
 
     this.$form = this.$node.is("form") ? this.$node : this.$node.find("form");
-    this.$container.attr("aria-labelledby", "dialog-title");
 
-    if ($content.length) {
-      $content.attr("id", "dialog-content");
-      this.$container.attr("aria-describedby", "dialog-content");
+    this.$container.attr("aria-labelledby", labelledBy);
+    this.$container.removeAttr("aria-describedby");
+    if ($content.length && $content.attr("id")) {
+      this.$container.attr("aria-describedby", $content.attr("id"));
     }
 
     if (this.#config.closeOnClickSelector) {

--- a/app/javascript/src/controller_default.js
+++ b/app/javascript/src/controller_default.js
@@ -13,10 +13,9 @@
  *
  **/
 
-
-const Dialog = require('./component_dialog');
-const SentryLogger=  require('./sentry_logger');
-const post = require('./utilities').post;
+const Dialog = require("./component_dialog");
+const SentryLogger = require("./sentry_logger");
+const post = require("./utilities").post;
 
 class DefaultController {
   constructor(app) {
@@ -33,8 +32,8 @@ class DefaultController {
     this.$body = $(document.body);
     this.$lastPoint = $(); // Use it to set a focal point in switching between components.
     this.constants = {
-      JS_ENHANCEMENT_DONE: "jsdone"
-    }
+      JS_ENHANCEMENT_DONE: "jsdone",
+    };
 
     isolatedMethodDeleteLinks();
   }
@@ -53,7 +52,6 @@ class DefaultController {
   }
 }
 
-
 /* Create standard Dialog component with single 'ok' type button.
  **/
 function createDialog() {
@@ -63,11 +61,11 @@ function createDialog() {
     autoOpen: false,
     okText: $template.data("text-ok"),
     classes: {
-      "ui-dialog": $template.data("classes")
-    }
+      "ui-dialog": $template.data("classes"),
+    },
+    titleId: "dialog-ok-title",
   });
 }
-
 
 /* Create standard Dialog Confirmation component with 'ok' and 'cancel' type buttons.
  * Component allows passing a function to it's 'open()' function so that actions
@@ -79,11 +77,11 @@ function createDialogConfirmation() {
   return new Dialog($node, {
     autoOpen: false,
     classes: {
-      "ui-dialog": $template.data("classes")
-    }
+      "ui-dialog": $template.data("classes"),
+    },
+    titleId: "dialog-confirmation-title",
   });
 }
-
 
 /* Dialog Confirmation Delete is simply a Dialog Confirmation with a different
  * class name (dialog-confirmation-delete) added to meet style requirements
@@ -95,8 +93,9 @@ function createDialogConfirmationDelete() {
   return new Dialog($node, {
     autoOpen: false,
     classes: {
-      "ui-dialog": $template.data("classes")
-    }
+      "ui-dialog": $template.data("classes"),
+    },
+    titleId: "dialog-confirmation-delete-title",
   });
 }
 
@@ -106,7 +105,7 @@ function createDialogConfirmationDelete() {
  * with other scripts wanting to use e.preventDefault().
  **/
 function isolatedMethodDeleteLinks() {
-  $("header [data-method=delete]").on("click", function(e) {
+  $("header [data-method=delete]").on("click", function (e) {
     e.preventDefault();
     post(this.href, { _method: "delete" });
   });

--- a/app/views/api/autocomplete/_show.html.erb
+++ b/app/views/api/autocomplete/_show.html.erb
@@ -1,7 +1,10 @@
 <div class="component-dialog-api-request" id="autocomplete_items">
   <%= form_for @items, url: api_service_autocomplete_path(service_id: service.service_id, component_id: @items.component_id), method: :post, multipart: true do |form| %>
   <div class="govuk-form-group">
-      <%= form.label :file, t('dialogs.autocomplete.legend'), id: "dialog-title", class: "govuk-label govuk-label--m" %>
+    <%= form.label :file, t('dialogs.autocomplete.legend'), 
+      id: "autocomplet-items-dialog-title", 
+      class: "govuk-label govuk-label--m",
+      data: { node: "heading" } %>
 
       <% if items_present?(@items.component_id) %>
         <div class="govuk-warning-text govuk-!-margin-bottom-2">

--- a/app/views/api/branches/destroy_message.html.erb
+++ b/app/views/api/branches/destroy_message.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-branch-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.heading_delete', label: @branch.title) %>
   </h3>
 

--- a/app/views/api/component_validations/_new.html.erb
+++ b/app/views/api/component_validations/_new.html.erb
@@ -6,7 +6,7 @@
       html: { novalidate: true } do |f| %>
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
-          <legend id="dialog-title" class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <legend data-node="heading" id="<%=@component_validation.validator %>-dialog-title" class="govuk-fieldset__legend govuk-fieldset__legend--m">
             <%= @component_validation.label -%>
           </legend>
           <% if @component_validation.validator == 'max_files' %>

--- a/app/views/api/conditional_contents/edit.html.erb
+++ b/app/views/api/conditional_contents/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="component-dialog-api-request" id="conditional_content_dialog">
   <div class="conditional-visibility edit">
-    <h2 id="dialog-title" class="govuk-heading-m"><%= t('conditional_content.heading') %></h2>
+    <h2 id="conditional-content-dialog-title" class="govuk-heading-m" data-node="heading"><%= t('conditional_content.heading') %></h2>
     <%= form_for @conditional_content, url: api_service_update_conditional_content_path(service.service_id, params[:component_uuid]), method: :put, data: { turbo: true } do |f| %>
       <%= render 'form', f: f %>
     <% end %> 

--- a/app/views/api/destinations/new.html.erb
+++ b/app/views/api/destinations/new.html.erb
@@ -1,7 +1,11 @@
 <div class="component-dialog-api-request">
   <%= form_for @destination, url: api_service_flow_destinations_path(service.service_id, @destination.flow_uuid) do |f| %>
     <div class="govuk-form-group ">
-      <%= f.label :destination_uuid, t('dialogs.destination.label'), class: "govuk-label govuk-label--m", id: "dialog-title"  %>
+      <%= f.label :destination_uuid, t('dialogs.destination.label'), 
+        class: "govuk-label govuk-label--m", 
+        id: "change-destination-dialog-title",
+        data: { node: "heading "}
+      %>
       <div class="govuk-hint">
         <%= t('dialogs.destination.lede', title: @destination.title) %>
       </div>

--- a/app/views/api/external_start_page_urls/_external_start_page_url.html.erb
+++ b/app/views/api/external_start_page_urls/_external_start_page_url.html.erb
@@ -1,6 +1,8 @@
 <div class="component-dialog-api-request" id="external_start_page_url">
   <%= form_for @external_url, url: api_service_external_start_page_index_path(service.service_id), method: :post, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-    <h2 id="dialog-title" class="govuk-heading-m"><%= editing? ? t('external_start_page_url.editing_title') : t('external_start_page_url.title') %></h2>
+    <h2 id="external-start-page-dialog-title" class="govuk-heading-m" data-node="heading">
+      <%= editing? ? t('external_start_page_url.editing_title') : t('external_start_page_url.title') %>
+    </h2>
     
     <% if !editing? %>
       <p class="description"><%= t('external_start_page_url.content') %></p>

--- a/app/views/api/external_start_page_urls/preview.html.erb
+++ b/app/views/api/external_start_page_urls/preview.html.erb
@@ -1,5 +1,5 @@
 <div class="component-dialog-api-request" id="external_start_page_preview">
-  <h2 id="dialog-title" class="govuk-heading-m"><%= t('external_start_page_url.preview.title') %></h2>
+  <h2 id="preview-external-start-page-dialog-title" class="govuk-heading-m" data-node="heading"><%= t('external_start_page_url.preview.title') %></h2>
   <p class="description"><%= t('external_start_page_url.preview.content_one') %></p>
   <p class="description"><%= t('external_start_page_url.preview.content_two', href: govuk_link_to(t('external_start_page_url.preview.link_text'), settings_form_name_url_index_path(service.service_id))).html_safe %></p>
 

--- a/app/views/api/move/_branch_destination_no_default_next.html.erb
+++ b/app/views/api/move/_branch_destination_no_default_next.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request"
      data-component="DialogApiRequest" id="branch_destination_no_default_next">
 
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="no-default-next-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.move.you_cannot_move_this_page') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/move/_new.html.erb
+++ b/app/views/api/move/_new.html.erb
@@ -4,7 +4,11 @@
       <%= f.hidden_field :previous_flow_uuid, value: @move.previous_flow_uuid %>
       <%= f.hidden_field :previous_conditional_uuid, value: @move.previous_conditional_uuid %>
       <%= f.hidden_field :target_conditional_uuid, value: '' %>
-      <%= f.label :target_uuid, t('dialogs.move.label', title: @move.title), id: "dialog-title", class: "govuk-label govuk-label--m" %>
+      <%= f.label :target_uuid, t('dialogs.move.label', title: @move.title), 
+        id: "move-page-dialog-title", 
+        class: "govuk-label govuk-label--m",
+        data: { node: "heading" } 
+      %>
       <p> <%= t('dialogs.move.lede') %></p>
       <div class="govuk-form-group">
         <select class="govuk-select" name="move[target_uuid]" id="move_target_uuid">

--- a/app/views/api/move/_stacked_branches_not_supported.html.erb
+++ b/app/views/api/move/_stacked_branches_not_supported.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request"
      data-component="DialogApiRequest" id="stacked_branches_not_supported">
 
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="stacked-branch-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.move.you_cannot_move_this_page') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/pages/_delete_branch_destination_page_modal.html.erb
+++ b/app/views/api/pages/_delete_branch_destination_page_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-branch-destination-page-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.heading_delete', label: @page.title) %>
   </h3>
   <p data-node="content">

--- a/app/views/api/pages/_delete_branch_destination_page_no_default_next_modal.html.erb
+++ b/app/views/api/pages/_delete_branch_destination_page_no_default_next_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-branch-destination-no-default-next-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.heading_delete_no_default_next') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/pages/_delete_modal.html.erb
+++ b/app/views/api/pages/_delete_modal.html.erb
@@ -1,10 +1,10 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-page-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.heading_delete', label: @page.title) %>
   </h3>
-  <p data-node="content">
+  <p data-node="content" id="delete-page-dialog-description">
     <%= t('dialogs.message_delete') %>
   </p>
 

--- a/app/views/api/pages/_delete_page_used_for_branching_not_supported_modal.html.erb
+++ b/app/views/api/pages/_delete_page_used_for_branching_not_supported_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request"
      data-component="DialogApiRequest">
 
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-page-used-for-branching-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('pages.delete_modal.you_cannot_delete_this_page') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/pages/_delete_page_used_for_conditional_content_modal.html.erb
+++ b/app/views/api/pages/_delete_page_used_for_conditional_content_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-page-used-for-conditional-content-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('pages.delete_modal.you_cannot_delete_this_page') %>
   </h3>
 

--- a/app/views/api/pages/_delete_page_used_for_confirmation_email_modal.html.erb
+++ b/app/views/api/pages/_delete_page_used_for_confirmation_email_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-page-used-for-confirmation-email-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('pages.delete_modal.can_not_delete_email_page_heading') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/pages/_stack_branches_not_supported_modal.html.erb
+++ b/app/views/api/pages/_stack_branches_not_supported_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request"
      data-component="DialogApiRequest">
 
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="stacked-branches-not-supported-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('pages.delete_modal.you_cannot_delete_this_page') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/question_options/_delete_option_modal.html.erb
+++ b/app/views/api/question_options/_delete_option_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-question-option-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.heading_delete_option', label: @label) %>
   </h3>
   <p data-node="content">

--- a/app/views/api/question_options/_delete_option_used_for_branching_modal.html.erb
+++ b/app/views/api/question_options/_delete_option_used_for_branching_modal.html.erb
@@ -1,5 +1,5 @@
 <div class="component component-dialog component-dialog-delete" id="dialog-confirmation-delete">
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-option-used-for-branching-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('question_items.delete_modal.can_not_delete_heading') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/question_options/_delete_option_used_for_conditional_content_modal.html.erb
+++ b/app/views/api/question_options/_delete_option_used_for_conditional_content_modal.html.erb
@@ -1,5 +1,5 @@
 <div class="component component-dialog component-dialog-delete" id="dialog-confirmation-delete">
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-option-for-conditional-content-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('question_items.delete_modal.can_not_delete_heading') %>
   </h3>
 

--- a/app/views/api/questions/_delete_question_modal.html.erb
+++ b/app/views/api/questions/_delete_question_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="component component-dialog component-dialog-api-request dialog-delete"
      data-component="DialogApiRequest">
 
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-question-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('dialogs.heading_delete', label: @question.humanised_title) %>
   </h3>
   <p data-node="content">

--- a/app/views/api/questions/_delete_question_used_for_branching_modal.html.erb
+++ b/app/views/api/questions/_delete_question_used_for_branching_modal.html.erb
@@ -1,5 +1,5 @@
 <div class="component component-dialog component-dialog-delete" id="dialog-confirmation-delete">
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-question-used-forbranching-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('questions.delete_modal.can_not_delete_heading') %>
   </h3>
   <p data-node="content">

--- a/app/views/api/questions/_delete_question_used_for_conditional_content_modal.html.erb
+++ b/app/views/api/questions/_delete_question_used_for_conditional_content_modal.html.erb
@@ -1,5 +1,5 @@
 <div class="component component-dialog component-dialog-delete" id="dialog-confirmation-delete">
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-question-for-conditional-content-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('questions.delete_modal.can_not_delete_heading') %>
   </h3>
 

--- a/app/views/api/questions/_delete_question_used_for_confirmation_email_modal.html.erb
+++ b/app/views/api/questions/_delete_question_used_for_confirmation_email_modal.html.erb
@@ -1,5 +1,5 @@
 <div class="component component-dialog component-dialog-delete" id="dialog-confirmation-delete">
-  <h3 id="dialog-title" data-node="heading" class="govuk-label govuk-label--m">
+  <h3 id="delete-question-for-confirmation-email-dialog-title" data-node="heading" class="govuk-label govuk-label--m">
     <%= t('questions.delete_modal.can_not_delete_heading') %>
   </h3>
   <p data-node="content">

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -35,7 +35,7 @@
     <%= f.hidden_field :conditional_uuid, value: '' %>
 
     <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
-      <%= f.label :page_url, class: "govuk-label govuk-label--m", id: "dialog-title" %>
+      <%= f.label :page_url, class: "govuk-label govuk-label--m", id: "new-page-dialog-title", data: { node: "heading" } %>
       <div class="govuk-hint" id="add-page-hint"><%= t('activemodel.attributes.page_creation.page_url_hint') %></div>
       <% f.object.errors.each do |error|  %>
         <p class="govuk-error-message"><%= error.message %></p>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -28,7 +28,7 @@
         <%= form_for(@service_creation, url: services_path) do |f| %>
           <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
             <%= tag.div class: 'govuk-character-count', data: { module: 'govuk-character-count', maxlength: Editor::Service::MAXIMUM, threshold: 90 } do %>
-              <%= f.label :service_name, class: "govuk-label govuk-label--m", id: "dialog-title" %>
+              <%= f.label :service_name, class: "govuk-label govuk-label--m", id: "create-service-dialog-title", data: { node: 'heading'} %>
               <% f.object.errors.each do |error|  %>
                 <p class="govuk-error-message"><%= error.message %></p>
               <% end %>


### PR DESCRIPTION
So I somewhat got to the bottom of dialog accessible names not being announced.

Due to the way we do dialogs (in several differnet ways) there were often multiple dialog elements on a page, but hidden.

As we were using the same id for the dialog title element in each dialog, the `aria-labelledby` attribute was often referencing the wrong (and hidden) element (You'd think an accessibility checker would pick up on the duplicate ids, or the element being hidden... but no!)

This PR updates the dialog classes to be able to set the `aria-labelledby` attribute dynamically.

Using the fact that some modals already had the `data-node="heading"` attribute set for their title element, and expanding it across all dialog elements, allows us to find that element in the dialog extract its id and use it for the `aria-labelledby` attribute.

This allows all modals to be labelled uniquely, and ensures the title is correctly asscoaited with the modal, and is read out by screenreaders (well NVDA at least!)