### PR TITLE
[CDPTKAN-1253] Upgrade govuk-frontend to 5.14.0

### DIFF
--- a/app/javascript/packs/govuk.js
+++ b/app/javascript/packs/govuk.js
@@ -1,3 +1,3 @@
-require("govuk-frontend/govuk/all").initAll()
-require.context('govuk-frontend/govuk/assets/images', true)
+require("govuk-frontend/dist/govuk/all").initAll()
+require.context('govuk-frontend/dist/govuk/assets/images', true)
 import "./stylesheets/govuk.scss"

--- a/app/javascript/packs/stylesheets/govuk.scss
+++ b/app/javascript/packs/stylesheets/govuk.scss
@@ -1,5 +1,5 @@
-$govuk-assets-path: "~govuk-frontend/govuk/assets/";
-@import "govuk-frontend/govuk/all";
+$govuk-assets-path: "~govuk-frontend/dist/govuk/assets/";
+@import "govuk-frontend/dist/govuk/all";
 
 // Corrective tweak to make area non-full width in large view
 // Pointed out by design and shown in this example (at time of writing)

--- a/app/javascript/src/component_dialog_form.js
+++ b/app/javascript/src/component_dialog_form.js
@@ -180,7 +180,7 @@ class DialogForm {
       .get(0)
       ?.querySelector('[data-module="govuk-error-summary"]');
     if (errorSummary) {
-      new window.GOVUKFrontend.ErrorSummary(errorSummary).init();
+      new window.GOVUKFrontend.ErrorSummary(errorSummary);
     } else {
       let el = this.$node.parent().find("input[aria-invalid]").get(0);
       if (!el) {

--- a/app/views/partials/_head_tags.html.erb
+++ b/app/views/partials/_head_tags.html.erb
@@ -1,7 +1,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_pack_url('media/images/favicon.ico') %>" type="image/x-icon" />
-<link rel="mask-icon" href="<%= asset_pack_url('media/images/govuk-mask-icon.svg') %>" color="blue">
-<link rel="apple-touch-icon" sizes="180x180" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-180x180.png') %>">
-<link rel="apple-touch-icon" sizes="167x167" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-167x167.png') %>">
-<link rel="apple-touch-icon" sizes="152x152" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-152x152.png') %>">
-<link rel="apple-touch-icon" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon.png') %>">
+<link rel="icon" sizes="48x48" href="<%= asset_pack_url('media/images/favicon.ico') %>">
+<link rel="icon" sizes="any" href="<%= asset_pack_url('media/images/favicon.svg') %>" type="image/svg+xml">
+<link rel="mask-icon" href="<%= asset_pack_url('media/images/govuk-icon-mask.svg') %>" color="blue">
+<link rel="apple-touch-icon" href="<%= asset_pack_url('media/images/govuk-icon-180.png') %>">

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "accessible-autocomplete": "^2.0.4",
     "chai-dom": "^1.11.0",
     "dompurify": "^3.2.4",
-    "govuk-frontend": "4.8.0",
+    "govuk-frontend": "5.14.0",
     "govuk-markdown": "^0.3.0",
     "jquery": "^3.6.4",
     "jquery-ui-dist": "^1.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3160,10 +3160,10 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-govuk-frontend@4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.8.0.tgz#df4e56c762e93aae74fed214bb6be08e13783772"
-  integrity sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==
+govuk-frontend@5.14.0:
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.14.0.tgz#d93f1ffa88b0696114509cab86e4ea474006f8e0"
+  integrity sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==
 
 govuk-markdown@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/jira/software/projects/CDPTKAN/boards/6617?jql=assignee%20%3D%20712020%3A3d805bbe-8fa6-48b0-b8bd-f2d3612405d6&selectedIssue=CDPTKAN-1253

v5 restructures the package and renames icon assets:
- Point JS/SCSS imports at the new dist/govuk paths https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0
- ErrorSummary now initialises in the constructor (removed .init())
- Replace v4 favicon/touch-icon references in head tags with the v5 icon
  set (favicon.svg, govuk-icon-mask.svg, govuk-icon-180) https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0