### PR TITLE
Rotate ENCRYPTION_KEY and ENCRYPTION_SALT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ jobs:
       - ruby/install-deps
       - run: sudo apt-get update
       - browser-tools/install-chrome:
-          chrome-version: 138.0.7204.100
+          chrome-version: 138.0.7204.183
       - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,7 +431,7 @@ workflows:
           filters:
             branches:
               only:
-                - run-only-this-branch
+                - main
       - build_workers_image:
           context: *context
           requires:
@@ -443,7 +443,7 @@ workflows:
           filters:
             branches:
               only:
-                - run-only-this-branch
+                - main
       - deploy_to_test_eks:
           context: *context
           requires:
@@ -457,7 +457,6 @@ workflows:
           type: approval
           requires:
             - acceptance_tests_eks
-            - deploy_to_test_eks
           filters:
             branches:
               only:
@@ -465,8 +464,6 @@ workflows:
       - deploy_to_live_eks:
           context: *context
           requires:
-            - acceptance_tests_eks
-            - deploy_to_test_eks
             - production_deploy_approval
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
 jobs:
   login-to-aws:
     docker: &docker_image
-      - image: 'cimg/ruby:3.3-node'
+      - image: "cimg/ruby:3.3-node"
     steps:
       - checkout
       - aws-cli/setup:
@@ -36,7 +36,7 @@ jobs:
             - bash.env
   build:
     docker: &docker_image
-      - image: 'cimg/ruby:3.3-node'
+      - image: "cimg/ruby:3.3-node"
     steps:
       - checkout
       - ruby/install-deps
@@ -62,7 +62,7 @@ jobs:
           include_job_number_field: false
   lint:
     docker:
-      - image: 'cimg/ruby:3.3-node'
+      - image: "cimg/ruby:3.3-node"
     steps:
       - checkout
       - ruby/install-deps
@@ -72,7 +72,7 @@ jobs:
       - slack/status: *slack_status
   security:
     docker:
-      - image: 'cimg/ruby:3.3-node'
+      - image: "cimg/ruby:3.3-node"
     steps:
       - checkout
       - ruby/install-deps
@@ -80,15 +80,15 @@ jobs:
       - slack/status: *slack_status
   rspec_test:
     docker: &test_image
-      - image: 'cimg/ruby:3.3-node'
+      - image: "cimg/ruby:3.3-node"
       - environment:
           POSTGRES_DB: editor_local
           POSTGRES_PASSWORD: password
           POSTGRES_USER: postgres
-        image: 'cimg/postgres:12.9'
+        image: "cimg/postgres:12.9"
     environment: &test_environment
-      BUNDLE_JOBS: '3'
-      BUNDLE_RETRY: '3'
+      BUNDLE_JOBS: "3"
+      BUNDLE_RETRY: "3"
       PGHOST: 127.0.0.1
       PGPASSWORD: password
       PGUSER: postgres
@@ -102,7 +102,7 @@ jobs:
           pkg-manager: yarn
       - run: &wait_for_db
           name: Wait for DB
-          command: 'dockerize -wait tcp://localhost:5432 -timeout 1m'
+          command: "dockerize -wait tcp://localhost:5432 -timeout 1m"
       - run: &db_setup
           name: Database setup
           command: |
@@ -115,7 +115,7 @@ jobs:
       - slack/status: *slack_status
   js_test:
     docker:
-      - image: 'cimg/ruby:3.3-node'
+      - image: "cimg/ruby:3.3-node"
     steps:
       - checkout
       - run: *node_version
@@ -146,7 +146,7 @@ jobs:
             echo "export BUILD_SHA=$CIRCLE_SHA1" >> $BASH_ENV
       - run: &deploy_scripts
           name: cloning deploy scripts
-          command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
+          command: "git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts"
       - run:
           name: build testable editor web docker images
           environment:
@@ -180,7 +180,7 @@ jobs:
           environment:
             ENVIRONMENT_NAME: test
             IMAGE_TYPE: workers
-          command: './deploy-scripts/bin/build'
+          command: "./deploy-scripts/bin/build"
       - run:
           name: Restore env
           command: |
@@ -212,11 +212,11 @@ jobs:
             APPLICATION_NAME: fb-editor
             PLATFORM_ENV: test
             K8S_NAMESPACE: formbuilder-saas-test
