### PR TITLE
Fix heading structure (DAC Audit)

### DIFF
--- a/app/views/api/autocomplete/_show.html.erb
+++ b/app/views/api/autocomplete/_show.html.erb
@@ -1,10 +1,9 @@
 <div class="component-dialog-api-request" id="autocomplete_items">
   <%= form_for @items, url: api_service_autocomplete_path(service_id: service.service_id, component_id: @items.component_id), method: :post, multipart: true do |form| %>
   <div class="govuk-form-group">
-    <%= form.label :file, t('dialogs.autocomplete.legend'), 
-      id: "autocomplet-items-dialog-title", 
-      class: "govuk-label govuk-label--m",
-      data: { node: "heading" } %>
+    <h2 class="govuk-label-wrapper" id="autocomplete-items-dialog-title" data-node="heading">
+      <%= form.label :file, t('dialogs.autocomplete.legend'), class: "govuk-label govuk-label--m" %>    
+    </h2>
 
       <% if items_present?(@items.component_id) %>
         <div class="govuk-warning-text govuk-!-margin-bottom-2">

--- a/app/views/api/destinations/new.html.erb
+++ b/app/views/api/destinations/new.html.erb
@@ -1,11 +1,9 @@
 <div class="component-dialog-api-request">
   <%= form_for @destination, url: api_service_flow_destinations_path(service.service_id, @destination.flow_uuid) do |f| %>
     <div class="govuk-form-group ">
-      <%= f.label :destination_uuid, t('dialogs.destination.label'), 
-        class: "govuk-label govuk-label--m", 
-        id: "change-destination-dialog-title",
-        data: { node: "heading "}
-      %>
+      <h2 class="govuk-label-wrapper" id="change-destination-dialog-title" data-node="heading">
+        <%= f.label :destination_uuid, t('dialogs.destination.label'), class: "govuk-label govuk-label--m" %>
+      </h2>
       <div class="govuk-hint">
         <%= t('dialogs.destination.lede', title: @destination.title) %>
       </div>

--- a/app/views/api/move/_new.html.erb
+++ b/app/views/api/move/_new.html.erb
@@ -4,11 +4,9 @@
       <%= f.hidden_field :previous_flow_uuid, value: @move.previous_flow_uuid %>
       <%= f.hidden_field :previous_conditional_uuid, value: @move.previous_conditional_uuid %>
       <%= f.hidden_field :target_conditional_uuid, value: '' %>
-      <%= f.label :target_uuid, t('dialogs.move.label', title: @move.title), 
-        id: "move-page-dialog-title", 
-        class: "govuk-label govuk-label--m",
-        data: { node: "heading" } 
-      %>
+      <h2 class="govuk-label-wrapper" id="move-page-dialog-title" data-node="heading">
+        <%= f.label :target_uuid, t('dialogs.move.label', title: @move.title), class: "govuk-label govuk-label--m" %>
+      </h2>
       <p> <%= t('dialogs.move.lede') %></p>
       <div class="govuk-form-group">
         <select class="govuk-select" name="move[target_uuid]" id="move_target_uuid">

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -6,15 +6,11 @@
         <%= t('.title') %>
       </h1>
 
-      <div class="govuk-panel__body">
-        <p><%= t('.lede')%></p>
-      </div>
+      <h2 class="govuk-heading-l govuk-!-font-weight-regular"><%= t('.lede')%></h2>
 
-      <div>
-        <p><%= t('.body',
+      <p><%= t('.body',
                  contact_us_link: govuk_link_to( t('.contact_us_link_text'), 'https://moj-forms.service.justice.gov.uk/contact/')
                 ).html_safe %></p>
-      </div>
 
       <%= button_to @sign_in_url, method: :post, class: 'govuk-button fb-govuk-button  govuk-button--start govuk-!-margin-top-2' do %>
         <%= t('.sign_in') %>

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -35,7 +35,10 @@
     <%= f.hidden_field :conditional_uuid, value: '' %>
 
     <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
-      <%= f.label :page_url, class: "govuk-label govuk-label--m", id: "new-page-dialog-title", data: { node: "heading" } %>
+      <h2 class="govuk-label-wrapper" id="new-page-dialog-title" data-node="heading">
+        <%= f.label :page_url, class: "govuk-label govuk-label--m" %>
+      </h2>
+
       <div class="govuk-hint" id="add-page-hint"><%= t('activemodel.attributes.page_creation.page_url_hint') %></div>
       <% f.object.errors.each do |error|  %>
         <p class="govuk-error-message"><%= error.message %></p>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -30,7 +30,9 @@
         <%= form_for(@service_creation, url: services_path) do |f| %>
           <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
             <%= tag.div class: 'govuk-character-count', data: { module: 'govuk-character-count', maxlength: Editor::Service::MAXIMUM, threshold: 90 } do %>
-              <%= f.label :service_name, class: "govuk-label govuk-label--m", id: "create-service-dialog-title", data: { node: 'heading'} %>
+              <h2 class="govuk-label-wrapper" id="create-service-dialog-title" data-node="heading">
+                <%= f.label :service_name, class: "govuk-label govuk-label--m" %>
+              </h2>
               <% f.object.errors.each do |error|  %>
                 <p class="govuk-error-message"><%= error.message %></p>
               <% end %>


### PR DESCRIPTION
This PR fixes the heading hierarchy on the homepage.

It also updates all modals that used a label for their title to warp the label element in an `<h2>` tag to add heading semantics.