### PR TITLE
Testable editable elements spans

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ ruby '3.1.3'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'semantic-editable-headings'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'revert-editable-element-spans'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.33'
+# gem 'metadata_presenter', '3.3.33'
 
 gem 'activerecord-session_store'
 gem 'administrate', '~> 0.20.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,22 @@ GIT
     capybara_accessible_selectors (0.11.0)
       capybara (~> 3.36)
 
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: a1ecef0752b223ce5d9666021b9d50e1dcf6c58d
+  branch: revert-editable-element-spans
+  specs:
+    metadata_presenter (3.3.33)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (~> 4.1.1)
+      json-schema (~> 4.1.1)
+      kramdown (~> 2.4.0)
+      rails (~> 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+      uk_postcode
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -305,16 +321,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.3.33)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (~> 4.1.1)
-      json-schema (~> 4.1.1)
-      kramdown (~> 2.4.0)
-      rails (~> 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-      uk_postcode
     method_source (1.0.0)
     mini_mime (1.1.5)
     minitest (5.22.2)
@@ -807,7 +813,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.3.33)
+  metadata_presenter!
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -102,12 +102,15 @@ class EditableElement extends EditableBase {
     );
 
     const $editable = $node.find('[contentEditable="true"]');
-    console.log($editable);
 
-    const dataAttributes = $node.get(0).dataset;
+    let dataAttributes = $node.get(0)?.dataset;
+    dataAttributes ??= [];
+
     for (const attrName in dataAttributes) {
-      $editable.get(0).dataset[attrName] = dataAttributes[attrName];
-      delete $node.get(0).dataset[attrName];
+      const el = $editable.get(0);
+      if (el) {
+        el.dataset[attrName] = dataAttributes[attrName];
+      }
     }
 
     this.$editable = $editable;
