### PR TITLE
Add hidden heading instead of using group role

### DIFF
--- a/app/javascript/src/question_checkboxes.js
+++ b/app/javascript/src/question_checkboxes.js
@@ -87,10 +87,8 @@ class CheckboxesQuestion extends Question {
   addAccessibleLabels() {
     super.addAccessibleLabels();
     // Add a group label for the answers section
-    this.$node.find(".EditableComponentCollectionItem").first().parent().attr({
-      "role": "group",
-      "aria-label": this.labels.answers,
-    });
+    let headingTag = this.$node.find('fieldset').has('h2').length ? 'h3' : 'h2';
+    this.$node.find(".EditableComponentCollectionItem").first().parent().before(`<${headingTag} class="govuk-visually-hidden">${this.labels.answers}</${headingTag}>`);
 
     // Update the labels for all of the items
     this.$node

--- a/app/javascript/src/question_radios.js
+++ b/app/javascript/src/question_radios.js
@@ -82,16 +82,13 @@ class RadiosQuestion extends Question {
     this.config = conf;
     this._preservedItemCount = 2;
     $node.addClass("RadiosQuestion");
-    // this.addAccessibleLabels();
   }
 
   addAccessibleLabels() {
     super.addAccessibleLabels();
     // Add a group label for the answers section
-    this.$node.find(".EditableComponentCollectionItem").first().parent().attr({
-      "role": "group",
-      "aria-label": this.labels.answers,
-    });
+    let headingTag = this.$node.find('fieldset').has('h2').length ? 'h3' : 'h2';
+    this.$node.find(".EditableComponentCollectionItem").first().parent().before(`<${headingTag} class="govuk-visually-hidden">${this.labels.answers}</${headingTag}>`);
 
     // Update the labels for all of the items
     this.$node


### PR DESCRIPTION
This PR removes the use of an aria `group` role within radio and checkbox questions as this was raised as a WCAG issue in the audit.

Instead we add a visually hidden heading to try and help screenreader users gain extra context when editing.