### PR TITLE
Re-enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,33 +4,58 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  # Disable version updates, but leave security updates
-  open-pull-requests-limit: 0
+    time: "03:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 10
+  reviewers:
+  - StevenLeighton21
+  - mattempty
+  - danielglen-moj
 
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
-  # Disable version updates, but leave security updates
-  open-pull-requests-limit: 0
+    time: "03:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 10
+  reviewers:
+  - StevenLeighton21
+  - mattempty
+  - danielglen-moj
 
 - package-ecosystem: docker
   directory: "/docker/web"
   schedule:
     interval: daily
-  # Disable version updates, but leave security updates
-  open-pull-requests-limit: 0
+    time: "03:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 10
+  reviewers:
+  - StevenLeighton21
+  - mattempty
+  - danielglen-moj
 
 - package-ecosystem: docker
   directory: "/docker/workers"
   schedule:
     interval: daily
-  # Disable version updates, but leave security updates
-  open-pull-requests-limit: 0
+    time: "03:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 10
+  reviewers:
+  - StevenLeighton21
+  - mattempty
+  - danielglen-moj
 
 - package-ecosystem: docker
   directory: "/acceptance"
   schedule:
     interval: daily
-  # Disable version updates, but leave security updates
-  open-pull-requests-limit: 0
+    time: "03:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 10
+  reviewers:
+  - StevenLeighton21
+  - mattempty
+  - danielglen-moj


### PR DESCRIPTION
While the platform was actively developed dependabot tended to create more noise than value, but now we're no longer in active feature development it may be helpful to keep on top of version updates.

Revert in the event of excessive noise!