### PR TITLE
CDPTKAN-708: Fix code-scanning XSS alerts

### DIFF
--- a/app/javascript/src/component_dialog.js
+++ b/app/javascript/src/component_dialog.js
@@ -89,6 +89,8 @@ const { mergeObjects, safelyActivateFunction } = require("./utilities");
 
 const DialogActivator = require("./component_dialog_activator");
 
+const DOMPurify = require("dompurify");
+
 class Dialog {
   #className = "Dialog";
   #config;
@@ -158,7 +160,7 @@ class Dialog {
     let content = mergeObjects(this.#defaultText, text);
 
     this.#elements.heading.text(content.heading);
-    this.#elements.content.html(content.content);
+    this.#elements.content.html(DOMPurify.sanitize(content.content));
     this.#elements.confirm.text(content.confirm);
     this.#elements.cancel.text(content.cancel);
   }

--- a/app/javascript/src/controller_pages.js
+++ b/app/javascript/src/controller_pages.js
@@ -37,6 +37,7 @@ const DialogForm = require("./component_dialog_form");
 const DefaultController = require("./controller_default");
 const ServicesController = require("./controller_services");
 const Expander = require("./component_expander");
+const DOMPurify = require("dompurify");
 
 const ATTRIBUTE_DEFAULT_TEXT = "fb-default-text";
 
@@ -836,7 +837,7 @@ function enhanceQuestions(view) {
  **/
 function createDialogConfiguration() {
   var $template = $("[data-component-template=DialogConfiguration]");
-  var $node = $($template.text());
+  var $node = $(DOMPurify.sanitize($template.text()));
   return new Dialog($node, {
     autoOpen: false,
     closeText: this.text.dialogs.button_close,


### PR DESCRIPTION
.html() treats the string as HTML markup, so if `content/text` comes from user input or untrusted data, it can lead to XSS vulnerabilities ("DOM text reinterpreted as HTML").

JIRA: https://dsdmoj.atlassian.net/browse/CDPTKAN-708
Code Scanning Alerts: https://github.com/ministryofjustice/fb-editor/security/code-scanning