### PR TITLE
Stop reporting onclick handlers prevalent in editor

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,8 +13,8 @@ Rails.application.configure do
     policy.script_src  :self,
                        "https://unpkg.com/alpinejs",
                        "https://cdn.jsdelivr.net/npm/marked@2.1.3/marked.min.js",
-                       "https://*.googletagmanager.com"
-    policy.script_src_elem :unsafe_inline
+                       "https://*.googletagmanager.com",
+                       :unsafe_inline
     policy.style_src   :self,
                        :unsafe_inline
     policy.connect_src :self,


### PR DESCRIPTION
Unfortunately, adding unsafe-inline undoes a lot of work the CSP is supposed to do, but something has changed over the most recent package bumps where the editor has begun reporting every single inline click handler, so we have to squash these or we'll pollute sentry with thousands of events.