### PR TITLE
Update modals to have more explicit close button label (DAC Audit)

### DIFF
--- a/app/javascript/src/component_dialog.js
+++ b/app/javascript/src/component_dialog.js
@@ -236,6 +236,7 @@ class Dialog {
       autoOpen: false,
       classes: this.#config.classes,
       closeOnEscape: true,
+      closeText: this.#config.closeText,
       height: "auto",
       modal: true,
       resizable: false,

--- a/app/javascript/src/component_dialog_api_request.js
+++ b/app/javascript/src/component_dialog_api_request.js
@@ -183,6 +183,7 @@ class DialogApiRequest {
       autoOpen: false,
       classes: this.#config.classes,
       closeOnEscape: true,
+      closeText: this.#config.closeText,
       height: "auto",
       modal: true,
       resizable: false,

--- a/app/javascript/src/component_dialog_form.js
+++ b/app/javascript/src/component_dialog_form.js
@@ -267,6 +267,7 @@ class DialogForm {
       autoOpen: false,
       classes: this.#config.classes,
       closeOnEscape: true,
+      closeText: this.#config.closeText,
       height: "auto",
       modal: true,
       resizable: false,

--- a/app/javascript/src/components/menus/connection_menu.js
+++ b/app/javascript/src/components/menus/connection_menu.js
@@ -112,6 +112,7 @@ class ConnectionMenu extends ActivatedMenu {
       activator: $link,
       autoOpen: true,
       remote: false,
+      closeText: this.config.view.text.dialogs.button_close,
     });
   }
 

--- a/app/javascript/src/components/menus/page_menu.js
+++ b/app/javascript/src/components/menus/page_menu.js
@@ -1,149 +1,160 @@
-const {
-    mergeObjects,
-    post
-} = require('../../utilities');
-const ActivatedMenu = require('./activated_menu');
-const DialogApiRequest = require('../../component_dialog_api_request');
-const DialogForm = require('../../component_dialog_form');
+const { mergeObjects, post } = require("../../utilities");
+const ActivatedMenu = require("./activated_menu");
+const DialogApiRequest = require("../../component_dialog_api_request");
+const DialogForm = require("../../component_dialog_form");
 
 class PageMenu extends ActivatedMenu {
-    constructor($node, config) {
-        super($node, mergeObjects({
-            activator_classname: $node.data("activator-classname"),
-            container_id: $node.data("activated-menu-container-id"),
-            activator_text: $node.data("activator-text")
-        }, config));
+  constructor($node, config) {
+    super(
+      $node,
+      mergeObjects(
+        {
+          activator_classname: $node.data("activator-classname"),
+          container_id: $node.data("activated-menu-container-id"),
+          activator_text: $node.data("activator-text"),
+        },
+        config,
+      ),
+    );
 
-        $node.on("menuselect", (event, ui) => {
-            this.selection(event, ui.item);
+    $node.on("menuselect", (event, ui) => {
+      this.selection(event, ui.item);
+    });
+
+    this.activator.$node.addClass("PageMenuActivator");
+    this.container.$node.addClass("PageMenu");
+    this.uuid = $node.data("uuid");
+    this.title = $node.data("title");
+  }
+
+  // Handle item selections on the form step context menu elements.
+  selection(event, item) {
+    event.preventDefault();
+    var action = item.data("action");
+
+    switch (action) {
+      case "preview":
+        this.previewPage(item);
+        break;
+
+      case "delete-api":
+        this.deleteItemApi(item);
+        break;
+
+      case "delete-form":
+        this.deleteItemForm(item);
+        break;
+
+      case "move-api":
+        this.moveItemApi(item);
+        break;
+
+      case "toggle-external-start-page":
+        this.toggleExternalStartPage(item);
+        break;
+
+      case "disable-external-start-page":
+        this.disableExternalStartPage(item);
+        break;
+
+      case "preview-external-start-page":
+        this.previewExternalStartPage(item);
+        break;
+
+      default:
+        this.link(item);
+    }
+  }
+
+  link(element) {
+    var $link = element.find("> a");
+    location.href = $link.attr("href");
+  }
+
+  previewPage(element) {
+    var $link = element.find("> a");
+    window.open($link.attr("href"));
+  }
+
+  deleteItemApi(element) {
+    var $link = element.find("> a");
+    new DialogApiRequest($link.attr("href"), {
+      activator: $link,
+      closeOnClickSelector: "button.govuk-button",
+      closeText: this.config.view.text.dialogs.button_close,
+      onLoad: function (dialog) {
+        // Find and correct (make work!) any method:delete links
+        dialog.$node.find("[data-method=delete]").on("click", function (e) {
+          e.preventDefault();
+          post(this.dataset.url, { _method: "delete" });
         });
+      },
+    });
+  }
 
-        this.activator.$node.addClass("PageMenuActivator");
-        this.container.$node.addClass("PageMenu");
-        this.uuid = $node.data("uuid");
-        this.title = $node.data("title");
-    }
+  deleteItemForm(element) {
+    var $link = element.find("> a");
+    new DialogForm($link.attr("href"), {
+      activator: $link,
+      closeText: this.config.view.text.dialogs.button_close,
+      autoOpen: true,
+      remote: false,
+    });
+  }
 
-    // Handle item selections on the form step context menu elements.
-    selection(event, item) {
-        event.preventDefault();
-        var action = item.data("action");
-
-        switch (action) {
-            case "preview":
-                this.previewPage(item);
-                break;
-
-            case "delete-api":
-                this.deleteItemApi(item);
-                break;
-
-            case "delete-form":
-                this.deleteItemForm(item);
-                break;
-
-            case "move-api":
-                this.moveItemApi(item);
-                break;
-
-            case "toggle-external-start-page":
-                this.toggleExternalStartPage(item);
-                break;
-
-            case "disable-external-start-page":
-                this.disableExternalStartPage(item);
-                break;
-
-            case "preview-external-start-page":
-                this.previewExternalStartPage(item);
-                break;
-
-            default: this.link(item);
-        }
-    }
-
-    link(element) {
-        var $link = element.find("> a");
-        location.href = $link.attr("href");
-    }
-
-    previewPage(element) {
-        var $link = element.find("> a");
-        window.open($link.attr("href"));
-    }
-
-    deleteItemApi(element) {
-        var $link = element.find("> a");
-        new DialogApiRequest($link.attr("href"), {
-            activator: $link,
-            closeOnClickSelector: "button.govuk-button",
-            onLoad: function(dialog) {
-                // Find and correct (make work!) any method:delete links
-                dialog.$node.find("[data-method=delete]").on("click", function(e) {
-                    e.preventDefault();
-                    post(this.dataset.url, { _method: "delete" });
-                });
-            }
+  moveItemApi(element) {
+    var $link = element.find("> a");
+    new DialogForm($link.attr("href"), {
+      activator: $link,
+      closeText: this.config.view.text.dialogs.button_close,
+      autoOpen: true,
+      remote: false,
+      onLoad: function (dialog) {
+        dialog.$node.find("#move_target_uuid").on("change", function (e) {
+          // Get the selected option and then update the hidden conditional
+          // uuid field
+          var selectedOption = $(this).find("option").eq(this.selectedIndex);
+          var conditionalUuid = selectedOption.data("conditional-uuid");
+          dialog.$node
+            .find("#move_target_conditional_uuid")
+            .val(conditionalUuid);
         });
-    }
+      },
+    });
+  }
 
-    deleteItemForm(element) {
-        var $link = element.find("> a");
-        new DialogForm($link.attr("href"), {
-            activator: $link,
-            autoOpen: true,
-            remote: false,
-        });
-    }
+  toggleExternalStartPage(element) {
+    var $link = element.find("> a");
+    new DialogForm($link.attr("href"), {
+      activator: $link,
+      closeText: this.config.view.text.dialogs.button_close,
+      autoOpen: true,
+      remote: true,
+      onError: function (data, dialog) {
+        var responseHtml = $.parseHTML(data.responseText);
+        var $newHtml = $(responseHtml[0]).html();
+        dialog.$node.html($newHtml);
+        dialog.refresh();
+      },
+      onSuccess: function () {
+        window.location.reload();
+      },
+    });
+  }
 
-    moveItemApi(element) {
-        var $link = element.find("> a");
-        new DialogForm($link.attr("href"), {
-            activator: $link,
-            autoOpen: true,
-            remote: false,
-            onLoad: function(dialog) {
-                dialog.$node.find("#move_target_uuid").on("change", function(e) {
-                    // Get the selected option and then update the hidden conditional
-                    // uuid field
-                    var selectedOption = $(this).find("option").eq(this.selectedIndex)
-                    var conditionalUuid = selectedOption.data("conditional-uuid")
-                    dialog.$node.find("#move_target_conditional_uuid").val(conditionalUuid)
-                });
-            }
-        });
-    }
+  disableExternalStartPage(element) {
+    var $link = element.find("> a");
+    post($link.attr("href"), { _method: "delete" });
+  }
 
-    toggleExternalStartPage(element) {
-        var $link = element.find("> a");
-        new DialogForm($link.attr("href"), {
-            activator: $link,
-            autoOpen: true,
-            remote: true,
-            onError: function(data, dialog) {
-                var responseHtml = $.parseHTML(data.responseText);
-                var $newHtml = $(responseHtml[0]).html();
-                dialog.$node.html($newHtml);
-                dialog.refresh();
-              },
-              onSuccess: function() {
-                window.location.reload()
-              },
-        });
-    }
-
-    disableExternalStartPage(element) {
-        var $link = element.find("> a");
-        post($link.attr("href"), { _method: "delete" });
-    }
-
-    previewExternalStartPage(element) {
-        var $link = element.find("> a");
-        new DialogForm($link.attr("href"), {
-            activator: $link,
-            autoOpen: true,
-            remote: true,
-        });
-    }
+  previewExternalStartPage(element) {
+    var $link = element.find("> a");
+    new DialogForm($link.attr("href"), {
+      activator: $link,
+      closeText: this.config.view.text.dialogs.button_close,
+      autoOpen: true,
+      remote: true,
+    });
+  }
 }
 module.exports = PageMenu;

--- a/app/javascript/src/controller_default.js
+++ b/app/javascript/src/controller_default.js
@@ -64,6 +64,7 @@ function createDialog() {
       "ui-dialog": $template.data("classes"),
     },
     titleId: "dialog-ok-title",
+    closeText: this.text.dialogs.button_close,
   });
 }
 
@@ -79,6 +80,7 @@ function createDialogConfirmation() {
     classes: {
       "ui-dialog": $template.data("classes"),
     },
+    closeText: this.text.dialogs.button_close,
     titleId: "dialog-confirmation-title",
   });
 }
