### PR TITLE
Skip acceptance tests Notify mail deliveries

### DIFF
--- a/app/lib/host_env.rb
+++ b/app/lib/host_env.rb
@@ -12,7 +12,7 @@ module HostEnv
     def env_name
       return LOCAL if Rails.env.development? || Rails.env.test?
 
-      ENV.fetch('PLATFORM_ENV')
+      ENV.fetch('PLATFORM_ENV', '')
     end
 
     private

--- a/app/lib/notify_mailer_interceptor.rb
+++ b/app/lib/notify_mailer_interceptor.rb
@@ -1,0 +1,23 @@
+class NotifyMailerInterceptor
+  class << self
+    # Skips Notify mail deliveries when running acceptance tests
+    # Can be extended if needed in the future to cover other scenarios
+
+    def delivering_email(message)
+      if acceptance_tests?(message)
+        message.perform_deliveries = false
+        Rails.logger.info "Interceptor prevented sending email to: #{acceptance_test_email}"
+      end
+    end
+
+    private
+
+    def acceptance_tests?(message)
+      message.to.include?(acceptance_test_email)
+    end
+
+    def acceptance_test_email
+      ENV['ACCEPTANCE_TESTS_USER']
+    end
+  end
+end

--- a/app/lib/notify_mailer_interceptor.rb
+++ b/app/lib/notify_mailer_interceptor.rb
@@ -3,21 +3,21 @@ class NotifyMailerInterceptor
     # Skips Notify mail deliveries when running acceptance tests
     # Can be extended if needed in the future to cover other scenarios
 
+    SKIP_RECIPIENTS = %w[
+      fb-acceptance-tests@digital.justice.gov.uk
+    ].freeze
+
     def delivering_email(message)
-      if acceptance_tests?(message)
-        message.perform_deliveries = false
-        Rails.logger.info "Interceptor prevented sending email to: #{acceptance_test_email}"
-      end
+      return if allowed_recipient?(message.to.first)
+
+      message.perform_deliveries = false
+      Rails.logger.info "Interceptor prevented sending email to: #{message.to}"
     end
 
     private
 
-    def acceptance_tests?(message)
-      message.to.include?(acceptance_test_email)
-    end
-
-    def acceptance_test_email
-      ENV['ACCEPTANCE_TESTS_USER']
+    def allowed_recipient?(email)
+      SKIP_RECIPIENTS.exclude?(email)
     end
   end
 end

--- a/config/initializers/govuk_notify_rails.rb
+++ b/config/initializers/govuk_notify_rails.rb
@@ -8,3 +8,9 @@ ActionMailer::Base.add_delivery_method(
 Rails.configuration.govuk_notify_templates = Rails.application.config_for(
   :govuk_notify_templates, env: ENV.fetch('PLATFORM_ENV', 'test')
 ).with_indifferent_access
+
+Rails.application.config.to_prepare do
+  unless HostEnv.live?
+    NotifyMailer.register_interceptor(NotifyMailerInterceptor)
+  end
+end

--- a/spec/lib/host_env_spec.rb
+++ b/spec/lib/host_env_spec.rb
@@ -50,7 +50,7 @@ describe HostEnv do
   describe 'PLATFORM_ENV variable is set in production envs' do
     before do
       allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
-      allow(ENV).to receive(:fetch).with('PLATFORM_ENV').and_return(env_name)
+      allow(ENV).to receive(:fetch).with('PLATFORM_ENV', '').and_return(env_name)
     end
 
     context 'test host' do

--- a/spec/lib/notify_mailer_interceptor_spec.rb
+++ b/spec/lib/notify_mailer_interceptor_spec.rb
@@ -4,17 +4,16 @@ describe NotifyMailerInterceptor do
   let(:message) do
     Mail::Message.new(
       from: ['from@example.com'],
-      to: ['to@example.com']
+      to: [recipient_email]
     )
   end
 
   before do
-    allow(ENV).to receive(:[]).with('ACCEPTANCE_TESTS_USER').and_return(tests_user_email)
     described_class.delivering_email(message)
   end
 
-  context 'when the email recipient matches the acceptance tests user' do
-    let(:tests_user_email) { 'to@example.com' }
+  context 'when the email recipient is the acceptance tests user' do
+    let(:recipient_email) { 'fb-acceptance-tests@digital.justice.gov.uk' }
 
     it 'does not perform deliveries' do
       expect(message.perform_deliveries).to be(false)
@@ -22,7 +21,7 @@ describe NotifyMailerInterceptor do
   end
 
   context 'when the email recipient is not the acceptance tests user' do
-    let(:tests_user_email) { 'john@example.com' }
+    let(:recipient_email) { 'john@example.com' }
 
     it 'performs deliveries' do
       expect(message.perform_deliveries).to be(true)

--- a/spec/lib/notify_mailer_interceptor_spec.rb
+++ b/spec/lib/notify_mailer_interceptor_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe NotifyMailerInterceptor do
+  let(:message) do
+    Mail::Message.new(
+      from: ['from@example.com'],
+      to: ['to@example.com']
+    )
+  end
+
+  before do
+    allow(ENV).to receive(:[]).with('ACCEPTANCE_TESTS_USER').and_return(tests_user_email)
+    described_class.delivering_email(message)
+  end
+
+  context 'when the email recipient matches the acceptance tests user' do
+    let(:tests_user_email) { 'to@example.com' }
+
+    it 'does not perform deliveries' do
+      expect(message.perform_deliveries).to be(false)
+    end
+  end
+
+  context 'when the email recipient is not the acceptance tests user' do
+    let(:tests_user_email) { 'john@example.com' }
+
+    it 'performs deliveries' do
+      expect(message.perform_deliveries).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/OoqBKxm5

Although it is only a nuisance, every time the acceptance tests run there are some tests that will attempt to trigger Notify emails, but the API key for the test environment does not allow sending to the email recipient and returns an error that gets reported to Sentry.

This PR will intercept emails unless we are on `formbuilder-saas-live`. If the recipient is the acceptance tests user, will stop the delivery, meaning we will not call the Notify API so no error will be produced.