### PR TITLE
Testable to amend acceptance tests

### DIFF
--- a/acceptance/features/preview_a_page_spec.rb
+++ b/acceptance/features/preview_a_page_spec.rb
@@ -83,7 +83,7 @@ feature 'Preview page' do
 
   def then_I_should_see_that_I_should_add_a_file
     expect(page).to have_content('There is a problem')
-    expect(page).to have_content('Enter an answer for')
+    expect(page).to have_content('Choose a file to upload')
   end
 
   def and_I_remove_the_file


### PR DESCRIPTION
Unfortunately acceptance tests fail with latest PR merged (validation error message change).

Deploying a testable so it fully runs the acceptance tests to make sure we're not missing any other failure.