### PR TITLE
Add assistive text to all links that open in new tab

### DIFF
--- a/app/views/api/external_start_page_urls/_external_start_page_url.html.erb
+++ b/app/views/api/external_start_page_urls/_external_start_page_url.html.erb
@@ -7,7 +7,11 @@
     <% if !editing? %>
       <p class="description"><%= t('external_start_page_url.content') %></p>
 
-      <p class="description"><%= govuk_link_to t('external_start_page_url.help_link_text'), 'https://moj-forms.service.justice.gov.uk/building-and-editing/#start-page' %></p>
+      <p class="description">
+      <%= govuk_link_to 'https://moj-forms.service.justice.gov.uk/building-and-editing/#start-page', target: :blank, rel: 'noreferrer nofollow' do %>
+        <%= t('external_start_page_url.help_link_text') %><span class="govuk-visually-hidden"><%= t('assistive_text.new_tab') %></span>
+      <% end %>
+      </p>
       <br/>
       <%= f.govuk_text_field :url,
         label: { text: t('external_start_page_url.label'), size: 's', tag: 'h3' },

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -25,7 +25,9 @@
             <%= link_to t('.forms'), services_path %>
           </li>
           <li>
-            <%= link_to t('.user_guide'), t('.user_guide_url'), target: :_blank, noreferrer: true, nofollow: true %>
+            <%= link_to t('.user_guide_url'), target: :_blank, noreferrer: true, nofollow: true do %>
+              <%= t('.user_guide') %><span class="govuk-visually-hidden"><%= t('assistive_text.new_tab') %></span>
+            <% end %>
           </li>
           <% if moj_forms_dev? || moj_forms_admin? %>
             <li>
@@ -33,7 +35,9 @@
             </li>
           <% else %>
             <li>
-              <%= link_to t('.send_feedback'), t('.feedback_form_url'), target: :_blank, noreferrer: true, nofollow: true %>
+              <%= link_to t('.feedback_form_url'), target: :_blank, noreferrer: true, nofollow: true do %>
+                <%= t('.send_feedback') %><span class="govuk-visually-hidden"><%= t('assistive_text.new_tab') %></span>
+              <% end %>
             </li>
           <% end %>
           <li>

--- a/app/views/publish/_publish_environment.html.erb
+++ b/app/views/publish/_publish_environment.html.erb
@@ -9,7 +9,10 @@
   <% else %>
     <span class="govuk-!-font-weight-bold">Your <%= text_for_environment(environment) %> form will be published to: </span><%= form_url(environment) %><br/>
     <% if environment == 'dev' %>
-      <%= govuk_link_to 'Change', settings_form_name_url_index_path %></p>
+    <%= govuk_link_to settings_form_name_url_index_path do %>
+      Change<span class="govuk-visually-hidden">form name</span>
+    <% end %>
+    </p>
     <% end %>
   <% end %>
 

--- a/app/views/publish/_publish_for_review.html.erb
+++ b/app/views/publish/_publish_for_review.html.erb
@@ -17,7 +17,7 @@
             <li><%= t("publish.publish_for_review.confirmation.li_2") %></li>
           </ul>
           <p><%= t("publish.publish_for_review.confirmation.text_3") %></p>
-          <p><%= t("publish.publish_for_review.confirmation.text_4", href: govuk_link_to(t('publish.publish_for_review.confirmation.text_4_link_text'), t('publish.publish_for_review.confirmation.text_4_link_ref'))).html_safe %></p>
+          <p><%= t("publish.publish_for_review.confirmation.text_4", href: govuk_link_to((t('publish.publish_for_review.confirmation.text_4_link_text') + tag.span(t('assistive_text.new_tab'), class: 'govuk-visually-hidden')).html_safe, t('publish.publish_for_review.confirmation.text_4_link_ref'), target: '_blank', rel: 'noreferrer nofollow')).html_safe %></p>
         </p>
       </div>
     </div>
@@ -44,44 +44,44 @@
             <h2 class="govuk-heading-m"><%= t('publish.publish_for_review.info.heading') %></h2>
       
             <p>
