### PR TITLE
Change job called by cron to delete sessions older than 1 day only

### DIFF
--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -1,7 +1,7 @@
 namespace 'db:sessions' do
   desc 'Trim all sessions from the table'
   task trim: [:environment, 'db:load_config'] do
-    ActiveRecord::SessionStore::Session.where(created_at: ..(Time.zone.now - 1.days)).delete_all
+    ActiveRecord::SessionStore::Session.where(created_at: ..(Time.zone.now - 1.day)).delete_all
   rescue StandardError => e
     Sentry.capture_exception(e)
   end

--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -1,8 +1,7 @@
 namespace 'db:sessions' do
   desc 'Trim all sessions from the table'
   task trim: [:environment, 'db:load_config'] do
-    ActiveRecord::SessionStore::Session
-    .delete_all
+    ActiveRecord::SessionStore::Session.where(created_at: ..(Time.zone.now - 1.days)).delete_all
   rescue StandardError => e
     Sentry.capture_exception(e)
   end


### PR DESCRIPTION
`..` prefix = records where created at is <= yesterday, none
`..` suffix = records where created at is >= yesterday, today's sign in

So the job needs to use the prefix and remove all records created <= 1.days_ago

<img width="1298" alt="image" src="https://github.com/ministryofjustice/fb-editor/assets/7647632/9e1a441e-9add-429a-92d3-1b3567d9e958">
