### PR TITLE
Updates to component labelling

### DIFF
--- a/app/javascript/src/components/menus/content_menu.js
+++ b/app/javascript/src/components/menus/content_menu.js
@@ -10,30 +10,38 @@
  *       https://api.jqueryui.com/menu
  *
  **/
-const {
-  safelyActivateFunction,
-  mergeObjects
-} = require('../../utilities');
-const ActivatedMenu = require('./activated_menu');
+const { safelyActivateFunction, mergeObjects } = require("../../utilities");
+const ActivatedMenu = require("./activated_menu");
 
 class ContentMenu extends ActivatedMenu {
   constructor(component, $node, config) {
-    super($node, mergeObjects({
-      container_classname: "ContentMenu",
-      activator_text: ""
-    }, config));
+    super(
+      $node,
+      mergeObjects(
+        {
+          container_classname: "ContentMenu",
+          activator_text: "",
+        },
+        config,
+      ),
+    );
 
-    $node.on("menuselect", (event,ui) => {
-        this.selection(event, ui.item);
+    $node.on("menuselect", (event, ui) => {
+      this.selection(event, ui.item);
     });
 
-    if(component.$node.length) {
+    if (component.$node.length) {
       component.$node.prepend(this.activator.$node);
-      component.$node.on("focus.contentmenu", () => this.activator.$node.addClass("active"));
-      component.$node.on("blur.contentmenu", () => this.activator.$node.removeClass("active"));
+      component.$node.on("focus.contentmenu", () =>
+        this.activator.$node.addClass("active"),
+      );
+      component.$node.on("blur.contentmenu", () =>
+        this.activator.$node.removeClass("active"),
+      );
     }
 
     this.container.$node.addClass("ContentMenu");
+    this.activator.$node.attr("data-component-target", "propertiesButton");
     this.component = component;
   }
 
@@ -42,7 +50,7 @@ class ContentMenu extends ActivatedMenu {
     this.selectedItem = item;
 
     event.preventDefault();
-    switch(action) {
+    switch (action) {
       case "open":
         this.open();
       case "remove":
@@ -58,14 +66,14 @@ class ContentMenu extends ActivatedMenu {
   }
 
   open(config) {
-    if(this.component && this.component.state) {
-      this.component.state.mode = 'edit'
+    if (this.component && this.component.state) {
+      this.component.state.mode = "edit";
     }
     super.open(config);
   }
 
   close() {
-    if(this.component) {
+    if (this.component) {
       this.component.$node.removeClass("active");
     }
     super.close();
@@ -77,8 +85,11 @@ class ContentMenu extends ActivatedMenu {
   }
 
   conditionalContent(item) {
-    this.component.apiUrl = item.data('apiPath')
-    $(document).trigger("ContentMenuSelectionConditionalContent", { component: this.component, selectedItem: item });
+    this.component.apiUrl = item.data("apiPath");
+    $(document).trigger("ContentMenuSelectionConditionalContent", {
+      component: this.component,
+      selectedItem: item,
+    });
   }
 }
 

--- a/app/javascript/src/components/menus/question_menu.js
+++ b/app/javascript/src/components/menus/question_menu.js
@@ -45,6 +45,7 @@ class QuestionMenu extends ActivatedMenu {
     }
 
     this.container.$node.addClass("QuestionMenu");
+    this.activator.$node.attr("data-component-target", "propertiesButton");
     this.question = config.question;
     this.setEnabledValidations();
   }

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -658,7 +658,7 @@ function createContentMenu(component) {
   $(document.body).append($ul);
 
   return new ContentMenu(component, $ul, {
-    activator_text: template.data("activator-text"),
+    activator_text: template.data("activator-text").replace("{{index}} ", ""),
     menu: {
       position: {
         my: "left top",

--- a/app/javascript/src/controllers/orderable-item-controller.js
+++ b/app/javascript/src/controllers/orderable-item-controller.js
@@ -16,7 +16,7 @@ export default class extends Controller {
     useAncestry(this);
 
     // GLOBAL ALERT! app is a global object set in partials/_properties.html.erb
-    this.labels = app.text.components;
+    this.labels = app.text.components[this.type];
   }
 
   disconnect() {
@@ -145,9 +145,13 @@ export default class extends Controller {
    **/
   updateLabels() {
     if (this.hasUpButtonTarget)
-      this.upButtonTarget.setAttribute('aria-label', this.upButtonLabel);
+      this.upButtonTarget.setAttribute("aria-label", this.upButtonLabel);
     if (this.hasDownButtonTarget)
-      this.downButtonTarget.setAttribute('aria-label', this.downButtonLabel);
+      this.downButtonTarget.setAttribute("aria-label", this.downButtonLabel);
+  }
+
+  get type() {
+    return this.element.tagName == "EDITABLE-CONTENT" ? "content" : "component";
   }
 
   get upButtonLabel() {

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -231,7 +231,7 @@ function createQuestionMenu() {
   $(document.body).append($ul);
 
   return new QuestionMenu($ul, {
-    activator_text: template.data("activator-text"),
+    activator_text: template.data("activator-text").replace("{{index}} ", ""),
     $target: question.$editableLabel,
     question: question,
     menu: {

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -56,8 +56,16 @@
         label_question_if: "<%= t('branches.expression.if') %>"
       },
       components: {
-        move_up: "<%= t('components.actions.move_up') %>",
-        move_down: "<%= t('components.actions.move_down') %>",
+        content:  {
+          properties: "<%= t('content.menu.activator') %>",
+          move_up: "<%= t('components.actions.move_content_up') %>",
+          move_down: "<%= t('components.actions.move_content_down') %>",
+        },
+        component: {
+          properties: "<%= t('question.menu.activator') %>",
+          move_up: "<%= t('components.actions.move_component_up') %>",
+          move_down: "<%= t('components.actions.move_component_down') %>",
+        },
         types: {
           text: "<%= t('components.list.text')%>",
           textarea: "<%= t('components.list.textarea')%>",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -380,14 +380,16 @@ en:
     actions:
       add_component: 'Add component'
       add_content: 'Add content area'
-      move_up: 'Move component {{index}} up'
-      move_down: 'Move component {{index}} down'
+      move_component_up: 'Move component {{index}} up'
+      move_component_down: 'Move component {{index}} down'
+      move_content_up: 'Move content area {{index}} up'
+      move_content_down: 'Move content area {{index}} down'
     menu:
       question: 'Question'
       content_area: 'Content area'
   content:
     menu:
-      activator: 'Settings'
+      activator: 'Content area {{index}} properties'
       remove: 'Delete...'
       show_if: 'Show if...'
     dialog:
@@ -399,7 +401,7 @@ en:
   question:
     optional_flag: '(optional)'
     menu:
-      activator: 'Question properties'
+      activator: 'Question {{index}} properties'
       remove: 'Delete...'
       required: 'Required...'
       date_after: 'Earliest date...'


### PR DESCRIPTION
This PR improves the labelling on multiquestion pages by adding an index to content area properties and question properties buttons.

There's still much more that could be done to improve this - as simply numbering by index is not that helpful - especially after someone starts moving them around.

It would be much better if the buttons used the question title within their label to be explicit.

But this is an incremental improvement, so we'll push it.  And hopefully improve from there.