### PR TITLE
Add status announcement to save button

### DIFF
--- a/app/javascript/src/web-components/save-button.js
+++ b/app/javascript/src/web-components/save-button.js
@@ -75,6 +75,10 @@ class SaveButton extends HTMLButtonElement {
     return this.form.querySelector(`#${this.getAttribute("aria-describedby")}`);
   }
 
+  get status() {
+    return this.form.querySelector(`#${this.form.id}-save-status`);
+  }
+
   get $form() {
     return $(this.form);
   }
@@ -105,7 +109,8 @@ class SaveButton extends HTMLButtonElement {
     if (this.assistiveText) {
       this.insertAdjacentHTML(
         "afterend",
-        `<span class="sr-only" id="${this.form.id}-save-description"></span>`,
+        `<span class="sr-only" id="${this.form.id}-save-description"></span>
+                <span class="sr-only" id="${this.form.id}-save-status" role="status"></span>`,
       );
       this.setAttribute("aria-describedby", `${this.form.id}-save-description`);
     }
@@ -135,6 +140,7 @@ class SaveButton extends HTMLButtonElement {
   #handleClick(event) {
     if (this.saveRequired) {
       this.innerText = this.text.saving;
+      this.status.innerText = this.text.saving;
     } else {
       event.preventDefault();
     }


### PR DESCRIPTION
This PR fixes an issue raised in the DAC audit where the 'saving' status of the button isn't announced to screenreader users.

Added a second hidden span with an aria-role of 'status', this gets populated when the save button is clicked, and the 'status' roel ensures the text is announced instantly.

This, combined with the page title changes, and the page focus changes should mean that screenreader users are aware of saving occuring, and will know when it has completed.