### PR TITLE
Missin "Rerun failed tests" option in circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,6 +314,7 @@ jobs:
             chromedriver --version
       - run: *wait_for_db
       - run: *db_setup
+      - run: mkdir ~/acceptance
       - run:
           name: Run acceptance tests
           command: |
@@ -349,6 +350,7 @@ jobs:
             chromedriver --version
       - run: *wait_for_db
       - run: *db_setup
+      - run: mkdir ~/acceptance
       - run:
           name: Run acceptance tests
           command: |


### PR DESCRIPTION
Currently "Rerun failed tests" option in CircleCi is missing which was working perfectly before

<img width="393" height="527" alt="Screenshot 2026-07-20 at 11 37 50" src="https://github.com/user-attachments/assets/d36d4220-8d84-4f7b-9e74-7129b3e0d5b0" />
