### PR TITLE
Remove focus on editable element and scroll to new component

### DIFF
--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -127,7 +127,7 @@ PagesController.edit = function () {
   });
 
   // Setting focus for editing.
-  focusOnEditableComponent.call(view);
+  scrollToEditableComponent.call(view);
 
   // Bind listeners
   // --------------
@@ -582,32 +582,16 @@ function openConditionalContentDialog(component, activator, view) {
   }
 }
 
-/* Set focus on first editable component or, if a new component has been
- * added, the first element with that new component.
- **/
-function focusOnEditableComponent() {
+/* If a new component has been added, we scroll the page to the element
+ * scroll behaviour is set to auto, which respects the value set by css
+ * scroll-behaviour property.
+ * **/
+function scrollToEditableComponent() {
   const target = location.hash;
-  setTimeout(() => {
-    if (target && target.match(/^[#\w\d_-]+$/)) {
-      // Newly added component with fragment identifier so find first
-      // first editable item of last component.
-      let $newComponent = $(target);
-      if ($newComponent.length) {
-        if ($newComponent.prop("tagName").toLowerCase() == "editable-content") {
-          $newComponent.get(0).root.focus();
-        } else {
-          $newComponent.data("instance").focus();
-        }
-      }
-    } else {
-      const pageTitle = $("h1 .EditableElement").get(0);
-      if (pageTitle) {
-        pageTitle.focus();
-      } else {
-        $(".fb-editable").eq(0).focus();
-      }
-    }
-  });
+  if (target && target.match(/^[#\w\d_-]+$/)) {
+    const element = document.querySelector(target);
+    element?.scrollIntoView({ behaviour: "auto" });
+  }
 }
 
 /* Add edit functionality and component enhancements to content.

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -15,6 +15,14 @@ html {
   position: relative;
 }
 
+html,
+body {
+  scroll-behavior: smooth;
+  @media (prefers-reduced-motion) {
+    scroll-behaviour: auto;
+  }
+}
+
 .publish-create,
 .services-edit {
   main {


### PR DESCRIPTION
This PR updates the editro to no longer automatically place focus on the first editable element on page load. 

While this functionality is a useful hint as to the "editable" nature of the page, setting focus automatically is bad for assistive tech users (especially screenreaders) as it is non-expected behaviour and they are disoriented on page load.

We will follow this PR with something to help the UX/discovery of editing features on the page.