### PR TITLE
Dac aa fix question properties reflow

### DIFF
--- a/app/javascript/packs/runner_application.js
+++ b/app/javascript/packs/runner_application.js
@@ -9,7 +9,8 @@ require("../src/runner/analytics")
 require("../src/runner/index")
 
 // Entry point for fb-editor stylesheets
-import "../styles/application.scss"
+import "../styles/runner_application.scss"
+
 
 const accessibleAutocomplete = require("accessible-autocomplete")
 import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -72,6 +72,11 @@ a[disabled] {
   min-height: 55vh;
 }
 
+
+.pages-edit .fb-main-grid-wrapper {
+  padding-left: govuk-spacing(6);
+}
+
 /* FB-Editor styles
  * ---------------- */
 .fb-editable {

--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -73,8 +73,9 @@ a[disabled] {
 }
 
 
-.pages-edit .fb-main-grid-wrapper {
-  padding-left: govuk-spacing(6);
+// .pages-edit .fb-main-grid-wrapper {
+.govuk-width-container {
+  padding-left: govuk-spacing(7);
 }
 
 /* FB-Editor styles

--- a/app/javascript/styles/runner_application.scss
+++ b/app/javascript/styles/runner_application.scss
@@ -1,0 +1,19 @@
+/*
+ * This is a manifest file that'll be compiled into application.css, which will include all the files
+ * listed below.
+ *
+ * Any CSS and SCSS file within this directory, lib/assets/stylesheets, or any plugin's
+ * vendor/assets/stylesheets directory can be referenced here using a relative path.
+ *
+ * You're free to add application-wide styles to this file and they'll appear at the bottom of the
+ * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
+ * files in this directory. Styles in this file should be added after the last require_* statement.
+ * It is generally better to create a new file per style scope.
+ *
+ *= require_tree .
+ *= require_self
+ */
+
+@import "../packs/stylesheets/govuk";
+@import "./shared/content";
+


### PR DESCRIPTION
This PR fixes a reflow WCAG failure.  When zoomed in greater than 200%, the question properties dropdown menu activator went off screen.

This has been resolved by introducing padding to the left hand side of the container in order to give the activator space to appear.

See screenshots below at 400% zoom

Also, while reviewing this, I realised that we import *all* of the editor css into the preview, which is both unnecessary, and could potentially cause issues in that it is different from what would be present in the runner.  So this has been adjusted to only include the shared runner css.

**Before:**
![image](https://github.com/ministryofjustice/fb-editor/assets/595564/f84cb8be-737e-4d4f-83fe-25c14a2e2f4f)


**After:**
![image](https://github.com/ministryofjustice/fb-editor/assets/595564/ed3d2e13-8a89-4510-82d9-71cb8e2e7bfc)