-              <%= t('publish.publish_for_review.info.content', href: govuk_link_to(t('publish.publish_for_review.info.link_text'), t('publish.publish_for_review.info.link_url'))).html_safe %>
+              <%= t('publish.publish_for_review.info.content', href: govuk_link_to((t('publish.publish_for_review.info.link_text') + tag.span(t('assistive_text.new_tab'), class: 'govuk-visually-hidden')).html_safe, t('publish.publish_for_review.info.link_url'), target: '_blank', rel: 'noreferrer nofollow')).html_safe %>
               <%= t('publish.publish_for_review.info.content_2') %>
             </p>
           </div>
           <%= form.govuk_check_boxes_fieldset :declarations_checkboxes, legend: { text: t('publish.declarations.label'), size: "s" } do %>
             <%= form.govuk_check_box :declarations_checkboxes, :declaration_1,
               link_errors: true,
-              label: { text: t('publish.declarations.one', href: govuk_link_to(t('publish.declarations.one_link_text'), t('publish.declarations.one_link_ref'))).html_safe },
+              label: { text: t('publish.declarations.one', href: govuk_link_to((t('publish.declarations.one_link_text') + tag.span(t('assistive_text.new_tab'), class: 'govuk-visually-hidden')).html_safe, t('publish.declarations.one_link_ref'), target: '_blank', rel: 'noreferrer nofollow')).html_safe },
               checked: @declarations.declaration_1,
               'aria-label':  t('publish.declarations.one', href: t('publish.declarations.one_link_text')).html_safe
             %>
             <%= form.govuk_check_box :declarations_checkboxes, :declaration_2,
               link_errors: true,
-              label: { text: t('publish.declarations.two', href: govuk_link_to(t('publish.declarations.two_link_text'), t('publish.declarations.two_link_ref'))).html_safe },
+              label: { text: t('publish.declarations.two', href: govuk_link_to((t('publish.declarations.two_link_text') + tag.span(t('assistive_text.new_tab'), class: 'govuk-visually-hidden')).html_safe, t('publish.declarations.two_link_ref'), target: '_blank', rel: 'noreferrer nofollow')).html_safe },
               checked: @declarations.declaration_2,
               'aria-label':  t('publish.declarations.two', href: t('publish.declarations.two_link_text')).html_safe
             %>
             <%= form.govuk_check_box :declarations_checkboxes, :declaration_3,
               link_errors: true,
-              label: { text: t('publish.declarations.three', href: govuk_link_to(t('publish.declarations.three_link_text'), t('publish.declarations.three_link_ref'))).html_safe },
+              label: { text: t('publish.declarations.three', href: govuk_link_to((t('publish.declarations.three_link_text') + tag.span(t('assistive_text.new_tab'), class: 'govuk-visually-hidden')).html_safe, t('publish.declarations.three_link_ref'), target: '_blank', rel: 'noreferrer nofollow')).html_safe },
               checked: @declarations.declaration_3,
               'aria-label':  t('publish.declarations.three', href: t('publish.declarations.three_link_text')).html_safe
             %>
             <%= form.govuk_check_box :declarations_checkboxes, :declaration_4,
               link_errors: true,
-              label: { text: t('publish.declarations.four', href: govuk_link_to(t('publish.declarations.four_link_text'), t('publish.declarations.four_link_ref'))).html_safe },
+              label: { text: t('publish.declarations.four', href: govuk_link_to((t('publish.declarations.four_link_text') + tag.span(t('assistive_text.new_tab'), class: 'govuk-visually-hidden')).html_safe, t('publish.declarations.four_link_ref'), target: '_blank', rel: 'noreferrer nofollow')).html_safe },
               checked: @declarations.declaration_4,
               'aria-label':  t('publish.declarations.four', href: t('publish.declarations.four_link_text')).html_safe
             %>
             <%= form.govuk_check_box :declarations_checkboxes, :declaration_5,
               link_errors: true,
-              label: { text: t('publish.declarations.five',  href: govuk_link_to(t('publish.declarations.five_link_text'), t('publish.declarations.five_link_ref'))).html_safe },
+              label: { text: t('publish.declarations.five',  href: govuk_link_to((t('publish.declarations.five_link_text') + tag.span(t('assistive_text.new_tab'), class: 'govuk-visually-hidden')).html_safe, t('publish.declarations.five_link_ref'), target: '_blank', rel: 'noreferrer nofollow')).html_safe },
               checked: @declarations.declaration_5,
               'aria-label':  t('publish.declarations.five', href: t('publish.declarations.five_link_text')).html_safe
             %>
             <%= form.govuk_check_box :declarations_checkboxes, :declaration_6,
               link_errors: true,
