### PR TITLE
Update dialog form to call clearup methods when using escape

### DIFF
--- a/app/javascript/src/component_dialog_form.js
+++ b/app/javascript/src/component_dialog_form.js
@@ -147,7 +147,6 @@ class DialogForm {
 
     if (this.$node.dialog("instance")) {
       this.$node.dialog("open");
-      this.#state = "open";
       safelyActivateFunction(this.#config.onOpen, dialog);
 
       queueMicrotask(() => {
@@ -158,17 +157,10 @@ class DialogForm {
 
   close() {
     var dialog = this;
-    // Attempt to refocus on original activator
-    this.focusActivator();
 
     if (this.$node.dialog("instance")) {
       this.$node.dialog("close");
       safelyActivateFunction(dialog.#config.onClose, dialog);
-      this.#state = "closed";
-    }
-
-    if (this.#remoteSource) {
-      this.#destroy();
     }
   }
 
@@ -278,6 +270,16 @@ class DialogForm {
       height: "auto",
       modal: true,
       resizable: false,
+      open: () => {
+        this.#state = "open";
+      },
+      close: () => {
+        dialog.focusActivator();
+        dialog.#state = "closed";
+        if (dialog.#remoteSource) {
+          dialog.#destroy();
+        }
+      },
     });
 
     this.$container = dialog.$node.parents(".ui-dialog");


### PR DESCRIPTION
Biticed during accessibility testing that in a DialogForm using a template remote source if the escape key is used to close the modal, the dialog element was not cleaned up from the DOM correctly.

This is because the buttons we control in the tempalte calls the `close` method on the `DialogForm` class which does the cleanup along with calling the jQueryUI `close` method.

Pressing <kbd>Esc</kbd> calls the jQuery `close` method directly. Meaning the cleanup is not performed.

This PR moves the cleanup functions into the jQueryUI dialog `close` callback method meaning that they will always be called no matter how the dialog is closed.