### PR TITLE
Fix sequential focus on flow view

### DIFF
--- a/app/components/moj_forms/flow/flow_item_component.rb
+++ b/app/components/moj_forms/flow/flow_item_component.rb
@@ -30,7 +30,6 @@ module MojForms
 
       def default_attributes
         {
-          id: uuid,
           class: "flow-item #{type_classname}",
           data: {
             fb_id: uuid


### PR DESCRIPTION
Although we had removed the code that placed focus on the flow item title when returning to the flow item from editing a page, the hash fragment in the URL was still a valid ID of a flow-item on the page. This meant that the browser attempts to focus it but fails. 

When this happens the browser tries to be helpful and sets the `sequential focus navigation start point` meaning that when <kbd>Tab</kbd> is pressed it starts searching for focusable elements from the SFNSP - meaning the flow item title gains focus.  In our use case this is not expected behaviour for a screen reader user and is *not* helpful.

The fix for this is actually fairly easy - becasue we use the `data-fb-id` attribute for finding and scrolling to the flow item, we no longer actually need the `id` attribute on the flow item.  Removing this prevents the `sequential-focus-navigation-start-point` being set as there is no longer and id on the page matching the hash fragment in the url.