-          command: './deploy-scripts/bin/deploy-eks'
+          command: "./deploy-scripts/bin/deploy-eks"
       - slack/status: *testable_slack_status
   remove_testable_editors:
     docker:
-      - image: 'cimg/ruby:3.2.0-node'
+      - image: "cimg/ruby:3.2.0-node"
     steps:
       - checkout
       - ruby/install-deps
@@ -224,7 +224,7 @@ jobs:
       - run: *deploy_scripts
       - run:
           name: set kubernetes context for saas namespace
-          command: './deploy-scripts/bin/set_testable_editors_context'
+          command: "./deploy-scripts/bin/set_testable_editors_context"
       - run:
           name: remove testable editors
           command: bundle exec rails remove:testable_editors
@@ -245,7 +245,7 @@ jobs:
           environment:
             ENVIRONMENT_NAME: test
             IMAGE_TYPE: web
-          command: './deploy-scripts/bin/build'
+          command: "./deploy-scripts/bin/build"
       - slack/status: *slack_status
   build_workers_image:
     working_directory: ~/circle/git/fb-editor
@@ -270,7 +270,7 @@ jobs:
           environment:
             ENVIRONMENT_NAME: test
             IMAGE_TYPE: workers
-          command: './deploy-scripts/bin/build'
+          command: "./deploy-scripts/bin/build"
       - run:
           name: Restore env
           command: |
@@ -292,7 +292,7 @@ jobs:
             APPLICATION_NAME: fb-editor
             PLATFORM_ENV: test
             K8S_NAMESPACE: formbuilder-saas-test
-          command: './deploy-scripts/bin/deploy-eks'
+          command: "./deploy-scripts/bin/deploy-eks"
       - slack/status: *slack_status
   acceptance_tests_eks:
     docker: *test_image
@@ -379,7 +379,7 @@ jobs:
             APPLICATION_NAME: fb-editor
             PLATFORM_ENV: live
             K8S_NAMESPACE: formbuilder-saas-live
-          command: './deploy-scripts/bin/deploy-eks'
+          command: "./deploy-scripts/bin/deploy-eks"
       - slack/status:
           only_for_branches: main
           success_message: ":rocket:  Successfully deployed to Live (eks) :guitar:"
@@ -431,7 +431,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - run-only-this-branch
       - build_workers_image:
           context: *context
           requires:
@@ -443,7 +443,7 @@ workflows:
           filters:
             branches:
               only:
-                - main
+                - run-only-this-branch
       - deploy_to_test_eks:
           context: *context
           requires:
@@ -468,6 +468,10 @@ workflows:
             - acceptance_tests_eks
             - deploy_to_test_eks
             - production_deploy_approval
+          filters:
+            branches:
+              only:
+                - main
   deploy_testable_branch:
     jobs:
       - build:

--- a/app/services/encryption_service.rb
+++ b/app/services/encryption_service.rb
@@ -1,8 +1,8 @@
 class EncryptionService
   KEY = ActiveSupport::KeyGenerator.new(
-    ENV.fetch('ENCRYPTION_KEY')
+    ENV.fetch('ENCRYPTION_KEY', '')
   ).generate_key(
-    ENV.fetch('ENCRYPTION_SALT'),
+    ENV.fetch('ENCRYPTION_SALT', ''),
     ActiveSupport::MessageEncryptor.key_len
   ).freeze
 

--- a/app/services/encryption_service.rb
+++ b/app/services/encryption_service.rb
@@ -1,8 +1,8 @@
 class EncryptionService
   KEY = ActiveSupport::KeyGenerator.new(
-    ENV.fetch('ENCRYPTION_KEY', '')
+    ENV.fetch('ENCRYPTION_KEY')
   ).generate_key(
-    ENV.fetch('ENCRYPTION_SALT', ''),
+    ENV.fetch('ENCRYPTION_SALT'),
     ActiveSupport::MessageEncryptor.key_len
   ).freeze
 

--- a/app/services/new_encryption_service.rb
+++ b/app/services/new_encryption_service.rb
@@ -1,0 +1,16 @@
+class NewEncryptionService < EncryptionService
+  NEW_KEY = ActiveSupport::KeyGenerator.new(
+    ENV.fetch('NEW_ENCRYPTION_KEY', '')
+  ).generate_key(
+    ENV.fetch('NEW_ENCRYPTION_SALT', ''),
+    ActiveSupport::MessageEncryptor.key_len
+  ).freeze
+
+  private_constant :NEW_KEY
+
+  private
+
+  def encryptor
+    @encryptor ||= ActiveSupport::MessageEncryptor.new(NEW_KEY)
+  end
+end

