### PR TITLE
Fix id of select to match label for attribute

### DIFF
--- a/app/views/api/destinations/new.html.erb
+++ b/app/views/api/destinations/new.html.erb
@@ -11,7 +11,7 @@
       </div>
       <span><%= t('dialogs.destination.go_to') %></span>
        <div class="govuk-form-group">
-        <select class="govuk-select" name="destination_uuid" id="destination_uuid">
+        <select class="govuk-select" name="destination_uuid" id="destination_destination_uuid">
           <%= render partial: "branches/destinations_list",
                     locals: {
                       destinations: @destination.main_destinations,


### PR DESCRIPTION
Small fix to rectify the fact that the select in the change destination dialog had an id which didn't match the associated label.  