### PR TITLE
Update header home link

### DIFF
--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -7,9 +7,16 @@
       <%= image_pack_tag "logo--white.svg", alt: t('header.home_link_alt') %>
     </a>
 
-    <a href="/" class="govuk-header__link govuk-header__service-name" aria-label="<%= t('header.home_link_text') %>">
-      <%= t('header.service_name') %>
-    </a>
+    <% if user_signed_in? %>
+      <a href="/" class="govuk-header__link govuk-header__service-name" aria-label="<%= t('header.home_link_text') %>">
+        <%= t('header.service_name') %>
+      </a>
+    <% else %>
+      <span class="govuk-header__service-name">
+        <%= t('header.service_name') %>
+      </span>
+    <% end %>
+
 
     <% if user_signed_in? %>
       <nav class="fb-navigation-header" aria-label="Site menu">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,8 +163,8 @@ en:
       success: Options uploaded. Use preview or publish to view them.
   header:
     service_name: "MoJ Forms"
-    home_link_text: "Back to Home"
-    home_link_alt: "Ministry of Justice Logo - homepage"
+    home_link_text: "MoJ Forms - Back to your forms"
+    home_link_alt: "Ministry of Justice Logo"
 
   partials:
     header:


### PR DESCRIPTION
This fixes the labelling of the header home link to ensure that the visible text of the link (MoJ Forms) is included within the accessible name for the link.

The link is also made to not be a link if the user is not signed in, as it wouldn't go anywhere.  this also allows for the accessible name of the link to be more explicit as it will now always go the 'Your forms' list page.