### PR TITLE
Add logic check for showing prompt

### DIFF
--- a/app/controllers/settings/ms_list_controller.rb
+++ b/app/controllers/settings/ms_list_controller.rb
@@ -65,4 +65,18 @@ class Settings::MsListController < FormController
     "#{service.service_name}-#{deployment_environment == 'dev' ? 'test' : 'live'}-#{service.version_id}-attachments"
   end
   helper_method :human_readable_drive_name
+
+  def show_email_submission_prompt?
+    @ms_list_settings_dev.send_to_ms_list? &&
+      SubmissionSetting.find_by(
+        service_id: service.service_id,
+        deployment_environment: 'dev'
+      ).try(:send_confirmation_email?) ||
+    @ms_list_settings_production.send_to_ms_list? &&
+      SubmissionSetting.find_by(
+        service_id: service.service_id,
+        deployment_environment: 'production'
+      ).try(:send_confirmation_email?)
+  end
+  helper_method :show_email_submission_prompt?
 end

--- a/app/controllers/settings/ms_list_controller.rb
+++ b/app/controllers/settings/ms_list_controller.rb
@@ -67,12 +67,12 @@ class Settings::MsListController < FormController
   helper_method :human_readable_drive_name
 
   def show_email_submission_prompt?
-    @ms_list_settings_dev.send_to_ms_list? &&
+    @ms_list_settings_dev.send_to_ms_list_checked? &&
       SubmissionSetting.find_by(
         service_id: service.service_id,
         deployment_environment: 'dev'
       ).try(:send_confirmation_email?) ||
-      @ms_list_settings_production.send_to_ms_list? &&
+      @ms_list_settings_production.send_to_ms_list_checked? &&
         SubmissionSetting.find_by(
           service_id: service.service_id,
           deployment_environment: 'production'

--- a/app/controllers/settings/ms_list_controller.rb
+++ b/app/controllers/settings/ms_list_controller.rb
@@ -68,12 +68,12 @@ class Settings::MsListController < FormController
 
   def show_email_submission_prompt?
     @ms_list_settings_dev.send_to_ms_list_checked? &&
-      SubmissionSetting.find_by(
+      !SubmissionSetting.find_by(
         service_id: service.service_id,
         deployment_environment: 'dev'
       ).try(:send_confirmation_email?) ||
       @ms_list_settings_production.send_to_ms_list_checked? &&
-        SubmissionSetting.find_by(
+        !SubmissionSetting.find_by(
           service_id: service.service_id,
           deployment_environment: 'production'
         ).try(:send_confirmation_email?)

--- a/app/controllers/settings/ms_list_controller.rb
+++ b/app/controllers/settings/ms_list_controller.rb
@@ -72,11 +72,11 @@ class Settings::MsListController < FormController
         service_id: service.service_id,
         deployment_environment: 'dev'
       ).try(:send_confirmation_email?) ||
-    @ms_list_settings_production.send_to_ms_list? &&
-      SubmissionSetting.find_by(
-        service_id: service.service_id,
-        deployment_environment: 'production'
-      ).try(:send_confirmation_email?)
+      @ms_list_settings_production.send_to_ms_list? &&
+        SubmissionSetting.find_by(
+          service_id: service.service_id,
+          deployment_environment: 'production'
+        ).try(:send_confirmation_email?)
   end
   helper_method :show_email_submission_prompt?
 end

--- a/app/controllers/settings/ms_list_controller.rb
+++ b/app/controllers/settings/ms_list_controller.rb
@@ -71,12 +71,12 @@ class Settings::MsListController < FormController
       !SubmissionSetting.find_by(
         service_id: service.service_id,
         deployment_environment: 'dev'
-      ).try(:send_confirmation_email?) ||
+      ).try(:send_email?) ||
       @ms_list_settings_production.send_to_ms_list_checked? &&
         !SubmissionSetting.find_by(
           service_id: service.service_id,
           deployment_environment: 'production'
-        ).try(:send_confirmation_email?)
+        ).try(:send_email?)
   end
   helper_method :show_email_submission_prompt?
 end

--- a/app/views/settings/ms_list/index.html.erb
+++ b/app/views/settings/ms_list/index.html.erb
@@ -1,22 +1,24 @@
-<div class="govuk-grid-column-two-thirds">
-  <br/>
-  <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-    <div class="govuk-notification-banner__header">
-      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-        <%= I18n.t('settings.ms_list.banner.heading') %>
-      </h2>
-    </div>
-    <div class="govuk-notification-banner__content">
-      <p class="govuk-notification-banner__heading">
-        <%= I18n.t('settings.ms_list.banner.content_1') %>
-      </p>
-      <p>
-        <%= I18n.t('settings.ms_list.banner.content_2') %>
-      </p>
-      <a class="govuk_link" href=<%= settings_email_index_path(service.service_id) %>><%= I18n.t('settings.ms_list.banner.link_text') %></a>
+<% if show_email_submission_prompt? %>
+  <div class="govuk-grid-column-two-thirds">
+    <br/>
+    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+          <%= I18n.t('settings.ms_list.banner.heading') %>
+        </h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">
+          <%= I18n.t('settings.ms_list.banner.content_1') %>
+        </p>
+        <p>
+          <%= I18n.t('settings.ms_list.banner.content_2') %>
+        </p>
+        <a class="govuk_link" href=<%= settings_email_index_path(service.service_id) %>><%= I18n.t('settings.ms_list.banner.link_text') %></a>
+      </div>
     </div>
   </div>
-</div>
+<% end %>
 
 <%= mojf_settings_screen(
   heading:t('settings.ms_list.heading'),


### PR DESCRIPTION
Quick update to only show this info panel if there is an environment where sent to ms list is successfully configured and collect submission by email is not

It is ok if just send to list is configured, but advisable to have a backup for redundancy