### PR TITLE
Remove character count and improve error messages

### DIFF
--- a/acceptance/features/create_service_spec.rb
+++ b/acceptance/features/create_service_spec.rb
@@ -95,25 +95,25 @@ feature 'Create a service' do
 
   def then_I_should_see_a_validation_message_for_required
     expect(editor).to have_content(
-      I18n.t('activemodel.errors.messages.blank', attribute: 'Give your form a name')
+      I18n.t('activemodel.errors.models.service_creation.blank')
     )
   end
 
   def then_I_should_see_a_validation_message_for_min_length
     expect(editor).to have_content(
-      I18n.t('activemodel.errors.messages.too_short', attribute: 'Give your form a name', count: Editor::Service::MINIMUM)
+      I18n.t('activemodel.errors.models.service_creation.too_short', count: Editor::Service::MINIMUM)
     )
   end
 
   def then_I_should_see_a_validation_message_for_max_length
     expect(editor).to have_content(
-      I18n.t('activemodel.errors.messages.too_long', attribute: 'Give your form a name', count: Editor::Service::MAXIMUM)
+      I18n.t('activemodel.errors.models.service_creation.too_long', count: Editor::Service::MAXIMUM)
     )
   end
 
   def then_I_should_see_the_unique_validation_message
     expect(editor).to have_content(
-      I18n.t('activemodel.errors.messages.taken', attribute: 'Give your form a name')
+      I18n.t('activemodel.errors.models.service_creation.taken')
     )
   end
 

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -29,22 +29,18 @@
            data-component="FormCreateDialog">
         <%= form_for(@service_creation, url: services_path) do |f| %>
           <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' :'' %>">
-            <%= tag.div class: 'govuk-character-count', data: { module: 'govuk-character-count', maxlength: Editor::Service::MAXIMUM, threshold: 90 } do %>
               <h2 class="govuk-label-wrapper" id="create-service-dialog-title" data-node="heading">
                 <%= f.label :service_name, class: "govuk-label govuk-label--m" %>
               </h2>
-              <% f.object.errors.each do |error|  %>
-                <p class="govuk-error-message"><%= error.message %></p>
-              <% end %>
               <div class="govuk-hint" id="service-name-hint">
                 <%= t('services.form_name_change_hint') %>
               </div>
-              <%= f.text_field :service_name, class: "govuk-input govuk-js-character-count", 'aria-describedby': 'service-name-hint service_creation_service_name-info'%>
-              <div id="service_creation_service_name-info" class="govuk-hint govuk-character-count__message">
-                You can enter up to <%= Editor::Service::MAXIMUM %> characters
-              </div>
-            <% end %>
-
+              <% f.object.errors.each do |error|  %>
+                <p id="service-name-error" class="govuk-error-message">
+                <span class="govuk-visually-hidden"><%= t('activemodel.errors.assistive_prefix') %></span> <%= error.message %>
+                </p>
+              <% end %>
+              <%= f.text_field :service_name, class: "govuk-input", 'aria-describedby': "service-name-hint #{ f.object.errors.present? ? ' service-name-error' : ''}"%>
           </div>
           <%= f.button t('services.create'), class: "govuk-button fb-govuk-button", type: 'submit' %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -720,6 +720,12 @@ en:
           reserved: "That name is used for something else"
           has_space: "Your page name cannot include spaces"
           has_special_chars:  "Your page name cannot include special characters other than hyphens (-)"
+        service_creation:
+          blank: Enter a form name
+          taken: Your form name is already used by another form. Please modify it.
+          too_long: "Form name must be %{count} characters or less"
+          too_short: "Form name must be %{count} characters or more"
+          invalid: Form name contains characters that are not allowed
         branch:
           blank: "Select a destination for '%{attribute}'"
         conditional:
@@ -799,7 +805,7 @@ en:
       messages:
         blank: "Your answer for ‘%{attribute}’ cannot be blank."
         too_short: "%{attribute} must be %{count} characters or more"
-        too_long: "%{attribute} must be %{count} characters or fewer"
+        too_long: "%{attribute} must be %{count} characters or less"
         invalid: "Your answer for ‘%{attribute}' contains characters that are not allowed."
         taken: "Your answer for ‘%{attribute}' is already used by another form. Please modify it."
         unprocessable: 'There is an error in the metadata. Please try again and if the error persists contact us in the #ask-formbuilder channel'


### PR DESCRIPTION
The DAC accessibility audit raised issues with the communication of the character limit on the 'create a form' modal.  While not 100% sure the concerns raised were valid (sighted users are communicated the limit, just after a threshold is reached) we made the decision to lose the character counter on this input field.

This leaves the field without guidance as to how long the input can be, it is not expected that any user is likely to even come close to the 255 character limit in real use - our longest form title is 69 characters and the average is 34 characters.

This PR also fixes issues with the error messages - they are now correctly associated with the input field, and conform to the GOV.UK design system wording.

