### PR TITLE
CDPT-3082: Enable and fix acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,6 +323,7 @@ jobs:
             echo 'export ACCEPTANCE_TESTS_PASSWORD=$ACCEPTANCE_TESTS_PASSWORD' >> $BASH_ENV
             echo 'export CI_MODE=true' >> $BASH_ENV
             echo 'export SITEPRISM_DSL_VALIDATION_DISABLED=true' >> $BASH_ENV
+            echo 'export CREATE_FORM_ENABLED=true' >> $BASH_ENV
             source $BASH_ENV
 
             EXCLUDE_FILES="accessibility_spec.rb"
@@ -450,14 +451,14 @@ workflows:
           requires:
             - build_web_image
             - build_workers_image
-      # - acceptance_tests_eks:
-      #     context: *context
-      #     requires:
-      #       - deploy_to_test_eks
+      - acceptance_tests_eks:
+          context: *context
+          requires:
+            - deploy_to_test_eks
       - production_deploy_approval:
           type: approval
           requires:
-            # - acceptance_tests_eks
+            - acceptance_tests_eks
             - deploy_to_test_eks
           filters:
             branches:
@@ -466,7 +467,7 @@ workflows:
       - deploy_to_live_eks:
           context: *context
           requires:
-            # - acceptance_tests_eks
+            - acceptance_tests_eks
             - deploy_to_test_eks
             - production_deploy_approval
   deploy_testable_branch:

--- a/acceptance/features/accessibility_spec.rb
+++ b/acceptance/features/accessibility_spec.rb
@@ -13,6 +13,9 @@ feature.skip 'Accessibility' do
   scenario 'services list' do
     click_link(I18n.t('partials.header.forms'))
     then_the_page_should_be_accessible
+
+    click_button(I18n.t('services.create'))
+    then_the_page_should_be_accessible
   end
 
   scenario 'flow_view' do

--- a/acceptance/features/create_service_spec.rb
+++ b/acceptance/features/create_service_spec.rb
@@ -26,26 +26,26 @@ feature 'Create a service' do
     given_I_want_to_create_a_service
   end
 
-  xscenario 'validates the service name' do
+  scenario 'validates the service name' do
     given_I_add_a_service_with_empty_name
     when_I_create_the_service
     then_I_should_see_a_validation_message_for_required
   end
 
-  xscenario 'validates the service name min length' do
+  scenario 'validates the service name min length' do
     given_I_add_a_service_with_one_character
     when_I_create_the_service
     then_I_should_see_a_validation_message_for_min_length
   end
 
-  xscenario 'validates the service name max length' do
+  scenario 'validates the service name max length' do
 
     given_I_add_a_service_with_many_characters
     when_I_create_the_service
     then_I_should_see_a_validation_message_for_max_length
   end
 
-  xscenario 'creates the service with default pages' do
+  scenario 'creates the service with default pages' do
     given_I_add_a_service
     when_I_create_the_service
     then_I_should_see_the_new_service_name
@@ -56,13 +56,13 @@ feature 'Create a service' do
     then_I_should_not_be_able_to_add_page(start_page_title, exit_link_text)
   end
 
-  xscenario 'validates uniqueness of the service name' do
+  scenario 'validates uniqueness of the service name' do
     given_I_have_a_service
     when_I_try_to_create_a_service_with_the_same_name
     then_I_should_see_the_unique_validation_message
   end
 
-  xscenario 'prevent duplicate checkanswers and confirmation in a service' do
+  scenario 'prevent duplicate checkanswers and confirmation in a service' do
     given_I_add_a_service
     when_I_create_the_service
     then_I_should_see_default_service_pages

--- a/acceptance/pages/editor_app.rb
+++ b/acceptance/pages/editor_app.rb
@@ -32,6 +32,7 @@ class EditorApp < SitePrism::Page
   # Your forms
   element :services_link, :link, I18n.t('partials.header.forms')
   element :name_field, :field, I18n.t('activemodel.attributes.service_creation.service_name')
+  element :create_service_button, :button, I18n.t('services.create')
   # End Your forms
 
   # Pages flow

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -36,6 +36,8 @@ module CommonSteps
       editor.sign_in_email_field.set('fb-acceptance-tests@digital.justice.gov.uk')
       editor.sign_in_submit.click
     end
+    page.find('button.DialogActivator.govuk-button.fb-govuk-button', visible: true)
+    expect(page).to have_content(I18n.t('services.create'))
   end
 
   def given_I_have_a_service(service = service_name)

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -23,6 +23,32 @@
         <% end %>
       </ul>
 
+      <% if ENV['CREATE_FORM_ENABLED'].present? %>
+        <div class="component-dialog-form"
+             id="new-service-create-dialog"
+             data-activator-text="<%= t('services.create') %>"
+             data-cancel-text="<%= t('services.cancel') %>"
+             data-component="FormCreateDialog">
+          <%= form_for(@service_creation, url: services_path) do |f| %>
+            <div class="govuk-form-group <%= f.object.errors.present? ? 'govuk-form-group--error' : '' %>">
+              <h2 class="govuk-label-wrapper" id="create-service-dialog-title" data-node="heading">
+                <%= f.label :service_name, class: "govuk-label govuk-label--m" %>
+              </h2>
+              <div class="govuk-hint" id="service-name-hint">
+                <%= t('services.form_name_change_hint') %>
+              </div>
+              <% f.object.errors.each do |error| %>
+                <p id="service-name-error" class="govuk-error-message">
+                  <span class="govuk-visually-hidden"><%= t('activemodel.errors.assistive_prefix') %></span> <%= error.message %>
+                </p>
+              <% end %>
+              <%= f.text_field :service_name, class: "govuk-input", 'aria-describedby': "service-name-hint #{ f.object.errors.present? ? ' service-name-error' : ''}" %>
+            </div>
+            <%= f.button t('services.create'), class: "govuk-button fb-govuk-button", type: 'submit' %>
+          <% end %>
+        </div>
+      <% end %>
+
       <% if params[:owner].present? %>
           <%= render 'confirmation_transfer_ownership' %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -666,6 +666,7 @@ en:
     form_name_hint: "Maximum %{max_length} characters, including spaces. It cannot start with a number or include special characters except ' - ( )"
     form_name_change_hint: "You will be able to change this later in your form's settings"
     preview: 'Preview'
+    create: 'Create a new form'
     cancel: 'Cancel'
     branch: 'Add branching'
   activemodel:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       SECRET_KEY_BASE: "2de1e1ddc4dc9eebb238d35d6b131cd76c481adb6371ded658fa259411379431391e9431e6257d1ea9dccb80df5d693904b6a4ed3bec7984647fd79c86bf4db5"
       PUBLISH_FOR_REVIEW_USERNAME: 'mojforms'
       PUBLISH_FOR_REVIEW_PASSWORD: 'mojforms'
+      CREATE_FORM_ENABLED: 'true'
     depends_on:
       - editor-db
       - editor-metadata-app


### PR DESCRIPTION
- Acceptance tests are failing because of missing "Create a new form" button. To make it pass we need to display this button conditionally based on environment variable CREATE_FORM_ENABLED.
- "Create a new form" button needs to be enabled in test environment only.  