### PR TITLE
Enable announcements feature in live

### DIFF
--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -1,7 +1,7 @@
 <div class="fb-main-grid-wrapper" data-block-id="services" data-block-type="page" data-block-pagetype="services">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <%= render(AnnouncementComponent.new(user: current_user)) if FeatureFlags.announcements.enabled? %>
+      <%= render AnnouncementComponent.new(user: current_user) %>
 
       <h1 class="govuk-heading-xl" data-block-id="forms-heading" data-block-property="heading"><%= t('services.heading') %>
       </h1>

--- a/config/features.yml
+++ b/config/features.yml
@@ -3,10 +3,6 @@ feature_flags:
     local: true
     test: true   # formbuilder-saas-test
     live: false  # formbuilder-saas-live
-  announcements:
-    local: true
-    test: true
-    live: false
   transfer_ownership:
     local: true
     test: true   # formbuilder-saas-test

--- a/config/initializers/moj_forms_team.rb
+++ b/config/initializers/moj_forms_team.rb
@@ -1,20 +1,19 @@
-MOJ_FORMS_ADMIN = [
-  'claire.bowman@digital.justice.gov.uk',
-  'sijy.mathew@digital.justice.gov.uk',
-  'mark.jefferson@digital.justice.gov.uk',
-  'assma.banaris@digital.justice.gov.uk',
-  'fabien.marry@digital.justice.gov.uk',
-  'natalia.stutter@digital.justice.gov.uk',
-  'darren.rooke@digital.justice.gov.uk',
-  'daniel.glen@digital.justice.gov.uk'
+MOJ_FORMS_ADMIN = %w[
+  claire.bowman@digital.justice.gov.uk
+  sijy.mathew@digital.justice.gov.uk
+  mark.jefferson@digital.justice.gov.uk
+  assma.banaris@digital.justice.gov.uk
+  fabien.marry@digital.justice.gov.uk
+  darren.rooke@digital.justice.gov.uk
+  daniel.glen@digital.justice.gov.uk
 ].freeze
 
-MOJ_FORMS_DEVS = [
-  'matt.tei@digital.justice.gov.uk',
-  'chris.pymm@digital.justice.gov.uk',
-  'hellema.ibrahim@digital.justice.gov.uk',
-  'steven.leighton@digital.justice.gov.uk',
-  'jesus.laiz@digital.justice.gov.uk',
+MOJ_FORMS_DEVS = %w[
+  matt.tei@digital.justice.gov.uk
+  chris.pymm@digital.justice.gov.uk
+  hellema.ibrahim@digital.justice.gov.uk
+  steven.leighton@digital.justice.gov.uk
+  jesus.laiz@digital.justice.gov.uk
 ].freeze
 
 MOJ_FORMS_TEAM = MOJ_FORMS_ADMIN + MOJ_FORMS_DEVS.freeze


### PR DESCRIPTION
All the work was done in previous PRs, and this just remove the feature-flag condition effectively enabling the announcements in live.

Removed Natalia from the `MOJ_FORMS_ADMIN` constant, and linting.