### PR TITLE
Handle input being undefined

### DIFF
--- a/app/javascript/src/web-components/editable-content.js
+++ b/app/javascript/src/web-components/editable-content.js
@@ -92,12 +92,12 @@ class EditableContent extends HTMLElement {
         break;
       case "label":
         if (newValue != oldValue) {
-          this.input.setAttribute("aria-label", newValue);
+          this.input?.setAttribute("aria-label", newValue);
         }
         break;
       case "describedby":
         if (newValue != oldValue) {
-          this.input.setAttribute("aria-describedby", newValue);
+          this.input?.setAttribute("aria-describedby", newValue);
         }
         break;
     }
@@ -149,7 +149,7 @@ class EditableContent extends HTMLElement {
   // returns the markdown content of the input after filtering it through any
   // configured filters
   get value() {
-    let val = this.input.value;
+    let val = this.input?.value;
 
     for (const [key, filterFunction] of Object.entries(this.markdownFilters)) {
       val = filterFunction(val);


### PR DESCRIPTION
This PR fixes a few errors seen in sentry where the input in an editable content area is undefined. This should be an edge case, as every editable content area will have an input element, so this is likely an initialization timing issue so simply using optional chaining to prevent an error here.