-              label: { text: t('publish.declarations.six', href: govuk_link_to(t('publish.declarations.six_link_text'), t('publish.declarations.six_link_ref'))).html_safe },
+              label: { text: t('publish.declarations.six', href: govuk_link_to((t('publish.declarations.six_link_text') + tag.span(t('assistive_text.new_tab'), class: 'govuk-visually-hidden')).html_safe, t('publish.declarations.six_link_ref'), target: '_blank', rel: 'noreferrer nofollow')).html_safe },
               checked: @declarations.declaration_6,
               'aria-label':  t('publish.declarations.six', href: t('publish.declarations.six_link_text')).html_safe
             %>

--- a/app/views/settings/confirmation_email/index.html.erb
+++ b/app/views/settings/confirmation_email/index.html.erb
@@ -23,10 +23,10 @@
       text: t('warnings.confirmation_email.message',
       href:
         govuk_link_to(
-          t('warnings.confirmation_email.link_text'),
+          (t('warnings.confirmation_email.link_text') + tag.span(t('assistive_text.new_tab'), class: 'govuk-visually-hidden')).html_safe,
           t('warnings.confirmation_email.link_url'),
           target: :_blank,
-          rel: 'nofollow noreferrer'
+          rel: 'nofollow noreferrer',
         )
       ).html_safe
     ) %>

--- a/app/views/settings/email/_csv_fieldset.html.erb
+++ b/app/views/settings/email/_csv_fieldset.html.erb
@@ -7,7 +7,9 @@
     <%= f.object.class.human_attribute_name :csv_hint %>
   </div>
   <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-5">
-    <%= link_to f.object.class.human_attribute_name(:csv_sample), asset_url('/sample.csv'), class: 'govuk-link', target: '_blank', rel: 'noopener nofollow' %>
+    <%= link_to asset_url('/sample.csv'), class: 'govuk-link', target: '_blank', rel: 'noopener nofollow' do %>
+      <%= f.object.class.human_attribute_name(:csv_sample) %><span class="govuk-visually-hidden"><%= t('assistive_text.new_tab') %>
+    <% end %>
   </p>
 
   <%= f.govuk_check_box :service_csv_output, 1, 0,

--- a/app/views/settings/email/_pdf_fieldset.html.erb
+++ b/app/views/settings/email/_pdf_fieldset.html.erb
@@ -7,7 +7,9 @@
     <%= f.object.class.human_attribute_name :pdf_hint %>
   </div>
   <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-5">
-    <%= link_to f.object.class.human_attribute_name(:pdf_sample), asset_url('/sample.pdf'), class: 'govuk-link', target: '_blank', rel: 'noopener nofollow' %>
+  <%= link_to asset_url('/sample.pdf'), class: 'govuk-link', target: '_blank', rel: 'noopener nofollow' do %>
+    <%= f.object.class.human_attribute_name(:pdf_sample) %><span class="govuk-visually-hidden"><%= t('assistive_text.new_tab') %></span>
+  <% end %>
   </p>
 
   <%= f.govuk_text_field :service_email_pdf_heading,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
   assistive_text:
     warning: warning
     incomplete: incomplete
+    new_tab: (opens in a new tab)
   default_text:
     section_heading: '[Optional section heading]'
     lede: '[Optional lede paragraph]'
@@ -433,13 +434,13 @@ en:
       form_name:
         label: 'Form name'
         lede: This appears in the header of all your form pages and is what your form is listed as in the MoJ Forms editor. A good name describes the task the form is designed for and starts with an action, such as "Get help with..." or "Apply for..." %{href}.
-        href: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/settings" target="_blank" rel="noopener noreferrer">Learn more about naming a form</a>
+        href: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/settings" target="_blank" rel="noopener noreferrer">Learn more about naming a form<span class="govuk-visually-hidden">(opens in a new tab)</span></a>
       form_slug:
         label: 'URL'
         lede: "This will be your form's web address when it goes live. The URL should be easy to read and closely resemble your form name. Words should be in lower case and separated with hyphens. %{href}.<br /><br />Changing a live form's URL can cause problems for users so this option is only available before a form has been published to Live."
         lede_live: "This is your form's live web address. The URL should be easy to read and closely resemble your form name. Words should be in lower case and separated with hyphens. %{href}.<br /><br />As your form is now live, you cannot change your URL here. %{contact_us} to discuss changing your URL."
