### PR TITLE
CTPD-2764 Amended chrome version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ jobs:
       - ruby/install-deps
       - run: sudo apt-get update
       - browser-tools/install-chrome:
-          chrome-version: 138.0.7204.101
+          chrome-version: 138.0.7204.100
       - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install
@@ -340,7 +340,7 @@ jobs:
       - ruby/install-deps
       - run: sudo apt-get update
       - browser-tools/install-chrome:
-          chrome-version: 138.0.7204.101
+          chrome-version: 138.0.7204.100
       - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install


### PR DESCRIPTION
google-chrome-stable_138.0.7204.101-1_amd64.deb package is not available but google-chrome-stable_138.0.7204.100-1_amd64.deb is.