### PR TITLE
Send email on first publish to test (featured-flagged)

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -5,9 +5,14 @@ class NotifyMailer < GovukNotifyRails::Mailer
     @template_ids = Rails.configuration.govuk_notify_templates
   end
 
+  # Report the exception but do not re-raise it, as these errors
+  # are not recoverable so it is not useful to retry failed jobs
   # :nocov:
-  rescue_from 'Notifications::Client::BadRequestError' do |message|
-    Rails.logger.warn message.to_s
+  rescue_from 'Notifications::Client::BadRequestError' do |ex|
+    Rails.logger.warn("#{ex} - #{message.to}")
+    Sentry.capture_exception(
+      ex, contexts: { recipient: { emails: message.to.join(',') } }
+    )
   end
   # :nocov:
 

--- a/app/presenters/publish_service_presenter.rb
+++ b/app/presenters/publish_service_presenter.rb
@@ -32,7 +32,7 @@ class PublishServicePresenter
   end
 
   def url
-    "https://#{hostname}" if published?
+    form_url if published?
   end
 
   private

--- a/app/services/publisher/adapters/cloud_platform.rb
+++ b/app/services/publisher/adapters/cloud_platform.rb
@@ -59,14 +59,6 @@ class Publisher
 
       private
 
-      def first_published?
-        PublishService.completed
-        .where(
-          service_id:,
-          deployment_environment:
-        ).count == 1
-      end
-
       def create_config_dir
         FileUtils.mkdir_p(config_dir)
       end

--- a/app/services/publisher/after_completion.rb
+++ b/app/services/publisher/after_completion.rb
@@ -1,0 +1,37 @@
+class Publisher
+  class AfterCompletion
+    attr_reader :service_provisioner
+
+    delegate :deployment_environment, :service_id, :service_name, :created_by, :form_url,
+             to: :service_provisioner
+
+    alias_method :form_name, :service_name
+
+    def initialize(service_provisioner:)
+      @service_provisioner = service_provisioner
+    end
+
+    def call
+      if send_first_publish_to_test_email?
+        PublisherMailer.first_time_publish_to_test(
+          user:, form_name:, form_url:
+        ).deliver_later
+      end
+    end
+
+    private
+
+    def user
+      @user ||= User.find(created_by)
+    end
+
+    def send_first_publish_to_test_email?
+      return unless FeatureFlags.first_time_publish_to_test_email.enabled?
+      return unless deployment_environment.inquiry.dev?
+
+      PublishService.completed.where(
+        service_id:, deployment_environment:
+      ).one?
+    end
+  end
+end

--- a/app/services/publisher/service_provisioner.rb
+++ b/app/services/publisher/service_provisioner.rb
@@ -41,7 +41,7 @@ class Publisher
       binding
     end
 
-    delegate :service_name, to: :service
+    delegate :service_name, :created_by, to: :service
 
     def service_slug
       service_slug_config.presence || service.service_slug

--- a/app/services/publisher/utils/hostname.rb
+++ b/app/services/publisher/utils/hostname.rb
@@ -1,6 +1,10 @@
 class Publisher
   module Utils
     module Hostname
+      def form_url
+        "https://#{hostname}".freeze
+      end
+
       def hostname
         root_url = Rails.application.config
           .platform_environments[platform_environment][:url_root]

--- a/config/features.yml
+++ b/config/features.yml
@@ -7,3 +7,7 @@ feature_flags:
     local: true
     test: true   # formbuilder-saas-test
     live: false  # formbuilder-saas-live
+  first_time_publish_to_test_email:
+    local: true
+    test: true
+    live: false

--- a/spec/services/publisher/after_completion_spec.rb
+++ b/spec/services/publisher/after_completion_spec.rb
@@ -1,0 +1,79 @@
+RSpec.describe Publisher::AfterCompletion do
+  subject { described_class.new(service_provisioner:) }
+
+  let(:service_provisioner) { Publisher::ServiceProvisioner.new(args) }
+  let(:service_metadata) { metadata_fixture(:version) }
+
+  let(:service_id) { service_metadata['service_id'] }
+  let(:version_id) { service_metadata['version_id'] }
+  let(:platform_environment) { 'test' }
+
+  let(:args) do
+    {
+      service_id:,
+      version_id:,
+      deployment_environment:,
+      platform_environment:
+    }
+  end
+
+  before do
+    allow(
+      MetadataApiClient::Version
+    ).to receive(:find).with(service_id:, version_id:).and_return(
+      MetadataApiClient::Version.new(service_metadata)
+    )
+  end
+
+  describe '#call' do
+    context 'when deployment env is `production`' do
+      let(:deployment_environment) { 'production' }
+
+      it 'does not trigger the email' do
+        expect(PublisherMailer).not_to receive(:first_time_publish_to_test)
+        subject.call
+      end
+    end
+
+    context 'when deployment env is `dev`' do
+      let(:deployment_environment) { 'dev' }
+      let(:completed_scope) { double('completed_scope') }
+
+      before do
+        allow(PublishService).to receive(:completed).and_return(completed_scope)
+        allow(completed_scope).to receive(:where).with(
+          service_id:, deployment_environment:
+        ).and_return(results_double)
+      end
+
+      context 'when this service has been already published before' do
+        let(:results_double) { [Object, Object] }
+
+        it 'does not trigger the email' do
+          expect(PublisherMailer).not_to receive(:first_time_publish_to_test)
+          subject.call
+        end
+      end
+
+      context 'when this service is being published for the first time' do
+        let(:results_double) { [Object] } # just one result, corresponding to the current publishing
+
+        let(:user) { instance_double(User) }
+        let(:form_name) { 'Version Fixture' }
+        let(:form_url) { 'https://version-fixture.dev.test.form.service.justice.gov.uk' }
+
+        it 'triggers the email' do
+          expect(User).to receive(:find).with(service_metadata['created_by']).and_return(user)
+
+          expect(
+            PublisherMailer
+          ).to receive(:first_time_publish_to_test).with(
+            user:, form_name:, form_url:
+          ).and_return(double.as_null_object)
+
+          subject.call
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/te7rYMDe

Now that we have the Notify integration in place, we can hook the sending of the email and the rules for this to trigger.

Given we really don't want this email to be sent if the service couldn't be published due to some configuration error, or k8s commands error, it will be triggered as an `after_perform` callback on the `PublishServiceJob`, ensuring it only gets called if the job has finalised successfully.

Additionally this new service object has been called `AfterCompletion` as there might be other code we want to run here as well, but for now is only the email.

Note it is still behind feature flag so will not trigger on live editor, only in test/testable editors.