### PR TITLE
Use the available last 126 version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ jobs:
       - ruby/install-deps
       - run: sudo apt-get update
       - browser-tools/install-chrome:
-          chrome-version: 126.0.6478.214
+          chrome-version: 126.0.6478.182
       - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install


### PR DESCRIPTION
I've had to pin the chrome/driver version at 126 LTS for now, as 127 appears to cause capybara to miss confirm dialogs, causing one of the ATs to fail. Will be fixed/pin removed in a later PR