### PR TITLE
CDPTKAN-94: Fix flaky

### DIFF
--- a/acceptance/features/edit_multiple_questions_page_spec.rb
+++ b/acceptance/features/edit_multiple_questions_page_spec.rb
@@ -59,7 +59,7 @@ feature 'Edit multiple questions page' do
       ]
     }
 
-    xscenario 'adding and updating components' do
+    scenario 'adding and updating components' do
       and_I_edit_the_page(url: page_heading)
       then_the_save_button_should_be_disabled
       and_I_add_the_component(I18n.t('components.list.text'))
@@ -77,7 +77,7 @@ feature 'Edit multiple questions page' do
       then_I_can_answer_the_questions_in_the_page(preview_form)
     end
 
-    xscenario 'deleting a text component' do
+    scenario 'deleting a text component' do
       and_I_edit_the_page(url: page_heading)
       and_I_add_the_component(I18n.t('components.list.text'))
       and_I_add_the_component(I18n.t('components.list.textarea'))
@@ -90,7 +90,7 @@ feature 'Edit multiple questions page' do
       and_the_component_is_deleted(text_component_question, remaining: 1)
     end
 
-    xscenario 'deleting an email component' do
+    scenario 'deleting an email component' do
       and_I_edit_the_page(url: page_heading)
       and_I_add_the_component(I18n.t('components.list.text'))
       and_I_add_the_component(I18n.t('components.list.textarea'))

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -286,11 +286,13 @@ module CommonSteps
   def then_I_should_be_warned_when_leaving_page
     # click outside of fields that will make save button re-enable
     editor.service_name.click
+
+    # dismiss_confirm(wait: 1) { editor.pages_link.click } throws Capybara::ModalNotFound: Unable to find modal dialog.
+    # Therefore using page.evaluate_script
+
     # Headless Chrome hides the native beforeunload prompt from the driver, so
     # trigger it directly. dispatchEvent returns false when a handler cancels the
     # event, which is exactly what produces the browser's "leave page?" warning.
-
-    #dismiss_confirm(wait: 1) { editor.pages_link.click }
     warned = page.evaluate_script(
       "!window.dispatchEvent(new Event('beforeunload', {cancelable: true}))"
     )

--- a/acceptance/support/common_steps.rb
+++ b/acceptance/support/common_steps.rb
@@ -286,7 +286,15 @@ module CommonSteps
   def then_I_should_be_warned_when_leaving_page
     # click outside of fields that will make save button re-enable
     editor.service_name.click
-    dismiss_confirm(wait: 1) { editor.pages_link.click }
+    # Headless Chrome hides the native beforeunload prompt from the driver, so
+    # trigger it directly. dispatchEvent returns false when a handler cancels the
+    # event, which is exactly what produces the browser's "leave page?" warning.
+
+    #dismiss_confirm(wait: 1) { editor.pages_link.click }
+    warned = page.evaluate_script(
+      "!window.dispatchEvent(new Event('beforeunload', {cancelable: true}))"
+    )
+    expect(warned).to be(true)
   end
 
   def when_I_want_to_select_question_properties


### PR DESCRIPTION
Fix for the `confirm` modal dialog issue while running acceptance tests
### Error: 
```ruby
     Capybara::ModalNotFound:
       Unable to find modal dialog
     # ./acceptance/support/common_steps.rb:302:in 'CommonSteps#then_I_should_be_warned_when_leaving_page'
     # ./acceptance/features/edit_multiple_questions_page_spec.rb:99:in 'block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Selenium::WebDriver::Error::TimeoutError:
     #   timed out after 1 seconds (no such alert
     #     (Session info: chrome=150.0.7871.115))
     #   ./acceptance/support/common_steps.rb:302:in 'CommonSteps#then_I_should_be_warned_when_leaving_page'
 ```    

<img width="541" height="596" alt="Screenshot 2026-07-17 at 12 25 05" src="https://github.com/user-attachments/assets/07bc65e3-7f62-49b2-a687-f197d740c52c" />