@@ -119,10 +122,6 @@ class EditableElement extends EditableBase {
     this.$editable.on("keydown.editablecomponent", (e) =>
       singleLineInputRestrictions(e),
     );
-
-    // $node.attr("contentEditable", true);
-    // $node.attr("role", "textbox");
-    // $node.addClass("EditableElement");
 
     if (this._content == this._defaultContent) {
       this.$editable.attr("aria-describedby", "optional_content_description");
@@ -494,8 +493,6 @@ class EditableComponentBase extends EditableBase {
       ),
       hint: new EditableElement($node.find(config.selectorElementHint), config),
     };
-
-    console.log(this._elements);
   }
 
   get content() {

--- a/app/javascript/src/editable_components.js
+++ b/app/javascript/src/editable_components.js
@@ -96,20 +96,26 @@ class EditableElement extends EditableBase {
     this._defaultContent = defaultContent;
     this._required = required;
 
-    // Adding textare role makes contenteditable element show in the screenreader form controls rotor
+    // Wrap the content of the node with a contentEditable <span>
+    // Adding textbox role makes contenteditable element show in the screenreader form controls rotor
     $node.wrapInner(
       '<span class="EditableElement" contentEditable="true" role="textbox"></span>',
     );
 
     const $editable = $node.find('[contentEditable="true"]');
 
+    // Copy data attributes from the $node to the new $editable element
     let dataAttributes = $node.get(0)?.dataset;
     dataAttributes ??= [];
-
     for (const attrName in dataAttributes) {
       const el = $editable.get(0);
       if (el) {
         el.dataset[attrName] = dataAttributes[attrName];
+      }
+      // Delete the original data-fb-content-id attribute, as duplicates cause
+      // issues with acceptance tests
+      if (attrName == "fbContentId") {
+        delete $node.get(0)?.dataset[attrName];
       }
     }
 

--- a/app/javascript/src/question.js
+++ b/app/javascript/src/question.js
@@ -25,8 +25,6 @@ const SELECTOR_EDITABLE_LABEL =
 
 class Question {
   constructor($node, config) {
-    var $editableLabel = $(SELECTOR_EDITABLE_LABEL, $node);
-    var $heading = $(SELECTOR_LABEL_HEADING, $node);
     var conf = mergeObjects(
       {
         // Config defaults
@@ -50,9 +48,9 @@ class Question {
     this.config = conf;
     this.data = $node.data("fb-content-data");
     this.$node = $node;
-    this.$editableLabel = $editableLabel;
-    this.$heading = $heading;
     this.editable = editableComponent($node, conf);
+    this.$editableLabel = $(SELECTOR_EDITABLE_LABEL, $node);
+    this.$heading = $(SELECTOR_LABEL_HEADING, $node);
     this.menu = createQuestionMenu.call(this);
     this.labels = this.config.text.aria.question;
 
@@ -61,7 +59,7 @@ class Question {
     this.$editableLabel.on("focus", () => {
       this.$node.addClass("active");
     });
-    $editableLabel.on("blur", () => {
+    this.$editableLabel.on("blur", () => {
       this.$node.removeClass("active");
       this.setRequiredFlag.bind(this);
       this.$heading.attr("aria-label", this.$editableLabel.text());
@@ -181,14 +179,18 @@ class Question {
       );
 
     // Accessible label and description for the question hint text (where present)
-    this.$node.find(".govuk-hint").first().attr("aria-label", this.labels.hint);
+    this.$node
+      .find(".govuk-hint")
+      .first()
+      .find(".EditableElement")
+      .attr("aria-label", this.labels.hint);
 
     // For the label wrapping the heading we provide an accessible group name
     // Remove the 'for' attribute, otherwise clicking will focus the questions
     // form field
-    if (!this.$node.find("fieldset").length > 0) {
-      this.$node.find("label.govuk-label").first().attr("for", "");
-    }
+    // if (!this.$node.find("fieldset").length > 0) {
+    this.$node.find("label.govuk-label").first().attr("for", "");
+    // }
 
     // Accessibly prevent input in editor mode
     // 1. aria-disabled : communicate disabled state to AT

--- a/app/javascript/src/question_address.js
+++ b/app/javascript/src/question_address.js
@@ -17,7 +17,7 @@ const mergeObjects = utilities.mergeObjects;
 const Question = require("./question");
 
 const SELECTOR_HINT = ".govuk-hint";
-const SELECTOR_LABEL = "legend > h1 span, legend > h2 span";
+const SELECTOR_LABEL = "legend > h1, legend > h2";
 const SELECTOR_DISABLED = "input:not(:hidden)";
 
 class AddressQuestion extends Question {

--- a/app/javascript/src/question_autocomplete.js
+++ b/app/javascript/src/question_autocomplete.js
@@ -18,7 +18,7 @@ const mergeObjects = utilities.mergeObjects;
 const Question = require("./question");
 
 const SELECTOR_HINT = ".govuk-hint";
-const SELECTOR_LABEL = "label h1 span, label h2 span";
+const SELECTOR_LABEL = "label h1, label h2";
 
 class AutocompleteQuestion extends Question {
   constructor($node, config) {

--- a/app/javascript/src/question_checkboxes.js
+++ b/app/javascript/src/question_checkboxes.js
@@ -17,7 +17,7 @@ const mergeObjects = utilities.mergeObjects;
 const Question = require("./question");
 
 const SELECTOR_HINT = "fieldset > .govuk-hint";
-const SELECTOR_LABEL = "legend > h1 span, legend > h2 span";
+const SELECTOR_LABEL = "legend > h1, legend > h2";
 const SELECTOR_ITEM = ".govuk-checkboxes__item";
 const SELECTOR_ITEM_HINT = ".govuk-checkboxes__hint";
 const SELECTOR_ITEM_LABEL = ".govuk-checkboxes__label";
@@ -47,8 +47,8 @@ class CheckboxesQuestion extends Question {
           // @node is the collection item (e.g. <div> wrapping <input type=radio> and <label> elements)
           // Runs after the collection item has been cloned, so further custom manipulation can be
           // carried out on the element.
-          $node.find("label").text(config.text.option);
-          $node.find("span").text(config.text.optionHint);
+          $node.find(SELECTOR_ITEM_LABEL).text(config.text.option);
+          $node.find(SELECTOR_ITEM_HINT).text(config.text.optionHint);
         },
         beforeItemRemove: function (item) {
           // @item (EditableComponentItem) Item to be deleted.
@@ -88,7 +88,7 @@ class CheckboxesQuestion extends Question {
     super.addAccessibleLabels();
     // Add a group label for the answers section
     this.$node.find(".EditableComponentCollectionItem").first().parent().attr({
-      "aria-role": "group",
+      role: "group",
       "aria-label": this.labels.answers,
     });
 
@@ -106,8 +106,9 @@ class CheckboxesQuestion extends Question {
     // remove 'for' attribute to prevent AT reading this for the field itself
     $node
       .find(SELECTOR_ITEM_LABEL)
-      .attr("aria-label", `${this.labels.items.label} ${index}`)
-      .removeAttr("for");
+      .removeAttr("for")
+      .find(".EditableElement")
+      .attr("aria-label", `${this.labels.items.label} ${index}`);
 
     // Provide labels with indexes for input options
     $node
@@ -122,7 +123,7 @@ class CheckboxesQuestion extends Question {
     // Add labels for the hint text elements for each option
     // Add the describedyby for optional content too
     $node
-      .find(SELECTOR_ITEM_HINT)
+      .find(`${SELECTOR_ITEM_HINT} > .EditableElement`)
       .attr("aria-label", `${this.labels.items.hint} ${index}`)
       .attr("aria-describedby", "optional_content_description");
 

--- a/app/javascript/src/question_date.js
+++ b/app/javascript/src/question_date.js
@@ -17,7 +17,7 @@ const mergeObjects = utilities.mergeObjects;
 const Question = require("./question");
 
 const SELECTOR_HINT = ".govuk-hint";
-const SELECTOR_LABEL = "legend > h1 span, legend > h2 span";
+const SELECTOR_LABEL = "legend > h1, legend > h2";
 const SELECTOR_DISABLED = "input:not(:hidden)";
 
 class DateQuestion extends Question {

--- a/app/javascript/src/question_radios.js
+++ b/app/javascript/src/question_radios.js
@@ -16,7 +16,7 @@ const { mergeObjects, changeTag } = require("./utilities");
 const Question = require("./question");
 
 const SELECTOR_HINT = "fieldset > .govuk-hint";
-const SELECTOR_LABEL = "legend > h1 span, legend > h2 span";
+const SELECTOR_LABEL = "legend > h1, legend > h2";
 const SELECTOR_ITEM = ".govuk-radios__item";
 const SELECTOR_ITEM_HINT = ".govuk-radios__hint";
 const SELECTOR_ITEM_LABEL = ".govuk-radios__label";
@@ -46,8 +46,8 @@ class RadiosQuestion extends Question {
           // @node is the collection item (e.g. <div> wrapping <input type=radio> and <label> elements)
           // Runs after the collection item has been cloned, so further custom manipulation can be
           // carried out on the element.
-          $node.find("label").text(config.text.option);
-          $node.find("span").text(config.text.optionHint);
+          $node.find(SELECTOR_ITEM_LABEL).text(config.text.option);
+          $node.find(SELECTOR_ITEM_HINT).text(config.text.optionHint);
         },
         beforeItemRemove: function (item) {
           // @item (EditableComponentItem) Item to be deleted.
@@ -89,7 +89,7 @@ class RadiosQuestion extends Question {
     super.addAccessibleLabels();
     // Add a group label for the answers section
     this.$node.find(".EditableComponentCollectionItem").first().parent().attr({
-      "aria-role": "group",
+      role: "group",
       "aria-label": this.labels.answers,
     });
 
@@ -107,8 +107,9 @@ class RadiosQuestion extends Question {
     // remove 'for' attribute to prevent AT reading this for the field itself
     $node
       .find(SELECTOR_ITEM_LABEL)
-      .attr("aria-label", `${this.labels.items.label} ${index}`)
-      .removeAttr("for");
+      .removeAttr("for")
+      .find(".EditableElement")
+      .attr("aria-label", `${this.labels.items.label} ${index}`);
 
     // Provide labels with indexes for input options
     $node
@@ -123,7 +124,7 @@ class RadiosQuestion extends Question {
     // Add labels for the hint text elements for each option
     // Add the describedyby for optional content too
     $node
-      .find(SELECTOR_ITEM_HINT)
+      .find(`${SELECTOR_ITEM_HINT} > .EditableElement`)
       .attr("aria-label", `${this.labels.items.hint} ${index}`)
       .attr("aria-describedby", "optional_content_description");
 

--- a/app/javascript/src/question_text.js
+++ b/app/javascript/src/question_text.js
@@ -17,7 +17,7 @@ const mergeObjects = utilities.mergeObjects;
 const Question = require("./question");
 
 const SELECTOR_HINT = ".govuk-hint";
-const SELECTOR_LABEL = "label h1 span, label h2 span";
+const SELECTOR_LABEL = "label h1, label h2";
 
 class TextQuestion extends Question {
   constructor($node, config) {

--- a/app/javascript/src/question_textarea.js
+++ b/app/javascript/src/question_textarea.js
@@ -17,7 +17,7 @@ const mergeObjects = utilities.mergeObjects;
 const Question = require("./question");
 
 const SELECTOR_HINT = "[data-fb-node=hint]";
-const SELECTOR_LABEL = "label h1 span , label h2 span";
+const SELECTOR_LABEL = "label h1, label h2";
 
 class TextareaQuestion extends Question {
   constructor($node, config) {

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -357,7 +357,7 @@ a[disabled] {
 /* Editable components
  * ------------------- */
 
-h1 span.EditableElement {
+span.EditableElement {
   display: block;
 }
 

--- a/test/editable_components/editable_component_base_test.js
+++ b/test/editable_components/editable_component_base_test.js
@@ -106,12 +106,9 @@ describe("EditableComponentbase", function () {
       });
 
       it("should update the data on save", function () {
-        var $label = $node.find(".editable-label");
-        var $hint = $node.find(".editable-hint");
-
-        component._elements.label.$node.text("Updated Label");
+        component._elements.label.$editable.text("Updated Label");
         component._elements.label.update();
-        component._elements.hint.$node.text("Updated Hint");
+        component._elements.hint.$editable.text("Updated Hint");
         component._elements.hint.update();
 
         component.save();
@@ -126,7 +123,7 @@ describe("EditableComponentbase", function () {
 
     describe("focus", function () {
       it("should focus the first editable element", function () {
-        var label = document.querySelector(".editable-label");
+        var label = document.querySelector(".editable-label > span");
         component.focus();
 
         expect(document.activeElement).to.eql(label);

--- a/test/editable_components/editable_element/component_test.js
+++ b/test/editable_components/editable_element/component_test.js
@@ -19,19 +19,25 @@ describe('EditableElement', function() {
       created = undefined;
     });
 
+    it('should add the child span element', function() {
+      var $element = $('#'+COMPONENT_ID).find('span');
+      expect($element.length).to.equal(1);
+    });
+
+
     it('should add the contentEditable attribute', function() {
-      var $element = $('#'+COMPONENT_ID);
+      var $element = $(`#${COMPONENT_ID} > span`);
       expect($element.attr('contenteditable')).to.equal('true');
     });
 
     it('should add the textbox role', function() {
-      var $element = $('#'+COMPONENT_ID);
+      var $element = $(`#${COMPONENT_ID} > span`);
       expect($element.attr('role')).to.equal('textbox');
 
     });
 
     it('should add the component class name', function() {
-      var $element = $('#'+COMPONENT_ID);
+      var $element = $(`#${COMPONENT_ID} > span`);
       expect($element.hasClass(COMPONENT_CLASSNAME)).to.be.true
     });
 

--- a/test/editable_components/editable_element/events_test.js
+++ b/test/editable_components/editable_element/events_test.js
@@ -1,46 +1,44 @@
-require('../../setup');
+require("../../setup");
 
-describe('EditableElement', function() {
-  const helpers = require('./helpers');
-  const COMPONENT_ID = 'editable-element-events-test';
+describe("EditableElement", function () {
+  const helpers = require("./helpers");
+  const COMPONENT_ID = "editable-element-events-test";
 
-  describe('Events', function() {
+  describe("Events", function () {
     var created;
 
-    beforeEach(function() {
+    beforeEach(function () {
       created = helpers.createEditableElement(COMPONENT_ID);
     });
 
-    afterEach(function() {
+    afterEach(function () {
       helpers.teardownView(COMPONENT_ID);
       created = undefined;
     });
 
     // Would love to do this with spies rather than testing effects of the
     // function, but cannot get sinon spies to work here :-(
-    it('should call update() on blur', function() {
-      var $element = $('#'+COMPONENT_ID);
-      $element.text('My new content');
-      $element.trigger('blur');
-      expect(created.instance.content).to.equal('My new content');
+    it("should call update() on blur", function () {
+      var $element = $(`#${COMPONENT_ID} > span`);
+      $element.text("My new content");
+      $element.trigger("blur");
+      expect(created.instance.content).to.equal("My new content");
     });
 
     // Would love to do this with spies rather than testing effects of the
     // function, but cannot get sinon spies to work here :-(
-    it('should call focus() on focus.editablecomponent', function() {
-      var $element = $('#'+COMPONENT_ID);
+    it("should call focus() on focus.editablecomponent", function () {
+      var $element = $(`#${COMPONENT_ID} > span`);
 
-      created.$node.trigger('focus');
+      created.instance.$editable.trigger("focus");
 
       expect(document.activeElement).to.equal($element.get(0));
     });
 
     // not sure we can test this
-    it('should paste as plaintext');
+    it("should paste as plaintext");
 
     // not sure we can test this
-    it('should prevent newlines');
-
+    it("should prevent newlines");
   });
-
 });

--- a/test/editable_components/editable_element/methods_test.js
+++ b/test/editable_components/editable_element/methods_test.js
@@ -1,151 +1,154 @@
-require('../../setup');
+require("../../setup");
 
-describe('EditableElement', function() {
-
-  const helpers = require('./helpers');
+describe("EditableElement", function () {
+  const helpers = require("./helpers");
   const c = helpers.constants;
-  const COMPONENT_ID = 'editable-element-methods-testsvdb';
+  const COMPONENT_ID = "editable-element-methods-testsvdb";
 
-  describe('Methods', function() {
+  describe("Methods", function () {
     var created;
 
-    beforeEach(function() {
+    beforeEach(function () {
       created = helpers.createEditableElement(COMPONENT_ID);
     });
 
-    afterEach(function() {
+    afterEach(function () {
       helpers.teardownView(COMPONENT_ID);
       created = undefined;
     });
 
-    describe('edit()', function() {
-      it('should add the editing class', function() {
-        var $element = $('#'+COMPONENT_ID);
+    describe("edit()", function () {
+      it("should add the editing class", function () {
+        var $element = $(`#${COMPONENT_ID} > span`);
         expect($element.hasClass(c.EDIT_CLASSNAME)).to.be.false;
 
         created.instance.edit();
 
-        $element = $('#'+COMPONENT_ID);
+        $element = $(`#${COMPONENT_ID} > span`);
         expect($element.hasClass(c.EDIT_CLASSNAME)).to.be.true;
       });
     });
 
-    describe('update()', function() {
-      it('should update the content', function() {
-        var $element = $('#'+COMPONENT_ID);
+    describe("update()", function () {
+      it("should update the content", function () {
+        var $element = $(`#${COMPONENT_ID} > span`);
         expect(created.instance.content).to.equal(c.EDITABLE_TRIMMED_CONTENT);
 
-        $element.text('  My updated content  ');
+        $element.text("  My updated content  ");
         created.instance.update();
 
-        expect(created.instance.content).to.equal('My updated content');
+        expect(created.instance.content).to.equal("My updated content");
       });
 
-      it('should remove the editing class', function() {
+      it("should remove the editing class", function () {
         created.instance.edit();
 
-        $element = $('#'+COMPONENT_ID);
+        var $element = $(`#${COMPONENT_ID} > span`);
         expect($element.hasClass(c.EDIT_CLASSNAME)).to.be.true;
 
         created.instance.update();
         expect($element.hasClass(c.EDIT_CLASSNAME)).to.be.false;
       });
-
     });
 
-    describe('populate()', function() {
-      it('updates the content of the element', function() {
-        var $element = $('#'+COMPONENT_ID);
+    describe("populate()", function () {
+      it("updates the content of the element", function () {
+        var $element = $(`#${COMPONENT_ID} > span`);
         expect($element.text()).to.equal(c.EDITABLE_RAW_CONTENT);
 
-        created.instance.populate('new content');
+        created.instance.populate("new content");
 
-        $element = $('#'+COMPONENT_ID);
-        expect($element.text()).to.equal('new content');
+        $element = $(`#${COMPONENT_ID} > span`);
+        expect($element.text()).to.equal("new content");
       });
 
-      describe('without default content', function() {
-        it('updates with original content if content is empty', function() {
-          var $element = $('#'+COMPONENT_ID);
+      describe("without default content", function () {
+        it("updates with original content if content is empty", function () {
+          var $element = $(`#${COMPONENT_ID} > span`);
           expect($element.text()).to.equal(c.EDITABLE_RAW_CONTENT);
 
-          created.instance.populate('');
+          created.instance.populate("");
 
-          $element = $('#'+COMPONENT_ID);
+          $element = $(`#${COMPONENT_ID} > span`);
           expect($element.text()).to.equal(c.EDITABLE_TRIMMED_CONTENT);
         });
-      })
+      });
 
-      describe('with default content', function() {
-        beforeEach(function() {
+      describe("with default content", function () {
+        beforeEach(function () {
           created = helpers.createEditableElement(COMPONENT_ID, {
-            attributeDefaultText: 'defaultText',
+            attributeDefaultText: "defaultText",
           });
         });
 
-        it('updates with original content if content is empty', function() {
-          var $element = $('#'+COMPONENT_ID);
+        it("updates with original content if content is empty", function () {
+          var $element = $(`#${COMPONENT_ID} > span`);
           expect($element.text()).to.equal(c.EDITABLE_RAW_CONTENT);
 
-          created.instance.populate('');
+          created.instance.populate("");
 
-          $element = $('#'+COMPONENT_ID);
+          $element = $(`#${COMPONENT_ID} > span`);
           expect($element.text()).to.equal(c.EDITABLE_DEFAULT_CONTENT);
         });
       });
     });
 
-    describe('focus()', function() {
-      it('places focus on the $node', function() {
+    describe("focus()", function () {
+      it("places focus on the $node", function () {
         created.instance.focus();
-        expect(document.activeElement).to.eql(created.$node.get(0))
+        expect(document.activeElement).to.eql(
+          created.instance.$editable.get(0),
+        );
       });
     });
 
-    describe('content()', function() {
-
-      it('updates the content variable', function() {
-        created.instance.content = 'Updated content';
-        expect(created.instance.content).to.equal('Updated content');
-      })
-
-      it('updates the content in the node', function() {
-        created.instance.content = 'New content';
-        $element = $('#'+COMPONENT_ID);
-        expect($element.text()).to.equal('New content');
+    describe("content()", function () {
+      it("updates the content variable", function () {
+        created.instance.content = "Updated content";
+        expect(created.instance.content).to.equal("Updated content");
       });
 
-      it('calls the populate() method', function() {
+      it("updates the content in the node", function () {
+        created.instance.content = "New content";
+        $element = $(`#${COMPONENT_ID} > span`);
+        expect($element.text()).to.equal("New content");
+      });
+
+      it("calls the populate() method", function () {
         var spy = sinon.spy(created.instance, "populate");
-        created.instance.content = 'my new content';
-        expect(spy).to.have.been.calledWith('my new content');
+        created.instance.content = "my new content";
+        expect(spy).to.have.been.calledWith("my new content");
       });
 
-      it('calls the emitSaveRequired() method', function() {
+      it("calls the emitSaveRequired() method", function () {
         var spy = sinon.spy(created.instance, "emitSaveRequired");
-        created.instance.content = 'my new content';
+        created.instance.content = "my new content";
         expect(spy).to.have.been.calledOnce;
       });
 
-      it('triggers the saveRequired event', function() {
+      it("triggers the saveRequired event", function () {
         var eventCount = 0;
 
-        $(document).on('SaveRequired', function() {
+        $(document).on("SaveRequired", function () {
           eventCount++;
         });
-        created.instance.content = 'More new content';
+        created.instance.content = "More new content";
         expect(eventCount).to.equal(1);
-      })
+      });
 
-      it('doesn\'t trigger saveRequired when content is original', function() {
+      it("doesn't trigger saveRequired when content is original", function () {
         //reset
         helpers.teardownView(COMPONENT_ID);
         created = undefined;
         //new instance with default text
-        created = helpers.createEditableElement(COMPONENT_ID, {}, c.EDITABLE_TRIMMED_CONTENT);
+        created = helpers.createEditableElement(
+          COMPONENT_ID,
+          {},
+          c.EDITABLE_TRIMMED_CONTENT,
+        );
         var eventCount = 0;
 
-        $(document).on('SaveRequired', function() {
+        $(document).on("SaveRequired", function () {
           eventCount++;
         });
 
@@ -153,20 +156,24 @@ describe('EditableElement', function() {
         expect(eventCount).to.equal(0);
       });
 
-      it('doesn\'t trigger saveRequired when content is default', function() {
+      it("doesn't trigger saveRequired when content is default", function () {
         //reset
         helpers.teardownView(COMPONENT_ID);
         created = undefined;
         //new instance with default text
-        created = helpers.createEditableElement(COMPONENT_ID, {
+        created = helpers.createEditableElement(
+          COMPONENT_ID,
+          {
             attributeDefaultText: c.EDITABLE_DEFAULT_CONTENT,
-        }, ' ');
+          },
+          " ",
+        );
         var eventCount = 0;
 
-        $(document).on('SaveRequired', function() {
+        $(document).on("SaveRequired", function () {
           eventCount++;
         });
-        created.instance.content = '';
+        created.instance.content = "";
         expect(eventCount).to.equal(0);
       });
     });


### PR DESCRIPTION
This PR modifies the `EditableElement` class to insert a child span inside the element and use that as the `contentEditable` container.  

This is to allow headings to retain their semantics and to fix the fact that in radios and checkboxes making `<label>` elements `contentEditable` fails WCAG as they then have an invalid `role` of `textbox`.

- Manual testing seems to show this as all working
- JS tests have been updated to pass

### To do:
Acceptance tests are still failing