### PR TITLE
Add black focus border to editable content areas

### DIFF
--- a/app/javascript/styles/components/editable-content.scss
+++ b/app/javascript/styles/components/editable-content.scss
@@ -31,9 +31,14 @@ editable-content {
 editable-content > [mode="edit"] {
   [data-element="editable-content-input"] {
     display: block;
+    padding-top: 26px;
+    padding-left: 3px;
+    padding-right: 3px;
     outline: $govuk-focus-width solid $govuk-focus-colour;
     outline-offset: 0px;
-    padding-top: 26px;
+    border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+    border-radius: 0;
+    box-shadow: inset 0 0 0 $govuk-border-width-form-element;
   }
 }
 


### PR DESCRIPTION
Updates the focus border on editable content areas to pass WCAG contrast rules

<img width="746" alt="image" src="https://github.com/ministryofjustice/fb-editor/assets/595564/4d10f030-940b-4458-8cec-674ae1decef6">
