### PR TITLE
Prevent generation of slug with underscores from name

### DIFF
--- a/app/models/form_url_creation.rb
+++ b/app/models/form_url_creation.rb
@@ -42,7 +42,7 @@ class FormUrlCreation
 
   def parameterized_service_slug
     # parameterize, use first non-numeric char and limit to 57 chars
-    service_slug.slice(service_slug.index(/\D/), 57).strip.parameterize
+    service_slug.gsub('_', '-').slice(service_slug.index(/\D/), 57).strip.parameterize
   end
 
   def unique_service_slug?

--- a/spec/models/form_url_creation_spec.rb
+++ b/spec/models/form_url_creation_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe FormUrlCreation do
     context 'when service name contains special characters' do
       let(:attributes) do
         {
-          service_name: 'All 0f the ("special") characters?!'
+          service_name: 'All 0f the_("special") characters?!'
         }
       end
       let(:expected_service_slug) { 'all-0f-the-special-characters' }


### PR DESCRIPTION
Gsub underscores for hyphens in service name before generating service slug, update test to cover this