-        contact_us: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/contact" target="_blank" rel="noopener noreferrer">Contact us</a>
-        href: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/settings" target="_blank" rel="noopener noreferrer">Learn more about URL standards</a>
+        contact_us: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/contact" target="_blank" rel="noopener noreferrer">Contact us<span class="govuk-visually-hidden">(opens in a new tab)</span></a>
+        href: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/settings" target="_blank" rel="noopener noreferrer">Learn more about URL standards<span class="govuk-visually-hidden">(opens in a new tab)</span></a>
         hint: Maximum 57 characters. It cannot start with a number or include spaces or special characters except hyphens
         domain: .form.service.justice.gov.uk
     form_analytics:
@@ -458,7 +459,7 @@ en:
       link: Reference numbers and GOV.UK Pay
       heading: Reference numbers and GOV.UK Pay
       description: Generate and provide your users with a unique reference number for each submission. You can combine a reference number with a GOV.UK Pay payment link to easily match MoJ Forms submissions when taking payments. (For details, see the %{href}.)
-      href: <a class="govuk-link" href="%{url}" target="_blank" rel="noopener noreferrer">user guide</a>
+      href: <a class="govuk-link" href="%{url}" target="_blank" rel="noopener noreferrer">user guide<span class="govuk-visually-hidden">(opens in a new tab)</span></a>
       lede: Generate a unique reference number for each submission and link users to your GOV.UK Pay payment page.
     reference_number:
       warning: Updating these settings will reset the confirmation and submission emails and any changes you have made to the subjects and messages will be lost.
@@ -472,7 +473,7 @@ en:
     payment_link:
       legend: GOV.UK Pay payment links
       hint: This adds a reference number to a GOV.UK Pay payment link and inserts it in the confirmation page and confirmation email. (Requires a %{href}.)
-      href: <a class="govuk-link" href="%{url}" target="_blank" rel="noopener noreferrer">GOV.UK Pay account</a>
+      href: <a class="govuk-link" href="%{url}" target="_blank" rel="noopener noreferrer">GOV.UK Pay account<span class="govuk-visually-hidden">(opens in a new tab)</span></a>
       url: 'https://www.payments.service.gov.uk/'
       checkbox_label: Add payment links with reference numbers
       url_label: Your GOV.UK Pay payment link URL
@@ -481,7 +482,7 @@ en:
       lede: 'Give users the option of saving a partially completed form.'
       description: 'Give users the option of saving a partially completed form for up to 28 days.'
       page_lede: 'This places a save button at the bottom of each page of your form which will lead users through the save process. For details, see the %{href}'
-      href: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/settings/#save-for-later" target="_blank" rel="noopener noreferrer">user guide section on save for later.</a>
+      href: <a class="govuk-link" href="https://moj-forms.service.justice.gov.uk/settings/#save-for-later" target="_blank" rel="noopener noreferrer">user guide section on save for later.<span class="govuk-visually-hidden">(opens in a new tab)</span></a>
       label: Enable save for later
     submission:
       heading: 'Submission settings'
@@ -502,7 +503,7 @@ en:
       warning: Once you change the form owner, you will no longer be able to access or edit this form in MoJ Forms.
       confirmation_title: The form owner has been changed
       confirmation: ‘%{form_name}’ has been transferred to <strong>%{new_owner}</strong>.<br><br>They will see it on the ‘Your forms’ page the next time they sign in. We have also sent a confirmation email.<br><br>If you made this change by mistake, %{href}.
-      href: <a class="govuk-link" href="%{text_4_link_ref}" target="_blank" rel="noopener noreferrer">contact us</a>
+      href: <a class="govuk-link" href="%{text_4_link_ref}" target="_blank" rel="noopener noreferrer">contact us<span class="govuk-visually-hidden">(opens in a new tab)</span></a>
     collection_email:
       heading: 'Collect information by email'
       lede: 'Receive your form data in PDF and CSV attached to emails.'


### PR DESCRIPTION
This PR adds hidden assistive text to all places where we open a link in a new tab.  

It also amends some links to open within a new tab that didn't before (mostly on the request approval to publish page)

It also fixes the 'ambiguous' link on the Change form name and URL setting page.

Both of these correct WCAG issues raised in our DAC audit.