### PR TITLE
CDPTKAN-988 Fix issue with node versions

### DIFF
--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,12 +1,18 @@
 FROM ruby:3.3.11-alpine
 
+# Fixes the Node version issue by copying Node 16 directly from the official image
+COPY --from=node:16-alpine /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:16-alpine /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=node:16-alpine /usr/local/include/node /usr/local/include/node
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-merge-driver /usr/local/bin/npm-merge-driver || true
+
 ARG UID=1001
 
 RUN apk update
 RUN apk add git yarn build-base postgresql-contrib postgresql-dev \
       bash libcurl curl yaml-dev
 
-RUN apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.16/main/ nodejs
+#RUN apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.16/main/ nodejs
 RUN apk add clamav-daemon
 RUN apk add --no-cache gcompat
 


### PR DESCRIPTION
Fix issue building web docker image. When it has the wrong version of node.
https://app.circleci.com/pipelines/github/ministryofjustice/fb-editor/11206/workflows/52523c52-9143-4455-8818-4afcfa88a262
``` => ERROR [24/26] RUN yarn install --production --check-files              0.6s
------
 > [24/26] RUN yarn install --production --check-files:
0.439 yarn install v1.22.22
0.518 [1/5] Validating package.json...
0.523 error fb_editor@0.1.0: The engine "node" is incompatible with this module. Expected version "^16.20.1". Got "24.14.1"
0.533 error Found incompatible module.
0.533 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
------

 4 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 47)
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 60)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 39)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 46)
Dockerfile:51
--------------------
  49 |     ARG RAILS_ENV=production
  50 |     
  51 | >>> RUN yarn install --production --check-files
```