### PR TITLE
Stop CSP from reporting violation from inline click handlers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ ruby '3.2.0'
 # one of these lines:
 # gem 'metadata_presenter',
 #     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'bump-off-cobwebs'
+#     branch: 'bugfix/page-title'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.4.5'
+gem 'metadata_presenter', '3.4.6'
 
 gem 'activerecord-session_store'
 gem 'administrate', '~> 0.20.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
-    metadata_presenter (3.4.5)
+    metadata_presenter (3.4.6)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)
@@ -862,7 +862,7 @@ DEPENDENCIES
   govuk_notify_rails (~> 2.2.0)
   hashie
   listen (~> 3.8)
-  metadata_presenter (= 3.4.5)
+  metadata_presenter (= 3.4.6)
   omniauth-auth0 (~> 3.1.0)
   omniauth-rails_csrf_protection (~> 1.0.1)
   pg (>= 0.18, < 2.0)

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -14,6 +14,7 @@ Rails.application.configure do
                        "https://unpkg.com/alpinejs",
                        "https://cdn.jsdelivr.net/npm/marked@2.1.3/marked.min.js",
                        "https://*.googletagmanager.com"
+    policy.script_src_elem :unsafe_inline
     policy.style_src   :self,
                        :unsafe_inline
     policy.connect_src :self,


### PR DESCRIPTION
Adds unsafe inline to script src - we know this is generally better avoided, but is now reporting on all inline onclick handler events which is every page edit.

It's so error event noisy as to cause more problems in missed real events without turning this off.
Also bump MDP as it contains a bugfix worth applying.