--- a/app/services/new_encryption_service.rb
+++ b/app/services/new_encryption_service.rb
@@ -1,8 +1,8 @@
 class NewEncryptionService < EncryptionService
   NEW_KEY = ActiveSupport::KeyGenerator.new(
-    ENV.fetch('NEW_ENCRYPTION_KEY', '')
+    ENV.fetch('NEW_ENCRYPTION_KEY')
   ).generate_key(
-    ENV.fetch('NEW_ENCRYPTION_SALT', ''),
+    ENV.fetch('NEW_ENCRYPTION_SALT'),
     ActiveSupport::MessageEncryptor.key_len
   ).freeze
 

--- a/app/services/new_encryption_service.rb
+++ b/app/services/new_encryption_service.rb
@@ -1,8 +1,8 @@
 class NewEncryptionService < EncryptionService
   NEW_KEY = ActiveSupport::KeyGenerator.new(
-    ENV.fetch('NEW_ENCRYPTION_KEY')
+    ENV.fetch('NEW_ENCRYPTION_KEY', '')
   ).generate_key(
-    ENV.fetch('NEW_ENCRYPTION_SALT'),
+    ENV.fetch('NEW_ENCRYPTION_SALT', ''),
     ActiveSupport::MessageEncryptor.key_len
   ).freeze
 

--- a/deploy-eks/fb-editor-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-editor-chart/templates/deployment.yaml
@@ -108,6 +108,16 @@ spec:
               secretKeyRef:
                 name: fb-editor-secrets-{{ .Values.environmentName }}
                 key: encryption_salt
+          - name: NEW_ENCRYPTION_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: new_encryption_key
+          - name: NEW_ENCRYPTION_SALT
+            valueFrom:
+              secretKeyRef:
+                name: fb-editor-secrets-{{ .Values.environmentName }}
+                key: new_encryption_salt
           - name: DATABASE_URL
             valueFrom:
               secretKeyRef:

--- a/deploy-eks/fb-editor-chart/templates/secrets.yaml
+++ b/deploy-eks/fb-editor-chart/templates/secrets.yaml
@@ -12,7 +12,9 @@ data:
   auth0_client_secret: {{ .Values.auth0_client_secret }}
   encoded_private_key: {{ .Values.encoded_private_key}}
   encryption_key: {{ .Values.encryption_key }}
+  new_encryption_key: {{ .Values.new_encryption_key }}
   encryption_salt: {{ .Values.encryption_salt }}
+  new_encryption_salt: {{ .Values.new_encryption_salt }}
   submission_encryption_key: {{ .Values.submission_encryption_key }}
   service_sentry_dsn_test: {{ .Values.service_sentry_dsn_test }}
   service_sentry_dsn_live: {{ .Values.service_sentry_dsn_live }}

--- a/lib/tasks/rotate_encryption_key.rake
+++ b/lib/tasks/rotate_encryption_key.rake
@@ -1,0 +1,48 @@
+namespace :db do
+  desc 'Rotate encryption keys'
+  task rotate_encryption_key: :environment do
+    old_encryption = EncryptionService.new
+    new_encryption = NewEncryptionService.new
+
+    rotate_records = lambda do |model, attributes, old_enc, new_enc|
+      model.transaction do
+        model.find_each do |record|
+          updates = attributes.map do |attribute|
+            puts "\n\nModel: #{model}, Attribute: #{attribute}\n"
+            encrypted_value = record.attributes_before_type_cast[attribute]
+            decrypted_value = old_enc.decrypt(encrypted_value)
+            new_encrypted_value = new_enc.encrypt(decrypted_value)
+
+            [
+              attribute,
+              new_encrypted_value
+            ]
+          end
+
+          puts record.update_columns(updates.to_h)
+        end
+      end
+    end
+
+    rotate_records.call(
+      Identity,
+      %w[name email],
+      old_encryption,
+      new_encryption
+    )
+
+    rotate_records.call(
+      User,
+      %w[name email],
+      old_encryption,
+      new_encryption
+    )
+
+    rotate_records.call(
+      ServiceConfiguration,
+      %w[value],
+      old_encryption,
+      new_encryption
+    )
+  end
+end

