### PR TITLE
Revert "Re-enable dependabot"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,58 +4,33 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  reviewers:
-  - StevenLeighton21
-  - mattempty
-  - danielglen-moj
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0
 
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  reviewers:
-  - StevenLeighton21
-  - mattempty
-  - danielglen-moj
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0
 
 - package-ecosystem: docker
   directory: "/docker/web"
   schedule:
     interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  reviewers:
-  - StevenLeighton21
-  - mattempty
-  - danielglen-moj
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0
 
 - package-ecosystem: docker
   directory: "/docker/workers"
   schedule:
     interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  reviewers:
-  - StevenLeighton21
-  - mattempty
-  - danielglen-moj
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0
 
 - package-ecosystem: docker
   directory: "/acceptance"
   schedule:
     interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  reviewers:
-  - StevenLeighton21
-  - mattempty
-  - danielglen-moj
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0


### PR DESCRIPTION
Reverts ministryofjustice/fb-editor#2671

Turns out it hasn't been that useful to re-enable