### PR TITLE
Sort the publish records by created at for currently published status

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -26,6 +26,7 @@ module Admin
     def published(environment)
       PublishService.where(deployment_environment: environment)
                     .group_by(&:service_id)
+                    .order_by(&:created_at)
                     .map { |p| p.last.last }
                     .select(&:published?)
     end
@@ -33,6 +34,7 @@ module Admin
     def ever_published(environment)
       PublishService.where(deployment_environment: environment)
                     .group_by(&:service_id)
+                    .order_by(&:created_at)
                     .map(&:last)
                     .map { |p| p.select(&:published?) }
                     .map(&:last)

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -25,16 +25,16 @@ module Admin
 
     def published(environment)
       PublishService.where(deployment_environment: environment)
+                    .sort_by(&:created_at)
                     .group_by(&:service_id)
-                    .order_by(&:created_at)
                     .map { |p| p.last.last }
                     .select(&:published?)
     end
 
     def ever_published(environment)
       PublishService.where(deployment_environment: environment)
+                    .sort_by(&:created_at)
                     .group_by(&:service_id)
-                    .order_by(&:created_at)
                     .map(&:last)
                     .map { |p| p.select(&:published?) }
                     .map(&:last)

--- a/app/controllers/admin/overviews_controller.rb
+++ b/app/controllers/admin/overviews_controller.rb
@@ -260,7 +260,7 @@ module Admin
       PublishService.where(
         service_id:,
         deployment_environment: environment
-      ).last&.published?
+      ).sort_by(&:created_at).last.published?
     end
 
     def first_publish_date(service_id, environment)

--- a/app/controllers/admin/overviews_controller.rb
+++ b/app/controllers/admin/overviews_controller.rb
@@ -260,7 +260,7 @@ module Admin
       PublishService.where(
         service_id:,
         deployment_environment: environment
-      ).sort_by(&:created_at).last.published?
+      ).max_by(&:created_at).published?
     end
 
     def first_publish_date(service_id, environment)


### PR DESCRIPTION
I think the order isn't guaranteed, or can end up with records returned by 'last' after being put in an array that isn't actually the _latest_