### PR TITLE
Fix 'undo move' button height

### DIFF
--- a/app/javascript/styles/_index.scss
+++ b/app/javascript/styles/_index.scss
@@ -161,11 +161,9 @@ a[disabled] {
 
 .fb-govuk-button-inverted {
   @include button_type_link;
-}
-
-.fb-govuk-button-inverted {
-  @include button_type_link;
   box-shadow: none; // 0 1px 0 #002d18;
+  padding: 8px 10px 7px;
+  margin-bottom: 0;
 }
 
 /* Publishing
@@ -450,6 +448,10 @@ h1 span.EditableElement {
       margin-bottom: govuk-spacing(2);
       margin-left: 0;
       margin-right: auto;
+    }
+
+    a.fb-govuk-button {
+      box-shadow: none;
     }
 
     @include govuk-media-query($from: tablet) {

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -4,7 +4,7 @@
   <% if @undo_redo_button.present?%>
     <%= button_to api_service_previous_version_path(service.service_id, operation: @undo_redo_button[:action],undoable_action: @undo_redo_button[:undoable_action]),
       method: :get,
-      class: 'fb-govuk-button fb-govuk-button-inverted fb-govuk-button--inline',
+      class: 'govuk-button fb-govuk-button fb-govuk-button-inverted fb-govuk-button--inline',
       data: { element: 'undo-redo-button' } do
         @undo_redo_button[:text]
       end


### PR DESCRIPTION
https://trello.com/c/PYyU1n7o

The `fb-govuk-button-inverted` class applies top and bottom padding of 5px, when the `govuk-button` has 8px / 7px top/bottom padding.

Removed the box-shadow on the blue button, as otherwise it will make the bottom border look too thick and will not align with the undo button.

Applied to the undo button the `govuk-button` class so it has all the base styles.

## Before
![Screenshot 2024-05-13 at 15 48 13](https://github.com/ministryofjustice/fb-editor/assets/687910/c80c15df-56f9-4f5a-af28-13bc210a39e2)


## After
![Screenshot 2024-05-14 at 09 15 08](https://github.com/ministryofjustice/fb-editor/assets/687910/68da8fd0-d178-449f-bf73-f27c2b2b7a49)
