### PR TITLE
CDPT-2970: Update rake task time to investigate alerts frequency

### DIFF
--- a/deploy-eks/fb-editor-chart/templates/remove_test_services_configs.yaml
+++ b/deploy-eks/fb-editor-chart/templates/remove_test_services_configs.yaml
@@ -5,7 +5,7 @@ metadata:
   name: fb-editor-cron-remove-test-services-configs-{{ .Values.environmentName }}
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 spec:
-  schedule: "0 5 * * *"
+  schedule: "0 6 * * *"
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3
   jobTemplate:


### PR DESCRIPTION
- ```KubePodCrashLooping```  alert triggers everyday around from 5:00am to 5:30am. 
- Updating the cronjob time to check if rake task is causing the  ```KubePodCrashLooping```  alert 