### PR TITLE
Update styles to handle reflow/zoom on branch edit screen

### DIFF
--- a/app/javascript/styles/components/conditional.scss
+++ b/app/javascript/styles/components/conditional.scss
@@ -7,7 +7,7 @@
 
   padding-top: govuk-spacing(9);
   padding-bottom: govuk-spacing(4);
-  padding-right: 50px;
+  padding-right: govuk-spacing(4);
   position: relative;
 
   &:last-child {
@@ -27,6 +27,9 @@
 }
 
 .conditional--otherwise {
+  @include govuk-media-query($until: tablet) {
+    margin-bottom: govuk-spacing(6);
+  }
   padding-top: govuk-spacing(3);
 
   > h2 span {
@@ -34,20 +37,19 @@
   }
 }
 
-.conditional__expressions {
-  // margin-left: govuk-spacing(4);
-}
-
 .conditional__row {
   display: grid;
-  grid-template-columns: 16% auto 40px;
+  grid-template-columns: auto 40px;
   column-gap: govuk-spacing(2);
 }
 
 .conditional__add-expression {
   grid-column: 2 / 3;
   justify-self: start;
-  margin-left: govuk-spacing(3);
+  margin-left: govuk-spacing(1);
+  @include govuk-media-query($from: tablet) {
+    margin-left: govuk-spacing(3);
+  }
 }
 
 .conditional__remover {

--- a/app/javascript/styles/components/conditional.scss
+++ b/app/javascript/styles/components/conditional.scss
@@ -2,12 +2,12 @@
   border: 2px solid transparent;
 
   @include govuk-media-query($until: tablet) {
-    padding-right: govuk-spacing(5);
+    padding-right: govuk-spacing(3);
   }
 
   padding-top: govuk-spacing(9);
   padding-bottom: govuk-spacing(4);
-  padding-right: 100px;
+  padding-right: 50px;
   position: relative;
 
   &:last-child {
@@ -35,34 +35,19 @@
 }
 
 .conditional__expressions {
-  margin-left: govuk-spacing(4);
+  // margin-left: govuk-spacing(4);
 }
 
-.conditional__question {
-  padding-left: 15%;
-  position: relative;
+.conditional__row {
+  display: grid;
+  grid-template-columns: 16% auto 40px;
+  column-gap: govuk-spacing(2);
+}
 
-  .label {
-    @include govuk-font($size: 24);
-
-    display: inline-block;
-    font-weight: bold;
-    left: 0;
-    position: absolute;
-    top: 5px;
-  }
-
-  select {
-    width: 100%;
-  }
-
-  &.govuk-form-group--error {
-    border-left: none;
-  }
-
-  > h3 {
-    margin-top: 0;
-  }
+.conditional__add-expression {
+  grid-column: 2 / 3;
+  justify-self: start;
+  margin-left: govuk-spacing(3);
 }
 
 .conditional__remover {

--- a/app/javascript/styles/components/expression.scss
+++ b/app/javascript/styles/components/expression.scss
@@ -5,27 +5,18 @@
   border: none;
   padding: 0;
 
-  &:after {
-    background-color: $govuk-border-colour;
-    content: "";
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 12%;
-    width: 5px;
-    height: 100%;
-  }
-
   &.error {
-    &:after {
-      background-color: $govuk-error-colour;
-    }
-
     p {
       color: $govuk-error-colour;
       font-weight: bold;
       margin-top: govuk-spacing(3);
       margin-bottom: govuk-spacing(1);
+    }
+    .expression__question {
+      border-color: $govuk-error-colour;
+      > p:first-child {
+        margin-top: 0;
+      }
     }
   }
 }
@@ -34,12 +25,28 @@
   margin-top: govuk-spacing(9);
 }
 
+.expression__label {
+  @include govuk-font($size: 24);
+  font-weight: bold;
+  text-align: right;
+}
+
+.expression__question {
+  border-left: 5px solid $govuk-border-colour;
+  padding-left: govuk-spacing(2);
+
+  &--no-border {
+    border-color: transparent;
+  }
+}
+
+.expression__component {
+  width: 100%;
+}
 
 .expression__condition {
   clear: both;
-  margin-left: 15%;
   padding-top: govuk-spacing(7);
-  width: 85%;
 
   @include govuk-media-query($until: tablet) {
     & {
@@ -58,7 +65,6 @@
 }
 
 .expression__remover {
-  position: absolute;
-  right: -50px;
-  top: 0;
+  justify-self: center;
+  position: relative;
 }

--- a/app/javascript/styles/components/expression.scss
+++ b/app/javascript/styles/components/expression.scss
@@ -12,11 +12,16 @@
       margin-top: govuk-spacing(3);
       margin-bottom: govuk-spacing(1);
     }
+
     .expression__question {
       border-color: $govuk-error-colour;
       > p:first-child {
         margin-top: 0;
       }
+    }
+
+    .expression__layout {
+      border-color: $govuk-error-colour;
     }
   }
 }