@@ -95,6 +97,7 @@ function createDialogConfirmationDelete() {
     classes: {
       "ui-dialog": $template.data("classes"),
     },
+    closeText: this.text.dialogs.button_close,
     titleId: "dialog-confirmation-delete-title",
   });
 }

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -235,6 +235,7 @@ function addQuestionMenuListeners(view) {
     new DialogApiRequest(apiUrl, {
       activator: question.menu.selectedItem,
       closeOnClickSelector: ".govuk-button",
+      closeText: view.text.dialogs.button_close,
 
       onLoad: function (dialog) {
         // Find and correct (make work!) any method:delete links
@@ -283,6 +284,7 @@ function addQuestionMenuListeners(view) {
 
       new DialogForm(apiUrl, {
         activator: question.menu.selectedItem,
+        closeText: view.text.dialogs.button_close,
         remote: true,
         autoOpen: true,
         /*
@@ -421,6 +423,7 @@ function addQuestionMenuListeners(view) {
     var apiUrl = question.menu.selectedItem.data("apiPath");
     new DialogForm(apiUrl, {
       activator: question.menu.selectedItem,
+      closeText: view.text.dialogs.button_close,
       remote: true,
       autoOpen: true,
       submitOnClickSelector: 'button[type="submit"]',
@@ -455,6 +458,7 @@ function addQuestionMenuListeners(view) {
       var maxFilesVal = question.data.max_files;
       new DialogForm(apiUrl, {
         activator: question.menu.selectedItem,
+        closeText: view.text.dialogs.button_close,
         remote: true,
         autoOpen: true,
       });
@@ -489,6 +493,7 @@ function addEditableComponentItemMenuListeners(view) {
       if (collectionItem.component.canHaveItemsRemoved()) {
         new DialogApiRequest(url, {
           activator: selectedItem,
+          closeText: view.text.dialogs.button_close,
           closeOnClickSelector: ".govuk-button",
           onLoad: function (dialog) {
             dialog.$node.find("[data-method=delete]").on("click", function (e) {
@@ -556,6 +561,7 @@ function openConditionalContentDialog(component, activator, view) {
   if (url) {
     new DialogForm(url, {
       activator: activator,
+      closeText: view.text.dialogs.button_close,
       remote: true,
       requestMethod: "POST",
       requestData: data,
@@ -849,6 +855,7 @@ function createDialogConfiguration() {
   var $node = $($template.text());
   return new Dialog($node, {
     autoOpen: false,
+    closeText: this.text.dialogs.button_close,
     cancelText: $template.data("text-cancel"),
     okText: $template.data("text-ok"),
     classes: {

--- a/app/javascript/src/controller_publish.js
+++ b/app/javascript/src/controller_publish.js
@@ -12,15 +12,14 @@
  *
  **/
 
-
-const DefaultController = require('./controller_default');
-const DialogForm = require('./component_dialog_form');
+const DefaultController = require("./controller_default");
+const DialogForm = require("./component_dialog_form");
 
 class PublishController extends DefaultController {
   constructor(app) {
     super(app);
 
-    switch(app.page.action) {
+    switch (app.page.action) {
       case "create":
         PublishController.create.call(this);
         break;
@@ -31,37 +30,37 @@ class PublishController extends DefaultController {
   }
 }
 
-
 /* Setup for the Index action
  **/
-PublishController.index = function() {
+PublishController.index = function () {
   var view = this;
   setupPublishForms.call(view);
 
   // When to show 15 minute message.
-  if(view.publishFormTest.firstTimePublish() || view.publishFormProd.firstTimePublish()) {
+  if (
+    view.publishFormTest.firstTimePublish() ||
+    view.publishFormProd.firstTimePublish()
+  ) {
     view.dialog.open({
       ok: view.text.dialogs.button_publish,
       heading: view.text.dialogs.heading_publish,
-      content: view.text.dialogs.message_publish
+      content: view.text.dialogs.message_publish,
     });
   }
-}
-
+};
 
 /* Set up for the Create action
  **/
-PublishController.create = function() {
+PublishController.create = function () {
   var view = this;
   setupPublishForms.call(view);
   view.ready();
-}
-
+};
 
 /* Setup the Publish Form as an enhanced object.
  **/
 class PublishForm {
-  constructor($node) {
+  constructor($node, view) {
     var $content = $node.find(".govuk-form");
     var $radios = $node.find("input[type=radio]");
     var $activator = $node.parent().find('button[data-fb-action="publish"]');
@@ -71,22 +70,23 @@ class PublishForm {
     new DialogForm($node, {
       autoOpen: $errors.length ? true : false,
       activator: $activator,
-      onClose: function(dialog) {
-        $errors.parents().removeClass('error');
+      closeText: view.text.dialogs.button_close,
+      onClose: function (dialog) {
+        $errors.parents().removeClass("error");
         $errors.remove(); // Remove from DOM (includes removing all jQuery data)
-        dialog.$node.find('.govuk-form-group').removeClass('govuk-form-group--error');
-      }
-    })
+        dialog.$node
+          .find(".govuk-form-group")
+          .removeClass("govuk-form-group--error");
+      },
+    });
 
     this.$node = $node;
-
   }
 
   firstTimePublish() {
     return this.$node.data("first_publish");
   }
 }
-
 
 /* Show/hide content based on a yes/no type of radio button control.
  * @content (jQuery node) Content area to be shown/hidden
@@ -100,7 +100,7 @@ class PublishForm {
 class ModalContentVisibilityController {
   constructor($content, $radios) {
     // Set listener.
-    if($radios.length > 0) {
+    if ($radios.length > 0) {
       $radios.eq(0).on("change", this.toggle.bind(this));
       $radios.eq(1).on("change", this.toggle.bind(this));
       this.$content = $content;
@@ -111,23 +111,25 @@ class ModalContentVisibilityController {
 
   toggle() {
     // Set initial state.
-    if(this.$radios.last().prop("checked") || this.$radios.last().get(0).checked) {
+    if (
+      this.$radios.last().prop("checked") ||
+      this.$radios.last().get(0).checked
+    ) {
       this.$content.show();
-    }
-    else {
+    } else {
       this.$content.hide();
     }
   }
 }
 
-
 // Private
 
 /* Find and setup publish forms
  **/
-function setupPublishForms(page) {
-  this.publishFormTest = new PublishForm($("#publish-form-dev"));
-  this.publishFormProd = new PublishForm($("#publish-form-production"));
+function setupPublishForms() {
+  const view = this;
+  this.publishFormTest = new PublishForm($("#publish-form-dev"), view);
+  this.publishFormProd = new PublishForm($("#publish-form-production"), view);
 }
 
 module.exports = PublishController;

--- a/app/javascript/src/controller_services.js
+++ b/app/javascript/src/controller_services.js
@@ -131,6 +131,7 @@ function createPageAdditionDialog(view) {
   var $errors = $dialog.find(".govuk-error-message");
 
   view.pageAdditionDialog = new DialogForm($dialog, {
+    closeText: view.text.dialogs.button_close,
     autoOpen: $errors.length ? true : false,
     onClose: function () {
       $errors.parents().removeClass("error");

--- a/app/javascript/src/page_form_list.js
+++ b/app/javascript/src/page_form_list.js
@@ -12,48 +12,51 @@
  *
  **/
 
-
-const DialogForm = require('./component_dialog_form');
-const Dialog = require('./component_dialog');
-const DefaultController = require('./controller_default');
+const DialogForm = require("./component_dialog_form");
+const Dialog = require("./component_dialog");
+const DefaultController = require("./controller_default");
 
 class FormListPage extends DefaultController {
   constructor(app) {
     super(app);
+    const view = this;
 
     // Create dialog for handling new form input and error reporting.
-    new CreateFormDialog($("[data-component='FormCreateDialog']"));
-    new CreateTransferDialog($("[data-component='OwnershipTransferDialog']"));
-
+    new CreateFormDialog($("[data-component='FormCreateDialog']"), view);
+    new CreateTransferDialog(
+      $("[data-component='OwnershipTransferDialog']"),
+      view,
+    );
   }
 }
 
-
 class CreateFormDialog {
-  constructor($node) {
-    var $errors = $node.find( ".govuk-error-message");
+  constructor($node, view) {
+    var $errors = $node.find(".govuk-error-message");
 
     new DialogForm($node, {
       autoOpen: $errors.length ? true : false,
       activator: true,
       activatorText: $node.data("activator-text"),
+      closeText: view.text.dialogs.button_close,
       classes: {
-        "activator": "govuk-button fb-govuk-button"
+        activator: "govuk-button fb-govuk-button",
       },
-      onClose: function() {
-        $errors.parents().removeClass('error');
+      onClose: function () {
+        $errors.parents().removeClass("error");
         $errors.remove(); // Remove from DOM (includes removing all jQuery data)
-        $node.find('.govuk-form-group').removeClass('govuk-form-group--error');
-      }
+        $node.find(".govuk-form-group").removeClass("govuk-form-group--error");
+      },
     });
   }
 }
 
 class CreateTransferDialog {
-  constructor($node) {
+  constructor($node, view) {
     new Dialog($node, {
       autoOpen: true,
-      activator: false
+      activator: false,
+      closeText: view.text.dialogs.button_close,
     });
   }
 }

--- a/app/views/partials/_properties.html.erb
+++ b/app/views/partials/_properties.html.erb
@@ -123,6 +123,7 @@
         button_ok: "<%= t('dialogs.button_ok') %>",
         button_publish: "<%= t('publish.dialog.alert_button') %>",
         button_understood: "<%= t('dialogs.button_understood') -%>",
+        button_close: "<%= t('dialogs.button_close') %>",
         heading: "<%= t('dialogs.heading') %>",
         heading_delete: '<%= t('dialogs.heading_delete').html_safe %>',
         heading_delete_condition: "<%= t('dialogs.heading_delete_condtition').html_safe %>",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,7 @@ en:
     button_ok: 'OK'
     button_understood: 'Understood'
     button_update: 'Update'
+    button_close: 'Close modal'
     heading: General heading here
     heading_delete: 'Delete "%{label}"?'
     heading_delete_no_default_next: 'You cannot delete this page yet'

--- a/test/menus/connection_menu/helpers.js
+++ b/test/menus/connection_menu/helpers.js
@@ -81,7 +81,14 @@ function createConnectionMenu(id, config) {
     activator_text: constants.TEXT_ACTIVATOR,
     id: id,
     preventDefault: true,
-    selection_event: constants.EVENT_SELECTION_NAME
+    selection_event: constants.EVENT_SELECTION_NAME,
+    view: {
+      text: {
+        dialogs: {
+          button_close: 'Close'
+        }
+      }
+    }
   }, config);
 
   server = GlobalHelpers.createServer();

--- a/test/menus/page_menu/helpers.js
+++ b/test/menus/page_menu/helpers.js
@@ -52,7 +52,14 @@ function createPageMenu(id, config) {
     activator_text: constants.TEXT_ACTIVATOR,
     id: id,
     preventDefault: true,
-    selection_event: constants.EVENT_SELECTION_NAME
+    selection_event: constants.EVENT_SELECTION_NAME,
+    view: {
+      text: {
+        dialogs: {
+          button_close: 'Close'
+        }
+      }
+    }
   }, config);
 
   server = GlobalHelpers.createServer();


### PR DESCRIPTION
All of the modals in the editor uise jQuery UI's default close button label of "Close"

This label doesn't make sense out of context (e.g. a screenreader user viewing a list of controls on the page)

This PR updates our modal classes to have a config property for `closeText` which can be used to override this label.

The label text "Close modal" has been added to the translations file, and then exposed to js in the `properties.html.erb` template.  It is then injected into every modal instantiation call.