### PR TITLE
Show black border and yellow focus ring for ediatble components

### DIFF
--- a/app/javascript/styles/_editable_components.scss
+++ b/app/javascript/styles/_editable_components.scss
@@ -40,10 +40,8 @@ editable-content,
 // Not nice but trying to work around some margin annoyance caused by GDS css
 [data-fb-pagetype="page.multiplequestions"] {
   .EditableCollectionFieldComponent legend,
-  .EditableGroupFieldComponent {
-    legend {
-      display: contents;
-    }
+  .EditableGroupFieldComponent legend {
+    display: contents;
   }
 }
 
@@ -112,10 +110,27 @@ editable-content,
 }
 
 .EditableElement {
+  border: $govuk-border-width-form-element solid transparent;
+  padding: 4px;
+  margin-left: -4px;
   &:focus,
   &.active {
     outline: $govuk-focus-width solid $govuk-focus-colour;
+    outline-offset: 0;
+    border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+    border-radius: 0;
+    box-shadow: inset 0 0 0 $govuk-border-width-form-element;
   }
+}
+
+.govuk-radios__label.EditableElement,
+.govuk-checkboxes__label.EditableElement {
+  margin-left: 11px;
+}
+
+.govuk-radios__hint.EditableElement,
+.govuk-checkboxes__hint.EditableElement {
+  margin-left: 11px;
 }
 
 .EditableCollectionItemMenu {


### PR DESCRIPTION
This PR improves color contrast on focus for editable elements.  

The yellow border alone does not have a high enough contrast ratio to pass WCAG AA.

The focus state has been updated to add a black border in addition to the yellow focus ring to match GOV.UK design system form inputs.

**Before:**
![image](https://github.com/ministryofjustice/fb-editor/assets/595564/6affb387-b891-4539-97c6-6b5e907647c6)

**After:**
![image](https://github.com/ministryofjustice/fb-editor/assets/595564/1d65112b-5945-4f91-a7e9-da90fe5706da)

