### PR TITLE
Text colour fix

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -1201,13 +1201,14 @@ h1 span.EditableElement {
   }
 
   .govuk-panel__title {
+    color: govuk-colour("white");
     margin-bottom: govuk-spacing(
       6
     ); // Counter other rules to get back to original.
 
-    .govuk-heading-m {
-      color: govuk-colour("white");
-    }; // override heading colour for publish for review title
+    // .govuk-heading-m {
+    //   color: govuk-colour("white");
+    // }; // override heading colour for publish for review title
   }
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -1205,10 +1205,6 @@ h1 span.EditableElement {
     margin-bottom: govuk-spacing(
       6
     ); // Counter other rules to get back to original.
-
-    // .govuk-heading-m {
-    //   color: govuk-colour("white");
-    // }; // override heading colour for publish for review title
   }
 }
 

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -1204,6 +1204,10 @@ h1 span.EditableElement {
     margin-bottom: govuk-spacing(
       6
     ); // Counter other rules to get back to original.
+
+    .govuk-heading-m {
+      color: govuk-colour("white");
+    }; // override heading colour for publish for review title
   }
 }
 


### PR DESCRIPTION
Was inheriting text colour from govuk-heading-m, perhaps this was added in a recent component update? Overwriting in govuk-panel__title to fix this page, CYA pages unaffected

<img width="800" alt="image" src="https://github.com/ministryofjustice/fb-editor/assets/7647632/ec4b0c23-edd0-4e92-9d26-6ccd5c1edd2a">