--- a/lib/tasks/rotate_encryption_key.rake
+++ b/lib/tasks/rotate_encryption_key.rake
@@ -4,10 +4,11 @@ namespace :db do
     rotate_records = lambda do |model, attributes, old_enc = EncryptionService.new, new_enc = NewEncryptionService.new|
       model.transaction do
         records = model.all
-        count = records.count
 
-        puts "\nEncrypting #{model}: #{count} records\n"
-        records.each do |record|
+        puts "\nEncrypting #{model}: #{records.count} records\n"
+
+        count = 0
+        records.each_with_index do |record, index|
           updates = attributes.map do |attribute|
             encrypted_value = record.attributes_before_type_cast[attribute]
             decrypted_value = old_enc.decrypt(encrypted_value)
@@ -20,6 +21,7 @@ namespace :db do
           end
 
           record.update_columns(updates.to_h)
+          count = index + 1
         end
         puts "Updated #{model}: #{count} records"
       end

--- a/lib/tasks/rotate_encryption_key.rake
+++ b/lib/tasks/rotate_encryption_key.rake
@@ -1,10 +1,7 @@
 namespace :db do
   desc 'Rotate encryption keys'
   task rotate_encryption_key: :environment do
-    old_encryption = EncryptionService.new
-    new_encryption = NewEncryptionService.new
-
-    rotate_records = lambda do |model, attributes, old_enc, new_enc|
+    rotate_records = lambda do |model, attributes, old_enc = EncryptionService.new, new_enc = NewEncryptionService.new|
       model.transaction do
         records = model.all
         count = records.count
@@ -30,23 +27,17 @@ namespace :db do
 
     rotate_records.call(
       Identity,
-      %w[name email],
-      old_encryption,
-      new_encryption
+      %w[name email]
     )
 
     rotate_records.call(
       User,
-      %w[name email],
-      old_encryption,
-      new_encryption
+      %w[name email]
     )
 
     rotate_records.call(
       ServiceConfiguration,
-      %w[value],
-      old_encryption,
-      new_encryption
+      %w[value]
     )
   end
 end

--- a/lib/tasks/rotate_encryption_key.rake
+++ b/lib/tasks/rotate_encryption_key.rake
@@ -6,9 +6,12 @@ namespace :db do
 
     rotate_records = lambda do |model, attributes, old_enc, new_enc|
       model.transaction do
-        model.find_each do |record|
+        records = model.all
+        count = records.count
+
+        puts "\nEncrypting #{model}: #{count} records\n"
+        records.each do |record|
           updates = attributes.map do |attribute|
-            puts "\n\nModel: #{model}, Attribute: #{attribute}\n"
             encrypted_value = record.attributes_before_type_cast[attribute]
             decrypted_value = old_enc.decrypt(encrypted_value)
             new_encrypted_value = new_enc.encrypt(decrypted_value)
@@ -19,8 +22,9 @@ namespace :db do
             ]
           end
 
-          puts record.update_columns(updates.to_h)
+          record.update_columns(updates.to_h)
         end
+        puts "Updated #{model}: #{count} records"
       end
     end
 


### PR DESCRIPTION
### Steps to rotate ENCRYPTION_KEY and ENCRYPTION_SALT ###

Test Env: [https://fb-editor-test.apps.live.cloud-platform.service.justice.gov.uk](https://fb-editor-test.apps.live.cloud-platform.service.justice.gov.uk)

- Log in to Test Env and create test form, preview and submit
- Run rake task `bundle exec rake db:rotate_encryption_key` to update all `Identity`, `User` and `ServiceConfiguration` records using NEW_ENCRYPTION_KEY and NEW_ENCRYPTION_SALT
- Log in to Test Env should FAIL
- Rename the following
  - ENCRYPTION_KEY -> OLD_ENCRYPTION_KEY
  - ENCRYPTION_SALT -> OLD_ENCRYPTION_SALT
  - NEW_ENCRYPTION_KEY -> ENCRYPTION_KEY
  - NEW_ENCRYPTION_SALT -> ENCRYPTION_SALT
- Restart the pods/pipeline
- Log in to Test Env should PASS



Workflow:
<img width="597" height="549" alt="Screenshot 2026-06-16 at 13 18 39" src="https://github.com/user-attachments/assets/85e8b997-9384-4e48-9d81-16670155cb67" />

