### PR TITLE
Fix incorrect aria-role attribute to role (DAC Audit)

### DIFF
--- a/app/javascript/src/question_checkboxes.js
+++ b/app/javascript/src/question_checkboxes.js
@@ -88,7 +88,7 @@ class CheckboxesQuestion extends Question {
     super.addAccessibleLabels();
     // Add a group label for the answers section
     this.$node.find(".EditableComponentCollectionItem").first().parent().attr({
-      "aria-role": "group",
+      "role": "group",
       "aria-label": this.labels.answers,
     });
 

--- a/app/javascript/src/question_radios.js
+++ b/app/javascript/src/question_radios.js
@@ -89,7 +89,7 @@ class RadiosQuestion extends Question {
     super.addAccessibleLabels();
     // Add a group label for the answers section
     this.$node.find(".EditableComponentCollectionItem").first().parent().attr({
-      "aria-role": "group",
+      "role": "group",
       "aria-label": this.labels.answers,
     });
 


### PR DESCRIPTION
Really simple fix.  `aria-role` is invalid, the attribute should just be role.