@@ -25,18 +30,42 @@
   margin-top: govuk-spacing(9);
 }
 
-.expression__label {
-  @include govuk-font($size: 24);
-  font-weight: bold;
-  text-align: right;
-}
-
-.expression__question {
+.expression__layout {
   border-left: 5px solid $govuk-border-colour;
   padding-left: govuk-spacing(2);
 
   &--no-border {
-    border-color: transparent;
+    border-left: none;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    display: grid;
+    grid-template-columns: min(20%, 80px) auto;
+    column-gap: govuk-spacing(2);
+    border-left: none;
+  }
+}
+
+.expression__label {
+  @include govuk-font($size: 24);
+  font-weight: bold;
+  margin-bottom: govuk-spacing(2);
+  @include govuk-media-query($from: tablet) {
+    text-align: right;
+    margin-bottom: 0;
+    // align-self: center;
+    padding-top: govuk-spacing(1);
+  }
+}
+
+.expression__question {
+  @include govuk-media-query($from: tablet) {
+    border-left: 5px solid $govuk-border-colour;
+
+    padding-left: govuk-spacing(2);
+    &--no-border {
+      border-color: transparent;
+    }
   }
 }
 
@@ -46,7 +75,7 @@
 
 .expression__condition {
   clear: both;
-  padding-top: govuk-spacing(7);
+  padding-top: govuk-spacing(6);
 
   @include govuk-media-query($until: tablet) {
     & {

--- a/app/views/api/conditional_contents/_conditional_fields.html.erb
+++ b/app/views/api/conditional_contents/_conditional_fields.html.erb
@@ -31,9 +31,11 @@
         <% end %>
       </template>
 
-      <%= button_tag type: 'button', data: { action: 'dynamic-fields#add', dynamic_fields_type_param: 'expression'}, class: 'govuk-link fb-link-button prevent-modal-close' do %>
+      <div class="conditional__row">
+      <%= button_tag type: 'button', data: { action: 'dynamic-fields#add', dynamic_fields_type_param: 'expression'}, class: 'govuk-link fb-link-button prevent-modal-close conditional__add-expression' do %>
         <%= I18n.t('conditional_content.add_condition') %><span class="govuk-visually-hidden"><%= I18n.t('conditional_content.condition_target', type: 'rule', index: conditional.options[:child_index].to_i+1)%></span>
       <% end %>
+      </div>
     </div>
   </fieldset>
   <div class="conditional-separator">or</div>

--- a/app/views/api/conditional_contents/_conditional_fields.html.erb
+++ b/app/views/api/conditional_contents/_conditional_fields.html.erb
@@ -32,9 +32,11 @@
       </template>
 
       <div class="conditional__row">
-      <%= button_tag type: 'button', data: { action: 'dynamic-fields#add', dynamic_fields_type_param: 'expression'}, class: 'govuk-link fb-link-button prevent-modal-close conditional__add-expression' do %>
-        <%= I18n.t('conditional_content.add_condition') %><span class="govuk-visually-hidden"><%= I18n.t('conditional_content.condition_target', type: 'rule', index: conditional.options[:child_index].to_i+1)%></span>
-      <% end %>
+        <div class="expression__layout expression__layout--no-border">
+          <%= button_tag type: 'button', data: { action: 'dynamic-fields#add', dynamic_fields_type_param: 'expression'}, class: 'govuk-link fb-link-button prevent-modal-close conditional__add-expression' do %>
+            <%= I18n.t('conditional_content.add_condition') %><span class="govuk-visually-hidden"><%= I18n.t('conditional_content.condition_target', type: 'rule', index: conditional.options[:child_index].to_i+1)%></span>
+          <% end %>
+        </div>
       </div>
     </div>
   </fieldset>

--- a/app/views/api/conditional_contents/_expression_fields.html.erb
+++ b/app/views/api/conditional_contents/_expression_fields.html.erb
@@ -9,46 +9,47 @@
       data-expression-first-label-value="<%= t('branches.expression.if') %>"
       data-expression-other-label-value="<%= t('branches.expression.and') %>">
 
-
+  <div class="expression__layout">
     <div class="expression__label" data-expression-target="label">
       <%= t('branches.expression.if') %>
     </div>
 
     <div class="expression__question">
-    <%= expression.select :component,
-      @conditional_content.previous_questions,
-      { include_blank: t('branches.select_question') },
-      { class: "govuk-select expression__component #{ expression.object.errors[:component].any? ? 'govuk-select--error' : '' }",
-        'aria-label': 'Source question',
-        'aria-describedby': ( expression.object.errors[:component].any? ? "condition_#{conditional.options[:child_index]}_expression_#{expression.options[:child_index]}_component_error" : "") + "source_question_hint",
-        data: {
-          action: 'change->expression#getCondition',
-          expression_target: 'question',
-          expression_url_param: api_service_conditional_content_expressions_path(service.service_id, component_uuid, conditional.options[:child_index], expression.options[:child_index], '--componentId--'),
-        },
-      }
-    %>
-    <p class="expression__error" data-expression-target="errorMessage" data-error-type='unsupported' hidden><%= t('activemodel.errors.models.component_expression.unsupported') %></p>
-    <p class="expression__error" data-expression-target="errorMessage" data-error-type='samepage' hidden><%= t('activemodel.errors.models.component_expression.same_page') %></p>
-
-    <%= render partial: 'expression_condition',
-      locals: {
-        f: default_form_builder.new(:expression, expression.object, self, {}),
-        expression: expression.object,
-        conditional_index: conditional.options[:child_index],
-        expression_index: expression.options[:child_index]
-      }
-    %>
-</div>
-
-    <%= render(MojForms::IconButtonComponent.new(
-          label: 'Delete condition', 
-          icon: 'remove',
-          classes: %w[prevent-modal-close expression__remover],
-          html_attributes: {
-            data: { 
-              action: "expression#delete", 
-              expression_target: "deleteButton" }
+        <%= expression.select :component,
+          @conditional_content.previous_questions,
+          { include_blank: t('branches.select_question') },
+          { class: "govuk-select expression__component #{ expression.object.errors[:component].any? ? 'govuk-select--error' : '' }",
+            'aria-label': 'Source question',
+            'aria-describedby': ( expression.object.errors[:component].any? ? "condition_#{conditional.options[:child_index]}_expression_#{expression.options[:child_index]}_component_error" : "") + "source_question_hint",
+            data: {
+              action: 'change->expression#getCondition',
+              expression_target: 'question',
+              expression_url_param: api_service_conditional_content_expressions_path(service.service_id, component_uuid, conditional.options[:child_index], expression.options[:child_index], '--componentId--'),
+            },
           }
-        )) %>
+        %>
+        <p class="expression__error" data-expression-target="errorMessage" data-error-type='unsupported' hidden><%= t('activemodel.errors.models.component_expression.unsupported') %></p>
+        <p class="expression__error" data-expression-target="errorMessage" data-error-type='samepage' hidden><%= t('activemodel.errors.models.component_expression.same_page') %></p>
+
+        <%= render partial: 'expression_condition',
+          locals: {
+            f: default_form_builder.new(:expression, expression.object, self, {}),
+            expression: expression.object,
+            conditional_index: conditional.options[:child_index],
+            expression_index: expression.options[:child_index]
+          }
+        %>
+    </div>
+  </div>
+
+  <%= render(MojForms::IconButtonComponent.new(
+        label: 'Delete condition', 
+        icon: 'remove',
+        classes: %w[prevent-modal-close expression__remover],
+        html_attributes: {
+          data: { 
+            action: "expression#delete", 
+            expression_target: "deleteButton" }
+        }
+      )) %>
 </div>

--- a/app/views/api/conditional_contents/_expression_fields.html.erb
+++ b/app/views/api/conditional_contents/_expression_fields.html.erb
@@ -1,4 +1,4 @@
-<div  class="expression govuk-form-group <%= expression.object.errors.any? ? 'error' : '' %>"
+<div  class="conditional__row expression govuk-form-group <%= expression.object.errors.any? ? 'error' : '' %>"
       data-expressions-target="expression"
       data-conditional-target="expression"
       data-controller="expression"
@@ -10,11 +10,11 @@
       data-expression-other-label-value="<%= t('branches.expression.and') %>">
 
 
-  <div class="conditional__question">
-    <div class="label" data-expression-target="label">
+    <div class="expression__label" data-expression-target="label">
       <%= t('branches.expression.if') %>
     </div>
 
+    <div class="expression__question">
     <%= expression.select :component,
       @conditional_content.previous_questions,
       { include_blank: t('branches.select_question') },
@@ -30,7 +30,6 @@
     %>
     <p class="expression__error" data-expression-target="errorMessage" data-error-type='unsupported' hidden><%= t('activemodel.errors.models.component_expression.unsupported') %></p>
     <p class="expression__error" data-expression-target="errorMessage" data-error-type='samepage' hidden><%= t('activemodel.errors.models.component_expression.same_page') %></p>
-  </div>
 
     <%= render partial: 'expression_condition',
       locals: {
@@ -40,6 +39,7 @@
         expression_index: expression.options[:child_index]
       }
     %>
+</div>
 
     <%= render(MojForms::IconButtonComponent.new(
           label: 'Delete condition', 

--- a/app/views/branches/_conditional_fields.html.erb
+++ b/app/views/branches/_conditional_fields.html.erb
@@ -34,13 +34,15 @@
       </template>
 
       <div class="conditional__row">
+        <div class="expression__layout expression__layout--no-border">
         <%= button_tag type: 'button', data: { action: 'dynamic-fields#add', dynamic_fields_type_param: 'expression'}, class: 'govuk-link fb-link-button prevent-modal-close conditional__add-expression' do %>
           <%= I18n.t('conditional_content.add_condition') %><span class="govuk-visually-hidden"><%= I18n.t('conditional_content.condition_target', type: 'branch', index: conditional.options[:child_index].to_i+1)%></span>
         <% end %>
+        </div>
       </div>
 
       <div class="conditional__row expression govuk-!-margin-top-5 govuk-form-group <%= conditional.object.errors[:next].any? ? 'govuk-form-group--error error' : '' %>">
-
+      <div class="expression__layout expression__layout--no-border">
         <div class="expression__label">
           <%= t('branches.goto') %>
         </div>
@@ -78,6 +80,7 @@
             <% end %>
           </select>
         </div>
+      </div>
       </div>
 
     </div>

--- a/app/views/branches/_conditional_fields.html.erb
+++ b/app/views/branches/_conditional_fields.html.erb
@@ -33,46 +33,51 @@
         <% end %>
       </template>
 
-      <%= button_tag type: 'button', data: { action: 'dynamic-fields#add', dynamic_fields_type_param: 'expression'}, class: 'govuk-link fb-link-button prevent-modal-close' do %>
-        <%= I18n.t('conditional_content.add_condition') %><span class="govuk-visually-hidden"><%= I18n.t('conditional_content.condition_target', type: 'branch', index: conditional.options[:child_index].to_i+1)%></span>
-      <% end %>
-
-      <div class="conditional__question govuk-!-margin-top-5 govuk-form-group <%= conditional.object.errors[:next].any? ? 'govuk-form-group--error' : '' %>">
-        <% if conditional.object.errors[:next].any? %>
-          <p id="branch_conditionals_attributes_<%= conditional.options[:child_index] %>_next_error" class="govuk-error-message">
-          <span class="govuk-visually-hidden"><%= t('activemodel.errors.assistive_prefix') %></span>
-            <%= conditional.object.errors[:next].first + (conditional.options[:child_index]+1).to_s %>
-          </p>
+      <div class="conditional__row">
+        <%= button_tag type: 'button', data: { action: 'dynamic-fields#add', dynamic_fields_type_param: 'expression'}, class: 'govuk-link fb-link-button prevent-modal-close conditional__add-expression' do %>
+          <%= I18n.t('conditional_content.add_condition') %><span class="govuk-visually-hidden"><%= I18n.t('conditional_content.condition_target', type: 'branch', index: conditional.options[:child_index].to_i+1)%></span>
         <% end %>
+      </div>
 
-        <div class="label">
+      <div class="conditional__row expression govuk-!-margin-top-5 govuk-form-group <%= conditional.object.errors[:next].any? ? 'govuk-form-group--error error' : '' %>">
+
+        <div class="expression__label">
           <%= t('branches.goto') %>
         </div>
 
-        <select class="govuk-select conditional__destination"
-                name="branch[conditionals_attributes][<%= conditional.options[:child_index] %>][next]"
-                id="branch_conditionals_attributes_<%= conditional.options[:child_index] %>_next"
-                aria-label="Destination page for "
-                aria-describedby="<%= conditional.object.errors[:next].any? ? 'branch_conditionals_attributes_'+conditional.options[:child_index].to_s+'_next_error' : '' %> destination_hint"
-                data-conditional-target="destination">
-          <option value=""><%= t('branches.select_destination') %></option>
-          <%= render partial: "destinations_list",
-            locals: {
-              destinations: branch_destinations,
-              selected: conditional.object.next
-            }
-          %>
-          <% if branch_detached_destinations.present? %>
-            <optgroup class="branch-optgroup" label="<%= t('branches.detached_list') %>">
-              <%= render partial: "destinations_list",
-                locals: {
-                  destinations: branch_detached_destinations,
-                  selected: conditional.object.next
-                }
-              %>
-            </optgroup>
+        <div class="expression__question expression__question--no-border">
+
+          <% if conditional.object.errors[:next].any? %>
+            <p id="branch_conditionals_attributes_<%= conditional.options[:child_index] %>_next_error" class="govuk-error-message">
+            <span class="govuk-visually-hidden"><%= t('activemodel.errors.assistive_prefix') %></span>
+              <%= conditional.object.errors[:next].first + (conditional.options[:child_index]+1).to_s %>
+            </p>
           <% end %>
-        </select>
+          <select class="govuk-select expression__component"
+                  name="branch[conditionals_attributes][<%= conditional.options[:child_index] %>][next]"
+                  id="branch_conditionals_attributes_<%= conditional.options[:child_index] %>_next"
+                  aria-label="Destination page for "
+                  aria-describedby="<%= conditional.object.errors[:next].any? ? 'branch_conditionals_attributes_'+conditional.options[:child_index].to_s+'_next_error' : '' %> destination_hint"
+                  data-conditional-target="destination">
+            <option value=""><%= t('branches.select_destination') %></option>
+            <%= render partial: "destinations_list",
+              locals: {
+                destinations: branch_destinations,
+                selected: conditional.object.next
+              }
+            %>
+            <% if branch_detached_destinations.present? %>
+              <optgroup class="branch-optgroup" label="<%= t('branches.detached_list') %>">
+                <%= render partial: "destinations_list",
+                  locals: {
+                    destinations: branch_detached_destinations,
+                    selected: conditional.object.next
+                  }
+                %>
+              </optgroup>
+            <% end %>
+          </select>
+        </div>
       </div>
 
     </div>

--- a/app/views/branches/_expression_fields.html.erb
+++ b/app/views/branches/_expression_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="expression govuk-form-group <%= expression.object.errors.any? ? 'error' : '' %>"
+<div class="conditional__row expression govuk-form-group <%= expression.object.errors.any? ? 'error' : '' %>"
           data-expressions-target="expression"
           data-conditional-target="expression"
           data-controller="expression"
@@ -9,42 +9,44 @@
           data-expression-first-label-value="<%= t('branches.expression.if') %>"
           data-expression-other-label-value="<%= t('branches.expression.and') %>">
   
-    <div class="conditional__question">
-      <% if expression.object.errors[:component].any? %>
-        <p id="condition_<%= conditional.options[:child_index] %>_expression_<%= expression.options[:child_index] %>_component_error" class="govuk-error-message">
-          <span class="govuk-visually-hidden">Error:</span>
-          <%= expression.object.errors[:component].first %>
-        </p>
-      <% end %>
 
-      <div class="label" data-expression-target="label">
+      <div class="expression__label" data-expression-target="label">
         <%= t('branches.expression.if') %>
       </div>
 
-      <%= expression.select :component,
-        @branch.previous_questions,
-        { include_blank: t('branches.select_question') },
-        { class: "govuk-select expression__component #{ expression.object.errors[:component].any? ? 'govuk-select--error' : '' }",
-          'aria-label': 'Source question',
-          'aria-describedby': ( expression.object.errors[:component].any? ? "condition_#{conditional.options[:child_index]}_expression_#{expression.options[:child_index]}_component_error " : ""  ) + "source_question_hint",
-          data: {
-            action: 'change->expression#getCondition',
-            expression_target: 'question',
-            expression_url_param: api_service_branch_expressions_path(service.service_id, @branch.flow_uuid, conditional.options[:child_index], expression.options[:child_index], '--componentId--'),
-          },
+      <div class="expression__question">
+        <% if expression.object.errors[:component].any? %>
+          <p id="condition_<%= conditional.options[:child_index] %>_expression_<%= expression.options[:child_index] %>_component_error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span>
+            <%= expression.object.errors[:component].first %>
+          </p>
+        <% end %>
+
+        <%= expression.select :component,
+          @branch.previous_questions,
+          { include_blank: t('branches.select_question') },
+          { class: "govuk-select expression__component #{ expression.object.errors[:component].any? ? 'govuk-select--error' : '' }",
+            'aria-label': 'Source question',
+            'aria-describedby': ( expression.object.errors[:component].any? ? "condition_#{conditional.options[:child_index]}_expression_#{expression.options[:child_index]}_component_error " : ""  ) + "source_question_hint",
+            data: {
+              action: 'change->expression#getCondition',
+              expression_target: 'question',
+              expression_url_param: api_service_branch_expressions_path(service.service_id, @branch.flow_uuid, conditional.options[:child_index], expression.options[:child_index], '--componentId--'),
+            },
+          }
+        %>
+        <p class="expression__error" data-expression-target="errorMessage" data-error-type='unsupported' role="alert" hidden><%= t('activemodel.errors.messages.unsupported') %></p>
+
+      <%= render partial: 'expression_condition',
+        locals: {
+          f: default_form_builder.new(:expression, expression.object, self, {}),
+          expression: expression.object,
+          conditional_index: conditional.options[:child_index],
+          expression_index: expression.options[:child_index]
         }
       %>
-      <p class="expression__error" data-expression-target="errorMessage" data-error-type='unsupported' role="alert" hidden><%= t('activemodel.errors.messages.unsupported') %></p>
-    </div>
 
-    <%= render partial: 'expression_condition',
-      locals: {
-        f: default_form_builder.new(:expression, expression.object, self, {}),
-        expression: expression.object,
-        conditional_index: conditional.options[:child_index],
-        expression_index: expression.options[:child_index]
-      }
-      %>
+    </div>
 
     <%= render(MojForms::IconButtonComponent.new(
       label: 'Delete Condition', 

--- a/app/views/branches/_expression_fields.html.erb
+++ b/app/views/branches/_expression_fields.html.erb
@@ -9,7 +9,7 @@
           data-expression-first-label-value="<%= t('branches.expression.if') %>"
           data-expression-other-label-value="<%= t('branches.expression.and') %>">
   
-
+    <div class="expression__layout">
       <div class="expression__label" data-expression-target="label">
         <%= t('branches.expression.if') %>
       </div>
@@ -46,6 +46,7 @@
         }
       %>
 
+      </div>
     </div>
 
     <%= render(MojForms::IconButtonComponent.new(

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -41,7 +41,7 @@
   </h2>
 
   <div class="conditional__row expression govuk-form-group <%= @branch.errors[:default_next].empty? ? '' : 'govuk-form-group--error error' %>">
-    
+    <div class="expression__layout expression__layout--no-border"> 
     <div class="expression__label">
       <%= t('branches.goto') %>
     </div>
@@ -73,6 +73,7 @@
           </optgroup>
         <% end %>
       </select>
+    </div>
     </div>
   </div>
 </div>

--- a/app/views/branches/_form.html.erb
+++ b/app/views/branches/_form.html.erb
@@ -40,36 +40,40 @@
     <span class="govuk-heading-m"><%= t('branches.hint_otherwise') %></span>
   </h2>
 
-  <div class="conditional__question govuk-form-group <%= @branch.errors[:default_next].empty? ? '' : 'govuk-form-group--error' %>">
-    <% if @branch.errors[:default_next].any? %>
-      <p id="branch_default_next_error" class="govuk-error-message">
-        <span class="govuk-visually-hidden"><%= t('activemodel.errors.assistive_prefix') %></span>
-        <%= @branch.errors[:default_next].first.message %>
-      </p>
-    <% end %>
-
-    <div class="label">
+  <div class="conditional__row expression govuk-form-group <%= @branch.errors[:default_next].empty? ? '' : 'govuk-form-group--error error' %>">
+    
+    <div class="expression__label">
       <%= t('branches.goto') %>
     </div>
-    <p class="govuk-visually-hidden" id="branch_default_next_hint">The page that will be displayed if none of the branches have their conditions matched</p>
-    <select class="govuk-select" name="branch[default_next]" id="branch_default_next" class="conditional__destination" aria-label="Destination page" aria-describedby="branch_default_next_error branch_default_next_hint destination_otherwise_hint">
-      <%= render partial: "destinations_list",
-        locals: {
-          destinations: branch_destinations,
-          selected: @branch.previous_flow_default_next
-        }
-      %>
-      <% if branch_detached_destinations.present? %>
-        <optgroup class="branch-optgroup" label="<%= t('branches.detached_list') %>">
-          <%= render partial: "destinations_list",
-            locals: {
-              destinations: branch_detached_destinations,
-              selected: @branch.previous_flow_default_next
-            }
-          %>
-        </optgroup>
+
+    <div class="expression__question expression__question--no-border">
+      <% if @branch.errors[:default_next].any? %>
+        <p id="branch_default_next_error" class="govuk-error-message">
+          <span class="govuk-visually-hidden"><%= t('activemodel.errors.assistive_prefix') %></span>
+          <%= @branch.errors[:default_next].first.message %>
+        </p>
       <% end %>
-    </select>
+
+      <p class="govuk-visually-hidden" id="branch_default_next_hint">The page that will be displayed if none of the branches have their conditions matched</p>
+      <select class="govuk-select expression__component" name="branch[default_next]" id="branch_default_next" class="conditional__destination" aria-label="Destination page" aria-describedby="branch_default_next_error branch_default_next_hint destination_otherwise_hint">
+        <%= render partial: "destinations_list",
+          locals: {
+            destinations: branch_destinations,
+            selected: @branch.previous_flow_default_next
+          }
+        %>
+        <% if branch_detached_destinations.present? %>
+          <optgroup class="branch-optgroup" label="<%= t('branches.detached_list') %>">
+            <%= render partial: "destinations_list",
+              locals: {
+                destinations: branch_detached_destinations,
+                selected: @branch.previous_flow_default_next
+              }
+            %>
+          </optgroup>
+        <% end %>
+      </select>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
When zoomed, the "go to" labels for the branching screen would overlap the select box.  

This PR refactors the CSS for this layout using CSS grid, to create a more flexible layout that can stack at small sizes and when zoomed in.

Along with a couple of other tweaks this gives a better layout at 400% zoom.

**Before:**
![image](https://github.com/ministryofjustice/fb-editor/assets/595564/f330bb32-95fa-45c3-a16b-3a87d7c14326)


**After:**
![image](https://github.com/ministryofjustice/fb-editor/assets/595564/a06ff3ee-b50b-43a6-baa3-db2041a714ce)
