### PR TITLE
Add assistive text to all links that open in new tab

### DIFF
--- a/acceptance/features/publishing_page_spec.rb
+++ b/acceptance/features/publishing_page_spec.rb
@@ -298,12 +298,13 @@ end
   end
 
   def then_I_should_see_the_declarations_checkboxes
-    expect(page).to have_text(I18n.t('publish.declarations.one', href: I18n.t('publish.declarations.one_link_text')))
-    expect(page).to have_text(I18n.t('publish.declarations.two', href: I18n.t('publish.declarations.two_link_text')))
-    expect(page).to have_text(I18n.t('publish.declarations.three', href: I18n.t('publish.declarations.three_link_text')))
-    expect(page).to have_text(I18n.t('publish.declarations.four', href: I18n.t('publish.declarations.four_link_text')))
-    expect(page).to have_text(I18n.t('publish.declarations.five', href: I18n.t('publish.declarations.five_link_text')))
-    expect(page).to have_text(I18n.t('publish.declarations.six', href: I18n.t('publish.declarations.six_link_text')))
+    expect(page.text).to include( I18n.t('publish.declarations.one_link_text'))
+    expect(page.text).to include( I18n.t('assistive_text.new_tab'))
+    expect(page.text).to include( I18n.t('publish.declarations.two_link_text'))
+    expect(page.text).to include( I18n.t('publish.declarations.three_link_text'))
+    expect(page.text).to include( I18n.t('publish.declarations.four_link_text'))
+    expect(page.text).to include( I18n.t('publish.declarations.five_link_text'))
+    expect(page.text).to include( I18n.t('publish.declarations.six_link_text'))
   end
 
   def then_I_click_request_a_final_check

--- a/acceptance/features/reference_payment_spec.rb
+++ b/acceptance/features/reference_payment_spec.rb
@@ -153,10 +153,10 @@ feature 'Reference Payment Page' do
 
   def then_I_should_see_the_payment_link_settings_configuration
     expect(page).to have_content(I18n.t('settings.reference_payment.heading'))
-    expect(page).to have_content(I18n.t('settings.reference_payment.description', href:'user guide' ))
+    expect(page).to have_content(I18n.t('settings.reference_payment.description', href:'user guide (opens in new tab) ' )[0..50], normalize_ws: true, exact: false )
     expect(page).to have_content(I18n.t('settings.reference_number.hint'))
     expect(page).to have_content(I18n.t('settings.payment_link.legend'))
-    expect(page).to have_content(I18n.t('settings.payment_link.hint', href:'GOV.UK Pay account'))
+    expect(page).to have_content(I18n.t('settings.payment_link.hint', href:'GOV.UK Pay account')[0..50])
   end
 
   def with_setting(setting, value)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -513,7 +513,7 @@ en:
       description: Send the people completing your form a confirmation email with a copy of their answers.
   warnings:
     confirmation_email:
-      message: 'Your form must include an email question to enable a %{href}.'
+      message: 'Your form must include an email question to enable a %{href}'
       link_text: confirmation email
       link_url: 'https://moj-forms.service.justice.gov.uk/settings/#confirmation-email'
     submission_pages:


### PR DESCRIPTION
This PR adds hidden assistive text to all places where we open a link in a new tab.

It also amends some links to open within a new tab that didn't before (mostly on the request approval to publish page)

It also fixes the 'ambiguous' link on the Change form name and URL setting page.

Both of these correct WCAG issues raised in our DAC audit.
